### PR TITLE
Remove capistrano gems since we do not use it anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,12 +88,6 @@ group :development do
   gem "binding_of_caller"
   gem "better_errors"
   gem "bullet"
-  gem "capistrano-rails"
-  gem "capistrano-rvm"
-  gem "capistrano-bundler"
-  gem "capistrano3-puma"
-  gem "capistrano-rails-console", require: false
-  gem 'capistrano-sidekiq'
   gem 'foreman'
   gem "letter_opener"
   gem "listen", "~> 3.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrussh (1.4.0)
-      sshkit (>= 1.6.1, != 1.7.0)
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
@@ -109,29 +107,6 @@ GEM
     bullet (6.1.5)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    capistrano (3.14.1)
-      airbrussh (>= 1.0.0)
-      i18n
-      rake (>= 10.0.0)
-      sshkit (>= 1.9.0)
-    capistrano-bundler (2.0.1)
-      capistrano (~> 3.1)
-    capistrano-rails (1.6.1)
-      capistrano (~> 3.1)
-      capistrano-bundler (>= 1.1, < 3)
-    capistrano-rails-console (2.3.0)
-      capistrano (>= 3.5.0, < 4.0.0)
-      sshkit-interactive (~> 0.3.0)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
-    capistrano-sidekiq (1.0.3)
-      capistrano (>= 3.9.0)
-      sidekiq (>= 3.4, < 6.0)
-    capistrano3-puma (4.0.0)
-      capistrano (~> 3.7)
-      capistrano-bundler
-      puma (~> 4.0)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -300,9 +275,6 @@ GEM
       railties (>= 3.1)
     multipart-post (2.1.1)
     nenv (0.3.0)
-    net-scp (3.0.0)
-      net-ssh (>= 2.6.5, < 7.0.0)
-    net-ssh (6.1.0)
     nio4r (2.5.8)
     nokogiri (1.12.4)
       mini_portile2 (~> 2.6.1)
@@ -500,11 +472,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sshkit (1.21.0)
-      net-scp (>= 1.1.2)
-      net-ssh (>= 2.8.0)
-    sshkit-interactive (0.3.0)
-      sshkit (~> 1.12)
     strong_migrations (0.7.8)
       activerecord (>= 5)
     terminal-notifier (2.0.0)
@@ -566,12 +533,6 @@ DEPENDENCIES
   brakeman
   bugsnag
   bullet
-  capistrano-bundler
-  capistrano-rails
-  capistrano-rails-console
-  capistrano-rvm
-  capistrano-sidekiq
-  capistrano3-puma
   capybara (~> 3.35)
   capybara-screenshot
   chartkick


### PR DESCRIPTION
### Description

Since we've migrated to using Heroku instead of Azure deployments, we don't need to use Capistrano gems anymore to handle deployment

### Type of change
* Update

### How Has This Been Tested?
CI

### Screenshots
N/A
