### PR TITLE
Update the Installation Guide and link to it from Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Ruby for Good [code of conduct](https://github.com/rubyforgood/code-of-conduct).
 **First:** if you're unsure or afraid of *anything*, just ask or submit the issue or pull request anyways. You won't be yelled at for giving your best effort. The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contributions, and don't want a wall of rules to get in the way of that.
 
 ## Onboarding the App
+You can find detailed instructions on how to seup the app locally in [installation.md](/installation.md).
  1. Fork the repo.
  2. Clone your fork
  3. Run `cp config/database.yml.example config/database.yml` - This will copy the contents of `database.yml.example ` and put it in a new file called `database.yml`.

--- a/installation.md
+++ b/installation.md
@@ -1,6 +1,6 @@
-# Installing on Ubuntu
+# Installing on Ubuntu or macOS
 
-Following are instructions for installing DiaperBase on a freshly installed Ubuntu Desktop host. This will probably work identically on Ubuntu Server but that has not been tested yet.
+Following are instructions for installing Human Essentials on a freshly installed Ubuntu Desktop host or macOS. This will probably work identically on Ubuntu Server but that has not been tested yet.
 
 Many of these instructions can probably work as is, or easily be translated to work on a Mac.
 
@@ -9,20 +9,20 @@ There are two kinds of installations; one for a developer and another for a depl
 Obviously, if any of these steps are already done you will probably not need to do them, so just ignore those steps.
 
 
-### Project Page
+## Project Page
 
-The Github project page is at [https://github.com/rubyforgood/diaper](https://github.com/rubyforgood/diaper).
+The Github project page is at [https://github.com/rubyforgood/human-essentials](https://github.com/rubyforgood/human-essentials).
 
 
-### Installing OS Packages
+## Installing OS Packages
 
 You'll need to add some packages to those that are included in the installation by default:
 
-#### Ubuntu
+### Ubuntu
 
 `sudo apt install curl  git  nodejs  npm  postgresql  libpq-dev`
 
-#### OS X
+### macOS
 
 Install [Homebrew](https://brew.sh/) if you don't already have it
 
@@ -38,33 +38,38 @@ brew install postgresql
 ```
 
 
-### Installing the Diaper Software
+## Installing the Human Essentials Software
 
-If you will be using this machine for development, you will need to `git clone` the repo:
+If you will be using this machine for development, you will need 
+a copy of the Human Essentials repo.
 
-`git clone https://github.com/rubyforgood/diaper.git`
+Fork the repo on GitHub, and create a copy on your own user.
+
+To clone the repo, you'll need to use the `git clone` command.
+
+`git clone https://github.com/<your username>/human-essentials.git`
 
 If you only need to have the files but don't need to use git, you can download the zip file and unzip it:
 
 ```
-curl -o diaper.zip https://codeload.github.com/rubyforgood/diaper/zip/master \
-    && unzip diaper.zip \
-    && rm diaper.zip
+curl -o human-essentials.zip https://codeload.github.com/rubyforgood/human-essentials/zip/main \
+    && unzip human-essentials.zip \
+    && rm human-essentials.zip
 ```
 
 
-### Installing Yarn
+## Installing Yarn
 
-Go to your diaper project directory and do this:
+Go to your human-essentials project directory and do this:
 
-#### Ubuntu
+### Ubuntu
 
 ```
 sudo npm -g install yarn
 yarn install
 ```
 
-### OS X
+### macOS
 
 ```
 brew install yarn
@@ -73,7 +78,7 @@ brew install imagemagick
 ```
 
 
-### Installing rvm
+## Installing rvm
 
 Go to https://rvm.io/rvm/install and find and run the commands that install the gpg key and install rvm. At the time of this writing (2019-07-26), they are:
 
@@ -89,7 +94,7 @@ _Open a new terminal tab or window (this will not work in your current shell!)._
 If you see something like ‘rvm not found’, you may need to change your terminal settings so that something like “Run command as a login shell” is selected. In the default Ubuntu terminal, you would go to the Edit menu, then select the profile to edit, then select the “Command” tab, and select “Run command as a login shell”. Then open a new shell to proceed.
 
 
-### Installing Ruby and Ruby Gems
+## Installing Ruby and Ruby Gems
 
 Install the required version of Ruby (you may be prompted for your system password so that rvm can install some required packages):
 
@@ -100,22 +105,22 @@ Then, from your project directory, install the gems required for the project:
 `bundle`
 
 
-### Configuring Postgres
+## Configuring Postgres
 
 By default, Postgres has no password for the admin user. You'll need to set one. Run `psql` as the Unix user `postgres` that was added by the Postgres installation (Ubuntu only):
 
-#### Ubuntu
+### Ubuntu
 
 `sudo -u postgres psql`
 
-#### OS X
+### macOS
 
 ```
 brew services start postgresql
 psql postgres
 ```
 
-In `psql`, the following command would add a password whose value is `password`. For the default OS X / HomeBrew setup, the postgres user is not created but you view the user list using `\du` in psql. Replace `postgres`, below, with the user name.
+In `psql`, the following command would add a password whose value is `password`. For the default macOS / HomeBrew setup, the postgres user is not created but you view the user list using `\du` in psql. Replace `postgres`, below, with the user name.
 
 `alter user postgres password 'password';`
 
@@ -130,20 +135,20 @@ You will see in `config/database.yml` that the Postgres username and password ar
 
 `cp .env.example .env`
 
-Now edit the top two lines of this file. For OS X users, remember to replace `postgres`, below, with the user name you used in psql.
+Now edit the top two lines of this file. For macOS users, remember to replace `postgres`, below, with the user name you used in psql.
 
 ```
 PG_USERNAME=postgres
 PG_PASSWORD=password
 ```
 
-### Initializing the Data Base
+## Initializing the Database
 
-From your project directory, initialize the data base:
+From your project directory, initialize the database:
 
 `rails db:setup db:migrate db:test:prepare db:seed`
 
-### Testing the Application
+## Testing the Application
 
 You should now be able to successfully run the application:
 
@@ -152,4 +157,4 @@ bin/webpack-dev-server
 rails server
 ```
 
-Point a browser to `localhost:3000`. You should see the Diaper home page. For login credentials, consult the README.md file (at the time of this writing at [https://github.com/rubyforgood/diaper/blob/master/README.md#login](https://github.com/rubyforgood/diaper/blob/master/README.md#login).
+Point a browser to `localhost:3000`. You should see the Human Essentials home page. For login credentials, consult the README.md file (at the time of this writing at [https://github.com/rubyforgood/human-essentials/blob/master/README.md#login](https://github.com/rubyforgood/human-essentials/blob/master/README.md#login).


### PR DESCRIPTION
# Description
I had some issues setting up Human Essentials from the Contributing Guide. The installation guide is more thorough, and helped a lot, but was out of date. 

I updated several things in the installation guide.
* diaper -> human-essentials
* master -> main
* OS X -> macOS
* data base -> database
* Cleaned up headings to make them consistent and bigger
* In the header and description, reflected that macOS instructions were already added

I think there would be some benefits in cleaning this up further and having one source of truth for setup, but I wanted to keep the changes small because they were unrequested. Also, I referenced installation.md from CONTRIBUTING.md instead of replacing it, because I didn't see references to `bin/setup` inside installation.md, and didn't want to make larger changes, but having a hint of where to go for more help is really nice.

### Type of change

* Documentation update

### How Has This Been Tested?

I have reviewed the changes on GitHub at [installation.md](https://github.com/ChaelCodes/human-essentials/blob/cc-update-installation-and-contributing-guide/installation.md) and [CONTRIBUTING.md](https://github.com/ChaelCodes/human-essentials/blob/cc-update-installation-and-contributing-guide/CONTRIBUTING.md#onboarding-the-app).
