### PR TITLE
2695: Change "from" e-mail to info@humanessentials.app and move the "…

### DIFF
--- a/app/mailers/distribution_mailer.rb
+++ b/app/mailers/distribution_mailer.rb
@@ -24,7 +24,7 @@ class DistributionMailer < ApplicationMailer
     @from_email = current_organization.email.presence || current_organization.users.first.email
     @distribution_changes = distribution_changes
     attachments[format("%s %s.pdf", @partner.name, @distribution.created_at.strftime("%Y-%m-%d"))] = DistributionPdf.new(current_organization, @distribution).render
-    mail(to: @partner.email, from: @from_email, subject: "#{subject} from #{current_organization.name}")
+    mail(to: @partner.email, subject: "#{subject} from #{current_organization.name}")
   end
 
   def reminder_email(distribution_id)
@@ -33,6 +33,6 @@ class DistributionMailer < ApplicationMailer
     @distribution = distribution
     return if @distribution.past? || !@partner.send_reminders || @partner.deactivated?
 
-    mail(to: @partner.email, from: @distribution.organization.email, subject: "#{@partner.name} Distribution Reminder")
+    mail(to: @partner.email, subject: "#{@partner.name} Distribution Reminder")
   end
 end

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -4,7 +4,7 @@ class RequestsConfirmationMailer < ApplicationMailer
     @partner = request.partner
     @request_items = fetch_items(request)
 
-    mail(from: @organization.from_email, to: @partner.email, subject: "#{@organization.name} - Requests Confirmation")
+    mail(to: @partner.email, subject: "#{@organization.name} - Requests Confirmation")
   end
 
   private

--- a/app/views/distribution_mailer/partner_mailer.html.erb
+++ b/app/views/distribution_mailer/partner_mailer.html.erb
@@ -341,6 +341,11 @@
               <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 <tr>
                   <td>
+                    From: <a href="mailto:<%= @from_email %>"><%= @from_email %></a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <%= @default_email_text_interpolated.html_safe %>
                   </td>
                 </tr>

--- a/app/views/distribution_mailer/reminder_email.html.erb
+++ b/app/views/distribution_mailer/reminder_email.html.erb
@@ -7,5 +7,6 @@
     <% delivery_method = (@distribution.delivery?) ? "delivery" : "pick up"%>
     <p>Hello <%= @partner.name %>,</p>
     <p>This is a friendly reminder that tomorrow, <b><%= @distribution.issued_at.strftime("%A, %B #{@distribution.issued_at.day.ordinalize} %Y at %I:%M%p") %></b>, is your distribution <b><%= delivery_method %></b> date. </p>
+    <p>For more information: <a href="mailto:<%= @distribution.organization.email %>"><%= @distribution.organization.email %></a></p>
   </body>
 </html>

--- a/app/views/requests_confirmation_mailer/confirmation_email.html.erb
+++ b/app/views/requests_confirmation_mailer/confirmation_email.html.erb
@@ -9,5 +9,6 @@
 
 <p>You will receive a notification when a distribution has been created of the pick-up time and date.</p>
 
-<p>Your friends at,</p>
+<p>Your friends at</p>
 <p><%= @organization.name %></p>
+<p>For more info, please e-mail <a href="mailto:<%= @organization.from_email %>"><%= @organization.from_email %></a></p>

--- a/app/views/requests_confirmation_mailer/confirmation_email.text.erb
+++ b/app/views/requests_confirmation_mailer/confirmation_email.text.erb
@@ -8,5 +8,6 @@ This is an email confirmation that the <%= @organization.name %> has received yo
 
 You will receive a notification when a distribution has been created of the pick-up time and date.
 
-Your friends at,
+Your friends at
 <%= @organization.name %>
+For more info, please e-mail <%= @organization.from_email %>

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -3,14 +3,17 @@ RSpec.describe DistributionMailer, type: :mailer, needs_users: true do
     @organization.default_email_text = "Default email text example\n\n%{delivery_method} %{distribution_date}\n\n%{partner_name}\n\n%{comment}"
     @partner = create(:partner, name: 'PARTNER')
     @distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner)
+    @organization.update!(email: "me@org.com")
   end
 
   describe "#partner_mailer" do
     let(:distribution_changes) { {} }
     let(:mail) { DistributionMailer.partner_mailer(@organization, @distribution, 'test subject', distribution_changes) }
 
-    it "renders the body with organizations email text" do
+    it "renders the body with organization's email text" do
       expect(mail.body.encoded).to match("Default email text example")
+      expect(mail.html_part.body).to match(%(From: <a href="mailto:me@org.com">me@org.com</a>))
+      expect(mail.from).to eq(["info@humanessentials.app"])
       expect(mail.subject).to eq("test subject from DEFAULT")
     end
 
@@ -63,8 +66,10 @@ RSpec.describe DistributionMailer, type: :mailer, needs_users: true do
   describe "#reminder_email" do
     let(:mail) { DistributionMailer.reminder_email(@distribution.id) }
 
-    it "renders the body with organizations email text" do
+    it "renders the body with organization's email text" do
       expect(mail.body.encoded).to match("This is a friendly reminder")
+      expect(mail.body).to match(%(For more information: <a href="mailto:me@org.com">me@org.com</a>))
+      expect(mail.from).to eq(["info@humanessentials.app"])
       expect(mail.subject).to eq("PARTNER Distribution Reminder")
     end
 

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer, skip_seed: true do
     it 'renders the headers' do
       expect(mail.subject).to eq("#{request.organization.name} - Requests Confirmation")
       expect(mail.to).to include(request.partner.email)
-      expect(mail.from).to include(request.organization.email)
+      expect(mail.from).to include("info@humanessentials.app")
     end
 
     it 'renders the body' do
+      @organization.update!(email: "me@org.com")
       expect(mail.body.encoded).to match('This is an email confirmation')
+      expect(mail.body.encoded).to match('For more info, please e-mail me@org.com')
     end
   end
 end


### PR DESCRIPTION
…from" e-mail to the mail body

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2695 

### Description

Changes the "from" e-mail address to always be from `humanessentials.app` and moves the original "from" address to the body of the e-mail.
### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Local and unit testing.

### Screenshots

<img width="906" alt="image" src="https://user-images.githubusercontent.com/1986893/151683258-8e58c3fa-e47c-4f4a-b9de-a315ebb27f1f.png">