### PR TITLE
Implement #2522 (Add partner user to partner requests)

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -14,6 +14,7 @@ class RequestsController < ApplicationController
     @items = current_organization.items.alphabetized
     @partners = current_organization.partners.order(:name)
     @statuses = Request.statuses.transform_keys(&:humanize)
+    @partner_users = Partners::User.where(id: @paginated_requests.pluck(:partner_user_id))
     @selected_request_item = filter_params[:by_request_item_id]
     @selected_partner = filter_params[:by_partner]
     @selected_status = filter_params[:by_status]

--- a/app/models/partners/request.rb
+++ b/app/models/partners/request.rb
@@ -10,12 +10,14 @@
 #  updated_at      :datetime         not null
 #  organization_id :bigint
 #  partner_id      :bigint
+#  partner_user_id :integer
 #
 module Partners
   class Request < Base
     self.table_name = "partner_requests"
 
     belongs_to :partner, dependent: :destroy
+    belongs_to :partner_user, class_name: "Partners::User", foreign_key: :partner_user_id, optional: true
 
     has_many :item_requests, class_name: 'Partners::ItemRequest', foreign_key: :partner_request_id, dependent: :destroy, inverse_of: :request
     accepts_nested_attributes_for :item_requests, allow_destroy: true, reject_if: proc { |attributes| attributes["quantity"].blank? }

--- a/app/models/partners/request.rb
+++ b/app/models/partners/request.rb
@@ -17,7 +17,7 @@ module Partners
     self.table_name = "partner_requests"
 
     belongs_to :partner, dependent: :destroy
-    belongs_to :partner_user, class_name: "Partners::User", foreign_key: :partner_user_id, optional: true
+    belongs_to :partner_user, class_name: "Partners::User", optional: true
 
     has_many :item_requests, class_name: 'Partners::ItemRequest', foreign_key: :partner_request_id, dependent: :destroy, inverse_of: :request
     accepts_nested_attributes_for :item_requests, allow_destroy: true, reject_if: proc { |attributes| attributes["quantity"].blank? }

--- a/app/models/partners/request.rb
+++ b/app/models/partners/request.rb
@@ -24,6 +24,7 @@ module Partners
     has_many :child_item_requests, through: :item_requests
 
     validates :partner, presence: true
+    validates :partner_user, presence: true, on: :create
     validates_associated :item_requests
   end
 end

--- a/app/models/partners/user.rb
+++ b/app/models/partners/user.rb
@@ -33,6 +33,9 @@ module Partners
     devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable, :invitable, :trackable
 
     has_many :requests, class_name: 'Partners::Request', foreign_key: :partner_id, dependent: :destroy, inverse_of: :user
+    has_many :submitted_partner_requests, class_name: 'Partners::Request', foreign_key: :partner_user_id, dependent: :destroy, inverse_of: :partner_user
+    has_many :submitted_requests, class_name: 'Request', foreign_key: :partner_user_id, dependent: :destroy, inverse_of: :partner_user
+
     belongs_to :partner, dependent: :destroy
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -21,7 +21,7 @@ class Request < ApplicationRecord
   include Exportable
 
   belongs_to :partner
-  belongs_to :partner_user, class_name: "Partners::User", foreign_key: :partner_user_id, optional: true
+  belongs_to :partner_user, class_name: "Partners::User", optional: true
   belongs_to :organization
   belongs_to :distribution, optional: true
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -13,6 +13,7 @@
 #  distribution_id :integer
 #  organization_id :bigint
 #  partner_id      :bigint
+#  partner_user_id :integer
 #
 
 class Request < ApplicationRecord
@@ -20,6 +21,7 @@ class Request < ApplicationRecord
   include Exportable
 
   belongs_to :partner
+  belongs_to :partner_user, class_name: "Partners::User", foreign_key: :partner_user_id, optional: true
   belongs_to :organization
   belongs_to :distribution, optional: true
 

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -13,7 +13,7 @@ module Partners
     end
 
     def call
