### PR TITLE
Fix NDBM.org diaper-need URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are numerous other folks that can chime in and answer questions -- please 
 
 ## About
 
-This application is an inventory management system that is built to address the needs of [Diaper Banks](https://nationaldiaperbanknetwork.org/diaper-need-facts/) as directly and explicitly as possible. Diaper Banks maintain inventory, receive donations and other means of intaking diapers (and related supplies), and issue Distributions to community partner organizations. Like any non-profit, they also need to perform reports on this data, and have day-to-day operational information they need as well. This application aims to serve all those needs, as well as facilitate, wherever possible the general operations of the Diaper Bank themselves (eg. through using barcode readers, scale weighing, inventory audits).
+This application is an inventory management system that is built to address the needs of [Diaper Banks](https://nationaldiaperbanknetwork.org/diaper-need/) as directly and explicitly as possible. Diaper Banks maintain inventory, receive donations and other means of intaking diapers (and related supplies), and issue Distributions to community partner organizations. Like any non-profit, they also need to perform reports on this data, and have day-to-day operational information they need as well. This application aims to serve all those needs, as well as facilitate, wherever possible the general operations of the Diaper Bank themselves (eg. through using barcode readers, scale weighing, inventory audits).
 
 For a general overview of the application, please see the [Application Overview](https://github.com/rubyforgood/human-essentials/wiki/Application-Overview) wiki article.
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description
`.../diaper-need-facts`, used in the `README`, is 404 (7 Dec 2021)
This PR replaces it with with `.../diaper-need/` which exists and appears to fulfill the intent.

### Type of change
* Documentation update

### How Has This Been Tested?

Manually


### Other notes

Clearly not _critical_ — I just noticed it while reading up on the project and looking for Issue(s) to work on.
