### PR TITLE
These workflows remove emotional toll

### DIFF
--- a/.github/workflows/add-help-wanted-labels.yml
+++ b/.github/workflows/add-help-wanted-labels.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 * * * *'
+  workflow_dispatch: # Enable manual runs of the bot
+
+jobs:
+  add_help_wanted_labels:
+    runs-on: ubuntu-latest
+    name: Add help wanted labels
+    steps:
+      - name: Add help wanted labels
+        uses: rubyforgood/add-label-to-cards@v2.1
+        id: add-help-wanted-labels
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          column_name: 'To do'
+          label_to_add: 'Help Wanted'
+          project_name: 'Essentials Project Board'

--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -1,0 +1,31 @@
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 0 * * *'
+
+jobs:
+  unassign_issues:
+    runs-on: ubuntu-latest
+    name: Unassign issues
+    steps:
+      - name: Unassign issues
+        uses: rubyforgood/unassign-issues@v1
+        id: unassign_issues
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          unassign_inactive_in_hours: 360 # 15 days
+          warning_inactive_in_hours: 240 # 10 days
+      - name: Print the unassigned issues
+        run: echo "Unassigned issues = ${{steps.unassign_issues.outputs.unassigned_issues}}"
+      - name: Print the warned issues
+        run: echo "Warned issues = ${{steps.unassign_issues.outputs.warned_issues}}"
+      - name: Move unassigned issues from In Progress to To Do
+        uses: bjthompson805/move-issues@v1
+        id: move_issues
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          issues: ${{steps.unassign_issues.outputs.unassigned_issues}}
+          from_column: '16446973'
+          to_column: '16446972'
+      - name: Print moved issues
+        run: echo "Moved issues = ${{steps.move_issues.outputs.moved_issues}}"

--- a/.github/workflows/remove-help-wanted-labels-done.yml
+++ b/.github/workflows/remove-help-wanted-labels-done.yml
@@ -1,0 +1,17 @@
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 * * * *'
+
+jobs:
+  remove_help_wanted_labels:
+    runs-on: ubuntu-latest
+    name: Remove help wanted labels
+    steps:
+      - name: Remove help wanted labels
+        uses: rubyforgood/remove-label-from-cards@v1
+        id: remove-help-wanted-labels
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          label_to_remove: 'Help Wanted'
+          column_id: '16446973'

--- a/.github/workflows/remove-help-wanted-labels-in-progress.yml
+++ b/.github/workflows/remove-help-wanted-labels-in-progress.yml
@@ -1,0 +1,17 @@
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 * * * *'
+
+jobs:
+  remove_help_wanted_labels:
+    runs-on: ubuntu-latest
+    name: Remove help wanted labels
+    steps:
+      - name: Remove help wanted labels
+        uses: rubyforgood/remove-label-from-cards@v1
+        id: remove-help-wanted-labels
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          label_to_remove: 'Help Wanted'
+          column_id: '16446973'

--- a/.github/workflows/remove-help-wanted-labels-merged-to-qa.yml
+++ b/.github/workflows/remove-help-wanted-labels-merged-to-qa.yml
@@ -1,0 +1,17 @@
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 * * * *'
+
+jobs:
+  remove_help_wanted_labels:
+    runs-on: ubuntu-latest
+    name: Remove help wanted labels
+    steps:
+      - name: Remove help wanted labels
+        uses: rubyforgood/remove-label-from-cards@v1
+        id: remove-help-wanted-labels
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          label_to_remove: 'Help Wanted'
+          column_id: '16446979'


### PR DESCRIPTION
There is a lot of emotional energy involved with asking contributors if they are still working on issues, the status of PRs and so on.

These workflows (copied from CASA) automate all of that.

The main things is that when there is no activity on issues for a certain amount of time it will poke the person involved and if it goes on long enough it will un-assign them and add the help wanted label back.