### PR TITLE
2606: Fix bug with partner exports

### DIFF
--- a/app/controllers/partners/children_controller.rb
+++ b/app/controllers/partners/children_controller.rb
@@ -17,7 +17,7 @@ module Partners
         format.js
         format.html
         format.csv do
-          render(csv: @children.map(&:to_csv))
+          send_data Partners::Child.generate_csv(@children), filename: "Children-#{Time.zone.today}.csv"
         end
       end
       @family = current_partner.children

--- a/app/controllers/partners/families_controller.rb
+++ b/app/controllers/partners/families_controller.rb
@@ -18,7 +18,7 @@ module Partners
         format.js
         format.html
         format.csv do
-          render(csv: @families.map(&:to_csv))
+          send_data Partners::Family.generate_csv(@families), filename: "Families-#{Time.zone.today}.csv"
         end
       end
     end

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -2,23 +2,44 @@ module Exportable
   extend ActiveSupport::Concern
 
   class_methods do
+    # @return [Array<String>]
     def csv_export_headers
       raise 'not implemented'
     end
 
+    # @param data [Array<ApplicationRecord>]
+    # @return [Array<Array<String>>]
     def csv_export(data)
       [csv_export_headers] + data.map(&:csv_export_attributes)
     end
 
+    # @param data [Array<ApplicationRecord>]
+    # @param additional_headers [Array<String>]
+    # @return [String]
     def generate_csv(data, additional_headers = [])
       CSV.generate(headers: true) do |csv|
-        ([csv_export_headers + additional_headers] + data.map(&:csv_export_attributes)).each do |row|
+        csv_data = data.map do |record|
+          record.csv_export_attributes.map { |attr| normalize_csv_attribute(attr) }
+        end
+        ([csv_export_headers + additional_headers] + csv_data).each do |row|
           csv << row
         end
       end
     end
+
+    # @param attr [BasicObject]
+    # @return [String]
+    def normalize_csv_attribute(attr)
+      case attr
+      when Array
+        attr.join(',')
+      else
+        attr.to_s
+      end
+    end
   end
 
+  # @return [Array<BasicObject>]
   def csv_export_attributes
     raise 'not implemented'
   end

--- a/app/models/partners/child.rb
+++ b/app/models/partners/child.rb
@@ -26,6 +26,8 @@ module Partners
     has_many :child_item_requests, dependent: :destroy
 
     include Filterable
+    include Exportable
+
     scope :from_family, ->(family_id) {
       where(family_id: family_id)
     }
@@ -48,10 +50,6 @@ module Partners
       where("concat_ws(' ', families.guardian_first_name, families.guardian_last_name) ILIKE ?", "%#{query}%")
     }
 
