### PR TITLE
Prevent confusion caused by not being clear why requests fail or when they succeed

### DIFF
--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -26,6 +26,8 @@ module Partners
           [item[:name], item[:id]]
         end.sort
 
+        Rails.logger.info("[Request Creation Failure] partner_user_id=#{current_partner_user.id} reason=#{@errors.full_messages}")
+
         render :new, status: :unprocessable_entity
       end
     end

--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -17,7 +17,8 @@ module Partners
       create_service.call
 
       if create_service.errors.none?
-        redirect_to partner_user_root_path, notice: "Request was successfully created."
+        flash[:success] = 'Request was successfully created.'
+        redirect_to partners_request_path(create_service.partner_request.id)
       else
         @request = FamilyRequest.new({}, initial_items: 1)
         @errors = create_service.errors
@@ -25,7 +26,7 @@ module Partners
           [item[:name], item[:id]]
         end.sort
 
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -39,6 +39,8 @@ module Partners
           [item[:name], item[:id]]
         end.sort
 
+        Rails.logger.info("[Request Creation Failure] partner_user_id=#{current_partner_user.id} reason=#{@errors.full_messages}")
+
         render :new, status: :unprocessable_entity
       end
     end

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -30,7 +30,8 @@ module Partners
 
       create_service.call
       if create_service.errors.none?
-        redirect_to partner_user_root_path, notice: "Request was successfully created."
+        flash[:success] = 'Request was successfully created.'
+        redirect_to partners_request_path(create_service.partner_request.id)
       else
         @partner_request = create_service.partner_request
         @errors = create_service.errors
@@ -38,7 +39,7 @@ module Partners
           [item[:name], item[:id]]
         end.sort
 
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/javascript/stylesheets/tailwind.config.js
+++ b/app/javascript/stylesheets/tailwind.config.js
@@ -4,7 +4,11 @@ module.exports = {
   ],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    extend: {},
