### PR TITLE
fix(spec): create PartnerUser, not Partners::User

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -192,7 +192,7 @@ note = [
                                         status_in_diaper_base: partner_option[:status]
                                       })
 
-  Partners::User.create!(
+  PartnerUser.create!(
     name: Faker::Name.name,
     password: "password",
     password_confirmation: "password",

--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -86,5 +86,5 @@ def replace_user_passwords
   encrypted_password = u.encrypted_password
 
   User.all.update_all(encrypted_password: encrypted_password)
-  Partners::User.all.update_all(encrypted_password: encrypted_password)
+  PartnerUser.all.update_all(encrypted_password: encrypted_password)
 end

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
     after(:create) do |partner, _evaluator|
       # Create associated records on partnerbase DB
       partners_partner = create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
-      Partners::User.create!(
+      PartnerUser.create!(
         email: partner.email,
         partner: partners_partner,
         password: 'password'


### PR DESCRIPTION
Moving devise settings to PartnerUser in 52d9f47d broke the line in the
DB seed where we create a Partners::User and supply a password key arg.

See discussion in https://rubyforgood.slack.com/archives/C6WLZL0DD/p1625101155045100

Note: @edwinthinks, I've just made the DB creation work with this. If there was something important about seeding with `Partners::User` that should be preserved, then we'll need to add it to this or another PR.