### PR TITLE
[2405] - Friendly distribution date input

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -125,7 +125,6 @@ class DistributionsController < ApplicationController
 
   def update
     @distribution = Distribution.includes(:line_items).includes(:storage_location).find(params[:id])
-
     result = DistributionUpdateService.new(@distribution, distribution_params).call
 
     if result.success?

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -82,7 +82,7 @@
 #  zips_served                :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  diaper_bank_id             :integer
+#  diaper_bank_id             :bigint
 #  diaper_partner_id          :integer
 #
 module Partners

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -1,0 +1,40 @@
+<%= simple_form_for @distribution, method: :post, url: distributions_path(organization: @organization, request_id: params[:request_id]),
+                                   html: {class: "storage-location-required"},
+                                   wrapper_mappings: {
+                                   datetime: :custom_multi_select } do |f| %>
+  <div class="box-body">
+    <%= f.simple_fields_for :request do |r| %>
+      <%= r.input :id, as: :hidden %>
+    <% end %>
+    <%= f.association :partner,
+                      collection: current_organization.partners.alphabetized,
+                      label: "Partner",
+                      error: "Which partner is this distribution going to?" %>
+
+    <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date", html5: true %>
+    <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
+    <%= f.input :agency_rep, label: "Agency representative" %>
+    <%= f.input :delivery_method, as: :radio_buttons, collection: Distribution.delivery_methods.keys, label_method: :humanize, label: "Delivery method" %>
+
+    <%= render partial: "storage_locations/source", object: f, locals: { include_inactive_items: true }  %>
+
+    <%= f.input :comment, label: "Comment" %>
+
+    <fieldset style="margin-bottom: 2rem">
+      <legend>Items in this distribution</legend>
+      <%= f.simple_fields_for :line_items do |item| %>
+        <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
+          <%= render 'line_items/line_item_fields', f: item %>
+        </div>
+      <% end %>
+      <div class="row links justify-content-end">
+        <%= add_line_item_button f, "#distribution_line_items" %>
+      </div>
+
+    </fieldset>
+    </div>
+    <div class="card-footer">
+      <%= submit_button %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -1,40 +1,35 @@
-<%= simple_form_for @distribution, method: :post, url: distributions_path(organization: @organization, request_id: params[:request_id]),
-                                   html: {class: "storage-location-required"},
-                                   wrapper_mappings: {
-                                   datetime: :custom_multi_select } do |f| %>
-  <div class="box-body">
-    <%= f.simple_fields_for :request do |r| %>
-      <%= r.input :id, as: :hidden %>
-    <% end %>
-    <%= f.association :partner,
-                      collection: current_organization.partners.alphabetized,
-                      label: "Partner",
-                      error: "Which partner is this distribution going to?" %>
+<div class="box-body">
+  <%= f.simple_fields_for :request do |r| %>
+    <%= r.input :id, as: :hidden %>
+  <% end %>
+  <%= f.association :partner,
+                    collection: current_organization.partners.alphabetized,
+                    label: "Partner",
+                    error: "Which partner is this distribution going to?" %>
 
-    <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date", html5: true %>
-    <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
-    <%= f.input :agency_rep, label: "Agency representative" %>
-    <%= f.input :delivery_method, as: :radio_buttons, collection: Distribution.delivery_methods.keys, label_method: :humanize, label: "Delivery method" %>
+  <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date", html5: true %>
+  <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
+  <%= f.input :agency_rep, label: "Agency representative" %>
+  <%= f.input :delivery_method, as: :radio_buttons, collection: Distribution.delivery_methods.keys, label_method: :humanize, label: "Delivery method" %>
 
-    <%= render partial: "storage_locations/source", object: f, locals: { include_inactive_items: true }  %>
+  <%= render partial: "storage_locations/source", object: f, locals: { include_inactive_items: true }  %>
 
-    <%= f.input :comment, label: "Comment" %>
+  <%= f.input :comment, label: "Comment" %>
 
