### PR TITLE
Total quantity cache column for Itemizables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bootstrap-select-rails'
 gem "bugsnag"
 gem "chartkick"
 gem "cocoon"
+gem "counter_culture", "~> 2.8"
 gem "devise", '>= 4.7.1'
 gem 'discard', '~> 1.2'
 gem "devise_invitable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.3)
+    counter_culture (2.8.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -573,6 +576,7 @@ DEPENDENCIES
   capybara-screenshot
   chartkick
   cocoon
+  counter_culture (~> 2.8)
   database_cleaner
   devise (>= 4.7.1)
   devise_invitable

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -30,7 +30,7 @@ class TransfersController < ApplicationController
         @transfer.to.increase_inventory @transfer
       end
 
-      redirect_to transfers_path, notice: "#{@transfer.line_items.total} items have been transferred from #{@transfer.from.name} to #{@transfer.to.name}!"
+      redirect_to transfers_path, notice: "#{@transfer.reload.line_items_total} items have been transferred from #{@transfer.from.name} to #{@transfer.to.name}!"
     else
       raise StandardError.new(@transfer.errors.full_messages.join("</br>"))
     end
@@ -50,7 +50,7 @@ class TransfersController < ApplicationController
 
   def show
     @transfer = current_organization.transfers.includes(:line_items).includes(:from).includes(:to).includes(:items).find(params[:id])
-    @total = @transfer.line_items.total
+    @total = @transfer.line_items_total
     @line_items = @transfer.line_items.sorted
   end
 

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  comment             :text
+#  line_items_total    :integer          default(0), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  organization_id     :integer

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -3,6 +3,7 @@
 # Table name: audits
 #
 #  id                  :bigint           not null, primary key
+#  line_items_total    :integer          default(0), not null
 #  status              :integer          default("in_progress"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -86,7 +86,7 @@ module Itemizable
   end
 
   def total_quantity
-    line_items.total
+    line_items_total
   end
 
   def to_a

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -28,7 +28,7 @@ class DiaperDriveParticipant < ApplicationRecord
   scope :alphabetized, -> { order(:contact_name) }
 
   def volume
-    donations.map { |d| d.line_items.total }.reduce(:+)
+    donations.map(&:line_items_total).reduce(:+)
   end
 
   def donation_source_view

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -8,6 +8,7 @@ require 'time_util'
 #  comment                :text
 #  delivery_method        :integer          default("pick_up"), not null
 #  issued_at              :datetime
+#  line_items_total       :integer          default(0), not null
 #  reminder_email_enabled :boolean          default(FALSE), not null
 #  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -5,6 +5,7 @@
 #  id                          :integer          not null, primary key
 #  comment                     :text
 #  issued_at                   :datetime
+#  line_items_total            :integer          default(0), not null
 #  money_raised                :integer
 #  source                      :string
 #  created_at                  :datetime         not null

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -155,7 +155,7 @@ class Donation < ApplicationRecord
       issued_at.strftime("%F"),
       donation_site.try(:name),
       storage_location.name,
-      line_items.total,
+      line_items_total,
       line_items.size,
       comment
     ]

--- a/app/models/kit.rb
+++ b/app/models/kit.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  active              :boolean          default(TRUE)
+#  line_items_total    :integer          default(0), not null
 #  name                :string           not null
 #  value_in_cents      :integer          default(0)
 #  visible_to_partners :boolean          default(TRUE), not null

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -17,6 +17,7 @@ class LineItem < ApplicationRecord
 
   belongs_to :itemizable, polymorphic: true, inverse_of: :line_items, optional: false
   belongs_to :item
+  counter_culture :itemizable, column_name: 'line_items_total', delta_column: 'quantity'
 
   validates :item_id, presence: true
   validates :quantity, numericality: { only_integer: true, less_than: MAX_INT, greater_than: MIN_INT }

--- a/app/models/partner_distribution.rb
+++ b/app/models/partner_distribution.rb
@@ -16,7 +16,7 @@ class PartnerDistribution
       {
         "Date" => distribution.issued_at.strftime("%m/%d/%Y"),
         "Source Inventory" => distribution.storage_location.name,
-        "Total Items" => distribution.line_items.total
+        "Total Items" => distribution.line_items_total
       }.tap do |row|
         distribution.line_items.quantities_by_name.each do |_id, item_ref|
           row[item_ref[:name]] = item_ref[:quantity]

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -6,6 +6,7 @@
 #  amount_spent_in_cents :integer
 #  comment               :text
 #  issued_at             :datetime
