### PR TITLE
Fix bullet warnings in dashboard page

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,14 +5,14 @@ class DashboardController < ApplicationController
   def index
     setup_date_range_picker
 
-    @donations = current_organization.donations.includes(:diaper_drive, line_items: [:item]).during(helpers.selected_range)
+    @donations = current_organization.donations.during(helpers.selected_range)
     @recent_donations = @donations.recent
-    @purchases = current_organization.purchases.includes(:vendor, line_items: [:item]).during(helpers.selected_range)
-    @recent_purchases = @purchases.recent
-    @recent_distributions = current_organization.distributions.includes(:partner, line_items: [:item]).during(helpers.selected_range).recent
+    @purchases = current_organization.purchases.during(helpers.selected_range)
+    @recent_purchases = @purchases.recent.includes(:vendor)
+    @recent_distributions = current_organization.distributions.includes(:partner).during(helpers.selected_range).recent
 
     if Flipper.enabled?(:itemized_distributions, current_user)
-      @itemized_distributions = current_organization.distributions.includes(line_items: [:item]).during(helpers.selected_range)
+      @itemized_distributions = current_organization.distributions.includes(:line_items).during(helpers.selected_range)
       @onhand_quantities = current_organization.inventory_items.group("items.name").sum(:quantity)
       @onhand_minimums = current_organization.inventory_items
                                              .group("items.name")
@@ -24,7 +24,7 @@ class DashboardController < ApplicationController
 
     # calling .recent on recent donations by manufacturers will only count the last 3 donations
     # which may not make sense when calculating total count using a date range
-    @recent_donations_from_manufacturers = current_organization.donations.includes(:manufacturer, line_items: [:item]).during(helpers.selected_range).by_source(:manufacturer)
+    @recent_donations_from_manufacturers = current_organization.donations.during(helpers.selected_range).by_source(:manufacturer)
     @top_manufacturers = current_organization.manufacturers.by_donation_count
   end
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -73,8 +73,9 @@ class Donation < ApplicationRecord
   # TODO: move this to Organization.donations as an extension
   scope :during, ->(range) { where(donations: { issued_at: range }) }
   scope :by_source, ->(source) {
-    source = SOURCES[source] if source.is_a?(Symbol)
-    where(source: source)
+    return where(source: source) unless source.is_a?(Symbol)
+
+    includes(source).where(source: SOURCES[source])
   }
   scope :recent, ->(count = 3) { order(issued_at: :desc).limit(count) }
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -92,17 +92,47 @@ RSpec.describe Donation, type: :model do
     end
 
     describe "by_source >" do
+      subject(:by_source) { Donation.by_source(source).count }
+
       before(:each) do
         create(:donation, source: Donation::SOURCES[:misc])
         create(:diaper_drive_donation)
       end
 
-      it "returns all donations with the provided source" do
-        expect(Donation.by_source(Donation::SOURCES[:diaper_drive]).count).to eq(1)
+      context "when source is not a symbol" do
+        context "when source comes from the SOURCES hash" do
+          let(:source) { Donation::SOURCES[:diaper_drive] }
+
+          it "returns all donations with the provided source" do
+            is_expected.to eq(1)
+          end
+        end
+
+        context "when source is invalid" do
+          let(:source) { "Invalid String" }
+
+          it "does not throw errors, returns no results" do
+            is_expected.to be_zero
+          end
+        end
       end
 
-      it "allows a symbol as an argument, referencing the SOURCES hash" do
-        expect(Donation.by_source(:diaper_drive).count).to eq(1)
+      context "when source is a symbol" do
+        context "when source is valid" do
+          let(:source) { :diaper_drive }
+
+          it "allows a symbol as an argument, referencing the SOURCES hash" do
+            is_expected.to eq(1)
+          end
+        end
+
+        context "when source is invalid" do
+          let(:source) { :invalid }
+
+          it "does not throw errors, returns no results" do
+            is_expected.to be_zero
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2373 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
> List any dependencies that are required for this change. (gems, js libraries, etc.)
No gem/library was changed or added.

Include anything else we should know about. -->

In the dashboard page, [bullet](https://github.com/flyerhzm/bullet) was reporting some optimization to be done in the database queries that were used. I removed all of the warnings, by removing the unnecessary queries and adding the missing ones.

### Type of change

<!-- Please delete options that are not relevant. -->

* Tech debt

### How Has This Been Tested?

For the `bullet` warnings themselves, I manually tested if the warnings still showed up in the dashboard.

`bullet` also supports a [configuration](https://github.com/flyerhzm/bullet#configuration) that makes a spec fail if a `bullet` warning is raised:
```rb
# config/environments/development.rb
...
config.after_initialize do
  ...
  Bullet.raise = true
end
```
This could be useful in the future, but it can be kind of confusing for beginners and it would require fixing all of the bullet warnings first.

I also had to change a scope in the `Donation` model to add an `includes` call. To make sure this change was safe, I improved the tests for this scope.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

No bullet warnings are shown anymore, yay \o/
![image](https://user-images.githubusercontent.com/72531802/123126096-7e1f7e80-d41f-11eb-9758-5148f3106ed4.png)