-      @partner_request = Partners::Request.new(partner_id: partner.id, organization_id: organization_id, comments: comments, for_families: @for_families, sent: true)
+      @partner_request = Partners::Request.new(partner_id: partner.id, organization_id: organization_id, comments: comments, for_families: @for_families, sent: true, partner_user_id: partner_user_id)
       @partner_request = populate_item_request(@partner_request)
       @partner_request.assign_attributes(additional_attrs)
 
@@ -99,6 +99,7 @@ module Partners
       ::Request.new(
         organization_id: partner_request.organization_id,
         partner_id: partner_request.partner.diaper_partner_id,
+        partner_user_id: partner_user_id,
         comments: partner_request.comments,
         request_items: partner_request.item_requests.map do |ir|
           {

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -1,6 +1,10 @@
 <tr>
   <td class="date"><%= request_row.created_at.strftime("%m/%d/%Y") %></td>
   <td><%= request_row.partner.name %> </td>
+  <td>
+    <% partner_user = @partner_users.find { |pu| pu.id == request_row.partner_user_id } %>
+    <%= partner_user && "#{partner_user.name} <#{partner_user.email}>" %>
+  </td>
   <td class="<%= quota_column_class(request_row.total_items, request_row.partner) %>">
     <%= request_row.total_items %>
     <%= quota_display(request_row.partner) %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -88,7 +88,8 @@
               <thead>
               <tr>
                 <th style="width: 10px">Date</th>
-                <th>Requestor</th>
+                <th>Request was sent by:</th>
+                <th>Request Sender</th>
                 <th># of Items (Request Limit)</th>
                 <th>Comments</th>
                 <th>Status</th>
@@ -96,7 +97,7 @@
               </tr>
               </thead>
               <tbody>
-              <%= render partial: "request_row", collection: @paginated_requests %>
+                <%= render partial: "request_row", collection: @paginated_requests %>
               </tbody>
             </table>
           </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -34,8 +34,9 @@
           <div class="card-body p-0">
             <table class="table">
               <thead>
-                <tr >
+                <tr>
                 <th>Request was sent by:</th>
+                <th>Request Sender:</th>
                 <th>Request Status:</th>
                 <th>Comments:</th>
               </tr>
@@ -43,6 +44,7 @@
               <tbody>
               <tr>
                 <td><%= @request.partner.name %></td>
+                <td><%= @request.partner_user.present? ? "#{@request.partner_user.name} <#{@request.partner_user.email}>" : "" %></td>
                 <td><%= render partial: "status", locals: {status: @request.status} %></td>
                 <td><%= @request.comments || 'None' %></td>
               </tr>

--- a/db/migrate/20210924162800_add_partner_user_id_to_requests.rb
+++ b/db/migrate/20210924162800_add_partner_user_id_to_requests.rb
@@ -1,0 +1,6 @@
+# capture which partner user created the request
+class AddPartnerUserIdToRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :requests, :partner_user_id, :integer, null: true, default: nil
+  end
+end

--- a/db/migrate/20210924162800_add_partner_user_id_to_requests.rb
+++ b/db/migrate/20210924162800_add_partner_user_id_to_requests.rb
@@ -1,6 +1,6 @@
 # capture which partner user created the request
 class AddPartnerUserIdToRequests < ActiveRecord::Migration[6.1]
   def change
-    add_column :requests, :partner_user_id, :integer, null: true, default: nil
+    add_column :requests, :partner_user_id, :integer, default: nil
   end
 end

--- a/db/partners_migrate/20210924155700_add_partner_user_id_to_partner_requests.rb
+++ b/db/partners_migrate/20210924155700_add_partner_user_id_to_partner_requests.rb
@@ -1,6 +1,9 @@
 # capture which partner user created the partner request
 class AddPartnerUserIdToPartnerRequests < ActiveRecord::Migration[6.1]
   def change
-    add_column :partner_requests, :partner_user_id, :integer, null: true, default: nil
+    safety_assured do
+      add_column :partner_requests, :partner_user_id, :integer, default: nil
+      add_foreign_key :partner_requests, :users, column: :partner_user_id, primary_key: :id
+    end
   end
 end

--- a/db/partners_migrate/20210924155700_add_partner_user_id_to_partner_requests.rb
+++ b/db/partners_migrate/20210924155700_add_partner_user_id_to_partner_requests.rb
@@ -1,0 +1,6 @@
+# capture which partner user created the partner request
+class AddPartnerUserIdToPartnerRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :partner_requests, :partner_user_id, :integer, null: true, default: nil
+  end
+end

--- a/db/partners_schema.rb
+++ b/db/partners_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_18_010905) do
+ActiveRecord::Schema.define(version: 2021_09_24_155700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 2020_05_18_010905) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "for_families"
+    t.integer "partner_user_id"
     t.index ["organization_id"], name: "index_partner_requests_on_organization_id"
     t.index ["partner_id"], name: "index_partner_requests_on_partner_id"
   end

--- a/db/partners_schema.rb
+++ b/db/partners_schema.rb
@@ -275,5 +275,6 @@ ActiveRecord::Schema.define(version: 2021_09_24_155700) do
   add_foreign_key "children", "families"
   add_foreign_key "families", "partners"
   add_foreign_key "item_requests", "partner_requests"
+  add_foreign_key "partner_requests", "users", column: "partner_user_id"
   add_foreign_key "users", "partners"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_29_003516) do