+#  line_items_total      :integer          default(0), not null
 #  purchased_from        :string
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -96,7 +96,7 @@ class Purchase < ApplicationRecord
       purchased_from_view,
       storage_location.name,
       issued_at.strftime("%Y-%m-%d"),
-      line_items.total,
+      line_items_total,
       line_items.size,
       amount_spent_in_dollars
     ]

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -53,7 +53,7 @@ class Transfer < ApplicationRecord
       from.name,
       to.name,
       comment || "none",
-      line_items.total
+      line_items_total
     ]
   end
 

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -2,13 +2,14 @@
 #
 # Table name: transfers
 #
-#  id              :integer          not null, primary key
-#  comment         :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  from_id         :integer
-#  organization_id :integer
-#  to_id           :integer
+#  id               :integer          not null, primary key
+#  comment          :string
+#  line_items_total :integer          default(0), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  from_id          :integer
+#  organization_id  :integer
+#  to_id            :integer
 #
 
 class Transfer < ApplicationRecord

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -25,6 +25,6 @@ class Vendor < ApplicationRecord
   scope :alphabetized, -> { order(:business_name) }
 
   def volume
-    purchases.map { |d| d.line_items.total }.reduce(:+)
+    purchases.map(&:line_items_total).reduce(:+)
   end
 end

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -51,7 +51,7 @@ class DistributionPdf
     data += @distribution.line_items.sorted.map do |c|
       [c.item.name, dollar_value(c.item.value_in_cents), dollar_value(c.value_per_line_item), c.quantity, c.package_count]
     end
