### PR TITLE
Update webpack dev server configs

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -50,8 +50,8 @@ module.exports = function(api) {
       [
         '@babel/plugin-proposal-private-methods',
         {
-          loose: true,
-        },
+          loose: true
+        }
       ],
       [
         '@babel/plugin-proposal-object-rest-spread',

--- a/babel.config.js
+++ b/babel.config.js
@@ -48,6 +48,12 @@ module.exports = function(api) {
         }
       ],
       [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true,
+        },
+      ],
+      [
         '@babel/plugin-proposal-object-rest-spread',
         {
           useBuiltIns: true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "caniuse-lite": "^1.0.30000989",
     "chartkick": "^3.2.1",
     "fstream": "^1.0.12",
     "highcharts": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,10 +2513,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001219:
+  version "1.0.30001312"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz"
+  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
# Description
  
When I booted up `bin/webpack-dev-server` my terminal filled with warnings from Babel. I've seen these before and they're a pretty simple fix—you just need to add an additional configuration to the `babel.config.js` file. My Prettier settings in VSCode automatically added trailing commas to this file and since it hasn't been touched in 9 months, I figured it wouldn't be a big deal to leave them in.

In that same command, I was warned that the `caniuse-lite` package was out of date so I ran the necessary script to update that as well.

## Type of change

Warning fix/update

## How Has This Been Tested?

It passed through `rubocop -a` tests.

