### PR TITLE
Utilize update instead of increment/decrement to trigger paper_trail

### DIFF
--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -129,7 +129,8 @@ class StorageLocation < ApplicationRecord
       # Locate the storage box for the item, or create a new storage box for it
       inventory_item = inventory_items.find_or_create_by!(item_id: item_hash[:item_id])
       # Increase the quantity-on-record for that item
-      inventory_item.increment!(:quantity, item_hash[:quantity].to_i)
+      new_quantity = inventory_item.quantity + item_hash[:quantity].to_i
+      inventory_item.update!(quantity: new_quantity)
       # Record in the log that this has occurred
       log[item_hash[:item_id]] = "+#{item_hash[:quantity]}"
     end
@@ -181,7 +182,8 @@ class StorageLocation < ApplicationRecord
       # captured by the previous block.
       inventory_item = inventory_items.find_by(item_id: item_hash[:item_id])
       # Reduce the inventory box quantity
-      inventory_item.decrement!(:quantity, item_hash[:quantity])
+      new_quantity = inventory_item.quantity - item_hash[:quantity]
+      inventory_item.update(quantity: new_quantity)
       # Record in the log that this has occurred
       log[item_hash[:item_id]] = "-#{item_hash[:quantity]}"
     end


### PR DESCRIPTION
### Description

I noticed that we weren't keeping track of paper_trail changes on InventoryItem due to using `increment!` and `decrement!` which skips the callbacks and thus skips paper_trail's mechanisms.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

