### PR TITLE
Change emails sent from info@diaper.app to info@humanessentials.app

### DIFF
--- a/app/mailers/account_request_mailer.rb
+++ b/app/mailers/account_request_mailer.rb
@@ -12,7 +12,7 @@ class AccountRequestMailer < ApplicationMailer
     @account_request = AccountRequest.find(account_request_id)
 
     mail(
-      to: 'info@diaper.app',
+      to: 'info@humanessentials.app',
       subject: "[Account Request] #{@account_request.organization_name}"
     )
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 # Default Mailer Info
 class ApplicationMailer < ActionMailer::Base
-  default from: "info@diaper.app"
+  default from: "info@humanessentials.app"
   layout "mailer"
 end

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -1,5 +1,5 @@
 class PartnerMailer < ApplicationMailer
-  default from: "info@diaper.app"
+  default from: "info@humanessentials.app"
 
   def recertification_request(partner:)
     @partner = partner

--- a/app/views/account_requests/received.html.erb
+++ b/app/views/account_requests/received.html.erb
@@ -4,7 +4,7 @@
       <h2> Request Received! </h2>
       <p> We've sent you a email with instructions on next steps at <strong><%= @account_request.email %></strong>! </p>
     </div>
-    <p style="color: #ff0505;">Please check your spam filters for a email from <strong>info@diaper.app</strong></p>
+    <p style="color: #ff0505;">Please check your spam filters for a email from <strong>info@humanessentials.app</strong></p>
   </div>
 </div>
 

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -83,7 +83,7 @@
       <div class="text-center mt-10">
         <h2 class="text-4xl text-gray-600">The Human Essentials app removes the <br/> complexity from your day</h2>
         <p class="mt-1 text-gray-400">and lets you spend time helping those who need it.</p>
-        <a href="mailto:info@diaper.app?Subject=Diaperbase%20Interest"><button type="button" class="text-lg bg-green-500 text-white px-3 py-2 rounded-2xl mt-5">Get In Touch</button></a>
+        <a href="mailto:info@humanessentials.app?Subject=Diaperbase%20Interest"><button type="button" class="text-lg bg-green-500 text-white px-3 py-2 rounded-2xl mt-5">Get In Touch</button></a>
       </div>
     </div>
 
@@ -185,7 +185,7 @@
         <a href=<%="#{new_account_request_path}"%>><button type="button" class="text-lg bg-green-500 text-white px-3 py-2 mt-5 rounded-2xl">Request A Demo</button></a>
 
         <br/><br/>
-        <p class="text-gray-500">Have questions? Email us at <a class='text-blue-500' href="mailto:info@diaper.app?Subject=Diaperbase%20Interest" target="_top" >info@diaper.app</a></p>
+        <p class="text-gray-500">Have questions? Email us at <a class='text-blue-500' href="mailto:info@humanessentials.app?Subject=Diaperbase%20Interest" target="_top" >info@humanessentials.app</a></p>
       </div>
     </div>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = '"Diaper App" <accounts@diaper.app>'
+  config.mailer_sender = '"Human Essentials" <accounts@humanessentials.app>'
 
   # Configure the class responsible to send e-mails.
   config.mailer = "CustomDeviseMailer"

--- a/spec/mailers/account_request_mailer_spec.rb
+++ b/spec/mailers/account_request_mailer_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe AccountRequestMailer, type: :mailer do
       expect(mail.to).to eq([account_request.email])
     end
 
-    it 'should be from info@diaper.app' do
-      expect(mail.from).to eq(['info@diaper.app'])
+    it 'should be from info@humanessentials.app' do
+      expect(mail.from).to eq(['info@humanessentials.app'])
     end
 
     it 'should have the correct subject' do
@@ -58,8 +58,8 @@ RSpec.describe AccountRequestMailer, type: :mailer do
       end
     end
 
-    it 'should be sent to the info@diaper.app email address' do
-      expect(mail.to).to eq(['info@diaper.app'])
+    it 'should be sent to the info@humanessentials.app email address' do
+      expect(mail.to).to eq(['info@humanessentials.app'])
     end
 
     it 'should have the correct subject' do

--- a/spec/mailers/partner_mailer_spec.rb
+++ b/spec/mailers/partner_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PartnerMailer, type: :mailer do
 
     it "should be sent to the partner main email with the correct subject line" do
       expect(subject.to).to eq([partner.email])
-      expect(subject.from).to eq(['info@diaper.app'])
+      expect(subject.from).to eq(['info@humanessentials.app'])
       expect(subject.subject).to eq("[Action Required] Please Update Your Agency Information")
     end
   end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RequestMailer, type: :mailer do
 
     it "should be sent to the partner main email with the correct subject line" do
       expect(subject.to).to eq([request.partner.email])
-      expect(subject.from).to eq(['info@diaper.app'])
+      expect(subject.from).to eq(['info@humanessentials.app'])
       expect(subject.subject).to eq("Your essentials request (##{request.id}) has been canceled.")
     end
   end


### PR DESCRIPTION
### Description

Now that we've authenticated our humanessentials.app domain we are now able to start sending emails directly from `info@humanessentials.app` instead of `info@diaper.app`. This should prevent email deliverability issues we've been hearing about.

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
N/A

### Screenshots
N/A
