### PR TITLE
Temporary workaround for "this month" dashboard example failures in January

### DIFF
--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
             @this_years_donations = {
               today: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive1, diaper_drive_participant: diaper_drive_participant1, issued_at: date_to_view, item_quantity: 100, storage_location: storage_location, organization: @organization),
               yesterday: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive2, diaper_drive_participant: diaper_drive_participant2, issued_at: date_to_view.yesterday, item_quantity: 101, storage_location: storage_location, organization: @organization),
-              earlier_this_week: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive1, diaper_drive_participant: diaper_drive_participant1, issued_at: date_to_view.beginning_of_week, item_quantity: 102, storage_location: storage_location, organization: @organization),
+              earlier_this_week: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive1, diaper_drive_participant: diaper_drive_participant1, issued_at: date_to_view.beginning_of_week, item_quantity: 102, storage_location: storage_location, organization: @organization)
               # See https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
               # beginning_of_year: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive2, diaper_drive_participant: diaper_drive_participant2, issued_at: beginning_of_year, item_quantity: 103, storage_location: storage_location, organization: @organization)
             }
@@ -721,12 +721,12 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
             manufacturer1 = create(:manufacturer, name: "ABC Corp", organization: @organization)
             manufacturer2 = create(:manufacturer, name: "BCD Corp", organization: @organization)
             manufacturer3 = create(:manufacturer, name: "CDE Corp", organization: @organization)
-            manufacturer4 = create(:manufacturer, name: "DEF Corp", organization: @organization)
+            # manufacturer4 = create(:manufacturer, name: "DEF Corp", organization: @organization)
 
             @this_years_donations = {
               today: create(:manufacturer_donation, :with_items, manufacturer: manufacturer1, issued_at: date_to_view, item_quantity: 100, storage_location: storage_location, organization: @organization),
               yesterday: create(:manufacturer_donation, :with_items, manufacturer: manufacturer2, issued_at: date_to_view.yesterday, item_quantity: 101, storage_location: storage_location, organization: @organization),
-              earlier_this_week: create(:manufacturer_donation, :with_items, manufacturer: manufacturer3, issued_at: date_to_view.beginning_of_week, item_quantity: 102, storage_location: storage_location, organization: @organization),
+              earlier_this_week: create(:manufacturer_donation, :with_items, manufacturer: manufacturer3, issued_at: date_to_view.beginning_of_week, item_quantity: 102, storage_location: storage_location, organization: @organization)
               # See https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
               # beginning_of_year: create(:manufacturer_donation, :with_items, manufacturer: manufacturer4, issued_at: beginning_of_year, item_quantity: 103, storage_location: storage_location, organization: @organization)
             }

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -492,7 +492,8 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
               today: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive1, diaper_drive_participant: diaper_drive_participant1, issued_at: date_to_view, item_quantity: 100, storage_location: storage_location, organization: @organization),
               yesterday: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive2, diaper_drive_participant: diaper_drive_participant2, issued_at: date_to_view.yesterday, item_quantity: 101, storage_location: storage_location, organization: @organization),
               earlier_this_week: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive1, diaper_drive_participant: diaper_drive_participant1, issued_at: date_to_view.beginning_of_week, item_quantity: 102, storage_location: storage_location, organization: @organization),
-              beginning_of_year: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive2, diaper_drive_participant: diaper_drive_participant2, issued_at: beginning_of_year, item_quantity: 103, storage_location: storage_location, organization: @organization)
+              # See https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
+              # beginning_of_year: create(:diaper_drive_donation, :with_items, diaper_drive: diaper_drive2, diaper_drive_participant: diaper_drive_participant2, issued_at: beginning_of_year, item_quantity: 103, storage_location: storage_location, organization: @organization)
             }
 
             @last_years_donations = create_list(:diaper_drive_donation, 2, :with_items, diaper_drive: diaper_drive1, diaper_drive_participant: diaper_drive_participant1, issued_at: last_year_date, item_quantity: 104, storage_location: storage_location, organization: @organization)
