### PR TITLE
Fix bug to display sign out confirmation message.

### DIFF
--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |key, message| %>
   <div class="<%= flash_class(key) %> alert-dismissible" role="alert">
     <a href="#" class="close" data-dismiss="alert" aria-label="close" style="text-decoration: none;"><%= fa_icon('times') %></a>
-    <%== message %>
+    <%= message %>
   </div>
 <% end %>

--- a/app/views/shared/_flash_tailwind.html.erb
+++ b/app/views/shared/_flash_tailwind.html.erb
@@ -1,0 +1,45 @@
+<% if flash.any? %>
+  <div class="fixed inset-12 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-center z-50" data-flash-notifications='true'>
+
+    <% flash.each do |msg_type, msg| %>
+
+      <div x-data="{flashVisible: false, flashType: '<%= msg_type %>'}" x-show='flashVisible' x-init="() => {flashVisible=true; setTimeout(() => {flashVisible=false}, 5000)}" class="max-w-sm w-full bg-white shadow-lg rounded-lg pointer-events-auto"
+           x-transition:enter="transition ease-out duration-300"
+           x-transition:enter-start="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
+           x-transition:enter-end="translate-y-0 opacity-100 sm:translate-x-0"
+           x-transition:leave="transition ease-out duration-100"
+           x-transition:leave-start="transform opacity-100"
+           x-transition:leave-end="transform opacity-0">
+        <div class="rounded-lg shadow-xs overflow-hidden">
+          <div class="p-4">
+            <div class="flex items-start">
+              <div class="flex-shrink-0">
+                <svg class="h-6 w-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                     x-bind:class="{'text-green-400': flashType == 'success' || 'notice', 'text-red-500': flashType == 'error', 'text-yellow-300': flashType == 'alert'}">
+                  <path x-show="flashType == 'success'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  <path x-show="flashType == 'alert'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                  <path x-show="flashType == 'error'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                  <path x-show="flashType == 'notice'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+              </div>
+              <div class="ml-3 w-0 flex-1 pt-0.5">
+                <p class="text-sm leading-5 font-medium text-gray-900">
+                  <%= msg %>
+                </p>
+              </div>
+              <div class="ml-4 flex-shrink-0 flex">
+                <button x-on:click="flashVisible = false" class="inline-flex text-gray-400 focus:outline-none focus:text-gray-500 transition ease-in-out duration-150">
+                  <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    <% end %>
+
+  </div>
+<% end %>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body>
-
+  <%= render partial: "shared/flash_tailwind" %>
   <div class='pt-2' style="background: linear-gradient(135deg, #3023AE, #C86DD7)">
       <div class="container max-w-7xl mx-auto pt-5 px-5">
         <nav>
@@ -30,7 +30,7 @@
                 <a class="hidden md:block" href="#about">About</a>
                 <a class="hidden md:block" href="#testimonials">Testimonials</a>
                 <a class="hidden md:block" href="#contact">Contact</a>
-
+                
                 <div @click.away="open = false" class="relative" x-data="{ open: false }">
                   <button @click="open = !open" class="flex flex-row items-center w-full px-4 py-2 bg-green-500 hover:bg-green-600 rounded-2xl text-md">
                     <span class='text-lg'>Login</span>


### PR DESCRIPTION
Resolves [#2561](https://github.com/rubyforgood/human-essentials/issues/2561)

### Description

We added a partial, `_flash_tailwind.html.erb`, that renders Tailwind specific flash messages. The file can be used for any flash message, adjusting styling for each type. It could be useful if the entire UI is refactored with Tailwind in the future. We rendered it on the home page to alert the user about successfully signing out. We also fixed a typo in the `_flash.html.erb` view.

Something to also consider; the buttons on the home page and profile are "Log in" and "Log out", but the flash messages use "Signed in" and "Signed out". Maybe the messages can be changed to match the button text.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Logged in and logged out as multiple partners and banks to make sure the message appeared.

### Screenshots

![Screen Shot 2021-10-14 at 10 58 19 AM](https://user-images.githubusercontent.com/84349455/137343952-23d197aa-7eb8-4a33-a74b-4e820bf5f84c.png)

