### PR TITLE
[2748] Add ability to capture and sync NDBN Membership ids & account names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,8 +101,13 @@ gem "flipper-active_record"
 gem "flipper-ui"
 # Calculates latitude and longitude from an address.
 gem "geocoder"
+# Enable making HTTP requests
+gem 'httparty'
 # JSON Web Token encoding / decoding (e.g. for links in e-mails)
 gem "jwt"
+# A HTML scraping DSL to help with extraction NDBN member ids 
+# from their website
+gem 'scraping'
 
 ##### DEPENDENCY PINS ######
 # These are gems that aren't used directly, only as dependencies for other gems.

--- a/Gemfile
+++ b/Gemfile
@@ -105,9 +105,6 @@ gem "geocoder"
 gem 'httparty'
 # JSON Web Token encoding / decoding (e.g. for links in e-mails)
 gem "jwt"
-# A HTML scraping DSL to help with extraction NDBN member ids
-# from their website
-gem 'scraping'
 
 ##### DEPENDENCY PINS ######
 # These are gems that aren't used directly, only as dependencies for other gems.

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem "geocoder"
 gem 'httparty'
 # JSON Web Token encoding / decoding (e.g. for links in e-mails)
 gem "jwt"
-# A HTML scraping DSL to help with extraction NDBN member ids 
+# A HTML scraping DSL to help with extraction NDBN member ids
 # from their website
 gem 'scraping'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,9 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.0.1)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
@@ -274,6 +277,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_racer (0.6.1)
@@ -290,6 +296,7 @@ GEM
       monetize (~> 1.9)
       money (~> 6.13)
       railties (>= 3.0)
+    multi_xml (0.6.0)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -463,6 +470,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scraping (0.2.0)
+      nokogiri
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -544,6 +553,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -584,6 +594,7 @@ DEPENDENCIES
   geocoder
   groupdate (~> 6.0)
   guard-rspec
+  httparty
   image_processing
   jbuilder
   jquery-rails
@@ -617,6 +628,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails (~> 2.9.0)
   sass-rails
+  scraping
   shoulda-matchers (~> 5.0)
   simple_form
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,8 +470,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scraping (0.2.0)
-      nokogiri
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -628,7 +626,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails (~> 2.9.0)
   sass-rails
-  scraping
   shoulda-matchers (~> 5.0)
   simple_form
   simplecov

--- a/app/models/ndbn_member.rb
+++ b/app/models/ndbn_member.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: ndbn_members
+#
+#  account_name   :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  ndbn_member_id :bigint           not null, primary key
+#
+class NDBNMember < ApplicationRecord
+  self.primary_key = "ndbn_member_id"
+
+  validates_presence_of :ndbn_member_id
+  validates_presence_of :account_name
+  validates_uniqueness_of :ndbn_member_id
+end

--- a/app/models/ndbn_member.rb
+++ b/app/models/ndbn_member.rb
@@ -10,7 +10,7 @@
 class NDBNMember < ApplicationRecord
   self.primary_key = "ndbn_member_id"
 
-  validates_presence_of :ndbn_member_id
-  validates_presence_of :account_name
-  validates_uniqueness_of :ndbn_member_id
+  validates :ndbn_member_id, presence: true
+  validates :account_name, presence: true
+  validates :ndbn_member_id, uniqueness: true
 end

--- a/app/services/sync_ndbn_members.rb
+++ b/app/services/sync_ndbn_members.rb
@@ -2,19 +2,40 @@ class SyncNDBNMembers
   include HTTParty
   include Scraping
 
-  NDBN_MEMBERS_PAGE = 'https://ndbn.memberclicks.net/member-ids'.freeze
-  elements :ndbn_member_entries, '.contentpaneopen p'
+  NDBN_MEMBERS_PAGE = "https://ndbn.memberclicks.net/member-ids".freeze
+  elements :ndbn_member_entries, ".contentpaneopen p"
 
   class << self
     def sync
