### PR TITLE
Stop webmock from spawning too many connections

### DIFF
--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -4,4 +4,4 @@ allowed_sites = [
   "https://github.com/mozilla/geckodriver/releases",
   "https://selenium-release.storage.googleapis.com"
 ]
-WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
+WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites, net_http_connect_on_start: true)


### PR DESCRIPTION
### Description
I've noticed that system specs can sometimes spawn too many connections and hit the OS `ulimit`.

This is a [known issue](https://github.com/teamcapybara/capybara#gotchas) when using capybara with webmock.
The workaround is also documented [here](https://github.com/bblimke/webmock/blob/master/README.md#connecting-on-nethttpstart).

### Type of change

* Dev environment bug fix (non-breaking change which fixes an issue)
