### PR TITLE
Send Email when Applicant approved by Org

### DIFF
--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -6,4 +6,11 @@ class PartnerMailer < ApplicationMailer
 
     mail to: partner.email, subject: "[Action Required] Please Update Your Agency Information"
   end
+
+  def application_approved(partner:)
+    @partner = partner
+    @organization = partner.organization
+
+    mail to: partner.email, subject: "Application Approved"
+  end
 end

--- a/app/services/partner_approval_service.rb
+++ b/app/services/partner_approval_service.rb
@@ -11,6 +11,8 @@ class PartnerApprovalService
     Partners::Base.transaction do
       partner.profile.update!(partner_status: approved_partner_status)
       partner.approved!
+
+      PartnerMailer.application_approved(partner: partner).deliver_later
     rescue StandardError => e
       errors.add(:base, e.message)
       raise ActiveRecord::Rollback

--- a/app/views/partner_mailer/application_approved.html.erb
+++ b/app/views/partner_mailer/application_approved.html.erb
@@ -1,0 +1,16 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi <%= @partner.name %></p>
+
+    <p>
+      <%= @organization.name %> has approved your application.
+      <br>
+      <%= link_to "Check out your dashboard", partners_dashboard_url %>
+    </p>
+  </body>
+</html>

--- a/spec/mailers/partner_mailer_spec.rb
+++ b/spec/mailers/partner_mailer_spec.rb
@@ -19,5 +19,21 @@ RSpec.describe PartnerMailer, type: :mailer do
       expect(subject.subject).to eq("[Action Required] Please Update Your Agency Information")
     end
   end
-end
 
+  describe "#application_approved" do
+    subject { PartnerMailer.application_approved(partner: partner) }
+    let(:partner) { create(:partner) }
+
+    it "should be sent to the partner main email with the correct subject line" do
+      expect(subject.to).to eq([partner.email])
+      expect(subject.from).to eq(['info@humanessentials.app'])
+      expect(subject.subject).to eq("Application Approved")
+    end
+
+    it "renders the body with text that indicates the result and a link to their dashboard" do
+      expect(subject.body.encoded).to include("Hi #{partner.name}")
+      expect(subject.body.encoded).to include("#{partner.organization.name} has approved your application.")
+      expect(subject.body.encoded).to include("/partners/dashboard")
+    end
+  end
+end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2519 <!--fill issue number-->

### Description
Adds a notification email to send to partners when their organization approves their application.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change
<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Login as Organization user
Approve a user who is "Awaiting Review"
See email generate
Ensure link works in separate browser for partner user

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
new email template
<img width="863" alt="approved_email" src="https://user-images.githubusercontent.com/28073714/134786086-ce6c1a1f-0521-4c7e-8bce-22c95bd2da5c.png">
