### PR TITLE
Embiggens the width of the line item fields in multiple resources

### DIFF
--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -49,7 +49,7 @@
 
                     <%= f.input :comment %>
 
-                    <fieldset style="margin-bottom: 2rem;" class='w-50'>
+                    <fieldset style="margin-bottom: 2rem;" class='w-70'>
                       <legend>Items in this adjustment</legend>
                       <div id="adjustment_line_items" class="line-item-fields" data-capture-barcode="true">
                         <%= f.simple_fields_for :line_items do |item| %>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -89,7 +89,7 @@
       </div>
     </div>
 
-    <fieldset style="margin-bottom: 2rem;" class='w-50'>
+    <fieldset style="margin-bottom: 2rem;" class='w-70'>
       <legend>Items in this donation</legend>
       <div id="donation_line_items" data-capture-barcode="true">
 

--- a/app/views/kits/_form.html.erb
+++ b/app/views/kits/_form.html.erb
@@ -19,7 +19,7 @@
                 <%= f.input_field :value_in_dollars, class: "form-control", min: 0 %>
               <% end %>
 
-              <fieldset style="margin-bottom: 2rem;" class='w-50'>
+              <fieldset style="margin-bottom: 2rem;" class='w-70'>
                 <legend>Items in this Kit</legend>
                 <div id="kit_line_items" class="line-item-fields" data-capture-barcode="true">
                   <%= f.simple_fields_for :line_items do |item| %>

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -48,7 +48,7 @@
       </div>
     </div>
 
-    <fieldset style="margin-bottom: 2rem;" class='w-50'>
+    <fieldset style="margin-bottom: 2rem;" class='w-70'>
       <legend>Items in this purchase</legend>
       <div id="purchase_line_items" data-capture-barcode="true">
 

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -50,7 +50,7 @@
 
                     <%= f.input :comment %>
 
-                    <fieldset style="margin-bottom: 2rem;" class='w-50'>
+                    <fieldset style="margin-bottom: 2rem;" class='w-70'>
                       <legend>Items in this donation</legend>
                       <div id="transfer_line_items" class="line-item-fields" data-capture-barcode="true">
                         <%= f.simple_fields_for :line_items do |item| %>


### PR DESCRIPTION
Closes #2544

### Description
This was a minor CSS fix. I found all relevant instances of w-50 class
being used where it was constraining the line item fields and expanded
them to w-70.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Visit:

 - /app/adjustments/new
 - /app/donations/new
 - /app/kits/new
 - /app/purchases/new
 - /app/transfers/new

and confirm on each that the width of the form wraps correctly.

Not really practical to test this with specs.

### Screenshots
See description. It's all like that.