### PR TITLE
Relax the strict validations on making a request as a partner

### DIFF
--- a/app/models/partners/request.rb
+++ b/app/models/partners/request.rb
@@ -19,7 +19,6 @@ module Partners
 
     has_many :item_requests, class_name: 'Partners::ItemRequest', foreign_key: :partner_request_id, dependent: :destroy, inverse_of: :request
     accepts_nested_attributes_for :item_requests, allow_destroy: true, reject_if: proc { |attributes| attributes["quantity"].blank? }
-    validates :item_requests, presence: true
     has_many :child_item_requests, through: :item_requests
 
     validates :partner, presence: true

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -23,6 +23,10 @@ module Partners
         end
       end
 
+      if @partner_request.comments.blank? && @partner_request.item_requests.blank?
+        errors.add(:base, 'completely empty request')
+      end
+
       return self if errors.present?
 
       Partners::Base.transaction do
@@ -45,7 +49,12 @@ module Partners
     attr_reader :partner_user_id, :comments, :item_requests_attributes, :additional_attrs
 
     def populate_item_request(partner_request)
-      item_requests = item_requests_attributes.map do |ira|
+      # Exclude any line item that is completely empty
+      formatted_line_items = item_requests_attributes.reject do |attrs|
+        attrs['item_id'].blank? && attrs['quantity'].blank?
+      end
+
+      item_requests = formatted_line_items.map do |ira|
         Partners::ItemRequest.new(
           item_id: ira['item_id'],
           quantity: ira['quantity'],

--- a/spec/models/partners/request_spec.rb
+++ b/spec/models/partners/request_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Partners::Request, type: :model do
 
   describe 'validations' do
     it { should validate_presence_of(:partner) }
-    it { should validate_presence_of(:item_requests) }
     it { should accept_nested_attributes_for(:item_requests) }
   end
 end

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "/partners/requests", type: :request do
     context 'when given invalid parameters' do
       let(:partners_request_attributes) do
         {
-          comments: 'this is not going to work'
+          comments: ""
         }
       end
 

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -25,24 +25,25 @@ describe Partners::RequestCreateService do
     let(:additional_attrs) { { for_families: true } }
 
     context 'when the arguments are incorrect' do
-      context 'because no item_requests_attributes were defined' do
+      context 'because no item_requests_attributes and comments were defined' do
         let(:item_requests_attributes) { [] }
+        let(:comments) { "" }
 
         it 'should return the Partners::Request object with an error' do
           result = subject
 
           expect(result).to be_a_kind_of(Partners::RequestCreateService)
-          expect(result.errors[:item_requests]).to eq(["can't be blank"])
+          expect(result.errors[:base]).to eq(["completely empty request"])
         end
       end
 
       context 'because a unrecogonized item_id was provided' do
         let(:item_requests_attributes) do
           [
-            {
+            ActionController::Parameters.new(
               item_id: 0,
               quantity: Faker::Number.within(range: 1..10)
-            }
+            )
           ]
         end
 

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Managing requests", type: :system, js: true do
         visit new_partners_request_path
       end
 
-      context 'WHEN they create a request inproperly' do
+      context 'WHEN they create a request inproperly by not inputting anything' do
         before do
           click_button 'Submit Essentials Request'
         end
@@ -90,6 +90,20 @@ RSpec.describe "Managing requests", type: :system, js: true do
           expect(page).to have_content('Opps! Something went wrong with your Request')
           expect(page).to have_content('Ensure each line item has a item selected AND a quantity greater than 0.')
           expect(page).to have_content('Still need help? Submit a support ticket here and we do our best to follow up with you via email.')
+        end
+      end
+
+      context 'WHEN they create a request with only a comment' do
+        before do
+          fill_in 'Comments', with: Faker::Lorem.paragraph
+        end
+
+        it 'should be created without any issue' do
+          expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
+
+          expect(current_path).to eq(partners_request_path(Request.last.id))
+          expect(page).to have_content('Request has been successfully created!')
+          expect(page).to have_content("#{partner.organization.name} should have received the request.")
         end
       end
 
@@ -117,6 +131,9 @@ RSpec.describe "Managing requests", type: :system, js: true do
             last_row.find('option', text: item[:name], exact_text: true).select_option
             last_row.find_all('.form-control').last.fill_in(with: item[:quantity])
           end
+
+          # Trigger another row but keep it empty. It should still be valid!
+          click_link 'Add Another Item'
         end
 
         context 'THEN a request records will be created and the partner will be notified via flash message on the dashboard' do


### PR DESCRIPTION
Resolves #2489 

### Description

This PR prevents an undesired user experience in which we reject partner requests if it isn't "exactly" correct. This PR enables these two requests to go through:
- Only comment and no items
- A line item that is empty

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually and updated system spec

### Screenshots
N/A
