### PR TITLE
Add Rspec-Retry to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ group :test do
   gem 'magic_test'
   gem "orderly", "~> 0.1" # used for feature testing where this appears before that
   gem "rails-controller-testing"
+  gem "rspec-retry"
   gem 'simplecov'
   gem 'shoulda-matchers', '~> 5.1'
   gem 'webdrivers', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,6 +426,8 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.10.3)
     rubocop (1.23.0)
       parallel (~> 1.10)
@@ -622,6 +624,7 @@ DEPENDENCIES
   rb-readline (~> 0.5.3)
   recaptcha
   rspec-rails (~> 5.0.2)
+  rspec-retry
   rubocop
   rubocop-rails (~> 2.9.1)
   sass-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,13 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = :random
 
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+
+  config.around :each do |ex|
+    ex.run_with_retry retry: 3
+  end
+
 =begin
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running


### PR DESCRIPTION
Add in rspec-retry to the gemfile to provide some reprieve from the flaky tests and make people's pull requests more informative.

Obviously not the best solution long term solution but will update the test flakiness issue with more information.

Ran this 10 times through CI without any failures.