### PR TITLE
2714 Collapsed Menu hides text

### DIFF
--- a/app/views/layouts/_lte_admin_sidebar.html.erb
+++ b/app/views/layouts/_lte_admin_sidebar.html.erb
@@ -83,7 +83,7 @@
   </li>
 
   <li class="nav-item has-treeview <%= menu_open?(['users']) %>">
-    <a href="#" class="nav-link <%= active_class(['purchases']) %>">
+    <a href="#" class="nav-link <%= active_class(['users']) %>">
       <i class="nav-icon fas fa-users"></i>
       <p>Users
         <i class="fas fa-angle-left right"></i>

--- a/app/views/layouts/_lte_admin_sidebar.html.erb
+++ b/app/views/layouts/_lte_admin_sidebar.html.erb
@@ -2,7 +2,8 @@
 
   <li class="nav-item">
     <%= link_to(admin_dashboard_path, class: "nav-link #{active_class(['dashboard'])}") do %>
-      <i class="nav-icon fas fa-tachometer-alt"></i> <span>Admin Dashboard</span>
+      <i class="nav-icon fas fa-tachometer-alt"></i>
+      <p>Admin Dashboard</p>
     <% end %>
   </li>
 
@@ -85,7 +86,8 @@
     <a href="#" class="nav-link <%= active_class(['purchases']) %>">
       <i class="nav-icon fas fa-users"></i>
       <p>Users
-        <i class="fas fa-angle-left right"></i></p>
+        <i class="fas fa-angle-left right"></i>
+      </p>
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= 'active' if current_page?(admin_users_path) %>">
@@ -103,20 +105,23 @@
 
   <li class="nav-item <%= active_class(['account_requests']) %>">
     <%= link_to(admin_account_requests_path, class: "nav-link #{"active" if current_page?(admin_account_requests_path)}") do %>
-      <i class="nav-icon fa fa-sticky-note"></i> Account Requests
+      <i class="nav-icon fa fa-sticky-note"></i>
+      <p>Account Requests</p>
     <% end %>
   </li>
 
   <li class="nav-item <%= 'active' if current_page?(admin_questions_path) %>">
     <%= link_to(admin_questions_path, class: "nav-link #{"active" if current_page?(admin_questions_path)}") do %>
-      <i class="nav-icon fa fa-circle-o"></i> FAQ
+      <i class="nav-icon fa fa-circle-o"></i>
+      <p>FAQ</p>
     <% end %>
   </li>
 
   <% if (current_user.organization.present?) %>
     <li class="nav-item">
       <%= link_to(dashboard_path(organization_id: current_user.organization), class: "nav-link") do %>
-        <i class="nav-icon fas fa-home"></i> <span>My Organization</span>
+        <i class="nav-icon fas fa-home"></i>
+        <p>My Organization</p>
       <% end %>
     </li>
   <% end %>

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -210,7 +210,8 @@
   <% if current_user.organization_admin %>
     <li class="nav-item">
       <%= link_to(organization_path, class: "nav-link") do %>
-        <i class="nav-icon fas fa-home"></i> <span>My Organization</span>
+        <i class="nav-icon fas fa-home"></i>
+        <p>My Organization</p>
       <% end %>
     </li>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
 <!-- Site wrapper -->
 <div class="wrapper">
   <nav class="main-header navbar navbar-expand navbar-white navbar-light">
-    <a href="#" data-widget="pushmenu" data-auto-collapse-size="992">
+    <a id="collapse" href="#" data-widget="pushmenu" data-auto-collapse-size="992">
       <i class="fa fa-bars"></i>
     </a>
 

--- a/spec/system/navigation_system_spec.rb
+++ b/spec/system/navigation_system_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe "Navigation", type: :system, js: true, skip_seed: true do
+  describe "sidebar on home" do
+    before do
+      sign_in(user)
+      visit "/"
+    end
+
+    context "with organization user" do
+      let(:user) { create(:organization_admin) }
+      let(:links) { ["Dashboard", "Donations", "Purchases", "Requests", "Diaper Drives", "Distributions", "Pick Ups & Deliveries", "Partner Agencies", "Inventory", "Community", "Reporting & Auditing", "My Organization"] }
+
+      it "shows navigation options" do
+        sidebar = page.find(".sidebar")
+        links.each do |title|
+          expect(sidebar).to have_link(title)
+        end
+      end
+
+      context "with collapsed sidebar" do
+        before { click_link("collapse") }
+
+        it "hides text" do
+          page.all(".nav-sidebar > .nav-item > .nav-link").each do |link|
+            label = link.find("p", visible: :all)
+            expect(label).to match_style(width: "0px")
+            expect(links).to include(label.text(:all))
+          end
+        end
+      end
+    end
+  end
+
+  describe "sidebar on admin" do
+    before do
+      sign_in(user)
+      visit "/admin"
+    end
+
+    context "with superadmin user" do
+      let(:user) { create(:super_admin) }
+      let(:links) { ["Admin Dashboard", "Barcode Items", "Base Items", "Organizations", "Partners", "Users", "Account Requests", "FAQ", "My Organization"] }
+
+      it "shows navigation options" do
+        sidebar = page.find(".sidebar")
+        links.each do |title|
+          expect(sidebar).to have_link(title)
+        end
+      end
+
+      context "with collapsed sidebar" do
+        before { click_link("collapse") }
+
+        it "hides text" do
+          page.all(".nav-sidebar > .nav-item > .nav-link").each do |link|
+            label = link.find("p", visible: :all)
+            expect(label).to match_style(width: "0px")
+            expect(links).to include(label.text(:all))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2714 

### Description
Text in the navigation sidebar only hides correctly if it's wrapped in a `p` tag. "My Organization" was wrapped in a `span`, so it was always visible.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

There is a new system test for admin navigation, and navigation.

Steps to Reproduce:
1. Log in as an organization admin
1. Collapse the sidebar
1. No text is visible - just icons

### Screenshots
Old | New
--- | ---
![M is visible on My Organization](https://user-images.githubusercontent.com/8124558/151711908-4a2434f3-8161-453c-af40-99daece283bb.png) | ![The M is gone!](https://user-images.githubusercontent.com/8124558/151711967-c4e24578-0dcb-4dd5-9008-0b89535704e5.png)