-    data += [["", "", "", "", ""], ["Total Items Received", "", dollar_value(@distribution.value_per_itemizable), @distribution.line_items.total, ""]]
+    data += [["", "", "", "", ""], ["Total Items Received", "", dollar_value(@distribution.value_per_itemizable), @distribution.line_items_total, ""]]
 
     font_size 11
     # Line item table

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -64,7 +64,7 @@ module Exports
           distribution.storage_location.name
         },
         "Total Items" => ->(distribution) {
-          distribution.line_items.total
+          distribution.line_items_total
         },
         "Total Value" => ->(distribution) {
           distribution.cents_to_dollar(distribution.line_items.total_value)

--- a/app/views/dashboard/_diaper_drive.html.erb
+++ b/app/views/dashboard/_diaper_drive.html.erb
@@ -1,5 +1,5 @@
   <div class="float-center">
     <%= link_to donation do %>
-      <%= donation.line_items.total %> from <%= donation.diaper_drive&.name || donation.diaper_drive_participant.business_name %>
+      <%= donation.line_items_total %> from <%= donation.diaper_drive&.name || donation.diaper_drive_participant.business_name %>
     <% end %>
   </div>

--- a/app/views/dashboard/_distribution.html.erb
+++ b/app/views/dashboard/_distribution.html.erb
@@ -1,7 +1,7 @@
 <br>
 <div class="pull-left">
   <%= link_to distribution do %>
-    <%= distribution.line_items.total %> items distributed to
+    <%= distribution.line_items_total %> items distributed to
     <%= distribution.partner_name %>
   <% end %>
 </div>

--- a/app/views/dashboard/_donation.html.erb
+++ b/app/views/dashboard/_donation.html.erb
@@ -1,7 +1,7 @@
 <br>
 <div class="pull-left">
   <%= link_to donation do %>
-    <%= donation.line_items.total %> items from <%= donation.source %>
+    <%= donation.line_items_total %> items from <%= donation.source %>
   <% end %>
 </div>
 <div class="pull-right">

--- a/app/views/dashboard/_purchase.html.erb
+++ b/app/views/dashboard/_purchase.html.erb
@@ -1,7 +1,7 @@
 <br>
 <div class="pull-left">
   <%= link_to purchase do %>
-    <%= purchase.line_items.total %> items from <%= purchase.purchased_from_view %>
+    <%= purchase.line_items_total %> items from <%= purchase.purchased_from_view %>
   <% end %>
 </div>
 <div class="pull-right">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -236,7 +236,7 @@
           <div class="card-body">
             <div class="position-relative mb-4">
               <div class="box-body text-center float-center">
-                <h3 class="text-center"><%= number_with_delimiter(@recent_donations_from_manufacturers.sum { |d| d.line_items.total }) %>
+                <h3 class="text-center"><%= number_with_delimiter(@recent_donations_from_manufacturers.sum { |d| d.line_items_total }) %>
                   items donated <%= @selected_date_range_label %>
                   by <%= pluralize(@recent_donations_from_manufacturers.group_by(&:manufacturer).count, 'Manufacturer') %></h3>
                 <div class="box-body">

--- a/app/views/diaper_drive_participants/show.html.erb
+++ b/app/views/diaper_drive_participants/show.html.erb
@@ -77,7 +77,7 @@
               <% @diaper_drive_participant.donations.each do |donation| %>
                 <tr>
                   <td><%= donation.created_at.strftime("%m/%d/%Y") %></td>
-                  <td><%= donation.line_items.total %></td>
+                  <td><%= donation.line_items_total %></td>
                   <td><%= view_button_to donation, { text: "View donation details" } %></td>
                 </tr>
               <% end %>

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -3,7 +3,7 @@
   <td><%= distribution_row.partner.name %></td>
   <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %> </td>
   <td><%= distribution_row.storage_location.name %></td>
-  <td class="numeric"><%= distribution_row.line_items.total %></td>
+  <td class="numeric"><%= distribution_row.line_items_total %></td>
   <td class="numeric"><%= dollar_value(distribution_row.value_per_itemizable) %></td>
   <td><%= distribution_row.delivery_method.humanize %></td>
   <td><%= distribution_row.comment %></td>

--- a/app/views/distributions/_pickup_day_row.html.erb
+++ b/app/views/distributions/_pickup_day_row.html.erb
@@ -2,7 +2,7 @@
   <td><%= pickup_day_row.partner.name %></td>
   <td><%= pickup_day_row.issued_at.strftime("%l:%M %p") %> </td>
   <td><%= pickup_day_row.storage_location.name %></td>
-  <td><%= pickup_day_row.line_items.total %></td>
+  <td><%= pickup_day_row.line_items_total %></td>
   <td>
     <% if pickup_day_row.complete? %>
       Complete

--- a/app/views/donation_sites/show.html.erb
+++ b/app/views/donation_sites/show.html.erb
@@ -72,7 +72,7 @@
               <% @donation_site.donations.each do |donation| %>
                 <tr>
                   <td><%= donation.storage_location&.name %></td>
-                  <td><%= donation.line_items.total %></td>
+                  <td><%= donation.line_items_total %></td>
                   <td><%= donation.line_items.size %></td>
                   <td><%= link_to "View donation details", donation %></td>
                 </tr>

--- a/app/views/donations/_donation_row.html.erb
+++ b/app/views/donations/_donation_row.html.erb
@@ -3,7 +3,7 @@
   <td class="text-left date"><%= donation_row.issued_at.strftime("%F") %>
   <td><%= donation_row.donation_site.try(:name) %></td>
   <td><%= donation_row.storage_location.name %></td>
-  <td class="text-left numeric"><%= donation_row.line_items.total %></td>
+  <td class="text-left numeric"><%= donation_row.line_items_total %></td>
   <td class="text-left numeric"><%= dollar_value(donation_row.money_raised.to_i) %></td>
   <td class="text-left numeric"><%= dollar_value(donation_row.value_per_itemizable) %></td>
   <td><%= truncate donation_row.comment, length: 140, separator: /\w+/ %>

--- a/app/views/manufacturers/show.html.erb
+++ b/app/views/manufacturers/show.html.erb
@@ -46,7 +46,7 @@
               <% @manufacturer.donations.each do |donation| %>
                 <tr>
                   <td><%= donation.created_at.strftime("%m/%d/%Y") %></td>
-                  <td><%= donation.line_items.total %></td>
+                  <td><%= donation.line_items_total %></td>
                   <td>
                     <%= view_button_to donation, { text: "View donation details" }
                     %>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -140,7 +140,7 @@
                   <tr>
                     <td><%= dist.created_at.strftime("%m/%d/%Y") %></td>
                     <td><%= dist.storage_location.name %></td>
-                    <td><%= dist.line_items.total %></td>
+                    <td><%= dist.line_items_total %></td>
                     <td class="text-right">
                       <%= view_button_to distribution_path(dist) %>
                       <%= print_button_to print_distribution_path(dist, format: :pdf) %>

--- a/app/views/purchases/_purchase_row.html.erb
+++ b/app/views/purchases/_purchase_row.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= purchase_row.purchased_from_view %></td>
   <td><%= purchase_row.storage_location.name %></td>
-  <td class="numeric"><%= purchase_row.line_items.total %></td>
+  <td class="numeric"><%= purchase_row.line_items_total %></td>
   <td class="numeric"><%= purchase_row.line_items.size %></td>
   <td class="numeric"><%= dollar_value(purchase_row.amount_spent_in_cents) %></td>
   <td class="date"><%= purchase_row.issued_at.strftime("%F") %></td>

--- a/app/views/transfers/_transfer_row.html.erb
+++ b/app/views/transfers/_transfer_row.html.erb
@@ -3,7 +3,7 @@
   <td><%= transfer_row.to.name %></td>
   <td><%= transfer_row.created_at.strftime("%F") %></td>
   <td><%= transfer_row.comment || "none" %></td>
-  <td><%= transfer_row.line_items.total %></td>
+  <td><%= transfer_row.line_items_total %></td>
   <td>
     <%= delete_button_to transfer_path(transfer_row.id), { confirm: "Are you sure you want to permanently remove this transfer?" } %>
     <%= view_button_to transfer_row %>

--- a/app/views/vendors/show.html.erb
+++ b/app/views/vendors/show.html.erb
@@ -77,7 +77,7 @@
               <% @vendor.purchases.each do |purchase| %>
                 <tr>
                   <td><%= purchase.created_at.strftime("%m/%d/%Y") %></td>
-                  <td><%= purchase.line_items.total %></td>
+                  <td><%= purchase.line_items_total %></td>
                   <td><%= view_button_to purchase, { text: "View purchase details" } %></td>
                 </tr>
               <% end %>

--- a/db/migrate/20210724193104_add_line_items_total_to_distributions.rb
+++ b/db/migrate/20210724193104_add_line_items_total_to_distributions.rb
@@ -1,0 +1,9 @@
+class AddLineItemsTotalToDistributions < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :distributions, :line_items_total, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :distributions, :line_items_total
+  end
+end

--- a/db/migrate/20210724193444_add_line_items_total_to_audits.rb
+++ b/db/migrate/20210724193444_add_line_items_total_to_audits.rb
@@ -1,0 +1,9 @@
+class AddLineItemsTotalToAudits < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :audits, :line_items_total, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :audits, :line_items_total
+  end
+end

--- a/db/migrate/20210724193454_add_line_items_total_to_donations.rb
+++ b/db/migrate/20210724193454_add_line_items_total_to_donations.rb
@@ -1,0 +1,9 @@
+class AddLineItemsTotalToDonations < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :donations, :line_items_total, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :donations, :line_items_total
+  end
+end

--- a/db/migrate/20210724193512_add_line_items_total_to_purchases.rb
+++ b/db/migrate/20210724193512_add_line_items_total_to_purchases.rb
@@ -1,0 +1,9 @@
+class AddLineItemsTotalToPurchases < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :purchases, :line_items_total, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :purchases, :line_items_total
+  end
+end

--- a/db/migrate/20210724193520_add_line_items_total_to_transfers.rb
+++ b/db/migrate/20210724193520_add_line_items_total_to_transfers.rb
@@ -1,0 +1,9 @@
+class AddLineItemsTotalToTransfers < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :transfers, :line_items_total, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :transfers, :line_items_total
+  end
+end

--- a/db/migrate/20210724194805_add_line_items_total_to_adjustments.rb
+++ b/db/migrate/20210724194805_add_line_items_total_to_adjustments.rb
@@ -1,0 +1,9 @@
+class AddLineItemsTotalToAdjustments < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :adjustments, :line_items_total, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :adjustments, :line_items_total
+  end
+end

--- a/db/migrate/20210724194811_add_line_items_total_to_kits.rb
+++ b/db/migrate/20210724194811_add_line_items_total_to_kits.rb
@@ -1,0 +1,9 @@
+class AddLineItemsTotalToKits < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :kits, :line_items_total, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :kits, :line_items_total
+  end
+end

--- a/db/migrate/20210724215451_fix_line_item_counts.rb
+++ b/db/migrate/20210724215451_fix_line_item_counts.rb
@@ -1,0 +1,7 @@
+class FixLineItemCounts < ActiveRecord::Migration[6.1]
+  def up
+    LineItem.counter_culture_fix_counts
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_724_194_811) do
+ActiveRecord::Schema.define(version: 20_210_724_215_451) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_517_000_207) do
+ActiveRecord::Schema.define(version: 20_210_724_194_811) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.integer "line_items_total", default: 0, null: false
     t.index ["organization_id"], name: "index_adjustments_on_organization_id"
     t.index ["storage_location_id"], name: "index_adjustments_on_storage_location_id"
     t.index ["user_id"], name: "index_adjustments_on_user_id"
