### PR TITLE
Avoid having partners make account requests that is intended for banks

### DIFF
--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -1,12 +1,12 @@
 <% unless Rails.env.staging? %>
   <div class="bg-white" style='width: 35rem'>
     <div class="p-3">
-      <div class="mb-10 text-center">
-        <h1 class='text-3xl'>Essentials Bank Account Request Form</h1>
-        <p class='p-2 text-bold bg-yellow-200 text-center'>
-          This request form is only for banks that intend to distribute and manage relationships with their partners.
+      <div class="mb-10">
+        <h1 class='text-3xl text-center'>Essentials Bank Account Request Form</h1>
+        <p class='p-2 bg-yellow-200'>
+          Fill out the details below about your bank to request a free account to use Human Essentials for your organization's essentials bank.
           <br><br>
-          If you are a partner please go <%= link_to 'here', new_partner_user_session_path %> to login.
+          <span class='text-bold'>If you are a partner please go <%= link_to 'here', new_partner_user_session_path %> to login.</span
         </p>
       </div>
 
@@ -33,7 +33,7 @@
             </div>
 
             <div class="form-inputs">
-              <%= f.input :request_details, placeholder: 'Tell us more about your organization and how you would use the software account', label: "Request Details (min 50 characters)" %>
+              <%= f.input :request_details, placeholder: 'Tell us more about your organization and how you would use Human Essentials', label: "Request Details (min 50 characters)" %>
             </div>
           </div>
 
@@ -42,7 +42,7 @@
           </div>
 
           <div class="card-footer">
-            <%= submit_button({text: 'Submit Bank Account Request Form', icon: nil}) %>
+            <%= submit_button({text: 'Submit', icon: nil}) %>
           </div>
         <% end %>
       </div>

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -6,7 +6,7 @@
         <p class='p-2 bg-yellow-200'>
           Fill out the details below about your bank to request a free account to use Human Essentials for your organization's essentials bank.
           <br><br>
-          <span class='text-bold'>If you are a partner please go <%= link_to 'here', new_partner_user_session_path %> to login.</span
+          <span class='text-bold'>Do you <span class='text-italic'>partner</span> with diaper and/or period supply banks? If so please go to the <%= link_to 'partner app', new_partner_user_session_path %> to login.</span
         </p>
       </div>
 

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -1,8 +1,13 @@
 <% unless Rails.env.staging? %>
-  <div class="card" style='width: 30rem'>
-    <div class="card-body">
-      <div class="card-title mb-10">
-        <h3>Account Request Form</h3>
+  <div class="bg-white" style='width: 35rem'>
+    <div class="p-3">
+      <div class="mb-10 text-center">
+        <h1 class='text-3xl'>Essentials Bank Account Request Form</h1>
+        <p class='p-2 text-bold bg-yellow-200 text-center'>
+          This request form is only for banks that intend to distribute and manage relationships with their partners.
+          <br><br>
+          If you are a partner please go <%= link_to 'here', new_partner_user_session_path %> to login.
+        </p>
       </div>
 
       <div class='card-text'>
@@ -37,7 +42,7 @@
           </div>
 
           <div class="card-footer">
-            <%= submit_button({text: 'Submit', icon: nil}) %>
+            <%= submit_button({text: 'Submit Bank Account Request Form', icon: nil}) %>
           </div>
         <% end %>
       </div>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -8,6 +8,8 @@
   <!-- Bootstrap 3.3.7 -->
   <%= csrf_meta_tags %>
   <%= javascript_include_tag 'application' %>
+  <%= javascript_pack_tag 'application' %>
+  <%= stylesheet_pack_tag 'application' %>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
   <style>
@@ -37,10 +39,10 @@
   </script>
 </head>
 
-<body id="devise" class="hold-transition login-page <%= Rails.env.staging? ? 'login-page-test' : '' %>">
+<body id="devise" style="background: linear-gradient(135deg, #3023AE, #C86DD7)" class="hold-transition login-page <%= Rails.env.staging? ? 'login-page-test' : '' %>">
   <div class="login-box">
-    <div class="login-logo">
-      <img id="MastheadLogo" src="/img/diaper-base-logo-full-white-text.svg" style="width: 80%;" alt="Diaperbase" title="Diaperbase" class="serv_icon"/>
+    <div class="login-logo text-center">
+      <img id="MastheadLogo" src="/img/essentials.svg" alt="Diaperbase" title="Diaperbase" class="serv_icon"/>
     </div>
 
     <!-- /.login-logo -->

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -42,7 +42,7 @@
 <body id="devise" style="background: linear-gradient(135deg, #3023AE, #C86DD7)" class="hold-transition login-page <%= Rails.env.staging? ? 'login-page-test' : '' %>">
   <div class="login-box">
     <div class="login-logo text-center">
-      <img id="MastheadLogo" src="/img/essentials.svg" alt="Diaperbase" title="Diaperbase" class="serv_icon"/>
+      <img id="MastheadLogo" src="/img/essentials.svg" alt="Human Essentials" title="Human Essentials" class="serv_icon"/>
     </div>
 
     <!-- /.login-logo -->

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -66,7 +66,9 @@
             <div>
               <h2 class="">The easiest and most love-filled <br/> way to manage your <br/> Human Essentials bank.</h2>
               <p class='text-lg font-normal mb-3 mt-2'>Ready to make yourself more efficient?</p>
-              <a href=<%="#{new_account_request_path}"%>><button type="button" class="text-lg bg-green-500 text-white px-3 py-2 rounded-2xl">Request A Demo</button></a>
+              <a href=<%="#{new_account_request_path}"%>><button type="button" class="text-2xl bg-green-600 text-white px-3 py-2 rounded-2xl hover:bg-green-700">
+                Start for free here!
+              </button></a>
             </div>
           </div>
           <div class="hidden lg:block absolute right-52 w-1/4">

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -67,7 +67,7 @@
               <h2 class="">The easiest and most love-filled <br/> way to manage your <br/> Human Essentials bank.</h2>
               <p class='text-lg font-normal mb-3 mt-2'>Ready to make yourself more efficient?</p>
               <a href=<%="#{new_account_request_path}"%>><button type="button" class="text-2xl bg-green-600 text-white px-3 py-2 rounded-2xl hover:bg-green-700">
-                Start for free here!
+                Register your bank here for free!
               </button></a>
             </div>
           </div>


### PR DESCRIPTION
### Description

I'am seeing an increased number of partner users going through the account request form to get an Essentials Bank account. This is likely due to some confusion on wording that caused this to occur. This PR attempts to address this by changing wording.

Other Changes:
- Change the 'Request A Demo' to 'Start for free here!' to emphasize that the program is free. This is a common message we need to share.
- Update that background and logo to match 'Essentials'. See snapshots
- Add text disclaimer explaining what they are about to request.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested locally

### Screenshots
<img width="821" alt="Screen Shot 2021-07-17 at 8 31 28 AM" src="https://user-images.githubusercontent.com/11335191/126036948-a471bd1b-1c8a-49f9-a457-5f6d54ec2510.png">
<img width="959" alt="Screen Shot 2021-07-17 at 8 31 32 AM" src="https://user-images.githubusercontent.com/11335191/126036949-6998038c-29fc-4c57-aa32-94322434e8e9.png">
<img width="977" alt="Screen Shot 2021-07-17 at 8 31 43 AM" src="https://user-images.githubusercontent.com/11335191/126036950-35b60d23-a887-402c-af2b-65b215de8e22.png">
