### PR TITLE
Fix flaky partner system specs

### DIFF
--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -50,6 +50,33 @@ RSpec.describe "Partner management", type: :system, js: true do
     end
   end
 
+  describe 'adding another user to a partner account' do
+    let(:partner) { create(:partner, status: 'invited') }
+    before do
+      @user.update(organization_admin: true)
+    end
+
+    context 'when adding a new user to a partner account succesfully' do
+      let(:email) { Faker::Internet.email }
+
+      before do
+        visit url_prefix + "/partners/#{partner.id}"
+
+        click_on 'Add/Remind Partner'
+        assert page.has_content? "Add a User or Send a Reminder for #{partner.name}"
+
+        fill_in 'email', with: email
+
+        find_button('Invite User').click
+        assert page.has_content? "We have invited #{email} to #{partner.name}!"
+      end
+
+      it 'should create a new user for that partner' do
+        expect(Partners::User.find_by(email: email, partner: partner.profile)).not_to eq(nil)
+      end
+    end
+  end
+
   describe 'adding a new partner and inviting them' do
     context 'when adding & inviting a partner successfully' do
       let(:partner_attributes) do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Partner management", type: :system, js: true do
         visit url_prefix + "/partners/#{partner.id}"
 
         click_on 'Add/Remind Partner'
-        assert page.has_content? "Add a User or Send a Reminder for #{partner.name}"
+        assert page.has_content?("Add a User or Send a Reminder for #{partner.name}", wait: 5)
 
         fill_in 'email', with: email
 


### PR DESCRIPTION
Resolves #2476 (hopefully!)

### Description

Per https://github.com/rubyforgood/human-essentials/issues/2476 one of the tests exhibits flakiness in the CI system. This PR attempts to eliminate that flakiness by providing a bit of extra runtime, when necessary, on the commonly failing test step.

The changes include:
1. Reintroduce the tests that were flaky/failing and removed in a prior commit
2. Allow the commonly failing step to wait up to 5 seconds before failing (instead of the built-in default of 2)

Initially I struggled to reproduce the failure locally. I only got it to fail a couple of times locally and never with the browser visible on my machine. When I did watch the test run in the browser I observed that it often took a while for the test runner to discover the "Add/Remind Partner" post-click modal and interact with it. My suspicion is that the test is flaky because the amount of time to find the modal lands very close to the default wait time in Capybara (2 seconds) and occasionally pushes past that limit. It's hard for me to say why it takes a while for Capybara to see the modal (maybe it's animation/dynamic style change related?). In any case that was my best guess as to the cause so I added more wait time and that seems to help on my local machine.

As noted in the tests section I later found a more consistent reproduction of the issue that aligns with my theory that the failures are largely a timing issue.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I was able to get relatively repeatable failure on `main` (with the flaky test restored) by limiting my test runs to 2 CPUs on my Ubuntu machine.

I had 9/10 builds failing on this test with the following:
```shell script
for i in {1..10}; do taskset --all-tasks --cpu-list 0,1 bundle exec rspec --order rand:32850 spec/models/distribution_spec.rb spec/system/partner_system_spec.rb; done
```

After the patch from this PR I had zero builds failing on this test.

Before I found the repeatable failure configuration I ran the partner spec 50 times in a loop with no CPU constraints and had 2/50 builds failed on `main` (with the flaky tests restored). With the patch I had zero failures out of 50 runs.

It's quite possible a smaller set of tests would also be pretty repeatable with limited CPU resources but I didn't really have the spare time to drill down too much further. I could pursue that if the issue continues after this PR.

I _hope_ there were enough iterations to catch any issues but I'm not certain. For that reason my suggestion is to try this approach and if the failures continue the tests should be removed again and the issue reopened. That or abandon this particular end to end test in favor of lower level tests that make this end-to-end automated check mostly unnecessary.