### PR TITLE
Add in two new columns to the organization model 

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -74,6 +74,7 @@ class OrganizationsController < ApplicationController
       :zipcode, :email, :url, :logo, :intake_location,
       :default_storage_location, :default_email_text,
       :invitation_text, :reminder_day, :deadline_day,
+      :repackage_essentials, :distribute_monthly,
       partner_form_fields: []
     )
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,10 @@ module ApplicationHelper
     end
   end
 
+  def humanize_boolean(boolean)
+    I18n.t((!!boolean).to_s)
+  end
+
   def default_title_content
     if current_organization
       current_organization.name
@@ -45,6 +49,7 @@ module ApplicationHelper
     when "alert" then "alert alert-warning"
     end
   end
+
   ## Devise overrides
 
   def after_sign_in_path_for(resource)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -6,6 +6,7 @@
 #  city                     :string
 #  deadline_day             :integer
 #  default_storage_location :integer
+#  distribute_monthly       :boolean          default(FALSE), not null
 #  email                    :string
 #  intake_location          :integer
 #  invitation_text          :text
@@ -14,6 +15,7 @@
 #  name                     :string
 #  partner_form_fields      :text             default([]), is an Array
 #  reminder_day             :integer
+#  repackage_essentials     :boolean          default(FALSE), not null
 #  short_name               :string
 #  state                    :string
 #  street                   :string

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -38,8 +38,6 @@
             </div>
             <!-- form start -->
             <div class="card-body">
-
-
               <div class="form-inputs">
                 <%= f.input :name, required: true, autofocus: true, wrapper: :input_group do %>
                   <span class="input-group-text"><i class="fa fa-user"></i></span>
@@ -87,7 +85,11 @@
                   <%= f.text_area :invitation_text, class: "form-control" %>
                 <% end %>
 
-                <% default_email_text_hint = "You can use the variables <code>%{partner_name}</code>, <code>%{delivery_method}</code>, <code>%{distribution_date}</code>, and <code>%{comment}</code> to include the partner's name, delivery method, distribution date, and comment in the email." %>
+
+                <%= f.input :repackage_essentials, label: 'Does your bank repackage essentials?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
+                <%= f.input :distribute_monthly, label: 'Does your bank distribute monthly?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
+
+                <% default_email_text_hint = "You can use the variables <code>%{partner_name}</code>, <code>%{delivery_method}</code>, <code>%{distribution_date}</code>, and <code>%{comment}</code> to include the partner's name, delivery method, distribution date, and comments sent in the request." %>
                 <%= f.input :default_email_text, label: "Distribution Email Content", hint: default_email_text_hint.html_safe do %>
                   <%= f.rich_text_area :default_email_text %>
                 <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -40,6 +40,18 @@
                   <address><%= fa_icon "map-marker" %> <%= @organization.address %></address>
                 </div>
                 <div>
+                  <h4>Repackage Essentials?</h4>
+                  <p><%= fa_icon "inbox" %>
+                    <%= humanize_boolean(@organization.repackage_essentials) %>
+                  </p>
+                </div>
+                <div>
+                  <h4>Distribute Monthly?</h4>
+                  <p><%= fa_icon "paper-plane" %>
+                    <%= humanize_boolean(@organization.distribute_monthly) %>
+                  </p>
+                </div>
+                <div>
                   <h4>Reminder day</h4>
                   <p><%= fa_icon "calendar" %>
                     <%= @organization.reminder_day.blank? ? 'Not defined' : "The #{@organization.reminder_day.ordinalize} of each month" %>

--- a/db/migrate/20211230033135_add_fields_to_organization.rb
+++ b/db/migrate/20211230033135_add_fields_to_organization.rb
@@ -1,0 +1,6 @@
+class AddFieldsToOrganization < ActiveRecord::Migration[6.1]
+  def change
+    add_column :organizations, :repackage_essentials, :boolean, null: false, default: false
+    add_column :organizations, :distribute_monthly, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_24_151329) do
+ActiveRecord::Schema.define(version: 2021_12_30_033135) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -183,8 +184,8 @@ ActiveRecord::Schema.define(version: 2021_12_24_151329) do
     t.integer "organization_id"
     t.datetime "issued_at"
     t.string "agency_rep"
-    t.integer "state", default: 5, null: false
     t.boolean "reminder_email_enabled", default: false, null: false
+    t.integer "state", default: 5, null: false
     t.integer "delivery_method", default: 0, null: false
     t.index ["organization_id"], name: "index_distributions_on_organization_id"
     t.index ["partner_id"], name: "index_distributions_on_partner_id"
@@ -338,6 +339,8 @@ ActiveRecord::Schema.define(version: 2021_12_24_151329) do
     t.integer "default_storage_location"
     t.text "partner_form_fields", default: [], array: true
     t.integer "account_request_id"
+    t.boolean "repackage_essentials", default: false, null: false
+    t.boolean "distribute_monthly", default: false, null: false
     t.index ["latitude", "longitude"], name: "index_organizations_on_latitude_and_longitude"
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end
@@ -455,7 +458,7 @@ ActiveRecord::Schema.define(version: 2021_12_24_151329) do
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -475,7 +478,8 @@ ActiveRecord::Schema.define(version: 2021_12_24_151329) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -6,6 +6,7 @@
 #  city                     :string
 #  deadline_day             :integer
 #  default_storage_location :integer
+#  distribute_monthly       :boolean          default(FALSE), not null
 #  email                    :string
 #  intake_location          :integer
 #  invitation_text          :text
@@ -14,6 +15,7 @@
 #  name                     :string
 #  partner_form_fields      :text             default([]), is an Array
 #  reminder_day             :integer
+#  repackage_essentials     :boolean          default(FALSE), not null
 #  short_name               :string
 #  state                    :string
 #  street                   :string

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -6,6 +6,7 @@
 #  city                     :string
 #  deadline_day             :integer
 #  default_storage_location :integer
+#  distribute_monthly       :boolean          default(FALSE), not null
 #  email                    :string
 #  intake_location          :integer
 #  invitation_text          :text
@@ -14,6 +15,7 @@
 #  name                     :string
 #  partner_form_fields      :text             default([]), is an Array
 #  reminder_day             :integer
+#  repackage_essentials     :boolean          default(FALSE), not null
 #  short_name               :string
 #  state                    :string
 #  street                   :string

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe "Organization management", type: :system, js: true do
         expect(page.find(".alert.alert-danger.alert-dismissible")).to have_content "Failed to update"
       end
 
+      it 'can select if the org repackages essentials' do
+        choose('organization[repackage_essentials]', option: true)
+
+        click_on "Save"
+        expect(page).to have_content("Yes")
+      end
+
+      it 'can select if the org distributes essentials monthly' do
+        choose('organization[distribute_monthly]', option: true)
+
+        click_on "Save"
+        expect(page).to have_content("Yes")
+      end
+
       it 'can set a default storage location on the organization' do
         select(store.name, from: 'Default Storage Location')
 


### PR DESCRIPTION
This PR adds in two new columns on the organization model to track if they repackage essentials and if they distribute monthly. The purpose of capturing this information is for reporting purposes to the national network.

I created the fields as booleans since they are simple yes/no questions.

Screenshot of the two fields on the organization edit page:

<img width="322" alt="image" src="https://user-images.githubusercontent.com/667909/147720157-dc1ebb39-ef6a-49c1-a24d-5f069e26b6bf.png">
