### PR TITLE
Fix brittleness caused datetime of run with fixing time

### DIFF
--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
+  include ActiveSupport::Testing::TimeHelpers
+
+  before do
+    travel_to Time.zone.local(2022, 2, 15, 12, 30, 0)
+  end
+
+  after do
+    travel_back
+  end
+
   context "With a new Diaper bank" do
     before :each do
       @new_organization = create(:organization)


### PR DESCRIPTION
Resolves N/A

### Description
I noticed that some specs in the dashboard system specs are brittle and fail due to a dependence on when the test runs. One of the specs, for example, expects that the time of running is more than 7 days past the beginning of the year:

`total_inventory` as calculated below doesn't include a donation made at the beginning of the year. BUT! Since we are in the first 7 days of the year, it is going to include it.


```
            @this_years_donations = {
              today: create(:manufacturer_donation, :with_items, manufacturer: manufacturer1, issued_at: date_to_view, item_quantity: 100, storage_location: storage_location, organization: @organization),
              yesterday: create(:manufacturer_donation, :with_items, manufacturer: manufacturer2, issued_at: date_to_view.yesterday, item_quantity: 101, storage_location: storage_location, organization: @organization),
              earlier_this_week: create(:manufacturer_donation, :with_items, manufacturer: manufacturer3, issued_at: date_to_view.beginning_of_week, item_quantity: 102, storage_location: storage_location, organization: @organization),
              beginning_of_year: create(:manufacturer_donation, :with_items, manufacturer: manufacturer4, issued_at: beginning_of_year, item_quantity: 103, storage_location: storage_location, organization: @organization)
            }
            ....

          describe "This Week" do
            before do
              date_range_picker_select_range "Last 7 Days"
              click_on "Filter"
            end

            let(:total_inventory) { [@this_years_donations[:today], @this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:total_quantity).sum }
            let(:manufacturers) { [@this_years_donations[:today], @this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:manufacturer).map(&:name) }

            it "has a widget displaying the Donation totals from this week, only using donations from this week" do
              within "#manufacturers" do
                expect(page).to have_content(total_inventory)
              end
            end
```

**The way to address brittleness like this the easier way is to fix the time period in which the specs should be running which is done in this PR**


### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Running specs locally

### Screenshots
N/A