+      Rails.logger.info("Syncing NDBNMember started.")
+
       members_page = fetch_members_page
       member_entries = extract_member_entries(members_page)
 
       member_entries.each do |member|
-        ndbn = NDBNMember.find_or_initialize_by(ndbn_member_id: member[:ndbn_member_id])
-        ndbn.account_name = member[:account_name]
-        ndbn.save!
+        ndbn_member = NDBNMember.find_or_initialize_by(ndbn_member_id: member[:ndbn_member_id])
+        ndbn_member.account_name = member[:account_name]
+
+        # Skip if nothing has changed!
+        if ndbn_member.persisted? && !ndbn_member.changed?
+          next
+        elsif ndbn_member.persisted? && ndbn_member.changed?
+          Rails.logger.info("#{ndbn_member.id} changed their account name from #{ndbn_member.account_name_was} to #{ndbn_member.account_name}.")
+        elsif !ndbn_member.persisted?
+          Rails.logger.info("New record found! #{ndbn_member.id} - #{ndbn_member.account_name} has been added!")
+        end
+
+        Rails.logger.info("Updating....")
+        if ndbn_member.save
+          Rails.logger.info("Done!")
+        else
+          error_msg = "Failed to update #{ndbn_member_id} due to #{e.errors.full_messages}"
+          Rails.logger.info(error_msg)
+          Bugsnag.notify(error_msg)
+        end
       end
+
+      Rails.logger.info("Syncing NDBNMember finished.")
     end
 
     private
@@ -27,20 +48,17 @@ class SyncNDBNMembers
       entries = scrape(html_body).ndbn_member_entries
 
       # Removes the column header that only has the labels
-      entries.drop(1)
-
-      entries[1..-1].map do |entry|
+      entries[1..].map do |entry|
         split = entry.split(/\s/)
 
         member_id = split[0].squish
-        account_name = split[1..-1].join(' ')
+        account_name = split[1..].join(" ")
 
         {
           ndbn_member_id: member_id,
-          account_name: account_name,
+          account_name: account_name
         }
       end
     end
-
   end
 end

--- a/app/services/sync_ndbn_members.rb
+++ b/app/services/sync_ndbn_members.rb
@@ -1,0 +1,46 @@
+class SyncNDBNMembers
+  include HTTParty
+  include Scraping
+
+  NDBN_MEMBERS_PAGE = 'https://ndbn.memberclicks.net/member-ids'.freeze
+  elements :ndbn_member_entries, '.contentpaneopen p'
+
+  class << self
+    def sync
+      members_page = fetch_members_page
+      member_entries = extract_member_entries(members_page)
+
+      member_entries.each do |member|
+        ndbn = NDBNMember.find_or_initialize_by(ndbn_member_id: member[:ndbn_member_id])
+        ndbn.account_name = member[:account_name]
+        ndbn.save!
+      end
+    end
+
+    private
+
+    def fetch_members_page
+      get(NDBN_MEMBERS_PAGE).body
+    end
+
+    def extract_member_entries(html_body)
+      entries = scrape(html_body).ndbn_member_entries
+
+      # Removes the column header that only has the labels
+      entries.drop(1)
+
+      entries[1..-1].map do |entry|
+        split = entry.split(/\s/)
+
+        member_id = split[0].squish
+        account_name = split[1..-1].join(' ')
+
+        {
+          ndbn_member_id: member_id,
+          account_name: account_name,
+        }
+      end
+    end
+
+  end
+end

--- a/app/services/sync_ndbn_members.rb
+++ b/app/services/sync_ndbn_members.rb
@@ -39,12 +39,18 @@ class SyncNDBNMembers
     private
 
     def fetch_members_page
-      get(NDBN_MEMBERS_PAGE).body
+      res = get(NDBN_MEMBERS_PAGE)
+
+      if res.code != 200
+        raise "SyncNDBNMembers.sync failed due to getting a status code of #{res.code}"
+      end
+
+      res.body
     end
 
     def extract_member_entries(html_body)
       doc = Nokogiri::HTML(html_body)
