### PR TITLE
Speed up specs

### DIFF
--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -108,7 +108,7 @@ class StorageLocation < ApplicationRecord
   # NOTE: We should generalize this elsewhere -- Importable concern?
   def self.import_inventory(filename, org, loc)
     current_org = Organization.find(org)
-    adjustment = current_org.adjustments.create(storage_location_id: loc.to_i, user_id: current_org.users.find_by(organization_admin: true)&.id, comment: "Starting Inventory")
+    adjustment = current_org.adjustments.create!(storage_location_id: loc.to_i, user_id: current_org.users.find_by(organization_admin: true)&.id, comment: "Starting Inventory")
     # NOTE: this was originally headers: false; it may create buggy behavior
     CSV.parse(filename, headers: true) do |row|
       adjustment.line_items

--- a/spec/controllers/donation_sites_controller_spec.rb
+++ b/spec/controllers/donation_sites_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DonationSitesController, type: :controller do
+RSpec.describe DonationSitesController, type: :controller, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DonationsController, type: :controller do
+RSpec.describe DonationsController, type: :controller, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe HelpController, type: :controller do
+RSpec.describe HelpController, type: :controller, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ItemsController, type: :controller do
+RSpec.describe ItemsController, type: :controller, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe TransfersController, type: :controller do
+RSpec.describe TransfersController, type: :controller, skip_seed: true do
   context "While signed in" do
     before do
       sign_in(@user)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ApplicationHelper, type: :helper do
+RSpec.describe ApplicationHelper, type: :helper, skip_seed: true do
   describe "dashboard_path_from_user" do
     before(:each) do
       allow(helper).to receive(:current_user).and_return(user)

--- a/spec/helpers/diaper_driver_helper_spec.rb
+++ b/spec/helpers/diaper_driver_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe DiaperDriveHelper, type: :helper do
+RSpec.describe DiaperDriveHelper, type: :helper, skip_seed: true do
   describe '#is_virtual' do
     context 'when the diaper drive was held virtually' do
       let(:diaper_drive) { build(:diaper_drive, virtual: true) }

--- a/spec/helpers/partners_helper_spec.rb
+++ b/spec/helpers/partners_helper_spec.rb
@@ -10,7 +10,7 @@ require "rails_helper"
 #     end
 #   end
 # end
-RSpec.describe PartnersHelper, type: :helper do
+RSpec.describe PartnersHelper, type: :helper, skip_seed: true do
   # pending "add some examples to (or delete) #{__FILE__}"
   it "returns a generated path" do
     path_string = "/#{@organization.short_name}/organization"

--- a/spec/helpers/ui_helper_spec.rb
+++ b/spec/helpers/ui_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe UiHelper, type: :helper do
+RSpec.describe UiHelper, type: :helper, skip_seed: true do
   describe 'optional_data_text' do
     subject { helper.optional_data_text(field) }
 

--- a/spec/jobs/notify_partner_job_spec.rb
+++ b/spec/jobs/notify_partner_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe NotifyPartnerJob, job: true do
+RSpec.describe NotifyPartnerJob, job: true, skip_seed: true do
   describe "#perform" do
     let(:request) { create(:request) }
     let(:mailer) { double(:mailer) }

--- a/spec/jobs/partner_mailer_job_spec.rb
+++ b/spec/jobs/partner_mailer_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PartnerMailerJob, type: :job do
+RSpec.describe PartnerMailerJob, type: :job, skip_seed: true do
   describe "conditionally sending the emails" do
     let(:organization) { create :organization }
     let(:mailer_subject) { 'PartnerMailerJob subject' }

--- a/spec/jobs/reminder_deadline_job_spec.rb
+++ b/spec/jobs/reminder_deadline_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ReminderDeadlineJob, type: :job do
+RSpec.describe ReminderDeadlineJob, type: :job, skip_seed: true do
   let(:todays_day) { 10 }
   let(:not_today) { 11 }
   let(:deadline_day) { 20 }

--- a/spec/mailers/account_request_mailer_spec.rb
+++ b/spec/mailers/account_request_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AccountRequestMailer, type: :mailer do
+RSpec.describe AccountRequestMailer, type: :mailer, skip_seed: true do
   describe '#confirmation' do
     let(:mail) { AccountRequestMailer.confirmation(account_request_id: account_request_id) }
     let(:account_request_id) { account_request.id }

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionMailer, type: :mailer, :needs_users do
+RSpec.describe DistributionMailer, type: :mailer, needs_users: true do
   before do
     @organization.default_email_text = "Default email text example\n\n%{delivery_method} %{distribution_date}\n\n%{partner_name}\n\n%{comment}"
     @partner = create(:partner, name: 'PARTNER')

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionMailer, type: :mailer do
+RSpec.describe DistributionMailer, type: :mailer, :needs_users do
   before do
     @organization.default_email_text = "Default email text example\n\n%{delivery_method} %{distribution_date}\n\n%{partner_name}\n\n%{comment}"
     @partner = create(:partner, name: 'PARTNER')

--- a/spec/mailers/organization_mailer_spec.rb
+++ b/spec/mailers/organization_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe OrganizationMailer, type: :mailer do
+RSpec.describe OrganizationMailer, type: :mailer, skip_seed: true do
   describe "#partner_approval_request" do
     subject { described_class.partner_approval_request(organization: organization, partner: partner) }
     let(:partner) { create(:partner) }