-    <fieldset style="margin-bottom: 2rem">
-      <legend>Items in this distribution</legend>
-      <%= f.simple_fields_for :line_items do |item| %>
-        <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
-          <%= render 'line_items/line_item_fields', f: item %>
-        </div>
-      <% end %>
-      <div class="row links justify-content-end">
-        <%= add_line_item_button f, "#distribution_line_items" %>
+  <fieldset style="margin-bottom: 2rem">
+    <legend>Items in this distribution</legend>
+    <%= f.simple_fields_for :line_items do |item| %>
+      <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
+        <%= render 'line_items/line_item_fields', f: item %>
       </div>
+    <% end %>
+    <div class="row links justify-content-end">
+      <%= add_line_item_button f, "#distribution_line_items" %>
+    </div>
 
-    </fieldset>
-    </div>
-    <div class="card-footer">
-      <%= submit_button %>
-    </div>
+  </fieldset>
   </div>
-<% end %>
+  <div class="card-footer">
+    <%= submit_button %>
+  </div>
+</div>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -46,45 +46,8 @@
             <!-- Default box -->
             <div class="box">
               <div class="box-body">
-
-                <%= simple_form_for @distribution, html: {class: "storage-location-required"},
-                  wrapper_mappings: {
-                    datetime: :custom_multi_select
-                  } do |f| %>
-
-
-                  <%= f.input :id, disabled: true, label: "ID" %>
-
-                  <%= f.association :partner,
-                                    collection: current_organization.partners.alphabetized,
-                                    label: "Partner",
-                                    error: "Which partner is this distribution going to?" %>
-
-                  <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date" %>
-                  <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
-                  <%= f.input :agency_rep, label: "Agency representative" %>
-                  <%= f.input :delivery_method, as: :radio_buttons, collection: Distribution.delivery_methods.keys, label_method: :humanize, label: "Delivery method" %>
-
-                  <%= render partial: "storage_locations/source", object: f %>
-
-                  <%= f.input :comment, label: "Comment" %>
-
-                  <fieldset class='w-50'>
-                    <legend>Items in this distribution</legend>
-                    <%= f.simple_fields_for :line_items do |item| %>
-                      <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
-                        <%= render 'line_items/line_item_fields', f: item %>
-                      </div>
-                    <% end %>
-                    <div class="row links justify-content-end">
-                      <%= add_line_item_button f, "#distribution_line_items" %>
-                    </div>
-                  </fieldset>
-                  <div class="card-footer">
-                    <%= submit_button %>
-                  </div>
-                <% end %>
-                </div>
+                <%= render 'form', distribution: @distribution %>
+              </div>
           </div><!-- /.box -->
         </div>
       </div>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -46,7 +46,12 @@
             <!-- Default box -->
             <div class="box">
               <div class="box-body">
-                <%= render 'form', distribution: @distribution %>
+              <%= simple_form_for @distribution, html: {class: "storage-location-required"},
+                  wrapper_mappings: {
+                    datetime: :custom_multi_select
+                  } do |f| %>
+                <%= render 'form', distribution: @distribution, f: f %>
+              <% end %>
               </div>
           </div><!-- /.box -->
         </div>

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -34,48 +34,7 @@
           <div class="card-body">
             <!-- Default box -->
             <div class="box">
