### PR TITLE
Enables Display of Omitted Items in Adjustments

### DIFF
--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -25,8 +25,13 @@ class InventoryItem < ApplicationRecord
 
   scope :by_partner_key, ->(partner_key) { joins(:item).merge(Item.by_partner_key(partner_key)) }
   scope :active, -> { joins(:item).where(items: { active: true }) }
+  scope :inactive, -> { joins(:item).where(items: { active: false }) }
 
   delegate :name, to: :item, prefix: true
+
+  def to_h
+    { item_id: item_id, quantity: quantity, item_name: item.name }.stringify_keys
+  end
 
   def lower_than_on_hand_minimum_quantity?
     quantity < item.on_hand_minimum_quantity

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -112,7 +112,7 @@ class Item < ApplicationRecord
   end
 
   def to_h
-    { name: name, partner_key: partner_key }
+    { name: name, item_id: id }
   end
 
   def self.csv_export_headers

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -45,7 +45,7 @@
                   </p>
                   <%= simple_form_for @adjustment, html: { class: "storage-location-required", id: 'new_adjustment'} do |f| %>
 
-                    <%= render partial: "storage_locations/source", object: f %>
+                    <%= render partial: "storage_locations/source", object: f, locals: { include_omitted_items: true } %>
 
                     <%= f.input :comment %>
 

--- a/app/views/storage_locations/_source.html.erb
+++ b/app/views/storage_locations/_source.html.erb
@@ -4,6 +4,7 @@
   error ||= "Which location are you moving inventory from?"
   association_field ||= :storage_location
   include_inactive_items ||= false
+  include_omitted_items ||= false
 %>
 <%= source.association association_field,
   collection: storage_locations,
@@ -16,6 +17,7 @@
       storage_location_inventory_path: inventory_storage_location_path(
         organization_id: current_organization,
         include_inactive_items: include_inactive_items,
+        include_omitted_items: include_omitted_items,
         id: ":id",
         format: :json
       )

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -11,64 +11,86 @@ RSpec.describe "Adjustment management", type: :system, js: true do
   end
 
   context "With a new adjustment" do
-    before do
-      visit subject
-      click_on "New Adjustment"
-      select storage_location.name, from: "From storage location"
-      fill_in "Comment", with: "something"
-      select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
-    end
+    context "with a storage location that is bare", js: true do
+      let!(:bare_storage_location) { create(:storage_location, name: "We Got Nothin", organization: @organization) }
 
-    it "can add an inventory adjustment at a storage location", js: true do
-      fill_in "adjustment_line_items_attributes_0_quantity", with: add_quantity.to_s
+      before do
+        visit subject
+        click_on "New Adjustment"
+        select bare_storage_location.name, from: "From storage location"
+      end
 
-      expect do
-        click_on "Save"
-      end.to change { storage_location.size }.by(add_quantity)
-      expect(page).to have_content(/Adjustment was successful/i)
-    end
+      it "allows you to choose items that do not yet exist" do
+        select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
+        fill_in "adjustment_line_items_attributes_0_quantity", with: add_quantity.to_s
 
-    it "can subtract an inventory adjustment at a storage location", js: true do
-      fill_in "adjustment_line_items_attributes_0_quantity", with: sub_quantity.to_s
-
-      expect do
-        click_on "Save"
-      end.to change { storage_location.size }.by(sub_quantity)
-      expect(page).to have_content(/Adjustment was successful/i)
-    end
-
-    it "Does not include inactive items in the line item fields" do
-      visit url_prefix + "/adjustments/new"
-
-      item = Item.alphabetized.first
-
-      select storage_location.name, from: "From storage location"
-      expect(page).to have_content(item.name)
-      select item.name, from: "adjustment_line_items_attributes_0_item_id"
-
-      item.update(active: false)
-
-      page.refresh
-      within "#new_adjustment" do
-        select storage_location.name, from: "From storage location"
-        expect(page).to have_no_content(item.name)
+        expect do
+          click_on "Save"
+        end.to change { bare_storage_location.size }.by(add_quantity)
+        expect(page).to have_content(/Adjustment was successful/i)
       end
     end
 
-    it "politely informs the user that they're adjusting way too hard", js: true do
-      sub_quantity = -9001
-      storage_location = create(:storage_location, :with_items, name: "PICK THIS ONE", item_quantity: 10, organization: @organization)
-      visit url_prefix + "/adjustments"
-      click_on "New Adjustment"
-      select storage_location.name, from: "From storage location"
-      fill_in "Comment", with: "something"
-      select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
-      fill_in "adjustment_line_items_attributes_0_quantity", with: sub_quantity.to_s
+    context "with a storage location that has inventory" do
+      before do
+        visit subject
+        click_on "New Adjustment"
+        select storage_location.name, from: "From storage location"
+        fill_in "Comment", with: "something"
+        select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
+      end
 
-      expect do
-        click_button "Save"
-      end.not_to change { storage_location.size }
-      expect(page).to have_content("items exceed the available inventory")
+      it "can add an inventory adjustment at a storage location", js: true do
+        fill_in "adjustment_line_items_attributes_0_quantity", with: add_quantity.to_s
+
+        expect do
+          click_on "Save"
+        end.to change { storage_location.size }.by(add_quantity)
+        expect(page).to have_content(/Adjustment was successful/i)
+      end
+
+      it "can subtract an inventory adjustment at a storage location", js: true do
+        fill_in "adjustment_line_items_attributes_0_quantity", with: sub_quantity.to_s
+
+        expect do
+          click_on "Save"
+        end.to change { storage_location.size }.by(sub_quantity)
+        expect(page).to have_content(/Adjustment was successful/i)
+      end
+
+      it "Does not include inactive items in the line item fields" do
+        visit url_prefix + "/adjustments/new"
+
+        item = Item.alphabetized.first
+
+        select storage_location.name, from: "From storage location"
+        expect(page).to have_content(item.name)
+        select item.name, from: "adjustment_line_items_attributes_0_item_id"
+
+        item.update(active: false)
+
+        page.refresh
+        within "#new_adjustment" do
+          select storage_location.name, from: "From storage location"
+          expect(page).to have_no_content(item.name)
+        end
+      end
+
+      it "politely informs the user that they're adjusting way too hard", js: true do
+        sub_quantity = -9001
+        storage_location = create(:storage_location, :with_items, name: "PICK THIS ONE", item_quantity: 10, organization: @organization)
+        visit url_prefix + "/adjustments"
+        click_on "New Adjustment"
+        select storage_location.name, from: "From storage location"
+        fill_in "Comment", with: "something"
+        select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
+        fill_in "adjustment_line_items_attributes_0_quantity", with: sub_quantity.to_s
+
+        expect do
+          click_button "Save"
+        end.not_to change { storage_location.size }
+        expect(page).to have_content("items exceed the available inventory")
+      end
     end
   end
 


### PR DESCRIPTION
### Description
Closes #2543

This was a little tricky.

The inventory_storage_location_path action was used by a few different
places, so I parameterized the variant result.

The result was piped through a JSON builder using inventory item
records. This was pretty easy to Duck type a Struct in place and pass
that in alongside the existing inventory items. I added spec coverage
for both the feature overall as well as some request specs for the route
and its variants (which hadn't existed previously).
### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually tested + specs

### Screenshots

![Screenshot from 2021-10-09 21-28-17](https://user-images.githubusercontent.com/502363/136678083-1448b778-4335-4be6-b9f4-0b2260f421d1.png)
