### PR TITLE
chore: add foreman to dev dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ group :development do
   gem "capistrano3-puma"
   gem "capistrano-rails-console", require: false
   gem 'capistrano-sidekiq'
+  gem 'foreman'
   gem "letter_opener"
   gem "listen", "~> 3.5.0"
   gem "rails-erd"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
       railties (>= 3.2, < 7)
     font-ionicons-rails (2.0.1.6)
       railties (>= 3.2, < 7.0)
+    foreman (0.87.2)
     formatador (0.2.5)
     fullcalendar-rails (3.9.0.0)
       jquery-rails (>= 4.0.5, < 5.0.0)
@@ -586,6 +587,7 @@ DEPENDENCIES
   flipper-ui
   font-awesome-rails
   font-ionicons-rails
+  foreman
   fullcalendar-rails
   geocoder
   groupdate (~> 5.2)

--- a/README.md
+++ b/README.md
@@ -64,14 +64,8 @@ Create a `database.yml` file on `config/` directory with your database configura
 ### Seed the database
 From the root of the app, run `bundle exec rails db:seed`. This will create some initial data to use while testing the app and developing new features, including setting up the default user.
 
-### Installing foreman
-Run the following command to install [foreman](https://github.com/ddollar/foreman).
-```bash
-gem install foreman
-```
-
 ### Start the app
-Run `bundle exec rails s` or `bin/start` (recommended since it runs webpacker in the background!) and browse to http://localhost:3000/
+Run `bundle exec rails server` or `bundle exec bin/start` (recommended since it runs webpacker in the background!) and browse to http://localhost:3000/
 
 ### Login
 To login to the web application, use these default credentials:


### PR DESCRIPTION
Removes need for separate instruction to install foreman.

### Description

Instead of having a separate instruction to install `foreman`, we can just include it as a dev dependency.

Also, prepends `bundle exec` to the `bin/start` command in the README. Especially since we prefix the other commands with that, it's otherwise misleading to devs who might infer that the bin/start script somehow takes care of that internally.

### Type of change

* Dev dependency update

### How Has This Been Tested?

Run locally