+    extend: {
+      animation: {
+        'pulse-once': 'pulse 1s ease-in-out'
+      }
+    },
   },
   variants: {
     extend: {},

--- a/app/views/layouts/partners/application.html.erb
+++ b/app/views/layouts/partners/application.html.erb
@@ -7,6 +7,8 @@
   <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
   <%= csrf_meta_tags %>
   <%= javascript_include_tag 'application' %>
+  <%= stylesheet_pack_tag 'application' %>
+  <%= javascript_pack_tag 'application' %>
   <%= raw fullstory_script(current_user: current_user) if Rails.env.production? %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">

--- a/app/views/partners/individuals_requests/new.html.erb
+++ b/app/views/partners/individuals_requests/new.html.erb
@@ -26,7 +26,9 @@
         <div class="card">
           <div class="card-body">
 
-            <%= @errors&.full_messages %>
+            <% if @errors.present? %>
+              <%= render partial: 'partners/requests/error' %>
+            <% end %>
 
             <%= simple_form_for @request, url: partners_individuals_requests_path, html: {role: 'form', class: 'form-horizontal'} do |form| %>
 

--- a/app/views/partners/requests/_error.html.erb
+++ b/app/views/partners/requests/_error.html.erb
@@ -1,0 +1,16 @@
+<div class='bg-red-200 p-3 mb-10 animate-pulse-once flex flex-col sm:flex-row items-center rounded text-center'>
+  <div class='p-4 text-red-500'>
+    <svg xmlns="http://www.w3.org/2000/svg" width="150" height="150" fill="currentColor" class="bi bi-exclamation-triangle-fill" viewBox="0 0 16 16">
+      <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+    </svg>
+  </div>
+  <div class='text-red-600 md:text-left'>
+    <h3 class='text-4xl font-extrabold'>Opps! Something went wrong with your Request</h3>
+    <p class='text-lg font-bold'>
+      Ensure each line item has a item selected AND a quantity greater than 0.
+    </p>
+    <p class='text-md'>
+      Still need help? Submit a support ticket <%= link_to 'here', support_ticket_form_url, target: '_blank' %> and we do our best to follow up with you via email.
+    </p>
+  </div>
+</div>

--- a/app/views/partners/requests/_success.html.erb
+++ b/app/views/partners/requests/_success.html.erb
@@ -1,0 +1,14 @@
+<div class='bg-green-200 p-3 mb-10 animate-pulse-once flex flex-col sm:flex-row items-center rounded text-center'>
+  <div class='p-4 text-green-500'>
+    <svg xmlns="http://www.w3.org/2000/svg" width="150" height="150" fill="currentColor" class="bi bi-check-circle-fill" viewBox="0 0 16 16">
+      <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+    </svg>
+  </div>
+  <div class='text-green-600 md:text-left'>
+    <h3 class='text-4xl font-extrabold'>Request has been successfully created!</h3>
+    <p class='text-lg'>
+      <span class='font-extrabold'><%= current_partner.organization.name %></span> should have received the request. <br> You should also be receiving a email confirmation in a few minutes.
+    </p>
+  </div>
+</div>
+

--- a/app/views/partners/requests/new.html.erb
+++ b/app/views/partners/requests/new.html.erb
@@ -26,12 +26,11 @@
         <div class="card">
           <div class="card-body">
 
-
-            <% # TODO - handle the @errors cleanly %>
-            <% # @errors.full_messages %>
+            <% if @errors.present? %>
+              <%= render partial: 'error' %>
+            <% end %>
 
             <%= simple_form_for @partner_request, html: {role: 'form', class: 'form-horizontal'} do |form| %>
-
               <%= form.input :comments, label: "Comments:", as: :text, class: "form-control", wrapper: :input_group %>
 
               <table class='table'>

--- a/app/views/partners/requests/new.html.erb
+++ b/app/views/partners/requests/new.html.erb
@@ -27,7 +27,7 @@
           <div class="card-body">
 
             <% if @errors.present? %>
-              <%= render partial: 'error' %>
+              <%= render partial: 'partners/requests/error' %>
             <% end %>
 
             <%= simple_form_for @partner_request, html: {role: 'form', class: 'form-horizontal'} do |form| %>

--- a/app/views/partners/requests/show.html.erb
+++ b/app/views/partners/requests/show.html.erb
@@ -18,7 +18,6 @@
   </div><!-- /.container-fluid -->
 </section>
 
-
 <section class="content">
   <div class="container-fluid">
     <div class="row">
@@ -28,6 +27,11 @@
             <h3 class="card-title">Request Details</h3>
           </div>
           <div class="card-body">
+
+            <% if flash[:success] %>
+              <%= render partial: 'partners/requests/success' %>
+            <% end %>
+
             <div>
               <span class='text-2xl font-bold'>Request ID:</span>
               <p class='text-lg'>
@@ -48,24 +52,11 @@
 
             <div>
               <span class='text-2xl font-bold'>Requested Items:</span>
-              <div class='w-96 text-lg mt-1'>
-                <table class='table'>
-                  <thead>
-                    <tr>
-                      <th>Quantity</th>
-                      <th>Item</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <% @partner_request.item_requests.each do |item| %>
-                      <tr>
-                        <td><%= item.quantity %></td>
-                        <td><%= item.name %></td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
+              <ul class='text-lg'>
+                <% @partner_request.item_requests.each do |item| %>
+                  <li><%= item.quantity %> of <%= item.name %></li>
+                <% end %>
+              </ul>
             </div>
             <div>
               <span class='text-2xl font-bold'>Submitted:</span>

--- a/app/views/partners/requests/show.html.erb
+++ b/app/views/partners/requests/show.html.erb
@@ -29,24 +29,47 @@
           </div>
           <div class="card-body">
             <div>
-              <h2><%= @partner_request.partner.name %> Request ID: <%= @partner_request.id %></h2>
+              <span class='text-2xl font-bold'>Request ID:</span>
+              <p class='text-lg'>
+                <%= @partner_request.id %>
+              </p>
             </div>
 
             <div>
-              Comments:
-              <p><%= @partner_request.comments %></p>
-            </div>
-
-            <div>
-              Requested Items:
-              <ul>
-                <% @partner_request.item_requests.each do |item| %>
-                  <li><%= item.quantity %> of <%= item.name %></li>
+              <span class='text-2xl font-bold'>Comments:</span>
+              <p>
+                <% if @partner_request.comments.present? %>
+                  <%= @partner_request.comments %>
+                <% else %>
+                  <span class='italic text-gray-400'> None Provided </span>
                 <% end %>
-              </ul>
+              </p>
+            </div>
+
+            <div>
+              <span class='text-2xl font-bold'>Requested Items:</span>
+              <div class='w-96 text-lg mt-1'>
+                <table class='table'>
+                  <thead>
+                    <tr>
+                      <th>Quantity</th>
+                      <th>Item</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% @partner_request.item_requests.each do |item| %>
+                      <tr>
+                        <td><%= item.quantity %></td>
+                        <td><%= item.name %></td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
             </div>
             <div>
-              <p>Submitted: <%= @partner_request.created_at.localtime.strftime('%F %T') %></p>
+              <span class='text-2xl font-bold'>Submitted:</span>
+              <p class='text-lg'><%= @partner_request.created_at.localtime.strftime('%F %T') %></p>
             </div>
             <p><%= link_to "Your Previous Requests", partners_requests_path, class: 'btn btn-success' %></p>
           </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -34,7 +34,7 @@
           <div class="card-body p-0">
             <table class="table">
               <thead>
-              <tr>
+                <tr >
                 <th>Request was sent by:</th>
                 <th>Request Status:</th>
                 <th>Comments:</th>

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "/partners/requests", type: :request do
       end
       it 'should redirect to the dashboard' do
         subject.call
-        expect(response).to redirect_to(partners_dashboard_path)
+        expect(response).to redirect_to(partners_request_path(Request.last.id))
       end
     end
 

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe "Managing requests", type: :system, js: true do
         visit new_partners_individuals_request_path
       end
 
+      context 'WHEN they create a request inproperly' do
+        before do
+          click_button 'Submit Essentials Request'
+        end
+
+        it 'should show an error message with the instructions ' do
+          expect(page).to have_content('Opps! Something went wrong with your Request')
+          expect(page).to have_content('Ensure each line item has a item selected AND a quantity greater than 0.')
+          expect(page).to have_content('Still need help? Submit a support ticket here and we do our best to follow up with you via email.')
+        end
+      end
+
       context 'WHEN they create a request properly' do
         let(:items_to_select) { Organization.find(partner_user.partner.diaper_bank_id).valid_items.sample(3) }
         let(:item_details) do
@@ -42,16 +54,12 @@ RSpec.describe "Managing requests", type: :system, js: true do
           before do
             expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
 
-            expect(current_path).to eq(partners_dashboard_path)
-            expect(page).to have_content('Request was successfully created.')
+            expect(current_path).to eq(partners_request_path(Request.last.id))
+            expect(page).to have_content('Request has been successfully created!')
           end
 
           it 'AND the partner_user can view the details of the created individuals request in a seperate page' do
-            partner_request_id = Partners::Request.last.id
-
             visit partners_request_path(id: Partners::Request.last.id)
-
-            expect(page).to have_content("#{partner_user.partner.name} Request ID: #{partner_request_id}")
 
             # Should have the proper quantity per each item.
             item_details.each do |item|
@@ -71,6 +79,18 @@ RSpec.describe "Managing requests", type: :system, js: true do
       before do
         login_as(partner_user, scope: :partner_user)
         visit new_partners_request_path
+      end
+
+      context 'WHEN they create a request inproperly' do
+        before do
+          click_button 'Submit Essentials Request'
+        end
+
+        it 'should show an error message with the instructions ' do
+          expect(page).to have_content('Opps! Something went wrong with your Request')
+          expect(page).to have_content('Ensure each line item has a item selected AND a quantity greater than 0.')
+          expect(page).to have_content('Still need help? Submit a support ticket here and we do our best to follow up with you via email.')
+        end
       end
 
       context 'WHEN they create a request properly' do
@@ -103,16 +123,14 @@ RSpec.describe "Managing requests", type: :system, js: true do
           before do
             expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
 
-            expect(current_path).to eq(partners_dashboard_path)
-            expect(page).to have_content('Request was successfully created.')
+            expect(current_path).to eq(partners_request_path(Request.last.id))
+            expect(page).to have_content('Request has been successfully created!')
+            expect(page).to have_content("#{partner.organization.name} should have received the request.")
           end
 
           it 'AND the partner_user can view the details of the created request in a seperate page' do
-            partner_request_id = Partners::Request.last.id
-
             visit partners_request_path(id: Partners::Request.last.id)
 
-            expect(page).to have_content("#{partner_user.partner.name} Request ID: #{partner_request_id}")
             item_details.each do |item|
               expect(page).to have_content("#{item[:quantity]} of #{item[:name]}")
             end


### PR DESCRIPTION

### Description

This PR adds helpful messaging to indicate when a request did not get created properly and also make it clear when it does. See snapshots below for what it looks like.

Notable changes:
- Changed the status code of the failure from 200 to 422 for easier tracking when things don't work.
- Added helpful logging to let us know when a request fails and why.
- Did some quick visual treatment on the partners/request show page.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Updated system specs & tested locally.

### Screenshots
<img width="1562" alt="Screen Shot 2021-07-20 at 7 36 15 PM" src="https://user-images.githubusercontent.com/11335191/126412325-c421de8a-a950-4702-bf84-95214ea87c02.png">
<img width="1657" alt="Screen Shot 2021-07-20 at 7 36 58 PM" src="https://user-images.githubusercontent.com/11335191/126412330-43105c8b-103a-4c3d-a898-892e2f0ff91e.png">

