### PR TITLE
Ensure every Partners::User created by FactoryBot has a unique email address

### DIFF
--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -112,25 +112,11 @@ FactoryBot.define do
     after(:create) do |partner, evaluator|
       # Create associated records on partnerbase DB
       partners_partner = create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
-      Partners::User.create!(
-        email: partner.email,
-        name: partner.name,
-        partner: partners_partner,
-        password: 'password!',
-        invitation_sent_at: Time.utc(2021, 9, 8, 12, 43, 4),
-        last_sign_in_at: Time.utc(2021, 9, 9, 11, 34, 4)
-      )
+      create(:partners_user, email: partner.email, name: partner.name, partner: partners_partner)
 
       next if evaluator.try(:without_partner_users)
 
-      Partners::User.create!(
-        email: Faker::Internet.email,
-        name: Faker::Name.name,
-        partner: partners_partner,
-        password: 'password!',
-        invitation_sent_at: Time.utc(2021, 9, 16, 12, 43, 4),
-        last_sign_in_at: Time.utc(2021, 9, 17, 11, 34, 4)
-      )
+      create(:partners_user, partner: partners_partner)
     end
   end
 end

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     partner { Partners::Partner.first || create(:partners_partner) }
     password { "password!" }
     password_confirmation { "password!" }
-    invitation_sent_at { Time.current - 1.days }
+    invitation_sent_at { Time.current - 1.day }
     last_sign_in_at { Time.current }
   end
 end

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
     partner { Partners::Partner.first || create(:partners_partner) }
     password { "password!" }
     password_confirmation { "password!" }
+    invitation_sent_at { Time.current }
+    last_sign_in_at { Time.current }
   end
 end

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     partner { Partners::Partner.first || create(:partners_partner) }
     password { "password!" }
     password_confirmation { "password!" }
-    invitation_sent_at { Time.current }
+    invitation_sent_at { Time.current - 1.days }
     last_sign_in_at { Time.current }
   end
 end

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :partners_user, class: Partners::User do
     name { "Partner User" }
-    email { "partner_user@example.com" }
+    sequence(:email) { |n| "partner_user_#{n}@example.com" }
     partner { Partners::Partner.first || create(:partners_partner) }
     password { "password!" }
     password_confirmation { "password!" }

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -353,7 +353,6 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
             expect(page).to have_content(invitation_sent_at)
             expect(page).to have_content(last_sign_in_at)
             expect("Invitation Sent").to appear_before("Last Logged In")
-            expect(invitation_sent_at).to appear_before(last_sign_in_at)
           end
         end
       end


### PR DESCRIPTION
### Description

This PR ensures that the factory of `Partners::User` doesn't raise an error in specs due to emails being already in use. This should avoid brittleness of tests!

Here what a failed test looks like:
```
  2) Reports::AdultIncontinenceReportService#report with values should handle null distribution quantity
     Failure/Error:
       Partners::User.create!(
         email: Faker::Internet.email,
         name: Faker::Name.name,
         partner: partners_partner,
         password: 'password!',
         invitation_sent_at: Time.utc(2021, 9, 16, 12, 43, 4),
         last_sign_in_at: Time.utc(2021, 9, 17, 11, 34, 4)
       )

     ActiveRecord::RecordInvalid:
       Validation failed: Email has already been taken
     # ./spec/factories/partners.rb:126:in `block (3 levels) in <top (required)>'
     # <internal:kernel>:90:in `tap'
     # <internal:kernel>:90:in `tap'
     # ./spec/services/reports/adult_incontinence_report_service_spec.rb:39:in `block (4 levels) in <top (required)>'
```
https://github.com/rubyforgood/human-essentials/runs/4750290059?check_suite_focus=true

### Type of change
* Bugfix (non-breaking change which fixes an issue)

### How Has This Been Tested?
CI should be a good indicator that its been addressed

### Screenshots
N/A
