### PR TITLE
2676: Reduce dashboard spec date sensitivity, improve descriptions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -51,10 +51,6 @@ jobs:
       - name: Install PostgreSQL client
         run: |
           sudo apt-get -yqq install libpq-dev
-      - name: Fix the datetime
-        run: |
-          sudo timedatectl set-ntp 0
-          sudo timedatectl set-time 2022-02-17
       - name: Build App
         env:
           POSTGRES_HOST: localhost

--- a/spec/support/pages/organization_dashboard_page.rb
+++ b/spec/support/pages/organization_dashboard_page.rb
@@ -30,8 +30,13 @@ class OrganizationDashboardPage < OrganizationPage
     end
   end
 
-  def filter_to_date_range(range_name)
+  def filter_to_date_range(range_name, custom_dates = nil)
     select_date_filter_range range_name
+
+    if custom_dates.present?
+      fill_in :filters_date_range, with: "#{custom_dates}\n"
+    end
+
     click_on "Filter"
   end
 

--- a/spec/support/pages/organization_dashboard_page.rb
+++ b/spec/support/pages/organization_dashboard_page.rb
@@ -112,7 +112,7 @@ class OrganizationDashboardPage < OrganizationPage
     end
   end
 
-  def recent_manufacturer_donation_links
+  def top_manufacturer_donation_links
     within manufacturers_section do
       all(".manufacturer a").map(&:text)
     end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -94,9 +94,6 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
 
     describe "Inventory Totals" do
       test_time = Time.zone.now
-      let(:date_to_view) { Time.zone.now }
-      let(:last_year_date) { Time.zone.now - 1.year }
-      let(:beginning_of_year) { Time.zone.now.beginning_of_year }
 
       describe "Summary" do
         before do

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
     end
 
     describe "Inventory Totals" do
+      test_time = Time.zone.now
       let(:date_to_view) { Time.zone.now }
       let(:last_year_date) { Time.zone.now - 1.year }
       let(:beginning_of_year) { Time.zone.now.beginning_of_year }
@@ -115,12 +116,6 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
       end
 
       describe "Donations" do
-        around do |example|
-          travel_to(date_to_view)
-          example.run
-          travel_back
-        end
-
         it "has a link to create a new donation" do
           org_new_donation_page = OrganizationNewDonationPage.new org_short_name: org_short_name
 
@@ -146,124 +141,113 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
         #   end
         # end
 
-        context "when constrained to date range" do
-          before do
-            @organization.donations.destroy_all
-            @this_years_donations = {
-              today: create(:donation, :with_items, issued_at: date_to_view, item_quantity: 100, storage_location: storage_location, organization: @organization),
-              yesterday: create(:diaper_drive_donation, :with_items, issued_at: date_to_view.yesterday, item_quantity: 101, storage_location: storage_location, organization: @organization),
-              earlier_this_week: create(:donation_site_donation, :with_items, issued_at: date_to_view.beginning_of_week, item_quantity: 102, storage_location: storage_location, organization: @organization),
-              beginning_of_year: create(:manufacturer_donation, :with_items, issued_at: beginning_of_year, item_quantity: 103, storage_location: storage_location, organization: @organization)
-            }
-            @last_years_donations = create_list(:donation, 2, :with_items, issued_at: last_year_date, item_quantity: 104, storage_location: storage_location, organization: @organization)
-            org_dashboard_page.visit
-          end
+        # 1, 20, 300, ..., 900000000
+        # assuming each value is used once, summing these values makes easily recognizable totals
+        # .fetch() from it so too-high indices raise IndexError
+        # legal indices are in -8..8 (i.e., inclusive)
+        item_quantities = (1..9).map { |i| i * 10**(i - 1) }
 
