### PR TITLE
Add libv8-node & nokogiri '-darwin' versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,7 @@ GEM
     letter_opener (1.7.0)
       launchy (~> 2.2)
     libv8-node (16.10.0.0-arm64-darwin)
+    libv8-node (16.10.0.0-x86_64-darwin)
     libv8-node (16.10.0.0-x86_64-linux)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -286,6 +287,8 @@ GEM
     nenv (0.3.0)
     nio4r (2.5.8)
     nokogiri (1.12.5-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
@@ -531,6 +534,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
### Description
My MBPro (2.3 GHz 8-Core Intel Core i9; macOS 12.1 (21C52)) seems to "wish" these changes had been in #2636 / ca1a1851—`bundle install` keeps adding them, so I offer them in case they help anyone else.

### Type of change
Bug fix (non-breaking change which fixes an issue) (🤷‍♂️)

### How Has This Been Tested?

Ran specs; only failure on initial run passed on re-run