### PR TITLE
Store screenshots of failed browser test

### DIFF
--- a/spec/system/account_request_system_spec.rb
+++ b/spec/system/account_request_system_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Account request flow', type: :system, js: true do
 
     it 'should prompt prospective users to request an account on the live app' do
       visit new_account_request_path
-      expect(page).to have_link('click here', href: 'https://diaper.app/account_requests/blah')
+      expect(page).to have_link('click here', href: 'https://diaper.app/account_requests/new')
     end
   end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2488

### Description
Change GitHub workflow to upload artifacts from /tmp/screenshots which is where capybara saves screenshots from failed tests

I forced a system test to fail to verify this works here: https://github.com/rubyforgood/human-essentials/actions/runs/1339442747
 
### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

By forcing a system test to fail and seeing [artifacts uploaded to GitHub](https://github.com/rubyforgood/human-essentials/actions/runs/1339442747).
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
