### PR TITLE
Check if primary_user is within list of Partner::Users

### DIFF
--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe Partner, type: :model, skip_seed: true do
     let(:partner) { create(:partner) }
 
     it 'should return the asssociated primary Partners::User' do
-      primary_partner_user = Partners::User.find_by(partner_id: partner.profile.id)
-      expect(subject).to eq(primary_partner_user)
+      partner_users = Partners::User.where(partner_id: partner.profile.id)
+      expect(partner_users).to include(subject)
     end
   end
 


### PR DESCRIPTION
Resolves #2716

### Description
`spec/models/partner_spec.rb` was erroring in my local test environment when testing [`primary_partner_user`](https://github.com/rubyforgood/human-essentials/blob/c2d112b04143b6d2dcf29f4b4c065685b769cf2a/app/models/partner.rb#L70-L82).

https://github.com/rubyforgood/human-essentials/blob/c2d112b04143b6d2dcf29f4b4c065685b769cf2a/spec/models/partner_spec.rb#L125-L133

There were two partner users being returned for the same partner. This resulted in flakiness. We're now checking if the primary_user is in the list of Partner::Users, instead of searching with `find_by`, which does not guarantee order.

### Type of change

* Spec Flakiness Fix

### How Has This Been Tested?

Ran `bundle exec rspec spec/models/partner_spec.rb` locally.