-              <%= simple_form_for @distribution, method: :post,
-                url: distributions_path(organization: @organization, request_id: params[:request_id]),
-                html: {class: "storage-location-required"},
-                wrapper_mappings: {
-                  datetime: :custom_multi_select
-                } do |f| %>
-                <div class="box-body">
-                  <%= f.simple_fields_for :request do |r| %>
-                    <%= r.input :id, as: :hidden %>
-                  <% end %>
-                  <%= f.association :partner,
-                                    collection: current_organization.partners.alphabetized,
-                                    label: "Partner",
-                                    error: "Which partner is this distribution going to?" %>
-
-                  <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date" %>
-                  <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
-                  <%= f.input :agency_rep, label: "Agency representative" %>
-                  <%= f.input :delivery_method, as: :radio_buttons, collection: Distribution.delivery_methods.keys, label_method: :humanize, label: "Delivery method" %>
-
-                  <%= render partial: "storage_locations/source", object: f, locals: { include_inactive_items: true }  %>
-
-                  <%= f.input :comment, label: "Comment" %>
-
-                  <fieldset style="margin-bottom: 2rem">
-                    <legend>Items in this distribution</legend>
-                    <%= f.simple_fields_for :line_items do |item| %>
-                      <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
-                        <%= render 'line_items/line_item_fields', f: item %>
-                      </div>
-                    <% end %>
-                    <div class="row links justify-content-end">
-                      <%= add_line_item_button f, "#distribution_line_items" %>
-                    </div>
-
-                  </fieldset>
-                  </div>
-                  <div class="card-footer">
-                    <%= submit_button %>
-                  </div>
-                </div>
-              <% end %>
+              <%= render 'form', distribution: @distribution %>
           </div><!-- /.box -->
         </div>
       </div>

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -34,7 +34,12 @@
           <div class="card-body">
             <!-- Default box -->
             <div class="box">
-              <%= render 'form', distribution: @distribution %>
+            <%= simple_form_for @distribution, method: :post, url: distributions_path(organization: @organization, request_id: params[:request_id]),
+                                   html: {class: "storage-location-required"},
+                                   wrapper_mappings: {
+                                   datetime: :custom_multi_select } do |f| %>
+              <%= render 'form', distribution: @distribution, f: f %>
+            <% end %>
           </div><!-- /.box -->
         </div>
       </div>

--- a/db/partners_schema.rb
+++ b/db/partners_schema.rb
@@ -150,10 +150,7 @@ ActiveRecord::Schema.define(version: 20_200_518_010_905) do
   end
 
   create_table "partners", force: :cascade do |t|
-    t.integer "diaper_bank_id"
-    t.string "executive_director_name"
-    t.string "program_contact_name"
-    t.string "pick_up_name"
+    t.bigint "diaper_bank_id"
     t.text "application_data"
     t.integer "diaper_partner_id"
     t.string "partner_status", default: "pending"
@@ -212,12 +209,15 @@ ActiveRecord::Schema.define(version: 20_200_518_010_905) do
     t.integer "greater_2_times_fpl"
     t.integer "poverty_unknown"
     t.string "ages_served"
+    t.string "executive_director_name"
     t.string "executive_director_phone"
     t.string "executive_director_email"
+    t.string "program_contact_name"
     t.string "program_contact_phone"
     t.string "program_contact_mobile"
     t.string "program_contact_email"
     t.string "pick_up_method"
+    t.string "pick_up_name"
     t.string "pick_up_phone"
     t.string "pick_up_email"
     t.string "distribution_times"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -159,8 +159,8 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.integer "organization_id"
     t.datetime "issued_at"
     t.string "agency_rep"
-    t.integer "state", default: 5, null: false
     t.boolean "reminder_email_enabled", default: false, null: false
+    t.integer "state", default: 5, null: false
     t.integer "delivery_method", default: 0, null: false
     t.index ["organization_id"], name: "index_distributions_on_organization_id"
     t.index ["partner_id"], name: "index_distributions_on_partner_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,10 +2,9 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
-#  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  invitation_accepted_at :datetime
@@ -15,20 +14,17 @@
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
-#  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string           default("CHANGEME"), not null
-#  organization_admin     :boolean
+#  name                   :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0), not null
-#  super_admin            :boolean          default(FALSE)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  invited_by_id          :integer
-#  organization_id        :integer
+#  invited_by_id          :bigint
+#  partner_id             :bigint
 #
 
 FactoryBot.define do

--- a/spec/models/partners/partner_spec.rb
+++ b/spec/models/partners/partner_spec.rb
@@ -82,7 +82,7 @@
 #  zips_served                :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  diaper_bank_id             :integer