--- a/spec/mailers/partner_mailer_spec.rb
+++ b/spec/mailers/partner_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PartnerMailer, type: :mailer do
+RSpec.describe PartnerMailer, type: :mailer, skip_seed: true do
   describe "#recertification_request" do
     subject { PartnerMailer.recertification_request(partner: partner) }
     let(:partner) { create(:partner) }

--- a/spec/mailers/reminder_deadline_mailer_spec.rb
+++ b/spec/mailers/reminder_deadline_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe ReminderDeadlineMailer do
+describe ReminderDeadlineMailer, skip_seed: true do
   describe 'notify deadline' do
     let(:organization) { create :organization }
     let!(:user) { create(:organization_admin, organization: organization) }

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RequestMailer, type: :mailer do
+RSpec.describe RequestMailer, type: :mailer, skip_seed: true do
   describe "#request_cancel_partner_notification" do
     subject { described_class.request_cancel_partner_notification(request_id: request.id) }
     let(:request) { create(:request) }

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RequestsConfirmationMailer, type: :mailer do
+RSpec.describe RequestsConfirmationMailer, type: :mailer, skip_seed: true do
   let(:request) { create(:request) }
 
   describe "#confirmation_email" do

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -14,7 +14,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe AccountRequest, type: :model do
+RSpec.describe AccountRequest, type: :model, skip_seed: true do
   describe 'associations' do
     it { should have_one(:organization).class_name('Organization') }
   end

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -11,7 +11,7 @@
 #  user_id             :bigint
 #
 
-RSpec.describe Adjustment, type: :model do
+RSpec.describe Adjustment, type: :model, needs_users: true do
   it_behaves_like "itemizable"
   it_behaves_like "pagination"
 

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -14,7 +14,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Audit, type: :model do
+RSpec.describe Audit, type: :model, needs_users: true do
   it_behaves_like "itemizable"
 
   context "Validations >" do

--- a/spec/models/barcode_item_spec.rb
+++ b/spec/models/barcode_item_spec.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples "common barcode tests" do |barcode_item_factory|
   end
 end
 
-RSpec.describe BarcodeItem, type: :model do
+RSpec.describe BarcodeItem, type: :model, skip_seed: true do
   context "Barcodes of BaseItems ('Global')" do
     let(:base_item) { create(:base_item) }
     let(:global_barcode_item) { create(:global_barcode_item, barcodeable: base_item) }

--- a/spec/models/diaper_drive_participant_spec.rb
+++ b/spec/models/diaper_drive_participant_spec.rb
@@ -18,7 +18,7 @@
 
 require "rails_helper"
 
-RSpec.describe DiaperDriveParticipant, type: :model do
+RSpec.describe DiaperDriveParticipant, type: :model, skip_seed: true do
   it_behaves_like "provideable"
 
   context "Validations" do

--- a/spec/models/diaper_drive_spec.rb
+++ b/spec/models/diaper_drive_spec.rb
@@ -14,7 +14,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DiaperDrive, type: :model do
+RSpec.describe DiaperDrive, type: :model, skip_seed: true do
   let!(:diaper_drive) { create(:diaper_drive) }
   let!(:donation) { create(:donation, :with_items, item_quantity: 7, diaper_drive: diaper_drive) }
   let!(:donation2) { create(:donation, :with_items, item_quantity: 9, diaper_drive: diaper_drive) }

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -16,7 +16,7 @@
 #  storage_location_id    :integer
 #
 
-RSpec.describe Distribution, type: :model do
+RSpec.describe Distribution, type: :model, skip_seed: true do
   it_behaves_like "itemizable"
 
   context "Validations >" do

--- a/spec/models/donation_site_spec.rb
+++ b/spec/models/donation_site_spec.rb
@@ -12,7 +12,7 @@
 #  organization_id :integer
 #
 
-RSpec.describe DonationSite, type: :model do
+RSpec.describe DonationSite, type: :model, skip_seed: true do
   context "Validations >" do
     it "must belong to an organization" do
       expect(build(:donation_site, organization_id: nil)).not_to be_valid

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -17,7 +17,7 @@
 #  storage_location_id         :integer
 #
 
-RSpec.describe Donation, type: :model do
+RSpec.describe Donation, type: :model, needs_users: true do
   it_behaves_like "itemizable"
   it_behaves_like "pagination"
 

--- a/spec/models/inventory_item_spec.rb
+++ b/spec/models/inventory_item_spec.rb
@@ -10,7 +10,7 @@
 #  storage_location_id :integer
 #
 
-RSpec.describe InventoryItem, type: :model do
+RSpec.describe InventoryItem, type: :model, skip_seed: true do
   context "Validations >" do
     describe "quantity >" do
       it "is required" do

--- a/spec/models/item_category_spec.rb
+++ b/spec/models/item_category_spec.rb
@@ -11,7 +11,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe ItemCategory, type: :model do
+RSpec.describe ItemCategory, type: :model, skip_seed: true do
   describe 'validations' do
     subject { build(:item_category) }
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -21,7 +21,7 @@
 #  organization_id              :integer
 #
 
-RSpec.describe Item, type: :model do
+RSpec.describe Item, type: :model, skip_seed: true do
   describe 'Assocations >' do
     it { should belong_to(:item_category).optional }
   end

--- a/spec/models/kit_spec.rb
+++ b/spec/models/kit_spec.rb
@@ -13,7 +13,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe Kit, type: :model do
+RSpec.describe Kit, type: :model, skip_seed: true do
   let(:kit) { build(:kit, name: "Test Kit") }
 
   context "Validations >" do

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -11,7 +11,7 @@
 #  itemizable_id   :integer
 #
 