@@ -509,13 +510,15 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
             let(:today_name) { @this_years_donations[:today].diaper_drive.name }
             let(:yesterday_name) { @this_years_donations[:yesterday].diaper_drive.name }
             let(:week_name) { @this_years_donations[:earlier_this_week].diaper_drive.name }
-            let(:year_name) { @this_years_donations[:beginning_of_year].diaper_drive.name }
+            # See https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
+            # let(:year_name) { @this_years_donations[:beginning_of_year].diaper_drive.name }
             it "has a widget displaying the year-to-date Diaper drive totals, only using donations from this year" do
               within "#diaper_drives" do
                 expect(page).to have_content(today_name)
                 expect(page).to have_content(yesterday_name)
                 expect(page).to have_content(week_name)
-                expect(page).to have_content(year_name)
+                # See https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
+                # expect(page).to have_content(year_name)
                 expect(page).to have_content(total_inventory)
               end
             end
@@ -636,7 +639,8 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
             let(:today_name) { @this_years_donations[:today].diaper_drive.name }
             let(:yesterday_name) { @this_years_donations[:yesterday].diaper_drive.name }
             let(:week_name) { @this_years_donations[:earlier_this_week].diaper_drive.name }
-            let(:year_name) { @this_years_donations[:beginning_of_year].diaper_drive.name }
+            # See https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
+            # let(:year_name) { @this_years_donations[:beginning_of_year].diaper_drive.name }
             let(:last_year_name) { @last_years_donations[0].diaper_drive.name }
             it "has a widget displaying the Diaper drive totals from last year, only using donations from last year" do
               within "#diaper_drives" do
@@ -644,7 +648,8 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
                 expect(page).to have_content(today_name)
                 expect(page).to have_content(yesterday_name)
                 expect(page).to have_content(week_name)
-                expect(page).to have_content(year_name)
+                # See https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
+                # expect(page).to have_content(year_name)
                 expect(page).to have_content(last_year_name)
               end
             end
@@ -722,7 +727,8 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
               today: create(:manufacturer_donation, :with_items, manufacturer: manufacturer1, issued_at: date_to_view, item_quantity: 100, storage_location: storage_location, organization: @organization),
               yesterday: create(:manufacturer_donation, :with_items, manufacturer: manufacturer2, issued_at: date_to_view.yesterday, item_quantity: 101, storage_location: storage_location, organization: @organization),
               earlier_this_week: create(:manufacturer_donation, :with_items, manufacturer: manufacturer3, issued_at: date_to_view.beginning_of_week, item_quantity: 102, storage_location: storage_location, organization: @organization),
-              beginning_of_year: create(:manufacturer_donation, :with_items, manufacturer: manufacturer4, issued_at: beginning_of_year, item_quantity: 103, storage_location: storage_location, organization: @organization)
+              # See https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
+              # beginning_of_year: create(:manufacturer_donation, :with_items, manufacturer: manufacturer4, issued_at: beginning_of_year, item_quantity: 103, storage_location: storage_location, organization: @organization)
             }
             @last_years_donations = create_list(:manufacturer_donation, 2, :with_items, manufacturer: manufacturer1, issued_at: last_year_date, item_quantity: 104, storage_location: storage_location, organization: @organization)
             visit subject


### PR DESCRIPTION
**Temporary** fix for some of the failures identified in #2676

"This month" examples assume `beginning_of_year` is not in "this month".
This is invalid during January.

#2674 addresses this for CI builds, but [does not help dev boxes avoid this issue](https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1006128190).

**Quick fix** is to comment out the `beginning_of_year` donations,
then other lines (incl. expectations) relying on them

I plan/expect to revisit this as I am doing other work in the dashboard spec (e.g., #2657)—ideally _well_ before #2676's failures trigger 1 Jan 2023.

See also
https://github.com/rubyforgood/human-essentials/issues/2676#issuecomment-1008166066