@@ -85,6 +86,7 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "line_items_total", default: 0, null: false
     t.index ["adjustment_id"], name: "index_audits_on_adjustment_id"
     t.index ["organization_id"], name: "index_audits_on_organization_id"
     t.index ["storage_location_id"], name: "index_audits_on_storage_location_id"
@@ -162,6 +164,7 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.boolean "reminder_email_enabled", default: false, null: false
     t.integer "state", default: 5, null: false
     t.integer "delivery_method", default: 0, null: false
+    t.integer "line_items_total", default: 0, null: false
     t.index ["organization_id"], name: "index_distributions_on_organization_id"
     t.index ["partner_id"], name: "index_distributions_on_partner_id"
     t.index ["storage_location_id"], name: "index_distributions_on_storage_location_id"
@@ -192,6 +195,7 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.integer "money_raised"
     t.bigint "manufacturer_id"
     t.bigint "diaper_drive_id"
+    t.integer "line_items_total", default: 0, null: false
     t.index ["diaper_drive_id"], name: "index_donations_on_diaper_drive_id"
     t.index ["donation_site_id"], name: "index_donations_on_donation_site_id"
     t.index ["manufacturer_id"], name: "index_donations_on_manufacturer_id"
@@ -253,6 +257,7 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.boolean "active", default: true
     t.boolean "visible_to_partners", default: true, null: false
     t.integer "value_in_cents", default: 0