-      entries = doc.css('.contentpaneopen p').map { |t| t.text }
+      entries = doc.css(".contentpaneopen p").map { |t| t.text }
 
       # Removes the column header that only has the labels
       entries[1..].map do |entry|

--- a/app/services/sync_ndbn_members.rb
+++ b/app/services/sync_ndbn_members.rb
@@ -1,9 +1,7 @@
 class SyncNDBNMembers
   include HTTParty
-  include Scraping
 
   NDBN_MEMBERS_PAGE = "https://ndbn.memberclicks.net/member-ids".freeze
-  elements :ndbn_member_entries, ".contentpaneopen p"
 
   class << self
     def sync
@@ -45,7 +43,8 @@ class SyncNDBNMembers
     end
 
     def extract_member_entries(html_body)
-      entries = scrape(html_body).ndbn_member_entries
+      doc = Nokogiri::HTML(html_body)
+      entries = doc.css('.contentpaneopen p').map { |t| t.text }
 
       # Removes the column header that only has the labels
       entries[1..].map do |entry|

--- a/db/migrate/20220220125108_create_ndbn_members.rb
+++ b/db/migrate/20220220125108_create_ndbn_members.rb
@@ -1,0 +1,9 @@
+class CreateNdbnMembers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ndbn_members, primary_key: :ndbn_member_id do |t|
+      t.string :account_name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_16_010945) do
+ActiveRecord::Schema.define(version: 2022_02_20_125108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -320,6 +320,12 @@ ActiveRecord::Schema.define(version: 2022_01_16_010945) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["organization_id"], name: "index_manufacturers_on_organization_id"
+  end
+
+  create_table "ndbn_members", primary_key: "ndbn_member_id", force: :cascade do |t|
+    t.string "account_name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "organizations", id: :serial, force: :cascade do |t|

--- a/lib/tasks/sync_ndbn_members.rake
+++ b/lib/tasks/sync_ndbn_members.rake
@@ -1,0 +1,5 @@
+desc "This task is called by the Heroku scheduler add-on to sync up NDBNMember records"
+task :sync_ndbn_members => :environment do
+  SyncNDBNMembers.sync
+end
+

--- a/spec/factories/ndbn_members.rb
+++ b/spec/factories/ndbn_members.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: ndbn_members
+#
+#  account_name   :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  ndbn_member_id :bigint           not null, primary key
+#
+FactoryBot.define do
+  factory :ndbn_member, class: NDBNMember do
+    ndbn_member_id { 1 }
+    account_name { "MyString" }
+  end
+end

--- a/spec/factories/ndbn_members.rb
+++ b/spec/factories/ndbn_members.rb
@@ -9,7 +9,7 @@
 #
 FactoryBot.define do
   factory :ndbn_member, class: NDBNMember do
-    ndbn_member_id { 1 }
+    sequence(:ndbn_member_id) { |n| n }
     account_name { "MyString" }
   end
 end

--- a/spec/models/ndbn_member_spec.rb
+++ b/spec/models/ndbn_member_spec.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: ndbn_members
+#
+#  account_name   :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  ndbn_member_id :bigint           not null, primary key
+#
+require 'rails_helper'
+
+RSpec.describe NDBNMember, type: :model do
+
+  describe 'validations' do
+    subject { build(:ndbn_member) }
+    it { should validate_presence_of(:ndbn_member_id) }
+    it { should validate_presence_of(:account_name) }
+    it { should validate_uniqueness_of(:ndbn_member_id) }
+  end
+
+
+end

--- a/spec/models/ndbn_member_spec.rb
+++ b/spec/models/ndbn_member_spec.rb
@@ -7,16 +7,13 @@
 #  updated_at     :datetime         not null
 #  ndbn_member_id :bigint           not null, primary key
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe NDBNMember, type: :model do
-
-  describe 'validations' do
+  describe "validations" do
     subject { build(:ndbn_member) }
     it { should validate_presence_of(:ndbn_member_id) }
     it { should validate_presence_of(:account_name) }
     it { should validate_uniqueness_of(:ndbn_member_id) }
   end
-
-
 end

--- a/spec/services/sync_ndbn_members_spec.rb
+++ b/spec/services/sync_ndbn_members_spec.rb
@@ -1,6 +1,5 @@
 describe SyncNDBNMembers do
-
-  describe '.sync' do
+  describe ".sync" do
     subject { -> { described_class.sync } }
     let(:ndbn_member_id) { 200040 }
     let(:account_name) { "New Super Baby" }
@@ -22,34 +21,33 @@ describe SyncNDBNMembers do
     end
 
     before do
-      fake_http_response = double('fake_http_response', body: fake_html_body)
+      fake_http_response = double("fake_http_response", body: fake_html_body)
       allow(described_class).to receive(:get).with(SyncNDBNMembers::NDBN_MEMBERS_PAGE).and_return(fake_http_response)
     end
 
-    context 'when there are no exisiting NDBN Member records' do
-      it 'should create the NDBN Member records' do
+    context "when there are no exisiting NDBN Member records" do
+      it "should create the NDBN Member records" do
         expect { subject.call }.to change { NDBNMember.count }.from(0).to(2)
       end
     end
 
-    context 'when the account name of a NDBN Member has changed' do
+    context "when the account name of a NDBN Member has changed" do
       let(:old_account_name) { "Super Baby" }
 
       before do
         create(:ndbn_member, ndbn_member_id: ndbn_member_id, account_name: old_account_name)
       end
 
-      it 'should update the account name of the corresponding NDBN Member' do
+      it "should update the account name of the corresponding NDBN Member" do
         expect { subject.call }.to change { NDBNMember.find_by(ndbn_member_id: ndbn_member_id).account_name }.from(old_account_name).to(account_name)
       end
     end
 
-    context 'when no new NDBN Member has been added' do
-      it 'should not add any new NDBN Members' do
+    context "when no new NDBN Member has been added" do
+      it "should not add any new NDBN Members" do
         expect { subject.call }.to change { NDBNMember.count }.from(0).to(2)
         expect { subject.call }.not_to change { NDBNMember.count }
       end
     end
-
   end
 end

--- a/spec/services/sync_ndbn_members_spec.rb
+++ b/spec/services/sync_ndbn_members_spec.rb
@@ -1,0 +1,55 @@
+describe SyncNDBNMembers do
+
+  describe '.sync' do
+    subject { -> { described_class.sync } }
+    let(:ndbn_member_id) { 200040 }
+    let(:account_name) { "New Super Baby" }
+    let(:fake_html_body) do
+      <<-HTML
+      <table class="contentpaneopen">
+      <tbody><tr>
+      <td valign="top"><div class="content-wrapper" style="width: 690px;">
+      <h1>Organizational Member IDs</h1>
+      <p><strong>ID&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Account Name</strong></p>
+      <p><span style="font-size: 15px;">20040&nbsp;&nbsp;&nbsp; (914) Cares</span></p>
+      <p>#{ndbn_member_id}&nbsp;&nbsp;&nbsp; #{account_name}</p>
+
+      </div></td>
+      </tr>
+
+      </tbody></table>
+      HTML
+    end
+
+    before do
+      fake_http_response = double('fake_http_response', body: fake_html_body)
+      allow(described_class).to receive(:get).with(SyncNDBNMembers::NDBN_MEMBERS_PAGE).and_return(fake_http_response)
+    end
+
+    context 'when there are no exisiting NDBN Member records' do
+      it 'should create the NDBN Member records' do
+        expect { subject.call }.to change { NDBNMember.count }.from(0).to(2)
+      end
+    end
+
+    context 'when the account name of a NDBN Member has changed' do
+      let(:old_account_name) { "Super Baby" }
+
+      before do
+        create(:ndbn_member, ndbn_member_id: ndbn_member_id, account_name: old_account_name)
+      end
+
+      it 'should update the account name of the corresponding NDBN Member' do
+        expect { subject.call }.to change { NDBNMember.find_by(ndbn_member_id: ndbn_member_id).account_name }.from(old_account_name).to(account_name)
+      end
+    end
+
+    context 'when no new NDBN Member has been added' do
+      it 'should not add any new NDBN Members' do
+        expect { subject.call }.to change { NDBNMember.count }.from(0).to(2)
+        expect { subject.call }.not_to change { NDBNMember.count }
+      end
+    end
+
+  end
+end

--- a/spec/services/sync_ndbn_members_spec.rb
+++ b/spec/services/sync_ndbn_members_spec.rb
@@ -21,32 +21,48 @@ describe SyncNDBNMembers do
     end
 
     before do
-      fake_http_response = double("fake_http_response", body: fake_html_body)
-      allow(described_class).to receive(:get).with(SyncNDBNMembers::NDBN_MEMBERS_PAGE).and_return(fake_http_response)
+      stub_request(:get, SyncNDBNMembers::NDBN_MEMBERS_PAGE).to_return(body: fake_html_body)
     end
 
-    context "when there are no exisiting NDBN Member records" do
-      it "should create the NDBN Member records" do
-        expect { subject.call }.to change { NDBNMember.count }.from(0).to(2)
-      end
-    end
-
-    context "when the account name of a NDBN Member has changed" do
-      let(:old_account_name) { "Super Baby" }
-
+    context "when the HTTP request does not get a response of 200" do
+      let(:failed_status_code) { 500 }
       before do
-        create(:ndbn_member, ndbn_member_id: ndbn_member_id, account_name: old_account_name)
+        stub_request(:get, SyncNDBNMembers::NDBN_MEMBERS_PAGE).to_return(status: failed_status_code)
       end
 
-      it "should update the account name of the corresponding NDBN Member" do
-        expect { subject.call }.to change { NDBNMember.find_by(ndbn_member_id: ndbn_member_id).account_name }.from(old_account_name).to(account_name)
+      it "should raise an error regarding the response code" do
+        expect { subject.call }.to raise_error("SyncNDBNMembers.sync failed due to getting a status code of #{failed_status_code}")
       end
     end
 
-    context "when no new NDBN Member has been added" do
-      it "should not add any new NDBN Members" do
-        expect { subject.call }.to change { NDBNMember.count }.from(0).to(2)
-        expect { subject.call }.not_to change { NDBNMember.count }
+    context "when the HTTP request is successful" do
+      before do
+        stub_request(:get, SyncNDBNMembers::NDBN_MEMBERS_PAGE).to_return(body: fake_html_body)
+      end
+
+      context "when there are no exisiting NDBN Member records" do
+        it "should create the NDBN Member records" do
+          expect { subject.call }.to change { NDBNMember.count }.from(0).to(2)
+        end
+      end
+
+      context "when the account name of a NDBN Member has changed" do
+        let(:old_account_name) { "Super Baby" }
+
+        before do
+          create(:ndbn_member, ndbn_member_id: ndbn_member_id, account_name: old_account_name)
+        end
+
+        it "should update the account name of the corresponding NDBN Member" do
+          expect { subject.call }.to change { NDBNMember.find_by(ndbn_member_id: ndbn_member_id).account_name }.from(old_account_name).to(account_name)
+        end
+      end
+
+      context "when no new NDBN Member has been added" do
+        it "should not add any new NDBN Members" do
+          expect { subject.call }.to change { NDBNMember.count }.from(0).to(2)
+          expect { subject.call }.not_to change { NDBNMember.count }
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves #2748 

### Description

This PR adds the ability for the application to store and sync up NDBN Member records as shown on https://ndbn.memberclicks.net/member-ids. It does this through a class that encapsulates the logic for web scraping the site that will get triggered via rake task + Heroku scheduler.

**After merging in, we need to set the Heroku scheduler to run `rails sync_ndbn_members`**

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested locally + I think the test suite should be sufficient in testing this new behavior.

### Screenshots
N/A
