### PR TITLE
Add paper_trail gem to track InventoryItem changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem "uglifier", ">= 1.3.0"
 gem 'webpacker', '~> 5.4'
 gem "yajl-ruby"
 gem "recaptcha"
+gem "paper_trail" # for tracking history of InventoryItem
 
 group :production do
   gem 'lograge' # Reduce the noise of logs and include custom fields to it for easier access

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,6 +311,9 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
+    paper_trail (12.0.0)
+      activerecord (>= 5.2)
+      request_store (~> 1.1)
     paperclip (6.1.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
@@ -607,6 +610,7 @@ DEPENDENCIES
   mini_racer (~> 0.3.1)
   momentjs-rails
   nokogiri (>= 1.10.4)
+  paper_trail
   paperclip
   pg (~> 1.2.3)
   popper_js

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :log_active_user
   before_action :swaddled
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_paper_trail_whodunnit
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found!
 

--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -13,6 +13,8 @@
 class InventoryItem < ApplicationRecord
   MAX_INT = 2**31
 
+  has_paper_trail
+
   belongs_to :storage_location
   belongs_to :item
 

--- a/db/migrate/20210612212116_create_versions.rb
+++ b/db/migrate/20210612212116_create_versions.rb
@@ -1,0 +1,35 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[6.1]
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, { null: false }
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/migrate/20210612212116_create_versions.rb
+++ b/db/migrate/20210612212116_create_versions.rb
@@ -1,19 +1,13 @@
 # This migration creates the `versions` table, the only schema PT requires.
 # All other migrations PT provides are optional.
 class CreateVersions < ActiveRecord::Migration[6.1]
-  # The largest text column available in all supported RDBMS is
-  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
-  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
-  # when serializing very large objects, `text` might not be big enough.
-  TEXT_BYTES = 1_073_741_823
-
   def change
     create_table :versions do |t|
       t.string   :item_type, { null: false }
       t.bigint   :item_id,   null: false
       t.string   :event,     null: false
       t.string   :whodunnit
-      t.text     :object, limit: TEXT_BYTES
+      t.jsonb    :object
 
       # Known issue in MySQL: fractional second precision
       # -------------------------------------------------

--- a/db/migrate/20210612212117_add_object_changes_to_versions.rb
+++ b/db/migrate/20210612212117_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[6.1]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/migrate/20210612212117_add_object_changes_to_versions.rb
+++ b/db/migrate/20210612212117_add_object_changes_to_versions.rb
@@ -2,11 +2,7 @@
 # will store the `changes` diff for each update event. See the readme for
 # details.
 class AddObjectChangesToVersions < ActiveRecord::Migration[6.1]
-  # The largest text column available in all supported RDBMS.
-  # See `create_versions.rb` for details.
-  TEXT_BYTES = 1_073_741_823
-
   def change
-    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+    add_column :versions, :object_changes, :jsonb
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -430,6 +430,17 @@ ActiveRecord::Schema.define(version: 2021_06_26_170605) do
     t.index ["latitude", "longitude"], name: "index_vendors_on_latitude_and_longitude"
   end
 
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.datetime "created_at"
+    t.jsonb "object_changes"
+    t.index %w(item_type item_id), name: "index_versions_on_item_type_and_item_id"
+  end
+
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "adjustments", "organizations"
   add_foreign_key "adjustments", "storage_locations"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,10 +2,9 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
-#  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  invitation_accepted_at :datetime
@@ -15,20 +14,17 @@
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
-#  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string           default("CHANGEME"), not null
-#  organization_admin     :boolean
+#  name                   :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0), not null
-#  super_admin            :boolean          default(FALSE)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  invited_by_id          :integer
-#  organization_id        :integer
+#  invited_by_id          :bigint
+#  partner_id             :bigint
 #
 
 FactoryBot.define do


### PR DESCRIPTION
Addresses part of https://github.com/rubyforgood/human-essentials/issues/2377

### Description

Add paper_trail gem for tracking changes to `InventoryItem` model. This PR is best reviewed commit by commit.

https://github.com/rubyforgood/human-essentials/commit/578c4079b209a77a9784c55376ab157de298887a - runs a generator provided by `paper_trail` to create the `versions` table
https://github.com/rubyforgood/human-essentials/commit/95a6c1106c222b7aaddd39b4821283c09549e912 - as suggested in the issue, change the generated migration to use `jsonb` columns instead
https://github.com/rubyforgood/human-essentials/commit/34db4a9e235942a1689f816771f28f1ea22869db - add tracking to `InventoryItem` along with who made the change

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- I tested locally that changes to `InventoryItem` are tracked. I didn't add specs at the moment because I thought that would just be testing that the gem works correctly. I'll add relevant specs when I follow up with the view to see the historical inventory.
