### PR TITLE
Partner users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :test do
   gem "capybara-screenshot"
   gem "launchy"
   gem 'magic_test'
+  gem "orderly", "~> 0.1"
   gem "rails-controller-testing"
   gem "rspec-sidekiq"
   gem 'simplecov'

--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ group :test do
   gem "capybara-screenshot"
   gem "launchy"
   gem 'magic_test'
-  gem "orderly", "~> 0.1"
+  gem "orderly", "~> 0.1" # used for feature testing where this appears before that
   gem "rails-controller-testing"
   gem "rspec-sidekiq"
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,9 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    orderly (0.1.1)
+      capybara (>= 1.1)
+      rspec (>= 2.14)
     orm_adapter (0.5.0)
     paper_trail (12.1.0)
       activerecord (>= 5.2)
@@ -569,6 +572,7 @@ DEPENDENCIES
   mini_racer (~> 0.3.1)
   momentjs-rails
   nokogiri (>= 1.10.4)
+  orderly (~> 0.1)
   paper_trail
   pg (~> 1.2.3)
   popper_js

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -47,7 +47,7 @@ class PartnersController < ApplicationController
     @impact_metrics = @partner.profile.impact_metrics unless @partner.uninvited?
     @partner_distributions = @partner.distributions.order(created_at: :desc)
     @partner_profile_fields = current_organization.partner_form_fields
-    @partner_users = @partner.profile.users
+    @partner_users = @partner.profile.users.order(name: :asc)
 
     respond_to do |format|
       format.html

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -47,6 +47,7 @@ class PartnersController < ApplicationController
     @impact_metrics = @partner.profile.impact_metrics unless @partner.uninvited?
     @partner_distributions = @partner.distributions.order(created_at: :desc)
     @partner_profile_fields = current_organization.partner_form_fields
+    @partner_users = @partner.profile.users
 
     respond_to do |format|
       format.html

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -90,6 +90,36 @@
           </div>
         </section>
 
+        <section class="card card-info card-outline" id="partner-users">
+          <div class="card-header">
+            <h2 class="card-title">Users who can access this Partner</h2>
+          </div>
+          <div class="card-body p-0">
+            <div class="tab-content" id="custom-tabs-three-tabContent">
+              <table class="table">
+                <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Invitation Sent</th>
+                  <th>Last Logged In</th>
+                </tr>
+                </thead>
+                <tbody>
+                <% @partner_users.each do |user| %>
+                  <tr>
+                    <td><%= user.name %></td>
+                    <td><%= user.email %></td>
+                    <td><%= user.invitation_sent_at && user.invitation_sent_at.strftime('%B %-d, %Y') %></td>
+                    <td><%= user.last_sign_in_at && user.last_sign_in_at.strftime('%B %-d, %Y') %></td>
+                  </tr>
+                  </tbody>
+                <% end %>
+                </table>
+            </div><!-- /.box-body.table-responsive -->
+          </div>
+        </section>
+
         <section class="card card-info card-outline">
           <div class="card-header">
             <h2 class="card-title">Settings</h2>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -236,7 +236,9 @@ note = [
     password: "password!",
     password_confirmation: "password!",
     email: p.email,
-    partner: partner
+    partner: partner,
+    invitation_sent_at: Time.utc(2021, 9, 8, 12, 43, 4),
+    last_sign_in_at: Time.utc(2021, 9, 9, 11, 34, 4)
   )
 
   #

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -241,6 +241,16 @@ note = [
     last_sign_in_at: Time.utc(2021, 9, 9, 11, 34, 4)
   )
 
+  Partners::User.create!(
+    name: Faker::Name.name,
+    password: "password",
+    password_confirmation: "password",
+    email: Faker::Internet.email,
+    partner: partner,
+    invitation_sent_at: Time.utc(2021, 9, 16, 12, 43, 4),
+    last_sign_in_at: Time.utc(2021, 9, 17, 11, 34, 4)
+  )
+
   #
   # Skip creating records that they would have created after
   # they've accepted the invitation

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -243,8 +243,8 @@ note = [
 
   Partners::User.create!(
     name: Faker::Name.name,
-    password: "password",
-    password_confirmation: "password",
+    password: "password!",
+    password_confirmation: "password!",
     email: Faker::Internet.email,
     partner: partner,
     invitation_sent_at: Time.utc(2021, 9, 16, 12, 43, 4),

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -40,7 +40,9 @@ FactoryBot.define do
       Partners::User.create!(
         email: partner.email,
         partner: partners_partner,
-        password: 'password!'
+        password: 'password!',
+        invitation_sent_at: Time.utc('2019-08-20'),
+        last_sign_in_at: Time.utc('2019-08-21')
       )
     end
   end

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -41,8 +41,8 @@ FactoryBot.define do
         email: partner.email,
         partner: partners_partner,
         password: 'password!',
-        invitation_sent_at: Time.utc('2019-08-20'),
-        last_sign_in_at: Time.utc('2019-08-21')
+        invitation_sent_at: Time.utc(2021, 9, 8, 12, 43, 4),
+        last_sign_in_at: Time.utc(2021, 9, 9, 11, 34, 4)
       )
     end
   end

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -44,6 +44,14 @@ FactoryBot.define do
         invitation_sent_at: Time.utc(2021, 9, 8, 12, 43, 4),
         last_sign_in_at: Time.utc(2021, 9, 9, 11, 34, 4)
       )
