### PR TITLE
Fix brittleness due to varying order of product_list in reports spec

### DIFF
--- a/app/services/reports/other_products_report_service.rb
+++ b/app/services/reports/other_products_report_service.rb
@@ -55,7 +55,7 @@ module Reports
 
     # @return [String]
     def product_list
-      organization.items.other_categories.map(&:name).uniq.join(', ')
+      organization.items.other_categories.map(&:name).sort.uniq.join(', ')
     end
 
     # @return [Integer]

--- a/spec/services/reports/other_products_report_service_spec.rb
+++ b/spec/services/reports/other_products_report_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Reports::OtherProductsReportService, type: :service, skip_seed: t
                                       '% non-diaper products donated' => "0%",
                                       '% non-diaper products bought' => "0%",
                                       'Money spent on non-diaper products' => '$0.00',
-                                      'List of non-diaper products' => "Pads, Tampons, Bed Pads (Cloth), Bed Pads (Disposable), Bibs (Adult & Child), Diaper Rash Cream/Powder, Other, Cloth Potty Training Pants/Underwear, Wipes (Adult), Wipes (Baby)"
+                                      'List of non-diaper products' => organization.items.other_categories.map(&:name).sort.uniq.join(', ')
                                     },
                                     name: "Other Items"
                                   })
@@ -83,7 +83,7 @@ RSpec.describe Reports::OtherProductsReportService, type: :service, skip_seed: t
                                       '% non-diaper products donated' => "40%",
                                       '% non-diaper products bought' => "60%",
                                       'Money spent on non-diaper products' => '$30.00',
-                                      'List of non-diaper products' => "Pads, Tampons, Bed Pads (Cloth), Bed Pads (Disposable), Bibs (Adult & Child), Diaper Rash Cream/Powder, Other, Cloth Potty Training Pants/Underwear, Wipes (Adult), Wipes (Baby)"
+                                      'List of non-diaper products' => organization.items.other_categories.map(&:name).sort.uniq.join(', ')
                                     },
                                     name: "Other Items"
                                   })


### PR DESCRIPTION

### Description

This PR fixes a broken spec that is caused by the "List of non-diaper products" being in varying orders which causes the assertion to fail randomly. Notice in the `Diff` in the failure notice below:

```
  1) Reports::OtherProductsReportService#report should report normal values
     Failure/Error:
       expect(report.report).to eq({
                                     entries: {
                                       'Non-diaper products distributed' => '200',
                                       '% non-diaper products donated' => "40%",
                                       '% non-diaper products bought' => "60%",
                                       'Money spent on non-diaper products' => '$30.00',
                                       'List of non-diaper products' => "Pads, Tampons, Bed Pads (Cloth), Bed Pads (Disposable), Bibs (Adult & Child), Diaper Rash Cream/Powder, Other, Cloth Potty Training Pants/Underwear, Wipes (Adult), Wipes (Baby)"
                                     },
                                     name: "Other Items"
                                   })

       expected: {:entries=>{"% non-diaper products bought"=>"60%", "% non-diaper products donated"=>"40%", "List of n... on non-diaper products"=>"$30.00", "Non-diaper products distributed"=>"200"}, :name=>"Other Items"}
            got: {:entries=>{"% non-diaper products bought"=>"60%", "% non-diaper products donated"=>"40%", "List of n... on non-diaper products"=>"$30.00", "Non-diaper products distributed"=>"200"}, :name=>"Other Items"}

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -:entries => {"% non-diaper products bought"=>"60%", "% non-diaper products donated"=>"40%", "List of non-diaper products"=>"Pads, Tampons, Bed Pads (Cloth), Bed Pads (Disposable), Bibs (Adult & Child), Diaper Rash Cream/Powder, Other, Cloth Potty Training Pants/Underwear, Wipes (Adult), Wipes (Baby)", "Money spent on non-diaper products"=>"$30.00", "Non-diaper products distributed"=>"200"},
       +:entries => {"% non-diaper products bought"=>"60%", "% non-diaper products donated"=>"40%", "List of non-diaper products"=>"Other, Pads, Tampons, Bed Pads (Cloth), Bed Pads (Disposable), Bibs (Adult & Child), Diaper Rash Cream/Powder, Cloth Potty Training Pants/Underwear, Wipes (Adult), Wipes (Baby)", "Money spent on non-diaper products"=>"$30.00", "Non-diaper products distributed"=>"200"},
     # ./spec/services/reports/other_products_report_service_spec.rb:80:in `block (3 levels) in <top (required)>'
```

This PR fixes it by adding `sort` to ensure that the order stays the same

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
CI/CD

### Screenshots
N/A