### PR TITLE
Generate spring binstub for rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :development do
   gem "rails-erd"
   gem "spring"
   gem "spring-watcher-listen"
+  gem "spring-commands-rspec"
   gem "web-console"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,6 +465,8 @@ GEM
       activesupport (>= 5.2.0)
     slop (3.6.0)
     spring (2.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -601,6 +603,7 @@ DEPENDENCIES
   simplecov
   skylight
   spring
+  spring-commands-rspec
   spring-watcher-listen
   sprockets (~> 4.0.2)
   strong_migrations (~> 0.7.8)

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast.
+# This file loads Spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
@@ -8,7 +8,7 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version


### PR DESCRIPTION
### Description
Allows specs to be run with [spring](https://github.com/rails/spring) by invoking `bin/rspec`.

In some anecdotal testing locally, this shaved off ~10s from subsequent spec runs.

Note that this doesn't force the use of spring. It is only invoked when running specs via `bin/rspec`, so other invocations such as `bundle exec rspec` will bypass it. As such it is 'opt-in'. Spring can also be reset with `bin/spring stop` when needed.