+#  diaper_bank_id             :bigint
 #  diaper_partner_id          :integer
 #
 require "rails_helper"

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Distributions", type: :system do
       choose "Pick up"
 
       fill_in "Comment", with: "Take my wipes... please"
-      fill_in "distribution_issued_at", with: '01/01/2001 10:15'
+      fill_in "Distribution date", with: '01/01/2001 10:15'
 
       expect(PartnerMailerJob).to receive(:perform_later).once
       click_button "Save", match: :first
@@ -152,11 +152,8 @@ RSpec.feature "Distributions", type: :system do
     it "allows the user can change the issued_at date" do
       click_on "Edit", match: :first
       expect do
-        select('2018', from: 'distribution_issued_at_1i')
-        select('May', from: 'distribution_issued_at_2i')
-        select('7', from: 'distribution_issued_at_3i')
-        select('02 PM', from: 'distribution_issued_at_4i')
-        select('15', from: 'distribution_issued_at_5i')
+        fill_in "Distribution date", with: '07/05/2018 14:15'
+
         click_on "Save", match: :first
         distribution.reload
       end.to change { distribution.issued_at }.to(Time.zone.parse("2018-05-07 14:15:00"))

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Distributions", type: :system do
       choose "Pick up"
 
       fill_in "Comment", with: "Take my wipes... please"
-      fill_in "Distribution date", with: '01/01/2001 10:15'
+      fill_in "Distribution date", with: '01/01/2001 10:15:00 AM'
 
       expect(PartnerMailerJob).to receive(:perform_later).once
       click_button "Save", match: :first
@@ -152,11 +152,11 @@ RSpec.feature "Distributions", type: :system do
     it "allows the user can change the issued_at date" do
       click_on "Edit", match: :first
       expect do
-        fill_in "Distribution date", with: '07/05/2018 14:15'
+        fill_in "Distribution date", with: Time.zone.parse("2001-10-01 10:00")
 
         click_on "Save", match: :first
         distribution.reload
-      end.to change { distribution.issued_at }.to(Time.zone.parse("2018-05-07 14:15:00"))
+      end.to change { distribution.issued_at }.to(Time.zone.parse("2001-10-01 10:00"))
     end
 
     it "disallows the user from changing the quantity above the inventory quantity" do
@@ -320,11 +320,10 @@ RSpec.feature "Distributions", type: :system do
         diaper_type = @distribution.line_items.first.item.name
         first_item_name_field = 'distribution_line_items_attributes_0_item_id'
         select(diaper_type, from: first_item_name_field)
-
-        find_all(".numeric")[1].set 1
+        find_all(".numeric")[0].set 1
 
         click_on "Add another item"
-        find_all(".numeric")[2].set 3
+        find_all(".numeric")[1].set 3
 
         first("button", text: "Save").click
 

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Distributions", type: :system do
       choose "Pick up"
 
       fill_in "Comment", with: "Take my wipes... please"
-      fill_in 'Distribution date', with: '01/01/2001 10:15'
+      fill_in "distribution_issued_at", with: '01/01/2001 10:15'
 
       expect(PartnerMailerJob).to receive(:perform_later).once
       click_button "Save", match: :first

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature "Distributions", type: :system do
       choose "Pick up"
 
       fill_in "Comment", with: "Take my wipes... please"
+      fill_in 'Distribution date', with: '01/01/2001 10:15'
 
       expect(PartnerMailerJob).to receive(:perform_later).once
       click_button "Save", match: :first


### PR DESCRIPTION
Resolves #2405  <!--fill issue number-->

### Description
 Change the distribution date to be friendly for users ( It's possible to know what week day is clicking on the calendar icon)
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
* Access the distribution form (new and edit), select the distribution date and save it!

### Screenshots
* ![image](https://user-images.githubusercontent.com/4561599/122688824-e2aac580-d1f4-11eb-9a9b-ca549f4ec65d.png)
