### PR TITLE
Include partner user for partner requests so that the seed script doesn't hit validation error

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -318,7 +318,8 @@ note = [
     pr = Partners::Request.new(
       comments: Faker::Lorem.paragraph,
       partner: partner,
-      for_families: Faker::Boolean.boolean
+      for_families: Faker::Boolean.boolean,
+      partner_user: partner.primary_user
     )
 
     # Ensure that the item requests are valid with


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2552

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
This updates the issue keeping the seed script from completing. It fills in the partner's primary user as the `partner_user` for the `Partners::Request` created in the seed.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Drop the data base
Run `bin/setup`
see the script complete

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
Verify the issue by dropping the database and trying to run the `bin/setup`. It fails due to a model validation.

