### PR TITLE
Unique Case-Insensitive email required for Partner Organizations

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -40,8 +40,8 @@ class Partner < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :organization }
 
   validates :email, presence: true,
-                    uniqueness: true,
-                    format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, on: :create }
+                    uniqueness: { case_sensitive: false },
+                    format: { with: URI::MailTo::EMAIL_REGEXP, on: :create }
 
   validates :quota, numericality: true, allow_blank: true
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Partner, type: :model, skip_seed: true do
     it "still requires a unique email between organizations" do
       create(:partner, name: "Foo", email: "foo@example.com")
       expect(build(:partner, name: "Foo", email: "foo@example.com", organization: build(:organization))).to_not be_valid
+      expect(build(:partner, name: "Foo", email: "FOO@example.com", organization: build(:organization))).to_not be_valid
     end
 
     it "requires a unique email that is formatted correctly" do


### PR DESCRIPTION
Resolves #2715

### Description
Partner Organizations should have a unique email, but the check for uniqueness treated FOO@host.com and foo@host.com as different emails. Now it raises an error if two partners have the same email. While we were modifying the check, we swapped the hand-rolled regex for one provided by URI.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested by attempting to create a new partner agency locally with the same email and a different casing.
Created a test on the model to confirm that the same email in a different case is invalid.

### Screenshots
The error when the same email with a different casing is entered:
![errors on same email case: Failed to add partner due to: ["email has already been taken", "Validation failed: Email has already been taken"]](https://user-images.githubusercontent.com/8124558/150691803-7802de11-a521-4797-bf2f-c2dbcb2de9ae.png)