-RSpec.describe LineItem, type: :model do
+RSpec.describe LineItem, type: :model, skip_seed: true do
   let(:line_item) { build :line_item }
 
   context "Validations >" do

--- a/spec/models/manufacturer_spec.rb
+++ b/spec/models/manufacturer_spec.rb
@@ -11,7 +11,7 @@
 
 require "rails_helper"
 
-RSpec.describe Manufacturer, type: :model do
+RSpec.describe Manufacturer, type: :model, skip_seed: true do
   context "Validations" do
     it "must belong to an organization" do
       expect(build(:manufacturer, organization: nil)).not_to be_valid

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe Organization, type: :model do
 
     context "when no organization is provided" do
       it "updates all organizations" do
+        Organization.seed_items(@organization)
         second_organization = create(:organization)
         organization_item_count = @organization.items.size
         second_organization_item_count = second_organization.items.size

--- a/spec/models/organization_stats_spec.rb
+++ b/spec/models/organization_stats_spec.rb
@@ -1,7 +1,7 @@
 # == No Schema Information
 #
 
-RSpec.describe OrganizationStats, type: :model do
+RSpec.describe OrganizationStats, type: :model, skip_seed: true do
   let(:partners) { [] }
   let(:storage_locations) { [] }
   let(:donation_sites) { [] }

--- a/spec/models/partner_group_spec.rb
+++ b/spec/models/partner_group_spec.rb
@@ -8,7 +8,7 @@
 #  updated_at      :datetime         not null
 #  organization_id :bigint
 #
-RSpec.describe PartnerGroup, type: :model do
+RSpec.describe PartnerGroup, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:organization) }
     it { should have_many(:partners) }

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -15,7 +15,7 @@
 #  partner_group_id :bigint
 #
 
-RSpec.describe Partner, type: :model do
+RSpec.describe Partner, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:organization) }
     it { should belong_to(:partner_group).optional }

--- a/spec/models/partners/authorized_family_member_spec.rb
+++ b/spec/models/partners/authorized_family_member_spec.rb
@@ -14,7 +14,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::AuthorizedFamilyMember, type: :model do
+RSpec.describe Partners::AuthorizedFamilyMember, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:family) }
     it { should have_many(:child_item_requests).dependent(:nullify) }

--- a/spec/models/partners/child_item_request_spec.rb
+++ b/spec/models/partners/child_item_request_spec.rb
@@ -14,7 +14,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe Partners::ChildItemRequest, type: :model do
+RSpec.describe Partners::ChildItemRequest, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:item_request) }
     it { should belong_to(:child) }

--- a/spec/models/partners/child_spec.rb
+++ b/spec/models/partners/child_spec.rb
@@ -21,7 +21,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::Child, type: :model do
+RSpec.describe Partners::Child, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:family) }
     it { should have_many(:child_item_requests).dependent(:destroy) }

--- a/spec/models/partners/family_spec.rb
+++ b/spec/models/partners/family_spec.rb
@@ -26,7 +26,7 @@
 
 require "rails_helper"
 
-RSpec.describe Partners::Family, type: :model do
+RSpec.describe Partners::Family, type: :model, skip_seed: true do
   describe "associations" do
     it { should belong_to(:partner) }
     it { should have_many(:children).dependent(:destroy) }

--- a/spec/models/partners/item_request_spec.rb
+++ b/spec/models/partners/item_request_spec.rb
@@ -13,7 +13,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::ItemRequest, type: :model do
+RSpec.describe Partners::ItemRequest, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:request).class_name('Partners::Request').with_foreign_key(:partner_request_id) }
     it { should have_many(:child_item_requests).dependent(:destroy) }

--- a/spec/models/partners/partner_form_spec.rb
+++ b/spec/models/partners/partner_form_spec.rb
@@ -10,7 +10,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::PartnerForm, type: :model do
+RSpec.describe Partners::PartnerForm, type: :model, skip_seed: true do
   describe 'associations' do
     it { should have_one(:partner).with_primary_key(:diaper_bank_id).with_foreign_key(:diaper_bank_id) }
   end

--- a/spec/models/partners/partner_spec.rb
+++ b/spec/models/partners/partner_spec.rb
@@ -87,7 +87,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::Partner, type: :model do
+RSpec.describe Partners::Partner, type: :model, skip_seed: true do
   describe 'associations' do
     it { should have_many(:users).dependent(:destroy) }
     it { should have_many(:requests).dependent(:destroy) }

--- a/spec/models/partners/request_spec.rb
+++ b/spec/models/partners/request_spec.rb
@@ -14,7 +14,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::Request, type: :model do
+RSpec.describe Partners::Request, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:partner) }
     it { should have_many(:item_requests).dependent(:destroy) }

--- a/spec/models/partners/user_spec.rb
+++ b/spec/models/partners/user_spec.rb
@@ -28,7 +28,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::User, type: :model do
+RSpec.describe Partners::User, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:partner) }
     # TODO: make this spec work.

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -14,7 +14,7 @@
 #  vendor_id             :integer
 #
 
-RSpec.describe Purchase, type: :model do
+RSpec.describe Purchase, type: :model, skip_seed: true do
   it_behaves_like "itemizable"
 
   context "Validations >" do

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe StorageLocation, type: :model do
       end
     end
 
