### PR TITLE
Small method to add a user to a partner when they update a partners e…

### DIFF
--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -100,6 +100,19 @@ RSpec.describe Partner, type: :model, skip_seed: true do
     end
   end
 
+  describe '#invite_new_partner' do
+    let(:partner) { create(:partner) }
+
+    it "should call the PartnerUser.invite! when the partner is changed" do
+      allow(PartnerUser).to receive(:invite!)
+      partner.email = "randomtest@email.com"
+      partner.save!
+      expect(PartnerUser).to have_received(:invite!).with(
+        {email: "randomtest@email.com", partner: partner.profile}
+      )
+    end
+  end
+
   describe '#profile' do
     subject { partner.profile }
     let(:partner) { create(:partner) }


### PR DESCRIPTION
…mail.

Several banks have been confused about adding a new partner. They expect that when they change a partner's email that the new email entered will be added as a partner.

I added a small callback to check for a changed email and if there is to invite that person as a new partner.