### PR TITLE
[Fix] DOB year field was not showing correct options

### DIFF
--- a/app/views/partners/authorized_family_members/_form.html.erb
+++ b/app/views/partners/authorized_family_members/_form.html.erb
@@ -12,7 +12,7 @@
 
               <%= form.input :first_name, label: "First Name", class: "form-control", wrapper: :input_group %>
               <%= form.input :last_name, label: "Last Name", class: "form-control", wrapper: :input_group %>
-              <%= form.input :date_of_birth, as: :date, label: "Date of Birth" %>
+              <%= form.input :date_of_birth, as: :date, start_year: 100.years.ago.year, end_year: Time.current.year, label: "Date of Birth" %>
               <%= form.input :gender, collection: ["Male", "Female"], class: "form-control" %>
               <%= form.input :comments, label: "Comments", as: :text, class: "form-control", wrapper: :input_group %>
               <%= hidden_field_tag :family_id, authorized_family_member.family.id %>

--- a/app/views/partners/children/_form.html.erb
+++ b/app/views/partners/children/_form.html.erb
@@ -22,7 +22,7 @@
                               {class: 'form-control'} %>
               <br>
 
-              <%= form.input :date_of_birth, as: :date, label: "Date of Birth" %>
+              <%= form.input :date_of_birth, as: :date, start_year: 20.years.ago.year, end_year: Time.current.year, label: "Date of Birth" %>
               <%= form.input :gender, collection: ["Male", "Female"], class: "form-control" %>
 
               <%= form.label :child_lives_with, "Child Lives With" %><br>


### PR DESCRIPTION
Resolves #2495 

### Description

This PR addresses a bug report that indicated the year selections in the DOB in the children#new page was incorrect. This adjusts it so that it includes at least the last 20 years and 100 years for authorized family member.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally & CI

### Screenshots
<img width="795" alt="Screen Shot 2021-09-03 at 6 18 36 AM" src="https://user-images.githubusercontent.com/11335191/131997415-1dd9900d-2eea-4f95-860c-1615acad0b94.png">
