### PR TITLE
Eager loaded ci and alert spec stability

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,10 +10,13 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager load code on boot in CI. This produces slightly more consistent behavior from
+  # various system specs, may improve the accuracy of the simplecov coverage metrics when
+  # running with spring, and can improve the runtime of the full test suite in some cases.
+  # Disable eager load in local development because the average the additional load time when
+  # running a single test file at the time of this comment was around 2-3 seconds slower with
+  # eager loading enabled. For a single test within a file it lost even more time.
+  config.eager_load = ENV["CI"] == "true"
 
   config.action_mailer.default_url_options = { host: "localhost" }
 

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -157,7 +157,9 @@ RSpec.describe "Partner management", type: :system, js: true do
       expect(invite_alert.text).to eq("Send an invitation to #{partner.name} to begin using the partner application?")
 
       invite_alert.accept
-      expect(page.find(".alert")).to have_content "invited!"
+      Capybara.using_wait_time 5 do
+        expect(page.find(".alert")).to have_content "invited!"
+      end
     end
 
     it "shows invite button only for unapproved partners" do


### PR DESCRIPTION
### Description
This PR was inspired by an open issue for a flaky test but does not necessarily directly resolve it. While attempting to debug a different flaky test I discovered that another test case in `spec/system/partner_system_spec.rb` was flaky in my local environment.

Specifically if I ran `bundle exec rspec --order rand:18075 ./spec/system/partner_system_spec.rb:149` it would fail quite consistently locally with:
```
Partner management
  #index
WARN: Screenshot could not be saved. `page.current_path` is empty.
    allows a user to invite a partner (FAILED - 1)

Failures:

  1) Partner management #index allows a user to invite a partner
     Failure/Error: expect(page.find(".alert")).to have_content "invited!"
     
     Capybara::ElementNotFound:
       Unable to find css ".alert"
     
     [Screenshot Image]: /home/malf/code/human-essentials/tmp/screenshots/failures_r_spec_example_groups_partner_management_index_allows_a_user_to_invite_a_partner_935.png

     
     # ./spec/system/partner_system_spec.rb:160:in `block (3 levels) in <top (required)>'

Finished in 33.91 seconds (files took 7.76 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/system/partner_system_spec.rb:149 # Partner management #index allows a user to invite a partner
```

When watching it in a browser I saw that the expected behavior does eventually occur but the browser sits and waits to load the next bit of UI after accepting the invite alert in the spec. When I enabled eager loading in the test env the test passed. However eager loading locally tends to mean slower tests in the local env.

So I put together two changes in this PR:
1. Enable eager loading for the CI environment only
2. Wrap the test that is still flaky locally with some additional wait time which gets it passing pretty consistently locally for me

I did investigate a few other alternatives:

#### Alternative 1: Always eager load system specs
While you can run tasks `before(:suite)` and even `before(:each, type: :system)` triggering a `Rails.application.eager_load!` at those times did not seem to help the stability of the flaky test. It was only improved when the actual `config/test.rb` file changed. I imagine that has something to do with when/how the application is loaded for a system test but I didn't dig too deeply into it. I was not able to get the eager loading to run conditionally so I gave up on that approach after a bit

#### Alternative 2: Always eager load even locally
I ran some extremely unscientific benchmarks locally with and without eager loading running each spec file one at a time. In general the outcome was:
* Most files spent about 3.5-5 seconds more loading files for the test run
* Most files spent 0-2 seconds less time on test execution (they were actually slightly faster)
* The overall result was that most runs of an individual test file took about 2-3 seconds longer with eager loading enabled
* Some tests, particularly the long/slow ones, did show a net benefit. For example the item system spec took around 8 seconds less total (including file loading time) with eager loading enabled.

So while some cases looked better at the per-file level it was mostly just a bit slower across the board. Additionally if you were to compare a single test case it's going to almost always be slower. In practice I suspect most developers are going to run a single file or a single test case locally much more often than the whole suite so keeping the setting off for local envs is probably for the best for now.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran a series of tests before and after the change. Primarily running individual test files one at a time before and after.
