### PR TITLE
Get rid of the warnings on partner create around error messages

### DIFF
--- a/app/services/partner_create_service.rb
+++ b/app/services/partner_create_service.rb
@@ -12,8 +12,8 @@ class PartnerCreateService
     @partner = organization.partners.build(partner_attrs)
 
     unless @partner.valid?
-      @partner.errors.each do |k, v|
-        errors.add(k, v)
+      @partner.errors.each do |error|
+        errors.add(error.attribute, error.message)
       end
     end
 


### PR DESCRIPTION
### Description
This PR is addressing a couple warnings that surface when adding new partners in the app or via tests.

Prior to this change a test run of the partner system spec would trigger warnings like this:
```
  #new
DEPRECATION WARNING: Enumerating ActiveModel::Errors as a hash has been deprecated.
In Rails 6.1, `errors` is an array of Error objects,
therefore it should be accessed by a block with a single block
parameter like this:

person.errors.each do |error|
  attribute = error.attribute
  message = error.message
end

You are passing a block expecting two parameters,
so the old hash behavior is simulated. As this is deprecated,
this will result in an ArgumentError in Rails 6.2.
 (called from call at /home/malf/code/human-essentials/app/services/partner_create_service.rb:15)
```

Those warnings are no longer present for the partner tests that trigger a create flow as of this change. A similar change could likely be applied to other parts of the app that also show this type of warning. For now I wanted to keep it scoped to the small area of the app I'm poking at/slightly familiar with.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran the `partner_system_spec` before and after the change. Also did a manual before and after of the validation errors in the UI.