-    describe "import_inventory" do
+    describe "import_inventory", needs_users: true do
       it "imports storage locations from a csv file" do
         donations_count = Donation.count
         storage_location = create(:storage_location, organization_id: @organization.id)

--- a/spec/models/transfer_spec.rb
+++ b/spec/models/transfer_spec.rb
@@ -11,7 +11,7 @@
 #  to_id           :integer
 #
 
-RSpec.describe Transfer, type: :model do
+RSpec.describe Transfer, type: :model, skip_seed: true do
   it_behaves_like "itemizable"
 
   context "Validations >" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe User, type: :model do
       let!(:a_name_user) { create(:user, name: 'Amanda') }
 
       it "retrieves users in the correct order" do
+        create_default_users
         alphabetized_list = described_class.alphabetized
 
         expect(alphabetized_list.first).to eq(a_name_user)
@@ -78,6 +79,7 @@ RSpec.describe User, type: :model do
       let!(:deactivated_z_name_user) { create(:user, name: 'Zeke', discarded_at: discarded_at) }
 
       it "retrieves users in the correct order" do
+        create_default_users
         alphabetized_list = described_class.with_discarded.alphabetized
 
         expect(alphabetized_list).to eq(

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -18,7 +18,7 @@
 
 require "rails_helper"
 
-RSpec.describe Vendor, type: :model do
+RSpec.describe Vendor, type: :model, skip_seed: true do
   it_behaves_like "provideable"
 
   context "Methods" do

--- a/spec/queries/items_in_query_spec.rb
+++ b/spec/queries/items_in_query_spec.rb
@@ -1,6 +1,6 @@
 # Spec for /app/queries/items_in_query.rb
 
-RSpec.describe ItemsInQuery do
+RSpec.describe ItemsInQuery, skip_seed: true do
   let!(:storage_location) { create(:storage_location, organization: @organization) }
   let!(:other_storage_location) { create(:storage_location, :with_items, item: create(:item), item_quantity: 10, organization: @organization) }
   subject { ItemsInQuery.new(storage_location: storage_location, organization: @organization).call }

--- a/spec/queries/items_in_total_query_spec.rb
+++ b/spec/queries/items_in_total_query_spec.rb
@@ -1,6 +1,6 @@
 # Spec for /app/queries/items_in_total_query.rb
 
-RSpec.describe ItemsInTotalQuery do
+RSpec.describe ItemsInTotalQuery, skip_seed: true do
   let!(:storage_location) { create(:storage_location, organization: @organization) }
   let!(:other_storage_location) { create(:storage_location, :with_items, item: create(:item), item_quantity: 10, organization: @organization) }
   let!(:shared_item) { create(:item) }

--- a/spec/queries/items_out_query_spec.rb
+++ b/spec/queries/items_out_query_spec.rb
@@ -1,6 +1,6 @@
 # Spec for /app/queries/items_out_query.rb
 
-RSpec.describe ItemsOutQuery do
+RSpec.describe ItemsOutQuery, skip_seed: true do
   let!(:storage_location) { create(:storage_location, organization: @organization) }
   subject { ItemsOutQuery.new(storage_location: storage_location, organization: @organization).call }
 

--- a/spec/queries/items_out_total_query_spec.rb
+++ b/spec/queries/items_out_total_query_spec.rb
@@ -1,6 +1,6 @@
 # Spec for /app/queries/items_out_total_query.rb
 
-RSpec.describe ItemsOutTotalQuery do
+RSpec.describe ItemsOutTotalQuery, skip_seed: true do
   let!(:storage_location) { create(:storage_location, organization: @organization) }
   subject { ItemsOutTotalQuery.new(storage_location: storage_location, organization: @organization).call }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -221,7 +221,15 @@ RSpec.configure do |config|
       # If you are using :truncation, it will erase everything once `.clean`
       # is called.
       seed_base_items_for_tests
-      seed_with_default_records unless example.metadata[:skip_seed]
+
+      # Always create organization, almost no tests can be run without one
+      Rails.logger.info "\n\n-~=> Creating DEFAULT organization & partner"
+      @organization = create(:organization, name: "DEFAULT", skip_items: true)
+
+      unless example.metadata[:skip_seed]
+        Organization.seed_items(@organization)
+        seed_with_default_records
+      end
     end
   end
 
@@ -312,8 +320,6 @@ def __sweep_up_db_with_log
 end
 
 def seed_with_default_records
-  Rails.logger.info "\n\n-~=> Creating DEFAULT organization & partner"
-  @organization = create(:organization, name: "DEFAULT")
   @partner = create(:partner, organization: @organization)
   Rails.logger.info "\n\n-~=> Creating DEFAULT admins & user"
   @organization_admin = create(:organization_admin, name: "DEFAULT ORG ADMIN", organization: @organization)

--- a/spec/requests/account_requests_spec.rb
+++ b/spec/requests/account_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "/account_requests", type: :request do
+RSpec.describe "/account_requests", type: :request, skip_seed: true do
   describe "GET #new" do
     it "renders a successful response" do
       get new_account_request_url

--- a/spec/requests/adjustments_requests_spec.rb
+++ b/spec/requests/adjustments_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Adjustments", type: :request do
+RSpec.describe "Adjustments", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/admin/account_requests_requests_spec.rb
+++ b/spec/requests/admin/account_requests_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Admin::AccountRequestsController', type: :request do
+RSpec.describe 'Admin::AccountRequestsController', type: :request, skip_seed: true do
   context 'while signed in as a super admin' do
     before do
       sign_in(@super_admin)

--- a/spec/requests/admin/base_items_requests_spec.rb
+++ b/spec/requests/admin/base_items_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Admin::BaseItems", type: :request do
+RSpec.describe "Admin::BaseItems", type: :request, skip_seed: true do
   context "while signed in as a super admin" do
     before do
       sign_in(@super_admin)

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin::Organizations", type: :request do
+RSpec.describe "Admin::Organizations", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.id }
   end

