### PR TITLE
Speed up RSpec by not cleaning the DB twice and by using bulk insert …

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -172,23 +172,17 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do
-    Faker::Config.random = Random.new(42)
-
     # Use truncation in the case of doing `browser` tests because it
     # appears that transactions won't work since it really does
     # depend on the database to have records.
     DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.clean
   end
 
   config.before(:each, type: :request) do
-    Faker::Config.random = Random.new(42)
-
     # Use truncation in the case of doing `browser` tests because it
     # appears that transactions won't work since it really does
     # depend on the database to have records.
     DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.clean
   end
 
   config.before(:each) do |example|
@@ -268,11 +262,15 @@ def seed_base_items_for_tests
     @_base_items = []
     items_by_category.each do |category, entries|
       entries.each do |entry|
-        @_base_items << { name: entry["name"], category: category, partner_key: entry["key"] }
+        @_base_items << { name: entry["name"],
+                          category: category,
+                          partner_key: entry["key"],
+                          updated_at: Time.zone.now,
+                          created_at: Time.zone.now }
       end
     end
   end
-  BaseItem.create(@_base_items)
+  BaseItem.insert_all(@_base_items) # rubocop:disable Rails/SkipsModelValidations
   Rails.logger.info "~-=> Done creating Base Items!"
 end
 


### PR DESCRIPTION
…for base items.

### Description

The reason RSpecs are particularly slow for request and system specs is because these specs use truncation rather than transactions. Truncation requires a separate DB call to truncate every table. On my local, these calls take about half a second to complete. We were cleaning the DB both *before* and *after* every spec, when it should only be necessary to do it *after* (since we also clean before the suite begins). Removing this extra call saves half a second per test, which adds up to several minutes across the entire suite.

In addition, we were using `BaseItem.create` to create all items instead of `insert_all`. This results in many insert statements on every single test. Replacing it with `insert_all` also saves time since this runs on every single spec.

### Type of change

* Internal improvement

### How Has This Been Tested?

Local testing