### PR TITLE
Clarify Consolidated Login

### DIFF
--- a/app/services/consolidated_login_director.rb
+++ b/app/services/consolidated_login_director.rb
@@ -36,8 +36,8 @@ class ConsolidatedLoginDirector
     if @user && @partner_user
       @organization = "Bank"
       @organizations = [
-        [@user.organization.name, "Bank"],
-        [@partner_user.partner.name, "Partner"]
+        ["BANK ACCOUNT", "Bank"],
+        ["PARTNER ACCOUNT", "Partner"]
       ]
 
       @email = @user.email

--- a/app/views/consolidated_logins/new.html.erb
+++ b/app/views/consolidated_logins/new.html.erb
@@ -2,13 +2,13 @@
   <div class="login-box">
     <div class="card">
       <div class="card-body login-card-body">
-        <p class="login-box-msg">Let's get started!</p>
+        <h3 class="">This email is associated with both a bank and a partner account.</h3>
         <div class="form-inputs">
-          <%= f.input :email, autofocus: true %>
+          <%= f.input :email, label: 'Login Email:', autofocus: true %>
         </div>
         <% if resource.organization %>
           <div class="form-inputs">
-            <%= f.input :organization, collection: resource.organizations, include_blank: false %>
+            <%= f.input :organization, label: 'Account to Login With:', as: :radio_buttons, collection: resource.organizations, include_blank: false, label_html: { class:  "btn btn-primary btn-block" } %>
           </div>
         <% end %>
         <div class="col-12 text-center">
@@ -18,9 +18,6 @@
       <br>
       <div class="row">
         <div class="col-12 text-center">
-          <p class="mb-1">
-          <%= link_to "Sign up", new_account_request_path %><br />
-          </p>
         </div>
       </div>
     </div>

--- a/spec/services/consolidated_login_director_spec.rb
+++ b/spec/services/consolidated_login_director_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe ConsolidatedLoginDirector, skip_seed: true do
 
       expect(director.organization).to eq "Bank" # default to bank option
       expect(director.organizations).to eq [
-        ["A Bank", "Bank"],
-        ["A Partner", "Partner"]
+        ["BANK ACCOUNT", "Bank"],
+        ["PARTNER ACCOUNT", "Partner"]
       ]
 
       expect(director.email).to eq "both@example.com"

--- a/spec/system/consolidated_login_system_spec.rb
+++ b/spec/system/consolidated_login_system_spec.rb
@@ -24,11 +24,12 @@ RSpec.describe "Consolidated login with email lookup", type: :system, js: true d
 
     it "prefils email and presents a dropdown allowing the user to pick which org they'd like to log in for" do
       expect(page.find_field("Email").value).to eql(user.email)
-      expect(page).to have_select("user[organization]", options: ["A Bank", "A Partner"])
+      expect(page).to have_text("BANK ACCOUNT")
+      expect(page).to have_text("PARTNER ACCOUNT")
     end
 
     it "allows successful login based on the organization selected" do
-      select "A Partner", from: "user[organization]"
+      choose "PARTNER ACCOUNT"
       click_button "Continue"
 
       fill_in "Password", with: user.password


### PR DESCRIPTION
Add some visual cues to make it more obvious to the user if they are logging in with a bank or a partner account.

Users were having issues logging in when they have a bank and partner account with the same name. This tiny fix makes it more apparent which account they are about to log in with.

resolves #2615 

Before:

![](https://user-images.githubusercontent.com/667909/143145858-be9f1b14-50b1-479c-8c9e-da5432749168.png)

After:

<img width="426" alt="image" src="https://user-images.githubusercontent.com/667909/150889065-3d54aa96-e6cc-43d1-9d83-a84421bc68fc.png">
