### PR TITLE
Convert "Amount spent in cents" to "Amount spent in dollars"

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -87,7 +87,7 @@ class Purchase < ApplicationRecord
   end
 
   def self.csv_export_headers
-    ["Purchases from", "Storage Location", "Purchased Date", "Quantity of Items", "Variety of Items", "Amount spent in Cents"]
+    ["Purchases from", "Storage Location", "Purchased Date", "Quantity of Items", "Variety of Items", "Amount Spent"]
   end
 
   def csv_export_attributes
@@ -97,7 +97,7 @@ class Purchase < ApplicationRecord
       issued_at.strftime("%Y-%m-%d"),
       line_items.total,
       line_items.size,
-      amount_spent_in_cents
+      amount_spent_in_dollars
     ]
   end
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -76,6 +76,9 @@ test:
   <<: *default
   compile: true
 
+  # Extract and emit a css file
+  extract_css: false
+
   # Compile test packs to a separate directory
   public_output_path: packs-test
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -142,5 +142,16 @@ RSpec.describe Purchase, type: :model do
         end
       end
     end
+
+    describe "#csv_export_attributes" do
+      let(:purchase) { create(:purchase, :with_items) }
+
+      it "includes purchase information" do
+        expect(purchase.csv_export_attributes).to include(purchase.purchased_from_view)
+        expect(purchase.csv_export_attributes).to include(purchase.storage_location.name)
+        expect(purchase.csv_export_attributes).to include(purchase.issued_at.strftime("%Y-%m-%d"))
+        expect(purchase.csv_export_attributes).to include(purchase.amount_spent_in_dollars)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2406
### Description

- On the Purchases export, I changed the last column to be shown in dollars instead of cents, and I updated the header to reflect this change.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I added a test to `spec/models/purchases_spec.rb`

### Screenshots
<img width="830" alt="image" src="https://user-images.githubusercontent.com/4965672/123121604-4c081f80-d413-11eb-89e8-f1db3695a08a.png">