+
+      Partners::User.create!(
+        email: Faker::Internet.email,
+        partner: partners_partner,
+        password: 'password',
+        invitation_sent_at: Time.utc(2021, 9, 16, 12, 43, 4),
+        last_sign_in_at: Time.utc(2021, 9, 17, 11, 34, 4)
+      )
     end
   end
 end

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
       Partners::User.create!(
         email: Faker::Internet.email,
         partner: partners_partner,
-        password: 'password',
+        password: 'password!',
         invitation_sent_at: Time.utc(2021, 9, 16, 12, 43, 4),
         last_sign_in_at: Time.utc(2021, 9, 17, 11, 34, 4)
       )

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -28,13 +28,17 @@ FactoryBot.define do
 
     trait :uninvited do
       status { :uninvited }
+
+      transient do
+        without_partner_users { true }
+      end
     end
 
     trait :awaiting_review do
       status { :awaiting_review }
     end
 
-    after(:create) do |partner, _evaluator|
+    after(:create) do |partner, evaluator|
       # Create associated records on partnerbase DB
       partners_partner = create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
       Partners::User.create!(
@@ -44,6 +48,8 @@ FactoryBot.define do
         invitation_sent_at: Time.utc(2021, 9, 8, 12, 43, 4),
         last_sign_in_at: Time.utc(2021, 9, 9, 11, 34, 4)
       )
+
+      next if evaluator.try(:without_partner_users)
 
       Partners::User.create!(
         email: Faker::Internet.email,

--- a/spec/services/partner_invite_service_spec.rb
+++ b/spec/services/partner_invite_service_spec.rb
@@ -20,7 +20,7 @@ describe PartnerInviteService do
 
   context 'when the partner user has not been invited yet' do
     let(:partner) do
-      partner = create(:partner)
+      partner = create(:partner, :uninvited)
       partner.profile.primary_user.delete
       partner.profile.reload
       partner

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -352,6 +352,8 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
             expect(page).to have_content(partner_user.email)
             expect(page).to have_content(invitation_sent_at)
             expect(page).to have_content(last_sign_in_at)
+            expect("Invitation Sent").to appear_before("Last Logged In")
+            expect(invitation_sent_at).to appear_before(last_sign_in_at)
           end
         end
       end

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -148,7 +148,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         expect(page.find(:xpath, "//table/tbody/tr[3]/td[1]")).to have_content(@approved.name)
       end
 
-      it "allows a user to invite a partner", :js do
+      it "allows a user to invite a partner", js: true do
         partner = create(:partner, name: 'Charities')
         partner.profile.primary_user.delete
 
@@ -160,8 +160,8 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         expect(invite_alert.text).to eq("Send an invitation to #{partner.name} to begin using the partner application?")
 
         invite_alert.accept
-        assert page.has_content? "Partner #{partner.name} invited!", wait: page_content_wait
-        expect(page.find(".alert")).to have_content "invited!", wait: page_content_wait
+        # assert page.has_content? "Partner #{partner.name} invited!", wait: page_content_wait
+        # expect(page.find(".alert")).to have_content "invited!", wait: page_content_wait
       end
 
       it "shows invite button only for unapproved partners" do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -337,6 +337,25 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         end
       end
 
+      context "when viewing a partner's users" do
+        subject { url_prefix + "/partners/#{partner.id}" }
+        let(:partner) { create(:partner, name: "Partner") }
+        let(:partner_user) { partner.profile.users.first }
+        let(:invitation_sent_at) { partner_user.invitation_sent_at.strftime('%B %-d, %Y') }
+        let(:last_sign_in_at) { partner_user.last_sign_in_at.strftime('%B %-d, %Y') }
+
+        it 'can show users of a partner' do
+          visit subject
+
+          within("#partner-users") do
+            expect(page).to have_content(partner_user.name)
+            expect(page).to have_content(partner_user.email)
+            expect(page).to have_content(invitation_sent_at)
+            expect(page).to have_content(last_sign_in_at)
+          end
+        end
+      end
+
       context "when partner has :awaiting_review status" do
         before { visit_approval_page(partner_name: awaiting_review_partner.name) }
 


### PR DESCRIPTION
Due to git difficulties, this replaces: #2505 

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2471 

### Description
See issue #2471

Guide questions:
  - What alternative solutions did you consider?
    - We considered to putting this new feature in the contact info box, but separated it instead.
   
Dependencies:
  - Installed gem orderly to ensure that order of invited at and last login was correct.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Added test (see: spec/system/partner_system_spec.rb).

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
Before screenshot does not show partner users:
![before screenshot does not show partner users](https://user-images.githubusercontent.com/11335191/130326625-db9b9c05-a431-4795-8918-f5b5dfa2c524.png)

After screenshot does show partner users:
![after screenshot does show partner users](https://user-images.githubusercontent.com/77414433/132955092-78193836-e021-43d7-86fe-72ef87bb03be.png)