+    t.integer "line_items_total", default: 0, null: false
     t.index %w(name organization_id), name: "index_kits_on_name_and_organization_id", unique: true
     t.index ["organization_id"], name: "index_kits_on_organization_id"
   end
@@ -322,6 +327,7 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "vendor_id"
+    t.integer "line_items_total", default: 0, null: false
     t.index ["organization_id"], name: "index_purchases_on_organization_id"
     t.index ["storage_location_id"], name: "index_purchases_on_storage_location_id"
   end
@@ -365,6 +371,7 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "organization_id"
+    t.integer "line_items_total", default: 0, null: false
     t.index ["organization_id"], name: "index_transfers_on_organization_id"
   end
 

--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  comment             :text
+#  line_items_total    :integer          default(0), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  organization_id     :integer

--- a/spec/factories/audits.rb
+++ b/spec/factories/audits.rb
@@ -3,6 +3,7 @@
 # Table name: audits
 #
 #  id                  :bigint           not null, primary key
+#  line_items_total    :integer          default(0), not null
 #  status              :integer          default("in_progress"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -7,6 +7,7 @@
 #  comment                :text
 #  delivery_method        :integer          default("pick_up"), not null
 #  issued_at              :datetime
+#  line_items_total       :integer          default(0), not null
 #  reminder_email_enabled :boolean          default(FALSE), not null
 #  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -5,6 +5,7 @@
 #  id                          :integer          not null, primary key
 #  comment                     :text
 #  issued_at                   :datetime
+#  line_items_total            :integer          default(0), not null
 #  money_raised                :integer
 #  source                      :string
 #  created_at                  :datetime         not null

--- a/spec/factories/kits.rb
+++ b/spec/factories/kits.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  active              :boolean          default(TRUE)
+#  line_items_total    :integer          default(0), not null
 #  name                :string           not null
 #  value_in_cents      :integer          default(0)
 #  visible_to_partners :boolean          default(TRUE), not null

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -6,6 +6,7 @@
 #  amount_spent_in_cents :integer
 #  comment               :text
 #  issued_at             :datetime
+#  line_items_total      :integer          default(0), not null
 #  purchased_from        :string
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null

--- a/spec/factories/transfers.rb
+++ b/spec/factories/transfers.rb
@@ -2,13 +2,14 @@
 #
 # Table name: transfers
 #
