### PR TITLE
Hotfix for strong migrations prod issue

### DIFF
--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -12,7 +12,7 @@ StrongMigrations.auto_analyze = true
 
 # Set the version of the production database
 # so the right checks are run in development
-# StrongMigrations.target_version = 10
+StrongMigrations.target_version = 10
 
 # Add custom checks
 # StrongMigrations.add_check do |method, args|

--- a/db/migrate/20211230033135_add_fields_to_organization.rb
+++ b/db/migrate/20211230033135_add_fields_to_organization.rb
@@ -1,6 +1,8 @@
 class AddFieldsToOrganization < ActiveRecord::Migration[6.1]
   def change
-    add_column :organizations, :repackage_essentials, :boolean, null: false, default: false
-    add_column :organizations, :distribute_monthly, :boolean, null: false, default: false
+    add_column :organizations, :repackage_essentials, :boolean, null: false
+    add_column :organizations, :distribute_monthly, :boolean, null: false
+    change_column_default :organizations, :repackage_essentials, from: nil, to: false
+    change_column_default :organizations, :distribute_monthly, from: nil, to: false
   end
 end

--- a/db/migrate/20220103182104_add_categories_to_purchases.rb
+++ b/db/migrate/20220103182104_add_categories_to_purchases.rb
@@ -1,8 +1,8 @@
 class AddCategoriesToPurchases < ActiveRecord::Migration[6.1]
   def change
-    add_monetize :purchases, :amount_spent_on_diapers, currency: { present: false }
-    add_monetize :purchases, :amount_spent_on_adult_incontinence, currency: { present: false }
-    add_monetize :purchases, :amount_spent_on_other, currency: { present: false }
+    safety_assured { add_monetize :purchases, :amount_spent_on_diapers, currency: { present: false } }
+    safety_assured { add_monetize :purchases, :amount_spent_on_adult_incontinence, currency: { present: false } }
+    safety_assured { add_monetize :purchases, :amount_spent_on_other, currency: { present: false } }
     change_column_default :purchases, :amount_spent_on_diapers_cents, from: nil, to: 0
     change_column_default :purchases, :amount_spent_on_adult_incontinence_cents, from: nil, to: 0
     change_column_default :purchases, :amount_spent_on_other_cents, from: nil, to: 0

--- a/db/migrate/20220103231648_add_reminder_day_of_month_and_deadline_day_of_month_to_partner_groups.rb
+++ b/db/migrate/20220103231648_add_reminder_day_of_month_and_deadline_day_of_month_to_partner_groups.rb
@@ -1,8 +1,9 @@
 class AddReminderDayOfMonthAndDeadlineDayOfMonthToPartnerGroups < ActiveRecord::Migration[6.1]
   def change
-    add_column :partner_groups, :send_reminders, :boolean, default: :false, null: false
+    add_column :partner_groups, :send_reminders, :boolean,  null: false
     add_column :partner_groups, :reminder_day_of_month, :integer
     add_column :partner_groups, :deadline_day_of_month, :integer
+    change_column_default :partner_groups, :send_reminders, from: nil, to: false
     add_check_constraint :partner_groups, "deadline_day_of_month <= 28", name: "deadline_day_of_month_check", validate: false
     add_check_constraint :partner_groups, "reminder_day_of_month <= 14", name: "reminder_day_of_month_check", validate: false
     add_check_constraint :partner_groups, "deadline_day_of_month > reminder_day_of_month", name: "reminder_day_of_month_and_deadline_day_of_month_check", validate: false


### PR DESCRIPTION
Strong migrations prevented a deployment to prod, this PR fixes the non-safe migrations as well as turns on the strong migrations gem in development so future development migrations that fail strong migrations won't get through.

Additionally, I wasn't able to get the monetize migrations to be safe -- part of the rails-money gem. So I marked them as safe so we could move forward.