### PR TITLE
Pull db creds from ENV in dev, test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,8 +3,8 @@ default: &default
   encoding: unicode
   host: localhost
   database: diaper_dev
-  username: postgres
-  password: password
+  username: <%= ENV.fetch("PG_USERNAME", 'postgres') %>
+  password: <%= ENV.fetch("PG_PASSWORD", 'password') %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
@@ -14,8 +14,6 @@ development:
     timeout: 5000
   partners:
     <<: *default
-    username: postgres
-    password: password
     database: partner_dev
     migrations_paths: db/partners_migrate
     timeout: 5000
@@ -36,8 +34,6 @@ test:
     timeout: 5000
   partners:
     <<: *default
-    username: postgres
-    password: password
     database: partner_test
     migrations_paths: db/partners_migrate
     timeout: 5000


### PR DESCRIPTION
### Description
The existing `database.yml` file hardcodes postgresql credentials for local development, forcing contributors to change their local postgres setup and also causing confusion when following installation instructions to set customized password in `.env`.

This PR changes `database.yml` to pull local PG creds from `ENV`, defaulting to the hardcoded values when env vars aren't set.
It was motivated by trying to set up a new development box during Ruby for Good.

### Type of change

New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested locally and on CI.

### Questions
It's unclear to me whether we need `database.yml.example` anymore. It is mentioned in setup instructions but since `database.yml` has been added to git, any local modifications would show up as a local change.