-#  id              :integer          not null, primary key
-#  comment         :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  from_id         :integer
-#  organization_id :integer
-#  to_id           :integer
+#  id               :integer          not null, primary key
+#  comment          :string
+#  line_items_total :integer          default(0), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  from_id          :integer
+#  organization_id  :integer
+#  to_id            :integer
 #
 
 FactoryBot.define do

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  comment             :text
+#  line_items_total    :integer          default(0), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  organization_id     :integer

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -3,6 +3,7 @@
 # Table name: audits
 #
 #  id                  :bigint           not null, primary key
+#  line_items_total    :integer          default(0), not null
 #  status              :integer          default("in_progress"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Distribution, type: :model do
         expect(distribution_details[0]).to eq distribution.partner.name
         expect(distribution_details[1]).to eq distribution.issued_at.strftime("%F")
         expect(distribution_details[2]).to eq distribution.storage_location.name
-        expect(distribution_details[3]).to eq distribution.line_items.total
+        expect(distribution_details[3]).to eq distribution.line_items_total
         expect(distribution_details[5]).to eq distribution.delivery_method
         expect(distribution_details[6]).to eq distribution.state
         expect(distribution_details[7]).to eq distribution.agency_rep

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -7,6 +7,7 @@
 #  comment                :text
 #  delivery_method        :integer          default("pick_up"), not null
 #  issued_at              :datetime
+#  line_items_total       :integer          default(0), not null
 #  reminder_email_enabled :boolean          default(FALSE), not null
 #  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -5,6 +5,7 @@
 #  id                          :integer          not null, primary key
 #  comment                     :text
 #  issued_at                   :datetime
+#  line_items_total            :integer          default(0), not null
 #  money_raised                :integer
 #  source                      :string
 #  created_at                  :datetime         not null

--- a/spec/models/kit_spec.rb
+++ b/spec/models/kit_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  active              :boolean          default(TRUE)
+#  line_items_total    :integer          default(0), not null
 #  name                :string           not null
 #  value_in_cents      :integer          default(0)
 #  visible_to_partners :boolean          default(TRUE), not null

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -50,6 +50,25 @@ RSpec.describe LineItem, type: :model do
     end
   end
 
+  describe 'Counter Culture >' do
+    describe 'line_items_total' do
+      let(:line_item) { create(:line_item, quantity: 5) }
+      let(:itemizable) { line_item.itemizable }
+
+      it 'increments the itemizable value when created' do
+        expect { create(:line_item, itemizable: itemizable, quantity: 5) }.to change { itemizable.reload.line_items_total }.by(5)
+      end
+
+      it 'adjusts the itemizable value when updated' do
+        expect { line_item.update(quantity: 15) }.to change { itemizable.reload.line_items_total }.by(10)
+      end
+
+      it 'decrements the itemizable value when destroyed' do
+        expect { line_item.destroy }.to change { itemizable.reload.line_items_total }.by(-5)
+      end
+    end
+  end
+
   describe 'Methods >' do
     context '#value_per_line_item' do
       subject { line_item.value_per_line_item }

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -34,20 +34,6 @@ RSpec.describe LineItem, type: :model do
     end
   end
 
-  describe "package_count" do
-    it "is equal to the quanity divided by the package_size" do
-      item = create(:item, package_size: 10)
-      line_item = create(:line_item, :purchase, quantity: 100, item_id: item.id)
-      expect(line_item.package_count).to eq("10")
-    end
-
-    it "is nil if there is no package_size" do
-      item = create(:item)
-      line_item = create(:line_item, :purchase, quantity: 100, item_id: item.id)
-      expect(line_item.package_count).to be_nil
-    end
-  end
-
   describe "Scopes >" do
     describe "->active" do
       let!(:active_item) { create(:item, :active) }
@@ -116,10 +102,21 @@ RSpec.describe LineItem, type: :model do
           end
 
           it { is_expected.to eq((quantity / package_size).to_s) }
+
+          it "is equal to the quanity divided by the package_size" do
+            expect(line_item.package_count).to eq("1")
+          end
         end
 
         describe 'does not have packages' do
+          let(:package_size) { nil }
+          let(:quantity) { 100 }
+
           it { is_expected.to be_falsy }
+
+          it "is nil if there is no package_size" do
+            expect(line_item.package_count).to be_nil
+          end
         end
       end
     end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6,6 +6,7 @@
 #  amount_spent_in_cents :integer
 #  comment               :text
 #  issued_at             :datetime
+#  line_items_total      :integer          default(0), not null
 #  purchased_from        :string
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null