+ActiveRecord::Schema.define(version: 2021_09_24_162800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -368,6 +368,7 @@ ActiveRecord::Schema.define(version: 2021_07_29_003516) do
     t.integer "status", default: 0
     t.datetime "discarded_at"
     t.text "discard_reason"
+    t.integer "partner_user_id"
     t.index ["discarded_at"], name: "index_requests_on_discarded_at"
     t.index ["distribution_id"], name: "index_requests_on_distribution_id", unique: true
     t.index ["organization_id"], name: "index_requests_on_organization_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_24_162800) do
+ActiveRecord::Schema.define(version: 2021_09_26_131330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :partners_user, class: Partners::User do
+    name { "Partner User" }
+    email { "partner_user@example.com" }
+    partner { Partners::Partner.first || create(:partners_partner) }
+  end
+end

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -3,5 +3,7 @@ FactoryBot.define do
     name { "Partner User" }
     email { "partner_user@example.com" }
     partner { Partners::Partner.first || create(:partners_partner) }
+    password { "password" }
+    password_confirmation { "password" }
   end
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -13,6 +13,7 @@
 #  distribution_id :integer
 #  organization_id :bigint
 #  partner_id      :bigint
+#  partner_user_id :integer
 #
 
 def random_request_items
@@ -26,6 +27,7 @@ FactoryBot.define do
     organization { Organization.try(:first) || create(:organization) }
     request_items { random_request_items }
     comments { "Urgent" }
+    partner_user { Partners::User.try(:first) || create(:partners_user) }
   end
 
   trait :started do

--- a/spec/models/partners/request_spec.rb
+++ b/spec/models/partners/request_spec.rb
@@ -10,6 +10,7 @@
 #  updated_at      :datetime         not null
 #  organization_id :bigint
 #  partner_id      :bigint
+#  partner_user_id :integer
 #
 require "rails_helper"
 

--- a/spec/models/partners/request_spec.rb
+++ b/spec/models/partners/request_spec.rb
@@ -17,7 +17,6 @@ require "rails_helper"
 RSpec.describe Partners::Request, type: :model do
   describe 'associations' do
     it { should belong_to(:partner) }
-    it { should belong_to(:partner_user) }
     it { should have_many(:item_requests).dependent(:destroy) }
     it { should have_many(:child_item_requests).through(:item_requests) }
   end

--- a/spec/models/partners/request_spec.rb
+++ b/spec/models/partners/request_spec.rb
@@ -17,12 +17,14 @@ require "rails_helper"
 RSpec.describe Partners::Request, type: :model do
   describe 'associations' do
     it { should belong_to(:partner) }
+    it { should belong_to(:partner_user) }
     it { should have_many(:item_requests).dependent(:destroy) }
     it { should have_many(:child_item_requests).through(:item_requests) }
   end
 
   describe 'validations' do
     it { should validate_presence_of(:partner) }
+    it { should validate_presence_of(:partner_user).on(:create) }
     it { should accept_nested_attributes_for(:item_requests) }
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Request, type: :model do
                   request_items: [
                     { item_id: "25", quantity: "15" },
                     { item_id: "35", quantity: 18 },
-                ])
+      ])
       expect(request.request_items.first["item_id"]).to be 25
       expect(request.request_items.first["quantity"]).to be 15
       expect(request.request_items.last["item_id"]).to be 35

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -13,6 +13,7 @@
 #  distribution_id :integer
 #  organization_id :bigint
 #  partner_id      :bigint
