### PR TITLE
Add banner for partner login in bank login page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -147,3 +147,9 @@ tr.negative {
     transform: scale(1);
   }
 }
+
+.failed-login-banner {
+  background-color: cornsilk;
+  text-align: center;
+  padding: 0.5rem 0 0.5rem;
+}

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,12 @@
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
   layout "devise"
+  before_action :check_failed_login
+  skip_before_action :authorize_user
+  skip_before_action :authenticate_user!
+  # This one causes a redirect require_no_authentication
+  skip_before_action :require_no_authentication
+
   # GET /resource/sign_in
   def new
     super
@@ -23,4 +29,10 @@ class Users::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  private
+
+  def check_failed_login
+    @failed_login = (options = request.env["warden.options"]) && options[:action] == "unauthenticated" && options[:message] == :not_found_in_database
+  end
 end

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -5,7 +5,9 @@
     <div class="card">
       <div class="card-body login-card-body">
         <p class="login-box-msg">Sign in to start your session</p>
-
+        <% if @failed_login %>
+         <p class="failed-login-banner">You may try logging in via <%= link_to "Partner Login", (partners_users_path) %></p>
+        <% end %>
         <div class="form-inputs">
           <%= f.input :email, autofocus: true %>
         </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -6,7 +6,7 @@
       <div class="card-body login-card-body">
         <p class="login-box-msg">Sign in to start your session</p>
         <% if @failed_login %>
-         <p class="failed-login-banner">You may try logging in via <%= link_to "Partner Login", (partners_users_path) %></p>
+         <p class="failed-login-banner">Invalid Credentials. You may try logging in via <%= link_to "partner login here", (partners_users_path) %> if you believe your credentials should work.</p>
         <% end %>
         <div class="form-inputs">
           <%= f.input :email, autofocus: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ def set_up_flipper
 end
 
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { sessions: "users/sessions" }
   devise_for :partner_users, controllers: { sessions: "partners/sessions", invitations: 'partners/invitations', passwords: 'partners/passwords' }
 
   set_up_sidekiq


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2459  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

With these changes, if a partner attempts to log-in via Banks Login Page, a banner will pop up with a link to Partners Login Page. 

In this pull request, following are the changes

**Model**
- None

**Controller**
- Have introduced a new before_action method to check failed logins which checks warden options and figures out login failure reasons. With the correct reasons found, an instance variable is exposed for the view

**View**
- Have a conditional block to render banner with a link

Style
- Added styles for the banner

Alternatives
- Leverage warden callbacks to figure this out
- Show banner regardless of login attempt

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

**Steps to reproduce** 

- Go to Login and select Bank
- Type in a partner test credentials
- Click login

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

**Screenshot** showing banner when partner tries to login via Bank login page
![Screenshot from 2021-08-29 13-46-09](https://user-images.githubusercontent.com/41758940/131243604-7b07434f-d818-43ed-805b-9c900bba34fa.png)