--- a/spec/requests/admin/partners_requests_spec.rb
+++ b/spec/requests/admin/partners_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Admin::Partners", type: :request do
+RSpec.describe "Admin::Partners", type: :request, skip_seed: true do
   context "When logged in as a super admin" do
     before do
       sign_in(@super_admin)

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Admin::UsersController", type: :request do
+RSpec.describe "Admin::UsersController", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.id }
   end

--- a/spec/requests/admin_requests_spec.rb
+++ b/spec/requests/admin_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin", type: :request do
+RSpec.describe "Admin", type: :request, skip_seed: true do
   context "while signed in as a super admin" do
     before do
       sign_in(@super_admin_no_org)

--- a/spec/requests/attachments_requests_spec.rb
+++ b/spec/requests/attachments_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Attachments", type: :request do
+RSpec.describe "Attachments", type: :request, skip_seed: true do
   before do
     sign_in(@user)
   end

--- a/spec/requests/audits_requests_spec.rb
+++ b/spec/requests/audits_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Audits", type: :request do
+RSpec.describe "Audits", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/barcode_items_requests_spec.rb
+++ b/spec/requests/barcode_items_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "BarcodeItems", type: :request do
+RSpec.describe "BarcodeItems", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/dashboard_requests_spec.rb
+++ b/spec/requests/dashboard_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Dashboard", type: :request do
+RSpec.describe "Dashboard", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/diaper_drive_participants_requests_spec.rb
+++ b/spec/requests/diaper_drive_participants_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "DiaperDriveParticipants", type: :request do
+RSpec.describe "DiaperDriveParticipants", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/diaper_drives_requests_spec.rb
+++ b/spec/requests/diaper_drives_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "DiaperDrives", type: :request do
+RSpec.describe "DiaperDrives", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.id.to_param }
   end

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Distributions", type: :request do
+RSpec.describe "Distributions", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/donation_sites_requests_spec.rb
+++ b/spec/requests/donation_sites_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "DonationSites", type: :request do
+RSpec.describe "DonationSites", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Donations", type: :request do
+RSpec.describe "Donations", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Items", type: :request do
+RSpec.describe "Items", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/profiles_requests_spec.rb
+++ b/spec/requests/profiles_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Profiles", type: :request do
+RSpec.describe "Profiles", type: :request, skip_seed: true do
   let(:partner) { FactoryBot.create(:partner, organization: @organization) }
 
   let(:default_params) do

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Purchases", type: :request do
+RSpec.describe "Purchases", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/reports/annual_reports_requests_spec.rb
+++ b/spec/requests/reports/annual_reports_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Annual Reports", type: :request do
+RSpec.describe "Annual Reports", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param, year: 2018 }
   end

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Requests', type: :request do
+RSpec.describe 'Requests', type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/static_requests_spec.rb
+++ b/spec/requests/static_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Static", type: :request do
+RSpec.describe "Static", type: :request, skip_seed: true do
   describe "Not signed in" do
     describe "GET #index" do
       it "returns http success" do

--- a/spec/requests/transfers_requests_spec.rb
+++ b/spec/requests/transfers_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Transfers", type: :request do
+RSpec.describe "Transfers", type: :request, skip_seed: true do
   let(:valid_params) do
     { organization_id: @organization.short_name }
   end

--- a/spec/requests/users_requests_spec.rb
+++ b/spec/requests/users_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Users", type: :request do
+RSpec.describe "Users", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/vendors_requests_spec.rb
+++ b/spec/requests/vendors_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Vendors", type: :request do
+RSpec.describe "Vendors", type: :request, skip_seed: true do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/routing/account_requests_routing_spec.rb
+++ b/spec/routing/account_requests_routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AccountRequestsController, type: :routing do
+RSpec.describe AccountRequestsController, type: :routing, skip_seed: true do
   describe "routing" do
     it "routes to #new" do
       expect(get: "/account_requests/new").to route_to("account_requests#new")

--- a/spec/services/allocate_kit_inventory_service_spec.rb
+++ b/spec/services/allocate_kit_inventory_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AllocateKitInventoryService, type: :service do
+RSpec.describe AllocateKitInventoryService, type: :service, skip_seed: true do
   let(:organization) { create :organization }
   let(:item) { create(:item, name: "Item", organization: organization, on_hand_minimum_quantity: 5) }
   let(:item_out_of_stock) { create(:item, name: "Item out of stock", organization: organization, on_hand_minimum_quantity: 0) }

--- a/spec/services/consolidated_login_director_spec.rb
+++ b/spec/services/consolidated_login_director_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe ConsolidatedLoginDirector do
+RSpec.describe ConsolidatedLoginDirector, skip_seed: true do
   let(:director) { ConsolidatedLoginDirector.new }
 
   let(:user) do