-          describe "This Year" do
+        # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
+        max_recent_donation_links_count = 3
+
+        # Make up to this many (inclusive) donations for each filtered period
+        # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
+        # Donations outside of the filtered period
+        max_donations_in_filtered_period = max_recent_donation_links_count + 1
+
+        around do |example|
+          # Ensure "today" doesn't change for the server side during the example run
+          # Note, however, that this does *not* affect the client side
+          # So "today" for the server still might be "yesterday"
+          # —possibly even "last month" or "last year"-
+          # for the client
+          # Rely on rerun via rspec-retry for those edge cases
+          travel_to(test_time)
+          example.run
+          travel_back
+        end
+
+        [
+          # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+          ["Today",        test_time,                               test_time],
+          ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
+          ["Last 7 Days",  test_time -  6.days,                     test_time],
+          ["Last 30 Days", test_time - 29.days,                     test_time],
+          ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
+          ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
+          ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
+          ["All Time",     test_time - 100.years,                   test_time],
+          ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
+          # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+        ].each do |date_range_info|
+          filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
+
+          filtered_date_range = start_date.to_date..end_date.to_date
+          before_filtered_date_range = start_date.yesterday.to_date
+          after_filtered_date_range = end_date.tomorrow.to_date
+
+          start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
+
+          # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
+          # w/out making a fixed pattern
+          num_donations_in_filtered_period = rand(0..max_donations_in_filtered_period)
+
+          context "given 1 Donation on #{before_filtered_date_range}, " \
+                  "#{num_donations_in_filtered_period} during #{filtered_date_range}, and " \
+                  "1 on #{after_filtered_date_range}" do
+            custom_dates = if set_custom_dates
+              "#{start_date_formatted} - #{end_date_formatted}"
+            end
+
             before do
-              org_dashboard_page.filter_to_date_range "This Year"
+              filtered_dates = filtered_date_range.to_a
+              @quantities_donated_in_filtered_date_range = []
+
+              @item_quantity = item_quantities.to_enum
+
+              def create_next_donation(donation_date:)
+                quantity_in_donation = @item_quantity.next
+                create :donation, :with_items, issued_at: donation_date, item_quantity: quantity_in_donation, storage_location: storage_location, organization: @organization
+
+                quantity_in_donation
+              end
+
+              # days_this_year.sample in num_donations_in_filtered_period.times loop
+              # rather than
+              # days_this_year.sample(num_donations_in_filtered_period).each
+              # because Array#sample(n) on an Array with m<n elements returns only m elements
+              num_donations_in_filtered_period.times do
+                @quantities_donated_in_filtered_date_range << create_next_donation(donation_date: filtered_dates.sample)
+              end
+
+              # create Donations before & after the filtered date range
+              [before_filtered_date_range, after_filtered_date_range].each { create_next_donation donation_date: _1 }
             end
 
-            let(:total_inventory) { @this_years_donations.values.map(&:total_quantity).sum }
+            describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
+              before do
+                org_dashboard_page
+                  .visit
+                  .filter_to_date_range(filtered_date_range_label, custom_dates)
+              end
 
-            it "has a widget displaying the year-to-date Donation totals, only using donations from this year" do
-              expect(org_dashboard_page.total_donations).to eq total_inventory
-            end
+              expected_recent_donation_links_count = [max_recent_donation_links_count, num_donations_in_filtered_period].min
 
-            it "displays some recent donations" do
-              expect(org_dashboard_page.recent_donation_links)
-                .to include(match /10\d items/i) # e.g., "101 items", "103 items", etc.
-                .exactly(3).times
-            end
-          end
+              it "shows the correct total and #{expected_recent_donation_links_count} Recent Donation link(s)" do
+                expect(org_dashboard_page.total_donations).to eq @quantities_donated_in_filtered_date_range.sum
 
-          describe "Today" do
-            before do
-              org_dashboard_page.filter_to_date_range "Today"
-            end
+                recent_donation_links = org_dashboard_page.recent_donation_links
 
-            let(:total_inventory) { @this_years_donations[:today].total_quantity }
+                expect(recent_donation_links.count).to eq expected_recent_donation_links_count
 
-            it "has a widget displaying today's Donation totals, only using donations from today" do
-              expect(org_dashboard_page.total_donations).to eq total_inventory
-            end
+                # Expect the links to be something like "1 item...", "20 items from Manufacturer"
+                # Strip out the item counts
+                recent_quantities = recent_donation_links.map { _1.match(/\d+/).to_s.to_i }
 
-            it "displays some recent donations" do
-              expect(org_dashboard_page.recent_donation_links)
-                .to include(match /#{total_inventory} items/i) # e.g., "100 items"
-                .exactly(:once)
-            end
-          end
-
-          describe "Yesterday" do
-            before do
-              org_dashboard_page.filter_to_date_range "Yesterday"
-            end
-
-            let(:total_inventory) { @this_years_donations[:yesterday].total_quantity }
-
-            it "has a widget displaying the Donation totals from yesterday, only using donations from yesterday" do
-              expect(org_dashboard_page.total_donations).to eq total_inventory
-            end
-
-            it "displays some recent donations" do
-              expect(org_dashboard_page.recent_donation_links)
-                .to include(match /#{total_inventory} items/i) # e.g., "101 items"
-                .exactly(:once)
-            end
-          end
-
-          describe "This Week" do
-            before do
-              org_dashboard_page.filter_to_date_range "Last 7 Days"
-            end
-
-            let(:total_inventory) { [@this_years_donations[:today], @this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:total_quantity).sum }
-
-            it "has a widget displaying the Donation totals from this week, only using donations from this week" do
-              expect(org_dashboard_page.total_donations).to eq total_inventory
-            end
-
-            it "displays some recent donations" do
-              expect(org_dashboard_page.recent_donation_links)
-                .to include(match /10\d items/i) # e.g., "101 items", "103 items", etc.
-                .exactly(3).times
-            end
-          end
-
-          describe "This Month" do
-            before do
-              org_dashboard_page.filter_to_date_range "This Month"
-            end
-
-            let(:total_inventory) { %i[today yesterday earlier_this_week].map { |date| @this_years_donations[date].total_quantity }.sum }
-
-            it "has a widget displaying the Donation totals from this month, only using donations from this month" do
-              expect(org_dashboard_page.total_donations).to eq total_inventory
-            end
-
-            it "displays some recent donations" do
-              expect(org_dashboard_page.recent_donation_links)
-                .to include(match /10\d items/i) # e.g., "101 items", "103 items", etc.
-                .exactly(3).times
-            end
-          end
-
-          describe "All Time" do
-            before do
-              org_dashboard_page.filter_to_date_range "All Time"
-            end
-
-            let(:total_inventory) { @this_years_donations.values.map(&:total_quantity).sum + @last_years_donations.map(&:total_quantity).sum }
-
-            it "has a widget displaying the Donation totals from last year, only using donations from last year" do
-              expect(org_dashboard_page.total_donations).to eq total_inventory
-            end
-
-            it "displays some recent donations from that time" do
-              expect(org_dashboard_page.recent_donation_links)
-                .to include(match /10\d items/i) # e.g., "101 items", "103 items", etc.
-                .exactly(3).times
+                # By design, the setup may have created more Donations during the period than are visible in the Recent Donation links
+                # Make sure each Recent Donation link uniquely matches a single Donation
+                expect(@quantities_donated_in_filtered_date_range.intersection(recent_quantities)).to match_array recent_quantities
+              end
             end
           end
         end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -93,8 +93,6 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
     end
 
     describe "Inventory Totals" do
-      test_time = Time.zone.now
-
       describe "Summary" do
         before do
           create_list(:storage_location, 3, :with_items, item_quantity: 111, organization: @organization)
@@ -113,687 +111,689 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
           end
         end
       end
+    end
 
-      # 1, 20, 300, ..., 900000000
-      # assuming each value is used once, summing these values makes easily recognizable totals
-      # .fetch() from it so too-high indices raise IndexError
-      # legal indices are in -8..8 (i.e., inclusive)
-      item_quantities = (1..9).map { |i| i * 10**(i - 1) }
+    test_time = Time.zone.now
 
-      describe "Donations" do
-        it "has a link to create a new donation" do
-          org_new_donation_page = OrganizationNewDonationPage.new org_short_name: org_short_name
+    # 1, 20, 300, ..., 900000000
+    # assuming each value is used once, summing these values makes easily recognizable totals
+    # .fetch() from it so too-high indices raise IndexError
+    # legal indices are in -8..8 (i.e., inclusive)
+    item_quantities = (1..9).map { |i| i * 10**(i - 1) }
 
-          org_dashboard_page.visit
+    describe "Donations" do
+      it "has a link to create a new donation" do
+        org_new_donation_page = OrganizationNewDonationPage.new org_short_name: org_short_name
 
-          expect { org_dashboard_page.create_new_donation }
-            .to change { page.current_path }
-            .to org_new_donation_page.path
-        end
+        org_dashboard_page.visit
 
-        # it "doesn't count inactive items" do
-        #   item = create(:donation, :with_items, item_quantity: 100, storage_location: storage_location).items.first
-        #
-        #   visit subject
-        #   within "#donations" do
-        #     expect(page).to have_content("100")
-        #   end
-        #
-        #   item.update!(active: false)
-        #   visit subject
-        #   within "#donations" do
-        #     expect(page).to have_no_content("100")
-        #   end
-        # end
+        expect { org_dashboard_page.create_new_donation }
+          .to change { page.current_path }
+          .to org_new_donation_page.path
+      end
 
-        # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
-        max_recent_donation_links_count = 3
+      # it "doesn't count inactive items" do
+      #   item = create(:donation, :with_items, item_quantity: 100, storage_location: storage_location).items.first
+      #
+      #   visit subject
+      #   within "#donations" do
+      #     expect(page).to have_content("100")
+      #   end
+      #
+      #   item.update!(active: false)
+      #   visit subject
+      #   within "#donations" do
+      #     expect(page).to have_no_content("100")
+      #   end
+      # end
 
-        # Make up to this many (inclusive) donations for each filtered period
-        # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
-        # Donations outside of the filtered period
-        max_donations_in_filtered_period = max_recent_donation_links_count + 1
+      # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
+      max_recent_donation_links_count = 3
 
-        around do |example|
-          # Ensure "today" doesn't change for the server side during the example run
-          # Note, however, that this does *not* affect the client side
-          # So "today" for the server still might be "yesterday"
-          # —possibly even "last month" or "last year"-
-          # for the client
-          # Rely on rerun via rspec-retry for those edge cases
-          travel_to(test_time)
-          example.run
-          travel_back
-        end
+      # Make up to this many (inclusive) donations for each filtered period
+      # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
+      # Donations outside of the filtered period
+      max_donations_in_filtered_period = max_recent_donation_links_count + 1
 
-        [
-          # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-          ["Today",        test_time,                               test_time],
-          ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
-          ["Last 7 Days",  test_time -  6.days,                     test_time],
-          ["Last 30 Days", test_time - 29.days,                     test_time],
-          ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
-          ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
-          ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
-          ["All Time",     test_time - 100.years,                   test_time],
-          ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
-          # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-        ].each do |date_range_info|
-          filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
+      around do |example|
+        # Ensure "today" doesn't change for the server side during the example run
+        # Note, however, that this does *not* affect the client side
+        # So "today" for the server still might be "yesterday"
+        # —possibly even "last month" or "last year"-
+        # for the client
+        # Rely on rerun via rspec-retry for those edge cases
+        travel_to(test_time)
+        example.run
+        travel_back
+      end
 
-          filtered_date_range = start_date.to_date..end_date.to_date
-          before_filtered_date_range = start_date.yesterday.to_date
-          after_filtered_date_range = end_date.tomorrow.to_date
+      [
+        # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+        ["Today",        test_time,                               test_time],
+        ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
+        ["Last 7 Days",  test_time -  6.days,                     test_time],
+        ["Last 30 Days", test_time - 29.days,                     test_time],
+        ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
+        ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
+        ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
+        ["All Time",     test_time - 100.years,                   test_time],
+        ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
+        # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+      ].each do |date_range_info|
+        filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
 
-          start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
+        filtered_date_range = start_date.to_date..end_date.to_date
+        before_filtered_date_range = start_date.yesterday.to_date
+        after_filtered_date_range = end_date.tomorrow.to_date
 
-          # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
-          # w/out making a fixed pattern
-          num_donations_in_filtered_period = rand(0..max_donations_in_filtered_period)
+        start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
 
-          context "given 1 Donation on #{before_filtered_date_range}, " \
-                  "#{num_donations_in_filtered_period} during #{filtered_date_range}, and " \
-                  "1 on #{after_filtered_date_range}" do
-            custom_dates = if set_custom_dates
-              "#{start_date_formatted} - #{end_date_formatted}"
+        # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
+        # w/out making a fixed pattern
+        num_donations_in_filtered_period = rand(0..max_donations_in_filtered_period)
+
+        context "given 1 Donation on #{before_filtered_date_range}, " \
+                "#{num_donations_in_filtered_period} during #{filtered_date_range}, and " \
+                "1 on #{after_filtered_date_range}" do
+          custom_dates = if set_custom_dates
+            "#{start_date_formatted} - #{end_date_formatted}"
+          end
+
+          before do
+            filtered_dates = filtered_date_range.to_a
+            @quantities_donated_in_filtered_date_range = []
+
+            @item_quantity = item_quantities.to_enum
+
+            def create_next_donation(donation_date:)
+              quantity_in_donation = @item_quantity.next
+              create :donation, :with_items, issued_at: donation_date, item_quantity: quantity_in_donation, storage_location: storage_location, organization: @organization
+
+              quantity_in_donation
             end
 
+            # days_this_year.sample in num_donations_in_filtered_period.times loop
+            # rather than
+            # days_this_year.sample(num_donations_in_filtered_period).each
+            # because Array#sample(n) on an Array with m<n elements returns only m elements
+            num_donations_in_filtered_period.times do
+              @quantities_donated_in_filtered_date_range << create_next_donation(donation_date: filtered_dates.sample)
+            end
+
+            # create Donations before & after the filtered date range
+            [before_filtered_date_range, after_filtered_date_range].each { create_next_donation donation_date: _1 }
+          end
+
+          describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
             before do
-              filtered_dates = filtered_date_range.to_a
-              @quantities_donated_in_filtered_date_range = []
-
-              @item_quantity = item_quantities.to_enum
-
-              def create_next_donation(donation_date:)
-                quantity_in_donation = @item_quantity.next
-                create :donation, :with_items, issued_at: donation_date, item_quantity: quantity_in_donation, storage_location: storage_location, organization: @organization
-
-                quantity_in_donation
-              end
-
-              # days_this_year.sample in num_donations_in_filtered_period.times loop
-              # rather than
-              # days_this_year.sample(num_donations_in_filtered_period).each
-              # because Array#sample(n) on an Array with m<n elements returns only m elements
-              num_donations_in_filtered_period.times do
-                @quantities_donated_in_filtered_date_range << create_next_donation(donation_date: filtered_dates.sample)
-              end
-
-              # create Donations before & after the filtered date range
-              [before_filtered_date_range, after_filtered_date_range].each { create_next_donation donation_date: _1 }
+              org_dashboard_page
+                .visit
+                .filter_to_date_range(filtered_date_range_label, custom_dates)
             end
 
-            describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
-              before do
-                org_dashboard_page
-                  .visit
-                  .filter_to_date_range(filtered_date_range_label, custom_dates)
-              end
+            expected_recent_donation_links_count = [max_recent_donation_links_count, num_donations_in_filtered_period].min
 
-              expected_recent_donation_links_count = [max_recent_donation_links_count, num_donations_in_filtered_period].min
+            it "shows the correct total and #{expected_recent_donation_links_count} Recent Donation link(s)" do
+              expect(org_dashboard_page.total_donations).to eq @quantities_donated_in_filtered_date_range.sum
 
-              it "shows the correct total and #{expected_recent_donation_links_count} Recent Donation link(s)" do
-                expect(org_dashboard_page.total_donations).to eq @quantities_donated_in_filtered_date_range.sum
+              recent_donation_links = org_dashboard_page.recent_donation_links
 
-                recent_donation_links = org_dashboard_page.recent_donation_links
+              expect(recent_donation_links.count).to eq expected_recent_donation_links_count
 
-                expect(recent_donation_links.count).to eq expected_recent_donation_links_count
+              # Expect the links to be something like "1 item...", "20 items from Manufacturer"
+              # Strip out the item counts
+              recent_quantities = recent_donation_links.map { _1.match(/\d+/).to_s.to_i }
 
-                # Expect the links to be something like "1 item...", "20 items from Manufacturer"
-                # Strip out the item counts
-                recent_quantities = recent_donation_links.map { _1.match(/\d+/).to_s.to_i }
-
-                # By design, the setup may have created more Donations during the period than are visible in the Recent Donation links
-                # Make sure each Recent Donation link uniquely matches a single Donation
-                expect(@quantities_donated_in_filtered_date_range.intersection(recent_quantities)).to match_array recent_quantities
-              end
+              # By design, the setup may have created more Donations during the period than are visible in the Recent Donation links
+              # Make sure each Recent Donation link uniquely matches a single Donation
+              expect(@quantities_donated_in_filtered_date_range.intersection(recent_quantities)).to match_array recent_quantities
             end
           end
         end
       end
+    end
 
-      describe "Purchases" do
-        it "has a link to create a new purchase" do
-          org_new_purchase_page = OrganizationNewPurchasePage.new org_short_name: org_short_name
+    describe "Purchases" do
+      it "has a link to create a new purchase" do
+        org_new_purchase_page = OrganizationNewPurchasePage.new org_short_name: org_short_name
 
-          org_dashboard_page.visit
+        org_dashboard_page.visit
 
-          expect { org_dashboard_page.create_new_purchase }
-            .to change { page.current_path }
-            .to org_new_purchase_page.path
-        end
+        expect { org_dashboard_page.create_new_purchase }
+          .to change { page.current_path }
+          .to org_new_purchase_page.path
+      end
 
-        # it 'does not count inactive items' do
-        #   item = create(:purchase, :with_items, item_quantity: 100, storage_location: storage_location).items.first
-        #
-        #   visit subject
-        #   within "#purchases" do
-        #     expect(page).to have_content("100")
-        #   end
-        #
-        #   item.update!(active: false)
-        #   visit subject
-        #   within "#purchases" do
-        #     expect(page).to have_no_content("100")
-        #   end
-        # end
+      # it 'does not count inactive items' do
+      #   item = create(:purchase, :with_items, item_quantity: 100, storage_location: storage_location).items.first
+      #
+      #   visit subject
+      #   within "#purchases" do
+      #     expect(page).to have_content("100")
+      #   end
+      #
+      #   item.update!(active: false)
+      #   visit subject
+      #   within "#purchases" do
+      #     expect(page).to have_no_content("100")
+      #   end
+      # end
 
-        # as of 28 Jan 2022, the "Recent Purchases" list shows up to this many items matching the date filter
-        max_recent_purchase_links_count = 3
+      # as of 28 Jan 2022, the "Recent Purchases" list shows up to this many items matching the date filter
+      max_recent_purchase_links_count = 3
 
-        # Make up to this many (inclusive) purchases for each filtered period
-        # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
-        # Purchases outside of the filtered period
-        max_purchases_in_filtered_period = max_recent_purchase_links_count + 1
+      # Make up to this many (inclusive) purchases for each filtered period
+      # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
+      # Purchases outside of the filtered period
+      max_purchases_in_filtered_period = max_recent_purchase_links_count + 1
 
-        around do |example|
-          # Ensure "today" doesn't change for the server side during the example run
-          # Note, however, that this does *not* affect the client side
-          # So "today" for the server still might be "yesterday"
-          # —possibly even "last month" or "last year"-
-          # for the client
-          # Rely on rerun via rspec-retry for those edge cases
-          travel_to(test_time)
-          example.run
-          travel_back
-        end
+      around do |example|
+        # Ensure "today" doesn't change for the server side during the example run
+        # Note, however, that this does *not* affect the client side
+        # So "today" for the server still might be "yesterday"
+        # —possibly even "last month" or "last year"-
+        # for the client
+        # Rely on rerun via rspec-retry for those edge cases
+        travel_to(test_time)
+        example.run
+        travel_back
+      end
 
-        [
-          # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-          ["Today",        test_time,                               test_time],
-          ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
-          ["Last 7 Days",  test_time -  6.days,                     test_time],
-          ["Last 30 Days", test_time - 29.days,                     test_time],
-          ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
-          ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
-          ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
-          ["All Time",     test_time - 100.years,                   test_time],
-          ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
-          # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-        ].each do |date_range_info|
-          filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
+      [
+        # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+        ["Today",        test_time,                               test_time],
+        ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
+        ["Last 7 Days",  test_time -  6.days,                     test_time],
+        ["Last 30 Days", test_time - 29.days,                     test_time],
+        ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
+        ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
+        ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
+        ["All Time",     test_time - 100.years,                   test_time],
+        ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
+        # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+      ].each do |date_range_info|
+        filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
 
-          filtered_date_range = start_date.to_date..end_date.to_date
-          before_filtered_date_range = start_date.yesterday.to_date
-          after_filtered_date_range = end_date.tomorrow.to_date
+        filtered_date_range = start_date.to_date..end_date.to_date
+        before_filtered_date_range = start_date.yesterday.to_date
+        after_filtered_date_range = end_date.tomorrow.to_date
 
-          start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
+        start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
 
-          # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
-          # w/out making a fixed pattern
-          num_purchases_in_filtered_period = rand(0..max_purchases_in_filtered_period)
+        # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
+        # w/out making a fixed pattern
+        num_purchases_in_filtered_period = rand(0..max_purchases_in_filtered_period)
 
-          context "given 1 Purchase on #{before_filtered_date_range}, " \
-                  "#{num_purchases_in_filtered_period} during #{filtered_date_range}, and " \
-                  "1 on #{after_filtered_date_range}" do
-            custom_dates = if set_custom_dates
-              "#{start_date_formatted} - #{end_date_formatted}"
+        context "given 1 Purchase on #{before_filtered_date_range}, " \
+                "#{num_purchases_in_filtered_period} during #{filtered_date_range}, and " \
+                "1 on #{after_filtered_date_range}" do
+          custom_dates = if set_custom_dates
+            "#{start_date_formatted} - #{end_date_formatted}"
+          end
+
+          before do
+            filtered_dates = filtered_date_range.to_a
+            @quantities_donated_in_filtered_date_range = []
+
+            @item_quantity = item_quantities.to_enum
+
+            def create_next_purchase(purchase_date:)
+              quantity_in_purchase = @item_quantity.next
+              create :purchase, :with_items, issued_at: purchase_date, item_quantity: quantity_in_purchase, storage_location: storage_location, organization: @organization
+
+              quantity_in_purchase
             end
 
+            # days_this_year.sample in num_purchases_in_filtered_period.times loop
+            # rather than
+            # days_this_year.sample(num_purchases_in_filtered_period).each
+            # because Array#sample(n) on an Array with m<n elements returns only m elements
+            num_purchases_in_filtered_period.times do
+              @quantities_donated_in_filtered_date_range << create_next_purchase(purchase_date: filtered_dates.sample)
+            end
+
+            # create Purchases before & after the filtered date range
+            [before_filtered_date_range, after_filtered_date_range].each { create_next_purchase purchase_date: _1 }
+          end
+
+          describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
             before do
-              filtered_dates = filtered_date_range.to_a
-              @quantities_donated_in_filtered_date_range = []
-
-              @item_quantity = item_quantities.to_enum
-
-              def create_next_purchase(purchase_date:)
-                quantity_in_purchase = @item_quantity.next
-                create :purchase, :with_items, issued_at: purchase_date, item_quantity: quantity_in_purchase, storage_location: storage_location, organization: @organization
-
-                quantity_in_purchase
-              end
-
-              # days_this_year.sample in num_purchases_in_filtered_period.times loop
-              # rather than
-              # days_this_year.sample(num_purchases_in_filtered_period).each
-              # because Array#sample(n) on an Array with m<n elements returns only m elements
-              num_purchases_in_filtered_period.times do
-                @quantities_donated_in_filtered_date_range << create_next_purchase(purchase_date: filtered_dates.sample)
-              end
-
-              # create Purchases before & after the filtered date range
-              [before_filtered_date_range, after_filtered_date_range].each { create_next_purchase purchase_date: _1 }
+              org_dashboard_page
+                .visit
+                .filter_to_date_range(filtered_date_range_label, custom_dates)
             end
 
-            describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
-              before do
-                org_dashboard_page
-                  .visit
-                  .filter_to_date_range(filtered_date_range_label, custom_dates)
-              end
+            expected_recent_purchase_links_count = [max_recent_purchase_links_count, num_purchases_in_filtered_period].min
 
-              expected_recent_purchase_links_count = [max_recent_purchase_links_count, num_purchases_in_filtered_period].min
+            it "shows correct #{expected_recent_purchase_links_count} Recent Purchase link(s)" do
+              recent_purchase_links = org_dashboard_page.recent_purchase_links
 
-              it "shows correct #{expected_recent_purchase_links_count} Recent Purchase link(s)" do
-                recent_purchase_links = org_dashboard_page.recent_purchase_links
+              expect(recent_purchase_links.count).to eq expected_recent_purchase_links_count
 
-                expect(recent_purchase_links.count).to eq expected_recent_purchase_links_count
+              # Expect the links to be something like "1 item...", "20 items from Manufacturer"
+              # Strip out the item counts
+              recent_quantities = recent_purchase_links.map { _1.match(/\d+/).to_s.to_i }
 
-                # Expect the links to be something like "1 item...", "20 items from Manufacturer"
-                # Strip out the item counts
-                recent_quantities = recent_purchase_links.map { _1.match(/\d+/).to_s.to_i }
-
-                # By design, the setup may have created more Purchases during the period than are visible in the Recent Purchase links
-                # Make sure each Recent Purchase link uniquely matches a single Purchase
-                expect(@quantities_donated_in_filtered_date_range.intersection(recent_quantities)).to match_array recent_quantities
-              end
+              # By design, the setup may have created more Purchases during the period than are visible in the Recent Purchase links
+              # Make sure each Recent Purchase link uniquely matches a single Purchase
+              expect(@quantities_donated_in_filtered_date_range.intersection(recent_quantities)).to match_array recent_quantities
             end
           end
         end
       end
+    end
 
-      describe "Diaper Drives" do
-        around do |example|
-          travel_to(test_time)
-          example.run
-          travel_back
-        end
+    describe "Diaper Drives" do
+      around do |example|
+        travel_to(test_time)
+        example.run
+        travel_back
+      end
 
-        it "has a widget for diaper drive summary data" do
-          org_dashboard_page.visit
+      it "has a widget for diaper drive summary data" do
+        org_dashboard_page.visit
 
-          expect(org_dashboard_page).to have_diaper_drives_section
-        end
+        expect(org_dashboard_page).to have_diaper_drives_section
+      end
 
-        # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
-        max_recent_donation_links_count = 3
+      # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
+      max_recent_donation_links_count = 3
 
-        # Make up to this many (inclusive) donations for each filtered period
-        # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
-        # Donations outside of the filtered period
-        max_donations_in_filtered_period = max_recent_donation_links_count + 1
+      # Make up to this many (inclusive) donations for each filtered period
+      # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
+      # Donations outside of the filtered period
+      max_donations_in_filtered_period = max_recent_donation_links_count + 1
 
-        [
-          # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-          ["Today",        test_time,                               test_time],
-          ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
-          ["Last 7 Days",  test_time -  6.days,                     test_time],
-          ["Last 30 Days", test_time - 29.days,                     test_time],
-          ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
-          ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
-          ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
-          ["All Time",     test_time - 100.years,                   test_time],
-          ["Custom Range", test_time - 2.years,                     test_time - rand(180).days, :set_custom_dates] # arbitrary values
-          # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-        ].each do |date_range_info|
-          filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
+      [
+        # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+        ["Today",        test_time,                               test_time],
+        ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
+        ["Last 7 Days",  test_time -  6.days,                     test_time],
+        ["Last 30 Days", test_time - 29.days,                     test_time],
+        ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
+        ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
+        ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
+        ["All Time",     test_time - 100.years,                   test_time],
+        ["Custom Range", test_time - 2.years,                     test_time - rand(180).days, :set_custom_dates] # arbitrary values
+        # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+      ].each do |date_range_info|
+        filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
 
-          filtered_date_range = start_date.to_date..end_date.to_date
-          before_filtered_date_range = start_date.yesterday.to_date
-          after_filtered_date_range = end_date.tomorrow.to_date
+        filtered_date_range = start_date.to_date..end_date.to_date
+        before_filtered_date_range = start_date.yesterday.to_date
+        after_filtered_date_range = end_date.tomorrow.to_date
 
-          start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
+        start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
 
-          # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
-          # w/out making a fixed pattern
-          num_donations_in_filtered_period = rand(0..max_donations_in_filtered_period)
+        # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
+        # w/out making a fixed pattern
+        num_donations_in_filtered_period = rand(0..max_donations_in_filtered_period)
 
-          context "given 1 Donation on #{before_filtered_date_range}, " \
-                  "#{num_donations_in_filtered_period} during #{filtered_date_range}, and " \
-                  "1 on #{after_filtered_date_range}" do
-            custom_dates = if set_custom_dates
-              "#{start_date_formatted} - #{end_date_formatted}"
+        context "given 1 Donation on #{before_filtered_date_range}, " \
+                "#{num_donations_in_filtered_period} during #{filtered_date_range}, and " \
+                "1 on #{after_filtered_date_range}" do
+          custom_dates = if set_custom_dates
+            "#{start_date_formatted} - #{end_date_formatted}"
+          end
+
+          before do
+            filtered_dates = filtered_date_range.to_a
+
+            @item_quantity = item_quantities.to_enum
+
+            # Create some number of Diaper Drives
+            # Keep local copy of names so examples can create expected values
+            # without relying on fetching info from production code
+            @diaper_drives = (1..rand(2..5)).map do
+              name = "Diaper Drive #{_1}"
+              OpenStruct.new name: name, drive: create(:diaper_drive, name: name)
             end
 
+            def create_next_diaper_drive_donation(donation_date:)
+              quantity_in_donation = @item_quantity.next
+              drive = @diaper_drives.sample
+
+              create :diaper_drive_donation, :with_items, diaper_drive: drive.drive, diaper_drive_participant: @diaper_drive_participant, issued_at: donation_date, item_quantity: quantity_in_donation, storage_location: storage_location, organization: @organization
+
+              OpenStruct.new drive_name: drive.name, quantity: quantity_in_donation
+            end
+
+            # days_this_year.sample in num_donations_in_filtered_period.times loop
+            # rather than
+            # days_this_year.sample(num_donations_in_filtered_period).each
+            # because Array#sample(n) on an Array with m<n elements returns only m elements
+            @donations_in_filtered_date_range = num_donations_in_filtered_period.times.map do
+              create_next_diaper_drive_donation donation_date: filtered_dates.sample
+            end
+
+            # create Donations before & after the filtered date range
+            [before_filtered_date_range, after_filtered_date_range].each { create_next_diaper_drive_donation donation_date: _1 }
+          end
+
+          describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
             before do
-              filtered_dates = filtered_date_range.to_a
-
-              @item_quantity = item_quantities.to_enum
-
-              # Create some number of Diaper Drives
-              # Keep local copy of names so examples can create expected values
-              # without relying on fetching info from production code
-              @diaper_drives = (1..rand(2..5)).map do
-                name = "Diaper Drive #{_1}"
-                OpenStruct.new name: name, drive: create(:diaper_drive, name: name)
-              end
-
-              def create_next_diaper_drive_donation(donation_date:)
-                quantity_in_donation = @item_quantity.next
-                drive = @diaper_drives.sample
-
-                create :diaper_drive_donation, :with_items, diaper_drive: drive.drive, diaper_drive_participant: @diaper_drive_participant, issued_at: donation_date, item_quantity: quantity_in_donation, storage_location: storage_location, organization: @organization
-
-                OpenStruct.new drive_name: drive.name, quantity: quantity_in_donation
-              end
-
-              # days_this_year.sample in num_donations_in_filtered_period.times loop
-              # rather than
-              # days_this_year.sample(num_donations_in_filtered_period).each
-              # because Array#sample(n) on an Array with m<n elements returns only m elements
-              @donations_in_filtered_date_range = num_donations_in_filtered_period.times.map do
-                create_next_diaper_drive_donation donation_date: filtered_dates.sample
-              end
-
-              # create Donations before & after the filtered date range
-              [before_filtered_date_range, after_filtered_date_range].each { create_next_diaper_drive_donation donation_date: _1 }
+              org_dashboard_page
+                .visit
+                .filter_to_date_range(filtered_date_range_label, custom_dates)
             end
 
-            describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
-              before do
-                org_dashboard_page
-                  .visit
-                  .filter_to_date_range(filtered_date_range_label, custom_dates)
+            expected_recent_donation_links_count = [max_recent_donation_links_count, num_donations_in_filtered_period].min
+
+            it "shows the correct total and #{expected_recent_donation_links_count} Recent Donation link(s)" do
+              expect(org_dashboard_page.diaper_drive_total_donations).to eq @donations_in_filtered_date_range.map(&:quantity).sum
+
+              recent_donation_links = org_dashboard_page.recent_diaper_drive_donation_links
+
+              expect(recent_donation_links.count).to eq expected_recent_donation_links_count
+
+              # Expect the links to be something like "1 from Some Drive", "20 items from Another Drive"
+              # Strip out the item counts & drive names
+              recent_donations = recent_donation_links.map do
+                items_donated, drive_name = _1.match(/(\d+) from (.+)/).captures
+
+                # e.g., [1, "Some Drive"], [20, "Another Drive"]
+                OpenStruct.new quantity: items_donated.to_i, drive_name: drive_name
               end
 
-              expected_recent_donation_links_count = [max_recent_donation_links_count, num_donations_in_filtered_period].min
-
-              it "shows the correct total and #{expected_recent_donation_links_count} Recent Donation link(s)" do
-                expect(org_dashboard_page.diaper_drive_total_donations).to eq @donations_in_filtered_date_range.map(&:quantity).sum
-
-                recent_donation_links = org_dashboard_page.recent_diaper_drive_donation_links
-
-                expect(recent_donation_links.count).to eq expected_recent_donation_links_count
-
-                # Expect the links to be something like "1 from Some Drive", "20 items from Another Drive"
-                # Strip out the item counts & drive names
-                recent_donations = recent_donation_links.map do
-                  items_donated, drive_name = _1.match(/(\d+) from (.+)/).captures
-
-                  # e.g., [1, "Some Drive"], [20, "Another Drive"]
-                  OpenStruct.new quantity: items_donated.to_i, drive_name: drive_name
-                end
-
-                # By design, the setup may have created more Donations during the period than are visible in the Recent Donation links
-                # Make sure each Recent Donation link uniquely matches a single Donation
-                expect(@donations_in_filtered_date_range.intersection(recent_donations)).to match_array recent_donations
-              end
+              # By design, the setup may have created more Donations during the period than are visible in the Recent Donation links
+              # Make sure each Recent Donation link uniquely matches a single Donation
+              expect(@donations_in_filtered_date_range.intersection(recent_donations)).to match_array recent_donations
             end
           end
         end
       end
+    end
 
-      describe "Manufacturer Donations" do
-        around do |example|
-          travel_to(test_time)
-          example.run
-          travel_back
-        end
+    describe "Manufacturer Donations" do
+      around do |example|
+        travel_to(test_time)
+        example.run
+        travel_back
+      end
 
-        it "has a link to create a new donation" do
-          org_dashboard_page.visit
+      it "has a link to create a new donation" do
+        org_dashboard_page.visit
 
-          expect(org_dashboard_page).to have_manufacturers_section
-        end
+        expect(org_dashboard_page).to have_manufacturers_section
+      end
 
-        # it "doesn't count inactive items" do
-        #   item = create(:manufacturer_donation, :with_items, item_quantity: 100, storage_location: storage_location).items.first
-        #
-        #   visit subject
-        #   within "#manufacturers" do
-        #     expect(page).to have_content("100")
-        #   end
-        #
-        #   item.update!(active: false)
-        #   visit subject
-        #   within "#donations" do
-        #     expect(page).to have_no_content("100")
-        #   end
-        # end
+      # it "doesn't count inactive items" do
+      #   item = create(:manufacturer_donation, :with_items, item_quantity: 100, storage_location: storage_location).items.first
+      #
+      #   visit subject
+      #   within "#manufacturers" do
+      #     expect(page).to have_content("100")
+      #   end
+      #
+      #   item.update!(active: false)
+      #   visit subject
+      #   within "#donations" do
+      #     expect(page).to have_no_content("100")
+      #   end
+      # end
 
-        # as of 15 Feb 2022, the "Top Manufacturer Donations" list shows up to this many manufacturers
-        # which donated during the filtered date range
-        max_top_manufacturer_donations_links_count = 10
+      # as of 15 Feb 2022, the "Top Manufacturer Donations" list shows up to this many manufacturers
+      # which donated during the filtered date range
+      max_top_manufacturer_donations_links_count = 10
 
-        # Make donations for up to this many (inclusive) manufacturers for each filtered period
-        # Different from other sections because the final list also includes the before- and
-        # after-date-range donations
-        max_manufacturers_donated_in_filtered_period = max_top_manufacturer_donations_links_count - 1
+      # Make donations for up to this many (inclusive) manufacturers for each filtered period
+      # Different from other sections because the final list also includes the before- and
+      # after-date-range donations
+      max_manufacturers_donated_in_filtered_period = max_top_manufacturer_donations_links_count - 1
 
-        [
-          # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-          ["Today",        test_time,                               test_time],
-          ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
-          ["Last 7 Days",  test_time -  6.days,                     test_time],
-          ["Last 30 Days", test_time - 29.days,                     test_time],
-          ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
-          ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
-          ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
-          ["All Time",     test_time - 100.years,                   test_time],
-          ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
-          # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-        ].each do |date_range_info|
-          filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
+      [
+        # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+        ["Today",        test_time,                               test_time],
+        ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
+        ["Last 7 Days",  test_time -  6.days,                     test_time],
+        ["Last 30 Days", test_time - 29.days,                     test_time],
+        ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
+        ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
+        ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
+        ["All Time",     test_time - 100.years,                   test_time],
+        ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
+        # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+      ].each do |date_range_info|
+        filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
 
-          filtered_date_range = start_date.to_date..end_date.to_date
-          before_filtered_date_range = start_date.yesterday.to_date
-          after_filtered_date_range = end_date.tomorrow.to_date
+        filtered_date_range = start_date.to_date..end_date.to_date
+        before_filtered_date_range = start_date.yesterday.to_date
+        after_filtered_date_range = end_date.tomorrow.to_date
 
-          start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
+        start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
 
-          # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
-          # w/out making a fixed pattern
-          num_manufacturers_donated_in_filtered_period = rand(0..max_manufacturers_donated_in_filtered_period)
+        # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
+        # w/out making a fixed pattern
+        num_manufacturers_donated_in_filtered_period = rand(0..max_manufacturers_donated_in_filtered_period)
 
-          context "given 1 Manufacturer donating on #{before_filtered_date_range}, " \
-                  "#{num_manufacturers_donated_in_filtered_period} during #{filtered_date_range}, and " \
-                  "1 on #{after_filtered_date_range}" do
-            custom_dates = if set_custom_dates
-              "#{start_date_formatted} - #{end_date_formatted}"
+        context "given 1 Manufacturer donating on #{before_filtered_date_range}, " \
+                "#{num_manufacturers_donated_in_filtered_period} during #{filtered_date_range}, and " \
+                "1 on #{after_filtered_date_range}" do
+          custom_dates = if set_custom_dates
+            "#{start_date_formatted} - #{end_date_formatted}"
+          end
+
+          before do
+            filtered_dates = filtered_date_range.to_a
+
+            @item_quantity = item_quantities.to_enum
+
+            def create_next_manufacturer_donation(manufacturer:, donation_date:)
+              quantity_in_donation = @item_quantity.next
+
+              create :manufacturer_donation, :with_items, manufacturer: manufacturer, issued_at: donation_date, item_quantity: quantity_in_donation, storage_location: storage_location, organization: @organization
+
+              quantity_in_donation
             end
 
-            before do
-              filtered_dates = filtered_date_range.to_a
-
-              @item_quantity = item_quantities.to_enum
-
-              def create_next_manufacturer_donation(manufacturer:, donation_date:)
-                quantity_in_donation = @item_quantity.next
-
-                create :manufacturer_donation, :with_items, manufacturer: manufacturer, issued_at: donation_date, item_quantity: quantity_in_donation, storage_location: storage_location, organization: @organization
-
-                quantity_in_donation
-              end
-
-              # Generate new Manufacturers and their in-filtered-date-range donations
-              @manufacturer_donations_in_filtered_date_range = num_manufacturers_donated_in_filtered_period.times.map do |index|
-                @item_quantity.rewind
-                manufacturer_name = "In-date-range Manufacturer #{index}"
-
-                manufacturer = create :manufacturer, name: manufacturer_name, organization: @organization
-
-                # Ensure at least 1 donation in the filtered period
-                donation_quantities = rand(1..3).times.map do
-                  create_next_manufacturer_donation manufacturer: manufacturer, donation_date: filtered_dates.sample
-                end
-
-                OpenStruct.new manufacturer_name: manufacturer_name, total_quantity_donated: donation_quantities.sum
-              end
-
-              # create Donations before & after the filtered date range
+            # Generate new Manufacturers and their in-filtered-date-range donations
+            @manufacturer_donations_in_filtered_date_range = num_manufacturers_donated_in_filtered_period.times.map do |index|
               @item_quantity.rewind
-              @manufacturer_donations_outside_filtered_date_range = [
-                # rubocop:disable Layout/ExtraSpacing
-                ["Before", before_filtered_date_range],
-                ["After",   after_filtered_date_range]
-                # rubocop:enable Layout/ExtraSpacing
-              ].map do
-                prefix, date = _1
+              manufacturer_name = "In-date-range Manufacturer #{index}"
 
-                manufacturer_name = "#{prefix}-date-range Manufacturer"
-                manufacturer = create :manufacturer, name: manufacturer_name, organization: @organization
-                quantity_donated = create_next_manufacturer_donation manufacturer: manufacturer, donation_date: date
+              manufacturer = create :manufacturer, name: manufacturer_name, organization: @organization
 
-                OpenStruct.new manufacturer_name: manufacturer_name, total_quantity_donated: quantity_donated
+              # Ensure at least 1 donation in the filtered period
+              donation_quantities = rand(1..3).times.map do
+                create_next_manufacturer_donation manufacturer: manufacturer, donation_date: filtered_dates.sample
               end
+
+              OpenStruct.new manufacturer_name: manufacturer_name, total_quantity_donated: donation_quantities.sum
             end
 
-            describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
-              before do
-                org_dashboard_page
-                  .visit
-                  .filter_to_date_range(filtered_date_range_label, custom_dates)
+            # create Donations before & after the filtered date range
+            @item_quantity.rewind
+            @manufacturer_donations_outside_filtered_date_range = [
+              # rubocop:disable Layout/ExtraSpacing
+              ["Before", before_filtered_date_range],
+              ["After",   after_filtered_date_range]
+              # rubocop:enable Layout/ExtraSpacing
+            ].map do
+              prefix, date = _1
+
+              manufacturer_name = "#{prefix}-date-range Manufacturer"
+              manufacturer = create :manufacturer, name: manufacturer_name, organization: @organization
+              quantity_donated = create_next_manufacturer_donation manufacturer: manufacturer, donation_date: date
+
+              OpenStruct.new manufacturer_name: manufacturer_name, total_quantity_donated: quantity_donated
+            end
+          end
+
+          describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
+            before do
+              org_dashboard_page
+                .visit
+                .filter_to_date_range(filtered_date_range_label, custom_dates)
+            end
+
+            # max_manufacturers_donated_in_filtered_period + 2 because the list includes the before- & after-date-range donations, too
+            expected_top_manufacturer_donation_links_count = [max_top_manufacturer_donations_links_count, num_manufacturers_donated_in_filtered_period + 2].min
+
+            it "shows the correct total and #{expected_top_manufacturer_donation_links_count} Top Manufacturer Donation link(s)" do
+              # "Total" is filtered by the time period
+              expected_total_manufacturer_donations = @manufacturer_donations_in_filtered_date_range.map(&:total_quantity_donated).sum
+              expect(org_dashboard_page.manufacturers_total_donations).to eq expected_total_manufacturer_donations
+
+              top_manufacturer_donation_links = org_dashboard_page.top_manufacturer_donation_links
+
+              expect(org_dashboard_page.top_manufacturer_donation_links.count).to eq expected_top_manufacturer_donation_links_count
+
+              # Expect the links to be something like "In-date-range Manufacturer 1 (21)", "In-date-range Manufacturer 2 (4,321)", etc.
+              # Strip out the item counts & manufacturer names
+              top_manufacturer_donations = top_manufacturer_donation_links.map do
+                manufacturer_name, total_donated = _1.match(/(.+) \((\d+)\)/).captures
+
+                OpenStruct.new manufacturer_name: manufacturer_name, total_quantity_donated: total_donated.delete(",").to_i
               end
 
-              # max_manufacturers_donated_in_filtered_period + 2 because the list includes the before- & after-date-range donations, too
-              expected_top_manufacturer_donation_links_count = [max_top_manufacturer_donations_links_count, num_manufacturers_donated_in_filtered_period + 2].min
+              # The Top Donations list is *not* filtered by the time period
+              # It can contain both the before- and after-filtered-date-range donations
+              all_manufacturer_donations = @manufacturer_donations_in_filtered_date_range + @manufacturer_donations_outside_filtered_date_range
 
-              it "shows the correct total and #{expected_top_manufacturer_donation_links_count} Top Manufacturer Donation link(s)" do
-                # "Total" is filtered by the time period
-                expected_total_manufacturer_donations = @manufacturer_donations_in_filtered_date_range.map(&:total_quantity_donated).sum
-                expect(org_dashboard_page.manufacturers_total_donations).to eq expected_total_manufacturer_donations
-
-                top_manufacturer_donation_links = org_dashboard_page.top_manufacturer_donation_links
-
-                expect(org_dashboard_page.top_manufacturer_donation_links.count).to eq expected_top_manufacturer_donation_links_count
-
-                # Expect the links to be something like "In-date-range Manufacturer 1 (21)", "In-date-range Manufacturer 2 (4,321)", etc.
-                # Strip out the item counts & manufacturer names
-                top_manufacturer_donations = top_manufacturer_donation_links.map do
-                  manufacturer_name, total_donated = _1.match(/(.+) \((\d+)\)/).captures
-
-                  OpenStruct.new manufacturer_name: manufacturer_name, total_quantity_donated: total_donated.delete(",").to_i
-                end
-
-                # The Top Donations list is *not* filtered by the time period
-                # It can contain both the before- and after-filtered-date-range donations
-                all_manufacturer_donations = @manufacturer_donations_in_filtered_date_range + @manufacturer_donations_outside_filtered_date_range
-
-                # By design, the setup may have created more Donations during the period than are visible in the Top Donation links
-                # Make sure each Top Donation link uniquely matches a single Donation
-                expect(all_manufacturer_donations.intersection(top_manufacturer_donations)).to match_array top_manufacturer_donations
-              end
+              # By design, the setup may have created more Donations during the period than are visible in the Top Donation links
+              # Make sure each Top Donation link uniquely matches a single Donation
+              expect(all_manufacturer_donations.intersection(top_manufacturer_donations)).to match_array top_manufacturer_donations
             end
           end
         end
       end
+    end
 
-      describe "Distributions" do
-        around do |example|
-          travel_to(test_time)
-          example.run
-          travel_back
-        end
+    describe "Distributions" do
+      around do |example|
+        travel_to(test_time)
+        example.run
+        travel_back
+      end
 
-        it "has a link to create a new distribution" do
-          org_new_distribution_page = OrganizationNewDistributionPage.new org_short_name: org_short_name
+      it "has a link to create a new distribution" do
+        org_new_distribution_page = OrganizationNewDistributionPage.new org_short_name: org_short_name
 
-          expect(org_dashboard_page.visit).to have_distributions_section
+        expect(org_dashboard_page.visit).to have_distributions_section
 
-          expect { org_dashboard_page.create_new_distribution }
-            .to change { page.current_path }
-            .to org_new_distribution_page.path
-        end
+        expect { org_dashboard_page.create_new_distribution }
+          .to change { page.current_path }
+          .to org_new_distribution_page.path
+      end
 
-        # it "doesn't count inactive items" do
-        #   item = create(:inventory_item, quantity: 100, storage_location: storage_location).item
-        #   create(:distribution, :with_items, item: item, item_quantity: 100, storage_location: storage_location)
-        #
-        #   visit subject
-        #   within "#distributions" do
-        #     expect(page).to have_content("100")
-        #   end
-        #
-        #   item.update!(active: false)
-        #   visit subject
-        #   within "#distributions" do
-        #     expect(page).to have_no_content("100")
-        #   end
-        # end
+      # it "doesn't count inactive items" do
+      #   item = create(:inventory_item, quantity: 100, storage_location: storage_location).item
+      #   create(:distribution, :with_items, item: item, item_quantity: 100, storage_location: storage_location)
+      #
+      #   visit subject
+      #   within "#distributions" do
+      #     expect(page).to have_content("100")
+      #   end
+      #
+      #   item.update!(active: false)
+      #   visit subject
+      #   within "#distributions" do
+      #     expect(page).to have_no_content("100")
+      #   end
+      # end
 
-        # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
-        max_recent_distribution_links_count = 3
+      # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
+      max_recent_distribution_links_count = 3
 
-        # Make up to this many (inclusive) donations for each filtered period
-        # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
-        # Donations outside of the filtered period
-        max_distributions_in_filtered_period = max_recent_distribution_links_count + 1
+      # Make up to this many (inclusive) donations for each filtered period
+      # Keep it below (item_quantities.size - 1) so there's at least 2 values left for
+      # Donations outside of the filtered period
+      max_distributions_in_filtered_period = max_recent_distribution_links_count + 1
 
-        [
-          # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-          ["Today",        test_time,                               test_time],
-          ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
-          ["Last 7 Days",  test_time -  6.days,                     test_time],
-          ["Last 30 Days", test_time - 29.days,                     test_time],
-          ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
-          ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
-          ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
-          ["All Time",     test_time - 100.years,                   test_time],
-          ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
-          # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
-        ].each do |date_range_info|
-          filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
+      [
+        # rubocop:disable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+        ["Today",        test_time,                               test_time],
+        ["Yesterday",    test_time.yesterday,                     test_time.yesterday],
+        ["Last 7 Days",  test_time -  6.days,                     test_time],
+        ["Last 30 Days", test_time - 29.days,                     test_time],
+        ["This Month",   test_time.beginning_of_month,            test_time.end_of_month],
+        ["Last Month",   test_time.last_month.beginning_of_month, test_time.last_month.end_of_month],
+        ["This Year",    test_time.beginning_of_year,             test_time.end_of_year],
+        ["All Time",     test_time - 100.years,                   test_time],
+        ["Custom Range", test_time -   2.years,                   test_time - rand(180).days, :set_custom_dates] # arbitrary values
+        # rubocop:enable Layout/ExtraSpacing, Layout/SpaceAroundOperators
+      ].each do |date_range_info|
+        filtered_date_range_label, start_date, end_date, set_custom_dates = date_range_info
 
-          filtered_date_range = start_date.to_date..end_date.to_date
-          before_filtered_date_range = start_date.yesterday.to_date
-          after_filtered_date_range = end_date.tomorrow.to_date
+        filtered_date_range = start_date.to_date..end_date.to_date
+        before_filtered_date_range = start_date.yesterday.to_date
+        after_filtered_date_range = end_date.tomorrow.to_date
 
-          start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
+        start_date_formatted, end_date_formatted = [start_date, end_date].map { _1.strftime "%m/%d/%y"}
 
-          # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
-          # w/out making a fixed pattern
-          num_distributions_in_filtered_period = rand(0..max_distributions_in_filtered_period)
+        # Ideally different date ranges get different counts (incl. 0!) to test the various combinations
+        # w/out making a fixed pattern
+        num_distributions_in_filtered_period = rand(0..max_distributions_in_filtered_period)
 
-          context "given 1 Distribution on #{before_filtered_date_range}, " \
-                  "#{num_distributions_in_filtered_period} during #{filtered_date_range}, and " \
-                  "1 on #{after_filtered_date_range}" do
-            custom_dates = if set_custom_dates
-              "#{start_date_formatted} - #{end_date_formatted}"
+        context "given 1 Distribution on #{before_filtered_date_range}, " \
+                "#{num_distributions_in_filtered_period} during #{filtered_date_range}, and " \
+                "1 on #{after_filtered_date_range}" do
+          custom_dates = if set_custom_dates
+            "#{start_date_formatted} - #{end_date_formatted}"
+          end
+
+          before do
+            filtered_dates = filtered_date_range.to_a
+
+            @item_quantity = item_quantities.to_enum
+
+            # Create some number of Partners
+            # Keep local copy of names so examples can create expected values
+            # without relying on fetching info from production code
+            @partners = (1..rand(2..5)).map do
+              name = "Partner #{_1}"
+              OpenStruct.new name: name, partner: create(:partner, name: name, organization: @organization)
             end
 
+            def create_next_diaper_drive_distribution(distribution_date:)
+              quantity_in_distribution = @item_quantity.next
+              partner = @partners.sample
+
+              create :distribution, :with_items, partner: partner.partner, issued_at: distribution_date, item_quantity: quantity_in_distribution, storage_location: storage_location, organization: @organization
+
+              OpenStruct.new partner_name: partner.name, quantity: quantity_in_distribution
+            end
+
+            # days_this_year.sample in num_distributions_in_filtered_period.times loop
+            # rather than
+            # days_this_year.sample(num_distributions_in_filtered_period).each
+            # because Array#sample(n) on an Array with m<n elements returns only m elements
+            @distributions_in_filtered_date_range = num_distributions_in_filtered_period.times.map do
+              create_next_diaper_drive_distribution distribution_date: filtered_dates.sample
+            end
+
+            # create Distributions before & after the filtered date range
+            [before_filtered_date_range, after_filtered_date_range].each { create_next_diaper_drive_distribution distribution_date: _1 }
+          end
+
+          describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
             before do
-              filtered_dates = filtered_date_range.to_a
-
-              @item_quantity = item_quantities.to_enum
-
-              # Create some number of Partners
-              # Keep local copy of names so examples can create expected values
-              # without relying on fetching info from production code
-              @partners = (1..rand(2..5)).map do
-                name = "Partner #{_1}"
-                OpenStruct.new name: name, partner: create(:partner, name: name, organization: @organization)
-              end
-
-              def create_next_diaper_drive_distribution(distribution_date:)
-                quantity_in_distribution = @item_quantity.next
-                partner = @partners.sample
-
-                create :distribution, :with_items, partner: partner.partner, issued_at: distribution_date, item_quantity: quantity_in_distribution, storage_location: storage_location, organization: @organization
-
-                OpenStruct.new partner_name: partner.name, quantity: quantity_in_distribution
-              end
-
-              # days_this_year.sample in num_distributions_in_filtered_period.times loop
-              # rather than
-              # days_this_year.sample(num_distributions_in_filtered_period).each
-              # because Array#sample(n) on an Array with m<n elements returns only m elements
-              @distributions_in_filtered_date_range = num_distributions_in_filtered_period.times.map do
-                create_next_diaper_drive_distribution distribution_date: filtered_dates.sample
-              end
-
-              # create Distributions before & after the filtered date range
-              [before_filtered_date_range, after_filtered_date_range].each { create_next_diaper_drive_distribution distribution_date: _1 }
+              org_dashboard_page
+                .visit
+                .filter_to_date_range(filtered_date_range_label, custom_dates)
             end
 
-            describe("filtering to '#{filtered_date_range_label}'" + (set_custom_dates ? " (#{custom_dates})" : "")) do
-              before do
-                org_dashboard_page
-                  .visit
-                  .filter_to_date_range(filtered_date_range_label, custom_dates)
+            expected_recent_distribution_links_count = [max_recent_distribution_links_count, num_distributions_in_filtered_period].min
+
+            it "shows the correct total and #{expected_recent_distribution_links_count} Recent Distribution link(s)" do
+              expect(org_dashboard_page.total_distributed).to eq @distributions_in_filtered_date_range.map(&:quantity).sum
+
+              recent_distribution_links = org_dashboard_page.recent_distribution_links
+
+              expect(recent_distribution_links.count).to eq expected_recent_distribution_links_count
+
+              # Expect the links to be something like "1 from Some Drive", "20 items from Another Drive"
+              # Strip out the item counts & drive names
+              recent_distributions = recent_distribution_links.map do
+                items_distributed, partner_name = _1.match(/(\d+) items distributed to (.+)/).captures
+
+                # e.g., [1, "Some Drive"], [20, "Another Drive"]
+                OpenStruct.new quantity: items_distributed.to_i, partner_name: partner_name
               end
 
-              expected_recent_distribution_links_count = [max_recent_distribution_links_count, num_distributions_in_filtered_period].min
-
-              it "shows the correct total and #{expected_recent_distribution_links_count} Recent Distribution link(s)" do
-                expect(org_dashboard_page.total_distributed).to eq @distributions_in_filtered_date_range.map(&:quantity).sum
-
-                recent_distribution_links = org_dashboard_page.recent_distribution_links
-
-                expect(recent_distribution_links.count).to eq expected_recent_distribution_links_count
-
-                # Expect the links to be something like "1 from Some Drive", "20 items from Another Drive"
-                # Strip out the item counts & drive names
-                recent_distributions = recent_distribution_links.map do
-                  items_distributed, partner_name = _1.match(/(\d+) items distributed to (.+)/).captures
-
-                  # e.g., [1, "Some Drive"], [20, "Another Drive"]
-                  OpenStruct.new quantity: items_distributed.to_i, partner_name: partner_name
-                end
-
-                # By design, the setup may have created more Distributions during the period than are visible in the Recent Distribution links
-                # Make sure each Recent Distribution link uniquely matches a single Distribution
-                expect(@distributions_in_filtered_date_range.intersection(recent_distributions)).to match_array recent_distributions
-              end
+              # By design, the setup may have created more Distributions during the period than are visible in the Recent Distribution links
+              # Make sure each Recent Distribution link uniquely matches a single Distribution
+              expect(@distributions_in_filtered_date_range.intersection(recent_distributions)).to match_array recent_distributions
             end
           end
         end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
         end
       end
 
+      # 1, 20, 300, ..., 900000000
+      # assuming each value is used once, summing these values makes easily recognizable totals
+      # .fetch() from it so too-high indices raise IndexError
+      # legal indices are in -8..8 (i.e., inclusive)
+      item_quantities = (1..9).map { |i| i * 10**(i - 1) }
+
       describe "Donations" do
         it "has a link to create a new donation" do
           org_new_donation_page = OrganizationNewDonationPage.new org_short_name: org_short_name
@@ -140,12 +146,6 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
         #     expect(page).to have_no_content("100")
         #   end
         # end
-
-        # 1, 20, 300, ..., 900000000
-        # assuming each value is used once, summing these values makes easily recognizable totals
-        # .fetch() from it so too-high indices raise IndexError
-        # legal indices are in -8..8 (i.e., inclusive)
-        item_quantities = (1..9).map { |i| i * 10**(i - 1) }
 
         # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
         max_recent_donation_links_count = 3


### PR DESCRIPTION
Resolves #2676

### Description
- Reduce date sensitivity by generating expected-to-be filtered-in/out items for each time range
  - Removes #2674 because these changes should work equally well for both CI and dev boxes on any given day
  - Failure edge cases from `travel_to` on 'server side' setup just before end-of-day(/week/month/year?) but example running in  separate 'browser' process in following time period should be handled by `spec-retry` (#2728)
- Adds Some randomness & detail to exercise more aspects of the Dashboard rendering
- Improves `context`/`describe` group descriptions to better document behavior
- Adds cases for `All Time` and random(-ish) `Custom Range`
- Relatively easy to add more pre-defined date-picker/filter ranges in future

For that "bang", the "buck" is increased complexity
- move more values from `let()` to Ruby variables so they can be used in block descriptions
- generate `context`, `describe`, & `it` in a loop

### Type of change

* Bug fix (non-breaking change which fixes an issue)

This PR changes **no** production code.
Where the examples check/confirm details the prior examples didn't, I made the examples expect current behavior.
If that uncovers/illustrates any undesirable behavior, I suggest creating new Issue(s) and/or PR(s) to address it.

### Testing
Before I removed #2674, I changed its target date to several values to test it on CI.

It passed on
- Tue., 1 Mar 2022
- Mon., 7 Mar 2022

It failed with certificate errors (already expired in some cases; not yet valid in others) "on"
- 1 Jan 2022
- 1 Feb 2022
- 1 Jul 2022
- 1 Jan 2023

#### Knapsack Splitting
Though the `context`/`describe`/`it` blocks are generated at runtime in loops, the CI build logs show that Knapsack splits them among the CI nodes. Look for `With an existing Diaper bank`.

### Screenshots
Running only the examples changed so far:

![image](https://user-images.githubusercontent.com/2031462/154366944-fb5aaedb-02b5-4a5b-a7bc-63cb5eb522a4.png)

Image highlights
- The "randomly"-generated number of Donations created during each setup, and the expected number of Recent Donation links
- `All Time` and `Custom Range` cases

Raw text:
```
Dashboard
  With a new Diaper bank
    displays the getting started guide until the steps are completed
  With an existing Diaper bank
    Signage
      shows their organization name unless they have a logo set
    Diaper Drives
      has a widget for diaper drive summary data
      given 1 Donation on 2022-02-09, 2 during 2022-02-10..2022-02-16, and 1 on 2022-02-17
        filtering to 'Last 7 Days'
          shows the correct total and 2 Recent Donation link(s)
      given 1 Donation on 2021-12-31, 2 during 2022-01-01..2022-12-31, and 1 on 2023-01-01
        filtering to 'This Year'
          shows the correct total and 2 Recent Donation link(s)
      given 1 Donation on 1922-02-15, 1 during 1922-02-16..2022-02-16, and 1 on 2022-02-17
        filtering to 'All Time'
          shows the correct total and 1 Recent Donation link(s)
      given 1 Donation on 2020-02-15, 3 during 2020-02-16..2021-10-06, and 1 on 2021-10-07
        filtering to 'Custom Range' (02/16/20 - 10/06/21)
          shows the correct total and 3 Recent Donation link(s)
      given 1 Donation on 2022-02-14, 1 during 2022-02-15..2022-02-15, and 1 on 2022-02-16
        filtering to 'Yesterday'
          shows the correct total and 1 Recent Donation link(s)
      given 1 Donation on 2022-01-17, 0 during 2022-01-18..2022-02-16, and 1 on 2022-02-17
        filtering to 'Last 30 Days'
          shows the correct total and 0 Recent Donation link(s)
      given 1 Donation on 2022-01-31, 3 during 2022-02-01..2022-02-28, and 1 on 2022-03-01
        filtering to 'This Month'
          shows the correct total and 3 Recent Donation link(s)
      given 1 Donation on 2021-12-31, 4 during 2022-01-01..2022-01-31, and 1 on 2022-02-01
        filtering to 'Last Month'
          shows the correct total and 3 Recent Donation link(s)
      given 1 Donation on 2022-02-15, 2 during 2022-02-16..2022-02-16, and 1 on 2022-02-17
        filtering to 'Today'
          shows the correct total and 2 Recent Donation link(s)
    Inventory Totals
      Summary
```

Changes for the other sections are similar; the `Manufacturer Donations` group/section is a little different because of how the **Top Manufacturer Donations** list works.