--- a/spec/models/transfer_spec.rb
+++ b/spec/models/transfer_spec.rb
@@ -2,13 +2,14 @@
 #
 # Table name: transfers
 #
-#  id              :integer          not null, primary key
-#  comment         :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  from_id         :integer
-#  organization_id :integer
-#  to_id           :integer
+#  id               :integer          not null, primary key
+#  comment          :string
+#  line_items_total :integer          default(0), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  from_id          :integer
+#  organization_id  :integer
+#  to_id            :integer
 #
 
 RSpec.describe Transfer, type: :model do

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -37,11 +37,13 @@ describe Exports::ExportDistributionsCSVService do
       expect(subject[0]).to eq(expected_headers)
 
       distributions.each_with_index do |distribution, idx|
+        distribution.reload
+
         row = [
           distribution.partner.name,
           distribution.issued_at.strftime("%m/%d/%Y"),
           distribution.storage_location.name,
-          distribution.line_items.total,
+          distribution.line_items_total,
           distribution.cents_to_dollar(distribution.line_items.total_value),
           distribution.delivery_method,
           distribution.state,

--- a/spec/support/itemizable_shared_example.rb
+++ b/spec/support/itemizable_shared_example.rb
@@ -94,7 +94,7 @@ shared_examples_for "itemizable" do
       it "has an item total" do
         expect do
           2.times { subject.line_items << create(:line_item, model_f.to_sym, quantity: 5) }
-        end.to change { subject.line_items.total }.by(10)
+        end.to change { subject.reload.line_items_total }.by(10)
       end
     end
   end

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -254,9 +254,10 @@ RSpec.describe "Partner management", type: :system, js: true do
 
       let(:partner) do
         partner = create(:partner, :approved)
-        partner.distributions << create(:distribution, :with_items, item_quantity: 1231)
-        partner.distributions << create(:distribution, :with_items, item_quantity: 4564)
-        partner.distributions << create(:distribution, :with_items, item_quantity: 7897)
+        create(:distribution, :with_items, item_quantity: 1231, partner: partner)
+        create(:distribution, :with_items, item_quantity: 4564, partner: partner)
+        create(:distribution, :with_items, item_quantity: 7897, partner: partner)
+
         partner
       end
 


### PR DESCRIPTION
Resolves #2416

### Description

This effectively solves the N+1 query described in the issue, but also introduces a new practice to the project: counter caches.

The implementation is done using the gem [counter_culture](https://github.com/magnusvk/counter_culture), which in my experience is performant, its well documented, and up to date. This gem allow us to add counter caches with more flexibility than the native Rails implementation, for example in this PR a polymorphic quantity total.

For this initial implementation, I'm replacing the instances of `line_items.total` with `line_items_total` that corresponds to the `itemizable` polymorphic parent of the entity using a new column with the same name. This change will require new resources using the `Itemizable` concern to add the column.

I thought about adding a conditional, but in my opinion, it makes sense to have the cache column if we have `line_items`.

Regarding performance, you can see the logs in this gist: "[/diaper_bank/donations logs, old vs new](https://gist.github.com/kinduff/d12942f04fccb697348279f14fcda955)". I'm using a cached environment since it's more realistic for production. But in summary, here is the important part:

**Old**
```
Completed 200 OK in 279ms (Views: 114.6ms | ActiveRecord: 33.7ms | Allocations: 191508)
```

**New**
```
Completed 200 OK in 160ms (Views: 67.6ms | ActiveRecord: 15.2ms | Allocations: 152202)
```

I see a lot of areas we can improve using counter caches, this will without a doubt make the website snappier and consume less resources.

A note about the last commit, I'm adding a migration in order to run the command `LineItem.counter_culture_fix_counts` that will update all the parents with the new total in their corresponding column. I'm not sure if this is something you usually do, I for instance, prefer to run the script in production directly or use data_migrations. Please let me know.

### Type of change

* New feature (non-breaking change which adds functionality)
* This change requires a documentation update

### How Has This Been Tested?

I included the corresponding tests and modified the ones that were failing.

In order to test this, you'll need to pull the changes, migrate, and you're good to go.

Any `line_item` create, update, destroy action should update the column of their parent.

### Selfie

![index](https://user-images.githubusercontent.com/1270156/126881907-914d77be-584b-41aa-8c1c-a2f94c853b3c.gif)