--- a/spec/services/deallocate_kit_inventory_service_spec.rb
+++ b/spec/services/deallocate_kit_inventory_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DeallocateKitInventoryService, type: :service do
+RSpec.describe DeallocateKitInventoryService, type: :service, skip_seed: true do
   let(:organization) { create :organization }
   let(:item1) { create(:item, name: "Item11", organization: organization, on_hand_minimum_quantity: 5) }
   let(:item2) { create(:item, name: "Item 2", organization: organization, on_hand_minimum_quantity: 1) }

--- a/spec/services/distribution_content_change_service_spec.rb
+++ b/spec/services/distribution_content_change_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionContentChangeService, type: :service do
+RSpec.describe DistributionContentChangeService, type: :service, skip_seed: true do
   let(:line_item1) { { active: true, item_id: 32, name: "Adult Incontinence Pads", quantity: 382 } }
   let(:line_item2) { { active: true, item_id: 38, name: "Bed Pads (Disposable)", quantity: 36 } }
   let(:line_item3) { { active: true, item_id: 43, name: "Wipes (Adult)", quantity: 88 } }

--- a/spec/services/distribution_destroy_service_spec.rb
+++ b/spec/services/distribution_destroy_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DistributionDestroyService do
+describe DistributionDestroyService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(distribution_id).call }
     let(:distribution_id) { Faker::Number.number }

--- a/spec/services/distribution_reminder_spec.rb
+++ b/spec/services/distribution_reminder_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionReminder do
+RSpec.describe DistributionReminder, skip_seed: true do
   describe "conditionally sending the emails" do
     let(:organization) { create :organization }
 

--- a/spec/services/distribution_update_service_spec.rb
+++ b/spec/services/distribution_update_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionUpdateService, type: :service do
+RSpec.describe DistributionUpdateService, type: :service, skip_seed: true do
   describe "call" do
     # TODO: this function was extracted to the service object - do we need a parallel test?
 

--- a/spec/services/donation_destroy_service_spec.rb
+++ b/spec/services/donation_destroy_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DonationDestroyService do
+describe DonationDestroyService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(organization_id: organization_id, donation_id: donation_id) }
     let(:organization_id) { Faker::Number.number }

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -1,4 +1,4 @@
-describe Exports::ExportDistributionsCSVService do
+describe Exports::ExportDistributionsCSVService, skip_seed: true do
   describe '#generate_csv_data' do
     subject { described_class.new(distribution_ids: distribution_ids).generate_csv_data }
     let(:distribution_ids) { distributions.map(&:id) }

--- a/spec/services/exports/export_donations_csv_service_spec.rb
+++ b/spec/services/exports/export_donations_csv_service_spec.rb
@@ -1,4 +1,4 @@
-describe Exports::ExportDonationsCSVService do
+describe Exports::ExportDonationsCSVService, skip_seed: true do
   describe '#generate_csv_data' do
     subject { described_class.new(donation_ids: donation_ids).generate_csv_data }
     let(:donation_ids) { donations.map(&:id) }

--- a/spec/services/exports/export_report_csv_service_spec.rb
+++ b/spec/services/exports/export_report_csv_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Exports::ExportReportCSVService do
+describe Exports::ExportReportCSVService, skip_seed: true do
   describe ".generate_csv_data" do
     it "creates CSV data including headers" do
       report = {

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Exports::ExportRequestService do
+describe Exports::ExportRequestService, skip_seed: true do
   let(:org) { create(:organization) }
 
   let(:item_3t) { create :item, name: "3T Diapers" }

--- a/spec/services/inventory_check_service_spec.rb
+++ b/spec/services/inventory_check_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe InventoryCheckService, type: :service do
+RSpec.describe InventoryCheckService, type: :service, skip_seed: true do
   subject { InventoryCheckService }
   describe "call" do
     let(:item1) { create(:item, name: "Item 1", organization: @organization, on_hand_minimum_quantity: 5, on_hand_recommended_quantity: 10) }

--- a/spec/services/item_create_service_spec.rb
+++ b/spec/services/item_create_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ItemCreateService, type: :service do
+RSpec.describe ItemCreateService, type: :service, skip_seed: true do
   describe '#call' do
     subject { described_class.new(organization_id: organization_id, item_params: item_params).call }
     let(:organization_id) { organization.id }

--- a/spec/services/kit_create_service_spec.rb
+++ b/spec/services/kit_create_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe KitCreateService do
+describe KitCreateService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(**args).call }
     let(:args) do

--- a/spec/services/partner_approval_service_spec.rb
+++ b/spec/services/partner_approval_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerApprovalService do
+describe PartnerApprovalService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
     let(:partner) { create(:partner) }

--- a/spec/services/partner_create_service_spec.rb
+++ b/spec/services/partner_create_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerCreateService do
+describe PartnerCreateService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(organization: organization, partner_attrs: partner_attrs).call }
     let(:organization) { create(:organization) }

--- a/spec/services/partner_fetch_requestable_items_service_spec.rb
+++ b/spec/services/partner_fetch_requestable_items_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerFetchRequestableItemsService do
+describe PartnerFetchRequestableItemsService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(partner_id: partner_id).call }
     let(:partner_id) { partner.id }

--- a/spec/services/partner_invite_service_spec.rb
+++ b/spec/services/partner_invite_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerInviteService do
+describe PartnerInviteService, skip_seed: true do
   subject { described_class.new(partner: partner).call }
   let(:partner) { create(:partner) }
 

