### PR TITLE
sort item request dropdown

### DIFF
--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -6,7 +6,7 @@ module Partners
       requestable_items = PartnerFetchRequestableItemsService.new(partner_id: current_partner.partner.id).call
       @formatted_requestable_items = requestable_items.map do |rt|
         [rt.name, rt.id]
-      end
+      end.sort
     end
 
     def create

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -14,7 +14,7 @@ module Partners
       requestable_items = PartnerFetchRequestableItemsService.new(partner_id: current_partner.partner.id).call
       @formatted_requestable_items = requestable_items.map do |rt|
         [rt.name, rt.id]
-      end
+      end.sort
     end
 
     def show
@@ -56,4 +56,3 @@ module Partners
     end
   end
 end
-


### PR DESCRIPTION
Not sure if removing the `.sort` in #2131 was intentional. This puts it back in.