+#  partner_user_id :integer
 #
 
 RSpec.describe Request, type: :model do
@@ -32,11 +33,12 @@ RSpec.describe Request, type: :model do
 
   describe "item data" do
     it "coerces item quantity and id to always be an integer before saving" do
-      request = create(:request, request_items: [
-                         { item_id: "25", quantity: "15" },
-                         { item_id: "35", quantity: 18 },
-                       ])
-
+      request = create(:request,
+                  partner_user: Partners::User.first,
+                  request_items: [
+                    { item_id: "25", quantity: "15" },
+                    { item_id: "35", quantity: 18 },
+                ])
       expect(request.request_items.first["item_id"]).to be 25
       expect(request.request_items.first["quantity"]).to be 15
       expect(request.request_items.last["item_id"]).to be 35

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe Request, type: :model do
   describe "item data" do
     it "coerces item quantity and id to always be an integer before saving" do
       request = create(:request,
-                  partner_user: Partners::User.first,
-                  request_items: [
-                    { item_id: "25", quantity: "15" },
-                    { item_id: "35", quantity: 18 },
-                  ])
+                       partner_user: Partners::User.first,
+                       request_items: [
+                         { item_id: "25", quantity: "15" },
+                         { item_id: "35", quantity: 18 }
+                       ])
       expect(request.request_items.first["item_id"]).to be 25
       expect(request.request_items.first["quantity"]).to be 15
       expect(request.request_items.last["item_id"]).to be 35

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Request, type: :model do
                   request_items: [
                     { item_id: "25", quantity: "15" },
                     { item_id: "35", quantity: 18 },
-      ])
+                  ])
       expect(request.request_items.first["item_id"]).to be 25
       expect(request.request_items.first["quantity"]).to be 15
       expect(request.request_items.last["item_id"]).to be 35

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -117,10 +117,24 @@ RSpec.describe "Requests", type: :system, js: true do
 
     let!(:request) { create(:request, organization: @organization) }
 
-    it "should show the request" do
+    it "should show the request with a request sender if a partner user is set" do
       visit subject
       expect(page).to have_content("Request from #{request.partner.name}")
       expect(page).to have_content("Estimated on-hand")
+      expect(page).to have_content("Request Sender:")
+      partner_user = request.partner_user
+      expect(page).to have_content("#{partner_user.name} <#{partner_user.email}>")
+    end
+
+    it "should show the request without a request sender if a partner user is not set" do
+      partner_user = request.partner_user
+      request.partner_user_id = nil
+      request.save!
+      visit subject
+      expect(page).to have_content("Request from #{request.partner.name}")
+      expect(page).to have_content("Estimated on-hand")
+      expect(page).to have_content("Request Sender:")
+      expect(page).not_to have_content("#{partner_user.name} <#{partner_user.email}>")
     end
 
     it "should show the number of items on-hand" do


### PR DESCRIPTION
Resolves #2522

Adds Partner::User to Requests and Partner::Requests.
The field is optional so existing data is not impacted.

The partner user name and email shows up on the bank's requests show page (ex: /diaper_bank/requests/25).