--- a/spec/services/partner_request_recertification_service_spec.rb
+++ b/spec/services/partner_request_recertification_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerRequestRecertificationService do
+describe PartnerRequestRecertificationService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
     let(:partner) { create(:partner) }

--- a/spec/services/partners/request_approval_service_spec.rb
+++ b/spec/services/partners/request_approval_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Partners::RequestApprovalService do
+describe Partners::RequestApprovalService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
     let(:partner) { create(:partner) }

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Partners::RequestCreateService do
+describe Partners::RequestCreateService, skip_seed: true do
   describe '#call' do
     subject { described_class.new(**args).call }
     let(:args) do

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
 
   before(:all) do
     DatabaseCleaner.start
+    create_organization
     seed_base_items_for_tests
     seed_with_default_records
 

--- a/spec/services/request_destroy_service_spec.rb
+++ b/spec/services/request_destroy_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RequestDestroyService, type: :service do
+RSpec.describe RequestDestroyService, type: :service, skip_seed: true do
   describe '#call' do
     subject { described_class.new(request_id: request_id).call }
     let(:request_id) { request.id }

--- a/spec/services/service_object_errors_mixin_spec.rb
+++ b/spec/services/service_object_errors_mixin_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ServiceObjectErrorsMixin do
+describe ServiceObjectErrorsMixin, skip_seed: true do
   describe 'self.included' do
     before do
       stub_const 'TestClass', Class.new

--- a/spec/services/text_interpolator_service_spec.rb
+++ b/spec/services/text_interpolator_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TextInterpolatorService, type: :service do
+RSpec.describe TextInterpolatorService, type: :service, skip_seed: true do
   describe '#call' do
     subject { described_class.new(text, interpolations).call }
 

--- a/spec/services/transfer_destroy_service_spec.rb
+++ b/spec/services/transfer_destroy_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe TransferDestroyService, type: :service do
+RSpec.describe TransferDestroyService, type: :service, skip_seed: true do
   describe '#call' do
     subject { described_class.new(transfer_id: transfer_id).call }
     let(:transfer_id) { transfer.id }

--- a/spec/system/account_request_system_spec.rb
+++ b/spec/system/account_request_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Account request flow', type: :system, js: true do
+RSpec.describe 'Account request flow', type: :system, js: true, skip_seed: true do
   context 'when in staging' do
     before do
       allow(Rails.env).to receive(:staging?).and_return(true)

--- a/spec/system/account_system_spec.rb
+++ b/spec/system/account_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "User account management", type: :system, js: true do
+RSpec.describe "User account management", type: :system, js: true, skip_seed: true do
   subject { "/users/edit" }
 
   before do

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Adjustment management", type: :system, js: true do
+RSpec.describe "Adjustment management", type: :system, js: true, skip_seed: true do
   let!(:url_prefix) { "/#{@organization.to_param}" }
   let!(:storage_location) { create(:storage_location, :with_items, organization: @organization) }
   let(:add_quantity) { 10 }

--- a/spec/system/admin/account_requests_system_spec.rb
+++ b/spec/system/admin/account_requests_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Account Requests Admin", type: :system do
+RSpec.describe "Account Requests Admin", type: :system, skip_seed: true do
   context "while signed in as a super admin" do
     before do
       sign_in(@super_admin)

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Barcode Items Admin", type: :system do
+RSpec.describe "Barcode Items Admin", type: :system, skip_seed: true do
   context "while signed in as a super admin" do
     before do
       sign_in(@super_admin)

--- a/spec/system/admin/base_items_system_spec.rb
+++ b/spec/system/admin/base_items_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Base Item Admin", type: :system, js: true do
+RSpec.describe "Base Item Admin", type: :system, js: true, skip_seed: true do
   context "While signed in as an Administrative User (super admin)" do
     before do
       sign_in(@super_admin)

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin Organization Management", type: :system, js: true do
+RSpec.describe "Admin Organization Management", type: :system, js: true, skip_seed: true do
   context "While signed in as an Administrative User (super admin)" do
     before :each do
       sign_in(@super_admin)

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin Users Management", type: :system, js: true do
+RSpec.describe "Admin Users Management", type: :system, js: true, skip_seed: true do
   context "While signed in as an Administrative User (super admin)" do
     before do
       sign_in(@super_admin)

--- a/spec/system/authorization_system_spec.rb
+++ b/spec/system/authorization_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Authorization", type: :system, js: true do
+RSpec.describe "Authorization", type: :system, js: true, skip_seed: true do
   it "redirects to the dashboard when unauthorized user attempts access" do
     sign_in(@user)
     visit "/admin/dashboard"

--- a/spec/system/barcode_item_system_spec.rb
+++ b/spec/system/barcode_item_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Barcode management", type: :system, js: true do
+RSpec.describe "Barcode management", type: :system, js: true, skip_seed: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Dashboard", type: :system, js: true do
+RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
   context "With a new Diaper bank" do
     before :each do
       @new_organization = create(:organization)

--- a/spec/system/diaper_drive_participant_system_spec.rb
+++ b/spec/system/diaper_drive_participant_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Diaper Drive Participant", type: :system, js: true do
+RSpec.describe "Diaper Drive Participant", type: :system, js: true, skip_seed: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/diaper_drive_system_spec.rb
+++ b/spec/system/diaper_drive_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Diaper Drives", type: :system, js: true do
+RSpec.describe "Diaper Drives", type: :system, js: true, skip_seed: true do
   include DateRangeHelper
 
   before do

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Distributions", type: :system do
+RSpec.feature "Distributions", type: :system, skip_seed: true do
   before do
     sign_in(@user)
     @url_prefix = "/#{@organization.to_param}"

