### PR TITLE
feat: add pry-doc dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :development, :test do
   gem "fakeredis", require: "fakeredis/rspec"
   gem "guard-rspec"
   gem "knapsack_pro"
+  gem "pry-doc"
   gem "pry-rails"
   gem "pry-remote"
   gem "pry-nav"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-doc (1.1.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
     pry-rails (0.3.9)
@@ -515,6 +518,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yajl-ruby (1.4.1)
+    yard (0.9.26)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -576,6 +580,7 @@ DEPENDENCIES
   pg (~> 1.2.3)
   popper_js
   prawn-rails
+  pry-doc
   pry-nav
   pry-rails
   pry-remote


### PR DESCRIPTION
Just a dev convenience. Lets us quickly+cheaply look up method help docs from pry via

```
[3] pry(main)> ? Array#map

From: array.c (C Method):
Owner: Array
Visibility: public
Signature: map()
Number of lines: 12

Invokes the given block once for each element of self.

Creates a new array containing the values returned by the block.

See also Enumerable#collect.

If no block is given, an Enumerator is returned instead.

   a = [ "a", "b", "c", "d" ]
   a.collect {|x| x + "!"}           #=> ["a!", "b!", "c!", "d!"]
   a.map.with_index {|x, i| x * i}   #=> ["", "b", "cc", "ddd"]
   a                                 #=> ["a", "b", "c", "d"]

```

Syntax:
* instance method of a class: `? Array#map`
* method of an object instance: `? Array[]`, `? Array.try_convert`
  *  note: you can get help directly on the methods of local variables, e.g., `? my_array.map`
* to get the source code of the method rather than the help doc, use `$` instead of `?`
* `?` is an alias for `show-doc`, and `$` is an alias for `show-source`