### PR TITLE
Informative Account Request Status Field in Admin View

### DIFF
--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -48,6 +48,22 @@ class AccountRequest < ApplicationRecord
     organization.present?
   end
 
+  def approved?
+    "Approved" if confirmed? && AccountRequest.includes([:organization])
+  end
+
+  def pending_approval?
+    "Pending Approval" if confirmed? && !AccountRequest.includes([:organization])
+  end
+
+  def requested?
+    "Requested" unless confirmed?
+  end
+
+  def status
+    approved? || pending_approval? || requested?
+  end
+
   private
 
   def email_not_already_used_by_organization

--- a/app/views/admin/account_requests/index.html.erb
+++ b/app/views/admin/account_requests/index.html.erb
@@ -25,6 +25,7 @@
                 <th>Organization name</th>
                 <th>Organization website</th>
                 <th>Request details</th>
+                <th>Request status</th>
                 <th>Contact name</th>
                 <th>Contact email</th>
               </tr>
@@ -36,6 +37,7 @@
                   <td><%= account_request.organization_name %></td>
                   <td><%= account_request.organization_website %></td>
                   <td><%= account_request.request_details %></td>
+                  <td><%= account_request.status %></td>
                   <td><%= account_request.name %></td>
                   <td><%= account_request.email %></td>
               <% end %>
@@ -77,6 +79,7 @@
                 <th>Organization name</th>
                 <th>Organization website</th>
                 <th>Request details</th>
+                <th>Request status</th>
                 <th>Contact name</th>
                 <th>Contact email</th>
               </tr>
@@ -88,6 +91,7 @@
                   <td><%= account_request.organization_name %></td>
                   <td><%= account_request.organization_website %></td>
                   <td><%= account_request.request_details %></td>
+                  <td><%= account_request.status %></td>
                   <td><%= account_request.name %></td>
                   <td><%= account_request.email %></td>
               <% end %>

--- a/spec/system/admin/account_requests_system_spec.rb
+++ b/spec/system/admin/account_requests_system_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Account Requests Admin", type: :system do
             expect(page).to have_content(request.organization_name)
             expect(page).to have_content(request.organization_website)
             expect(page).to have_content(request.request_details)
+            expect(page).to have_content(request.status)
             expect(page).to have_content(request.name)
             expect(page).to have_content(request.email)
           end
@@ -41,6 +42,7 @@ RSpec.describe "Account Requests Admin", type: :system do
             expect(page).to have_content(request.organization_name)
             expect(page).to have_content(request.organization_website)
             expect(page).to have_content(request.request_details)
+            expect(page).to have_content(request.status)
             expect(page).to have_content(request.name)
             expect(page).to have_content(request.email)
           end


### PR DESCRIPTION
Resolves #2417 

### Description
This PR adds a "request status" column to `/admin/account_requests` that shows the status of any given Account Request. I chose to add the "Request status" column after the "request details" column, as I thought it made the most sense. To do this, I added a few methods (`#approved?`, `#pending_approval?`, `#requested?`) to the `AccountRequest` model that determine whether a status is "Approved," "Pending Approval," or "Requested," and a method called `#status` that determines which status to display in the Account Requests view. This PR also adds to the existing `account_requests_system_spec.rb` to test these changes.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- I tested these changes locally
- I have added expectations to the `account_requests_system_spec.rb` that checks that the `request.status` renders as expected
- I ran my changes against the test suite to ensure that all existing specs passed

### Screenshots
**After**:
![Screen Shot 2021-09-02 at 4 43 21 PM](https://user-images.githubusercontent.com/32834804/131925480-a7aa891e-0b74-44f8-9346-c537ad6f0622.png)