--- a/spec/system/donation_site_system_spec.rb
+++ b/spec/system/donation_site_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Donation Site", type: :system, js: true do
+RSpec.describe "Donation Site", type: :system, js: true, skip_seed: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/kit_system_spec.rb
+++ b/spec/system/kit_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Kit management", type: :system do
+RSpec.describe "Kit management", type: :system, skip_seed: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/layout_system_spec.rb
+++ b/spec/system/layout_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Layout", type: :system do
+RSpec.describe "Layout", type: :system, skip_seed: true do
   let!(:url_prefix) { "/#{@organization.to_param}" }
 
   describe "Body CSS Data" do

--- a/spec/system/log_in_system_spec.rb
+++ b/spec/system/log_in_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Authentication", type: :system, js: true do
+RSpec.describe "Authentication", type: :system, js: true, skip_seed: true do
   describe "Success" do
     it "should show dashboard upon signin" do
       sign_in(@user)

--- a/spec/system/manage_system_spec.rb
+++ b/spec/system/manage_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Organization Administration", type: :system, js: true do
+RSpec.describe "Organization Administration", type: :system, js: true, skip_seed: true do
   subject { "/#{@organization.to_param}/organization" }
 
   context "while signed in as a normal user" do

--- a/spec/system/manufacturer_system_spec.rb
+++ b/spec/system/manufacturer_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Manufacturer", type: :system do
+RSpec.describe "Manufacturer", type: :system, skip_seed: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Organization management", type: :system, js: true do
+RSpec.describe "Organization management", type: :system, js: true, skip_seed: true do
   include ActionView::RecordIdentifier
   let!(:url_prefix) { "/#{@organization.to_param}" }
 

--- a/spec/system/partners/approval_process_spec.rb
+++ b/spec/system/partners/approval_process_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Approval process for partners", type: :system, js: true do
+RSpec.describe "Approval process for partners", type: :system, js: true, skip_seed: true do
   describe 'filling in organization details and requesting for approval' do
     let(:partner_user) { partner.primary_partner_user }
     let!(:partner) { FactoryBot.create(:partner) }

--- a/spec/system/partners/coworker_invitations_system_spec.rb
+++ b/spec/system/partners/coworker_invitations_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Coworking invitations", type: :system, js: true do
+RSpec.describe "Coworking invitations", type: :system, js: true, skip_seed: true do
   describe 'inviting a new user as a partner user' do
     let(:partner_user) { partner.primary_partner_user }
     let!(:partner) { FactoryBot.create(:partner) }

--- a/spec/system/partners/helps_system_spec.rb
+++ b/spec/system/partners/helps_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Help", type: :system do
+RSpec.describe "Help", type: :system, skip_seed: true do
   let(:partner) { FactoryBot.create(:partner) }
   let(:partner_user) { partner.primary_partner_user }
 

--- a/spec/system/partners/log_in_system_spec.rb
+++ b/spec/system/partners/log_in_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Authentication", type: :system, js: true do
+RSpec.describe "Authentication", type: :system, js: true, skip_seed: true do
   describe 'logging in as a partner user' do
     let(:partner_user) do
       user = create(:partner).primary_partner_user

--- a/spec/system/partners/partner_dashboard_system_spec.rb
+++ b/spec/system/partners/partner_dashboard_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Partner Dashboard", type: :system, js: true do
+RSpec.describe "Partner Dashboard", type: :system, js: true, skip_seed: true do
   describe 'Requests In Progress' do
     let(:partner_user) { partner.primary_partner_user }
     let!(:partner) { FactoryBot.create(:partner) }

--- a/spec/system/sign_in_system_spec.rb
+++ b/spec/system/sign_in_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "User sign-in handling", type: :system, js: true do
+RSpec.describe "User sign-in handling", type: :system, js: true, skip_seed: true do
   subject { new_user_session_path }
 
   before do

--- a/spec/system/storage_location_system_spec.rb
+++ b/spec/system/storage_location_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Storage Locations", type: :system, js: true do
+RSpec.describe "Storage Locations", type: :system, js: true, skip_seed: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Transfer management", type: :system do
+RSpec.describe "Transfer management", type: :system, skip_seed: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/vendor_system_spec.rb
+++ b/spec/system/vendor_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Vendor", type: :system, js: true do
+RSpec.describe "Vendor", type: :system, js: true, skip_seed: true do
   before do
     sign_in(@user)
   end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description

This does a couple of things to speed up the specs.

* Only create item and partner data if necessary. About half the specs don't need this data at all. Probably more - there are a number of large spec files that only need it for one or two tests, but I left them as is for now.
* Only create users for Selenium specs and a few rare non-Selenium ones that need them. Previously, every single spec was creating users, even for model and helpers.
* Cache base items so it doesn't read a JSON file for every single test.

There are now two metadata keys which control which data is created:
* `skip_seed` - when set to true, it does not create items and partners
* `needs_users` - when set to true, users are created even outside Selenium (request/controller/system) specs.

Because Selenium specs are so much slower than anything else, this is really mainly useful when developing on a feature and needing to rerun specs for that specific thing, or create new ones. I noticed a significant speedup for things like model and service specs under this framework.

### Type of change

* Test improvement

### How Has This Been Tested?

Local testing.