### PR TITLE
[WIP] Refactor FAQ pages to use template layout

### DIFF
--- a/app/views/partners/helps/show.html.erb
+++ b/app/views/partners/helps/show.html.erb
@@ -1,41 +1,53 @@
-<section class="content">
+<section class="content-header">
   <div class="container-fluid">
-    <div class="row">
-      <div class="col-12">
-        <!-- Default box -->
-        <div class="card card-info mt-2">
-          <div class="card-header">
-            <h2 class="card-title">Frequently Asked Questions</h2>
-          </div>
-          <div class="card-body p-4">
-            <ul class="list-inside my-2 list-decimal space-y-5">
-              <% @partner_questions.each do |partner_question| %>
-                <div class="accordion" id="accordion">
-                  <div class="card">
-                    <div class="card-header" id="heading">
-                      <h2 class="mb-0">
-                        <button class="text-2xl font-bold list-none" type="button" data-toggle="collapse" data-target="#collapse<%= partner_question.id %>" aria-expanded="false" aria-controls="collapse<%= partner_question.id %>">
-                          <%= partner_question.title %>
-                        </button>
-                      </h2>
-                    </div>
-                    <div id="collapse<%= partner_question.id %>" class="collapse" aria-labelledby="heading" data-parent="#accordion">
-                      <div class="card-body">
-                        <%= partner_question.answer %>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              <% end %>
-              <li class="text-2xl font-bold list-none">Have suggestions to help improve the app or other questions about the app? Please <a href="https://human-essential.slack.com/archives/CG1NL2MRC"><u class='text-blue-400'>reach out on Slack.</u></a></li>
-              <li class="text-2xl font-bold list-none">Not a member of the Human Essentials Slack group? <a href="https://join.slack.com/t/human-essential/shared_invite/zt-bfa8tymd-d8Ks3Mq000COcRe~nfs~zg"><u class='text-blue-400'>Request a login.</u></a></li>
-              <li class="text-2xl font-bold list-none">Still need help? Submit a support ticket <u><%= link_to 'here', support_ticket_form_url, target: '_blank', class: 'text-blue-400' %></u> and we will do our best to follow up with you via email.</li>
-            </ul>
-          </div>
-          <!-- /.card-footer-->
-        </div>
-        <!-- /.card -->
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <h1>Frequently Asked Questions</h1>
       </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item">
+            <%= link_to 'Home', partner_user_root_path %>
+          </li>
+          <li class="breadcrumb-item active">FAQ</li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="row mx-1">
+    <div class="col-12 accordion" id="faqAccordion">
+      <% @partner_questions.each do |partner_question| %>
+      <div class="card card-info card-outline">
+        <a class="d-block w-100" href="#collapse-<%= partner_question.id %>" role="button" data-toggle="collapse" data-target="#collapse-<%= partner_question.id %>" aria-controls="collapse-<%= partner_question.id %>">
+          <div class="card-header" id="header-<%= partner_question.id %>">
+            <h4 class="card-title w-100">
+              <%= partner_question.title %>
+            </h4>
+          </div>
+        </a>
+        <div id="collapse-<%= partner_question.id %>" class="collapse" aria-labelledby="header-<%= partner_question.id %>" data-parent="#faqAccordion">
+          <div class="card-body">
+            <%= partner_question.answer %>
+          </div>
+        </div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="row py-3 mx-1">
+    <div class="col-12 text-center">
+      <p class="lead font-weight-bold">
+        Have suggestions to help improve the app or other questions about the app? Please <%= link_to 'reach out on Slack', 'https://human-essential.slack.com/archives/CG1NL2MRC', target: '_blank' %>.
+      </p>
+      <p class="lead font-weight-bold">
+        Not a member of the Human Essentials Slack group? <%= link_to 'Request a login.', 'https://join.slack.com/t/human-essential/shared_invite/zt-bfa8tymd-d8Ks3Mq000COcRe~nfs~zg', target: '_blank' %>
+      </p>
+      <p class="lead font-weight-bold">
+        Still need help? Submit a support ticket <%= link_to 'here', support_ticket_form_url, target: '_blank' %> and we will do our best to follow up with you via email.
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2767 

### Description

This is still WIP. It's apparent that the AdminLTE template was not used while originally creating the page.

**Links for when I pick this back up:**

- [AdminLTE 3 Docs](https://adminlte.io/docs/3.2/index.html)
- [AdminLTE example FAQ page](https://adminlte.io/themes/v3/pages/examples/faq.html)
- [AdminLTE GitHub repo](https://github.com/ColorlibHQ/AdminLTE)

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

It hasn't yet

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots

#### Before

**X-Small Breakpoint**

![screencapture-localhost-3000-partners-help-xs-before](https://user-images.githubusercontent.com/37842352/154820999-cdbbd6d7-04cc-4b7e-86e5-5b2ba556bd1a.png)

**Small Breakpoint**

![screencapture-localhost-3000-partners-help-sm-before](https://user-images.githubusercontent.com/37842352/154821013-51f44f0f-ca51-4d09-9a0a-33ac6040b5a5.png)

**Medium Breakpoint**

![screencapture-localhost-3000-partners-help-md-before](https://user-images.githubusercontent.com/37842352/154821021-5b6a8905-4796-4057-abc5-702223bc6dfc.png)

**Large Breakpoint**

![screencapture-localhost-3000-partners-help-lg-before](https://user-images.githubusercontent.com/37842352/154821027-1deb5cfe-2461-435e-bacf-b9f9157c6e81.png)

**X-Large Breakpoint**

![screencapture-localhost-3000-partners-help-xl-before](https://user-images.githubusercontent.com/37842352/154821034-607ca8e8-2d4b-4000-b828-116ab31cd6da.png)

**XX-Large Breakpoint**

![screencapture-localhost-3000-partners-help-xxl-before](https://user-images.githubusercontent.com/37842352/154821038-ca5d68ac-8a97-4845-843b-784dbdf42f88.png)

#### After

![screencapture-localhost-3000-partners-help-after](https://user-images.githubusercontent.com/37842352/154821082-faabffc5-3b34-4d4a-bfe3-ade30f72ae12.png)

More coming soon!