### PR TITLE
Restore schema version to match contents

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_730_153_347) do
+ActiveRecord::Schema.define(version: 2021_09_24_162800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Without this change:
```
$ bundle exec rails db:reset
Dropped database 'diaper_dev'
Dropped database 'partner_dev'
Dropped database 'diaper_test'
Dropped database 'partner_test'
Created database 'diaper_dev'
Created database 'partner_dev'
Created database 'diaper_test'
Created database 'partner_test'
You have 1 pending migration:
  20210924162800 AddPartnerUserIdToRequests
Run `bin/rails db:migrate` to update your database then try again.

$ bundle exec rails db:migrate
== 20210924162800 AddPartnerUserIdToRequests: migrating =======================
-- add_column(:requests, :partner_user_id, :integer, {:default=>nil})
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::DuplicateColumn: ERROR:  column "partner_user_id" of relation "requests" already exists
[path]/db/migrate/20210924162800_add_partner_user_id_to_requests.rb:4:in `change'

Caused by:
ActiveRecord::StatementInvalid: PG::DuplicateColumn: ERROR:  column "partner_user_id" of relation "requests" already exists
[path]/db/migrate/20210924162800_add_partner_user_id_to_requests.rb:4:in `change'

Caused by:
PG::DuplicateColumn: ERROR:  column "partner_user_id" of relation "requests" already exists
[path]/db/migrate/20210924162800_add_partner_user_id_to_requests.rb:4:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)

$ bundle exec rails db:migrate:status

database: diaper_dev

 Status   Migration ID    Migration Name
--------------------------------------------------
   up     20160617195143  Create donations
[...]
   up     20210730153347  Create delayed jobs
  down    20210924162800  Add partner user id to requests
```

425906d overwrote the version with 30 July 2021 15:33:47's—presumably during the merge—but did not remove the 24 Sep 2021 version's schema changes.

### Description
The simplest fix is simply to restore the later version.

#### Version/Date Formatting
If you are concerned about the version number's format change, please recall that the `_`s simply break up the integer value for human readability. The format changed to `YYYY_MM_DD_HHMMSS` in 6f94bed, stayed this way for several subsequent commits, then changed back with 425906d.

It's interesting that 6f94bed's version (`2021_06_26_170605`) predates 425906d's July date; I can't explain why 425906d has the earlier format 🤷‍♂️

#### Array Formatting Ignored
Another "format change" through history has been how arrays are specified. For example, 6f94bed also replaced `%w(...)` with `["...", ...]`:
```
@@ -32,7 +33,7 @@ ActiveRecord::Schema.define(version: 20_210_517_000_207) do
     t.bigint "record_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index %w(record_type record_id name), name: "index_action_text_rich_texts_uniqueness", unique: true
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
```

and 425906d changed some back.

I did **not** revisit any of that.

### Type of change

Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I manually reproduced it on cb440a5 as shown above.

With the fix in place:
```
$ bundle exec rails db:reset                                       
Dropped database 'diaper_dev'
Dropped database 'partner_dev'
Dropped database 'diaper_test'
Dropped database 'partner_test'
Created database 'diaper_dev'
Created database 'partner_dev'
Created database 'diaper_test'
Created database 'partner_test'
```
 then successfully ran specs and `rubocop`