-    CSV_HEADERS = %w[
-      id first_name last_name date_of_birth gender child_lives_with race agency_child_id
-      health_insurance comments created_at updated_at family_id item_needed_diaperid active archived
-    ].freeze
     CAN_LIVE_WITH = ['Mother', 'Father', 'Grandparent', 'Foster Parent', 'Other Parent/Relative'].freeze
     RACES = ['African American', 'Caucasian', 'Hispanic', 'Asian', 'American Indian', 'Pacific Islander', 'Multi-racial', 'Other'].freeze
     CHILD_ITEMS = ["Bed Pads (Cloth)",
@@ -86,11 +84,14 @@ module Partners
       "#{first_name} #{last_name}"
     end
 
-    def self.csv_headers
-      CSV_HEADERS
+    def self.csv_export_headers
+      %w[
+        id first_name last_name date_of_birth gender child_lives_with race agency_child_id
+        health_insurance comments created_at updated_at family_id item_needed_diaperid active archived
+      ].freeze
     end
 
-    def to_csv
+    def csv_export_attributes
       [
         id,
         first_name,

--- a/app/models/partners/family.rb
+++ b/app/models/partners/family.rb
@@ -32,6 +32,7 @@ module Partners
     validates :guardian_first_name, :guardian_last_name, :guardian_zip_code, presence: true
 
     include Filterable
+    include Exportable
 
     filterrific(
       available_filters: [
@@ -49,17 +50,6 @@ module Partners
 
     after_create :create_authorized
 
-    CSV_HEADERS = %w[
-      id guardian_first_name guardian_last_name guardian_zip_code guardian_country
-      guardian_phone agency_guardian_id home_adult_count home_child_count home_young_child_count
-      sources_of_income guardian_employed guardian_employment_type guardian_monthly_pay
-      guardian_health_insurance comments created_at updated_at partner_id military
-    ].freeze
-
-    def self.csv_headers
-      CSV_HEADERS
-    end
-
     def create_authorized
       authorized_family_members.create!(
         first_name: guardian_first_name,
@@ -75,7 +65,16 @@ module Partners
       home_child_count + home_young_child_count
     end
 
-    def to_csv
+    def self.csv_export_headers
+      %w[
+        id guardian_first_name guardian_last_name guardian_zip_code guardian_country
+        guardian_phone agency_guardian_id home_adult_count home_child_count home_young_child_count
+        sources_of_income guardian_employed guardian_employment_type guardian_monthly_pay
+        guardian_health_insurance comments created_at updated_at partner_id military
+      ].freeze
+    end
+
+    def csv_export_attributes
       [
         id,
         guardian_first_name,

--- a/app/views/partners/children/index.csv.erb
+++ b/app/views/partners/children/index.csv.erb
@@ -1,8 +1,0 @@
-<%= Partners::Child.csv_headers.join(',') %>
-<%=
-  CSV.generate do |csv|
-    @children.each do |child|
-      csv << child.to_csv
-    end
-  end
--%>

--- a/app/views/partners/families/index.csv.erb
+++ b/app/views/partners/families/index.csv.erb
@@ -1,8 +1,0 @@
-<%= Partners::Family.csv_headers.join(',') %>
-<%=
-  CSV.generate do |csv|
-    @families.each do |family|
-      csv << family.to_csv
-    end
-  end
--%>

--- a/spec/models/partners/child_spec.rb
+++ b/spec/models/partners/child_spec.rb
@@ -35,47 +35,4 @@ RSpec.describe Partners::Child, type: :model, skip_seed: true do
       expect(subject.display_name).to eq("#{subject.first_name} #{subject.last_name}")
     end
   end
-
-  describe "#csv_headers" do
-    subject { Partners::Child }
-    let(:csv_headers) do
-      %w[
-        id first_name last_name date_of_birth gender child_lives_with race agency_child_id
-        health_insurance comments created_at updated_at family_id item_needed_diaperid active archived
-      ]
-    end
-
-    it "should have correct csv headers" do
-      expect(subject.csv_headers).to eq(csv_headers)
-    end
-  end
-
-  describe "#to_csv" do
-    subject { partners_child }
-    let(:partners_child) { FactoryBot.create(:partners_child) }
-    let(:csv_array) do
-      [
-        subject.id,
-        subject.first_name,
-        subject.last_name,
-        subject.date_of_birth,
-        subject.gender,
-        subject.child_lives_with,
-        subject.race,
-        subject.agency_child_id,
-        subject.health_insurance,
-        subject.comments,
-        subject.created_at,
-        subject.updated_at,
-        subject.family_id,
-        subject.item_needed_diaperid,
-        subject.active,
-        subject.archived
-      ]
-    end
-
-    it "should return an array of values" do
-      expect(subject.to_csv).to eq(csv_array)
-    end
-  end
 end

--- a/spec/models/partners/family_spec.rb
+++ b/spec/models/partners/family_spec.rb
@@ -42,22 +42,6 @@ RSpec.describe Partners::Family, type: :model, skip_seed: true do
     it { should validate_presence_of(:guardian_zip_code) }
   end
 
-  describe "#csv_headers" do
-    subject { Partners::Family }
-    let(:csv_headers) do
-      %w[
-        id guardian_first_name guardian_last_name guardian_zip_code guardian_country
-        guardian_phone agency_guardian_id home_adult_count home_child_count home_young_child_count
-        sources_of_income guardian_employed guardian_employment_type guardian_monthly_pay
-        guardian_health_insurance comments created_at updated_at partner_id military
-      ]
-    end
-
-    it "should have correct csv headers" do
-      expect(subject.csv_headers).to eq(csv_headers)
-    end
-  end
-
   describe "#create_authorized" do
     subject { partners_family }
     let(:partners_family) { FactoryBot.create(:partners_family) }
@@ -83,39 +67,6 @@ RSpec.describe Partners::Family, type: :model, skip_seed: true do
 
     it "should return the family's total children count" do
       expect(subject.total_children_count).to eq(subject.home_child_count + subject.home_young_child_count)
-    end
-  end
-
-  describe "#to_csv" do
-    subject { partners_family }
-    let(:partners_family) { FactoryBot.create(:partners_family) }
-    let(:csv_array) do
-      [
-        subject.id,
-        subject.guardian_first_name,
-        subject.guardian_last_name,
-        subject.guardian_zip_code,
-        subject.guardian_country,
-        subject.guardian_phone,
-        subject.agency_guardian_id,
-        subject.home_adult_count,
-        subject.home_child_count,
-        subject.home_young_child_count,
-        subject.sources_of_income,
-        subject.guardian_employed,
-        subject.guardian_employment_type,
-        subject.guardian_monthly_pay,
-        subject.guardian_health_insurance,
-        subject.comments,
-        subject.created_at,
-        subject.updated_at,
-        subject.partner_id,
-        subject.military
-      ]
-    end
-
-    it "should return an array of values" do
-      expect(subject.to_csv).to eq(csv_array)
     end
   end
 end

--- a/spec/requests/partners/children_requests_spec.rb
+++ b/spec/requests/partners/children_requests_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe "/partners/children", type: :request do
+  let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).primary_user }
+  let(:partner) { create(:partner) }
+  let(:family) { create(:partners_family, partner: partner) }
+  let!(:child1) do
+    create(:partners_child,
+           first_name: 'John',
+           last_name: 'Smith',
+           date_of_birth: '2019-01-01',
+           gender: 'Male',
+           child_lives_with: %w(mother grandfather),
+           race: 'Other',
+           agency_child_id: 'Agency McAgence',
+           health_insurance: 'Private insurance',
+           comments: 'Some comment',
+           item_needed_diaperid: nil,
+           active: true,
+           archived: false,
+           family: family)
+  end
+  let!(:child2) do
+    create(:partners_child,
+           first_name: 'Jane',
+           last_name: 'Smith',
+           date_of_birth: '2018-01-01',
+           gender: 'Female',
+           child_lives_with: %w(father),
+           race: 'Hispanic',
+           agency_child_id: 'Agency McAgence',
+           health_insurance: 'Private insurance',
+           comments: 'Some comment',
+           item_needed_diaperid: nil,
+           active: true,
+           archived: false,
+           family: family)
+  end
+
+  describe "GET #index" do
+    before do
+      sign_in(partner_user, scope: :partner_user)
+    end
+
+    it 'should render without any issues' do
+      get partners_children_path
+      expect(response).to render_template(:index)
+    end
+
+    it 'should export CSV' do
+      headers = { 'Accept' => 'text/csv', 'Content-Type' => 'text/csv' }
+      get partners_children_path, headers: headers
+      csv = <<~CSV
+        id,first_name,last_name,date_of_birth,gender,child_lives_with,race,agency_child_id,health_insurance,comments,created_at,updated_at,family_id,item_needed_diaperid,active,archived
+        #{child1.id},John,Smith,2019-01-01,Male,"mother,grandfather",Other,Agency McAgence,Private insurance,Some comment,#{child1.created_at},#{child1.updated_at},#{family.id},"",true,false
+        #{child2.id},Jane,Smith,2018-01-01,Female,father,Hispanic,Agency McAgence,Private insurance,Some comment,#{child2.created_at},#{child2.updated_at},#{family.id},"",true,false
+      CSV
+      expect(response.body).to eq(csv)
+    end
+  end
+end

--- a/spec/requests/partners/family_requests_spec.rb
+++ b/spec/requests/partners/family_requests_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe "/partners/family", type: :request do
+  let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).primary_user }
+  let(:partner) { create(:partner) }
+  let!(:family1) do
+    create(:partners_family,
+           guardian_first_name: 'John',
+           guardian_last_name: 'Smith',
+           guardian_zip_code: '90210',
+           guardian_country: 'United States',
+           guardian_phone: '416-555-2345',
+           agency_guardian_id: 'Jane Smith',
+           home_adult_count: 2,
+           home_child_count: 3,
+           home_young_child_count: 1,
+           sources_of_income: %w[SSI TANF],
+           guardian_employed: true,
+           guardian_employment_type: 'Part-time',
+           guardian_monthly_pay: 4,
+           guardian_health_insurance: 'Medicaid',
+           comments: 'Some comment',
+           military: false,
+           partner: partner)
+  end
+
+  let!(:family2) do
+    create(:partners_family,
+           guardian_first_name: 'Mark',
+           guardian_last_name: 'Smith',
+           guardian_zip_code: '90210',
+           guardian_country: 'United States',
+           guardian_phone: '416-555-0987',
+           agency_guardian_id: 'Jane Smith',
+           home_adult_count: 1,
+           home_child_count: 2,
+           home_young_child_count: 2,
+           sources_of_income: %w[TANF],
+           guardian_employed: false,
+           guardian_employment_type: 'Part-time',
+           guardian_monthly_pay: 4,
+           guardian_health_insurance: 'Medicaid',
+           comments: 'Some comment 2',
+           military: true,
+           partner: partner)
+  end
+
+  describe "GET #index" do
+    before do
+      sign_in(partner_user, scope: :partner_user)
+    end
+
+    it 'should render without any issues' do
+      get partners_families_path
+      expect(response).to render_template(:index)
+    end
+
+    it 'should export CSV' do
+      headers = { 'Accept' => 'text/csv', 'Content-Type' => 'text/csv' }
+      get partners_families_path, headers: headers
+      csv = <<~CSV
+        id,guardian_first_name,guardian_last_name,guardian_zip_code,guardian_country,guardian_phone,agency_guardian_id,home_adult_count,home_child_count,home_young_child_count,sources_of_income,guardian_employed,guardian_employment_type,guardian_monthly_pay,guardian_health_insurance,comments,created_at,updated_at,partner_id,military
+        #{family1.id},John,Smith,90210,United States,416-555-2345,Jane Smith,2,3,1,"SSI,TANF",true,Part-time,4.0,Medicaid,Some comment,#{family1.created_at},#{family1.updated_at},2,false
+        #{family2.id},Mark,Smith,90210,United States,416-555-0987,Jane Smith,1,2,2,TANF,false,Part-time,4.0,Medicaid,Some comment 2,#{family2.created_at},#{family2.updated_at},2,true
+      CSV
+      expect(response.body).to eq(csv)
+    end
+  end
+end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2606.

### Description

This adds normalization to values being exported via CSV, in the `Exportable` module. As it happens, the Partner pages that do exports actually weren't using this module, so I changed them to do so. In this case the underlying issue was a column of `jsonb` type which was *also* using Rails' `serialize` method (so it was storing YAML, not JSON). But even without that, this would have shown a Ruby array rather than a nicely formatted string, so either way this would have happened. :)

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Local and unit tests.
