### PR TITLE
2696: Fix link color and change disposition to inline to view PDFs in…

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -150,3 +150,9 @@ tr.negative {
   text-align: center;
   padding: 0.5rem 0 0.5rem;
 }
+
+body a {
+  color:#007bff;
+  text-decoration:none;
+  background-color:transparent
+}

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -8,7 +8,7 @@
     <p>Proof of Agency Status
     <% if partner_profile.proof_of_partner_status.attached? %>
       <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
-      (Link): <%= link_to partner_profile.proof_of_partner_status.filename, rails_blob_path(partner_profile.proof_of_partner_status, disposition: 'attachment') %>
+      (Link): <%= link_to partner_profile.proof_of_partner_status.filename, rails_blob_path(partner_profile.proof_of_partner_status, disposition: 'inline') %>
   <% end %>
     </p>
     <p>Agency Mission: <%= partner_profile.agency_mission %></p>
@@ -142,7 +142,7 @@
       <h2 class='text-2xl underline'>Other Documents</h2>
       <ul>
         <% partner_profile.documents.each do |document| %>
-          <li><%= link_to document.filename, rails_blob_path(document, disposition: 'attachment') %></li>
+          <li><%= link_to document.filename, rails_blob_path(document, disposition: 'inline') %></li>
         <% end %>
       </ul>
   </div>


### PR DESCRIPTION
Resolves #2696 

### Description

This fixes a bug that caused links not to show up in the correct color. This was due to the AdminLTE rules being overridden by the Tailwind base rules. For now I've simply added a more specific rule for links. I haven't noticed any other obvious weirdness with CSS so this might be the only obvious symptom.

This also changes the download link disposition from "attachment" to "inline". I've verified that this will show PDFs in the browser (where the user can download them if they like) but will still download e.g. MS word documents.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Local testing.

### Screenshots

<img width="1243" alt="image" src="https://user-images.githubusercontent.com/1986893/152665531-41f74707-ace6-4b0b-b6a9-fb23564ceb4a.png">
