### PR TITLE
Fix some flaky specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -186,7 +186,9 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do |example|
-    unless example.metadata[:persisted_data]
+    if example.metadata[:persisted_data]
+      DatabaseCleaner.strategy = :truncation
+    else
       # The database cleaner will now begin at this point
       # up anything after this point when `.clean` is called.
       DatabaseCleaner.start


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

**Partially** may help with #2711 

### Description

There are some specs that are failing even after retry. This is due to how DatabaseCleaner was set up to clean the report specs - it was using a transaction, but the data was created outside a transaction, so the cleanup didn't actually do anything, which caused later specs to fail because e.g. the objects were assigned to the wrong organization. This failure **only** happened when specific specs were run _after_ the report spec - if they ran before it, they passed.

As an FYI, the way I solved this was:
* Copy the full list of files that was executed by the step that failed
* Copy the seed that was printed out
* Run `rspec --seed {seed} {files}`
* Remove all files that were after the failures
* Keep changing the files that came before the failures until there are only two files being run, the failing spec and one spec before it that's causing the second one to fail
* Investigate the issue at that point

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Unit tests.