### PR TITLE
2747 delete inactive partners

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -8,10 +8,10 @@ class PartnersController < ApplicationController
     @unfiltered_partners_for_statuses = Partner.where(organization: current_organization)
     @partners = Partner.includes(:partner_group).where(organization: current_organization)
     @partners = if filter_params.empty?
-                  @partners.active
-                else
-                  @partners.class_filter(filter_params)
-                end
+      @partners.active
+    else
+      @partners.class_filter(filter_params)
+    end
     @partners = @partners.alphabetized
     @partner_groups = PartnerGroup.includes(:partners, :item_categories).where(organization: current_organization)
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -55,6 +55,7 @@ class Partner < ApplicationRecord
   }
 
   scope :alphabetized, -> { order(:name) }
+  scope :active, -> { where.not(status: :deactivated) }
 
   include Filterable
   include Exportable
@@ -64,6 +65,14 @@ class Partner < ApplicationRecord
 
   def deactivated?
     status == 'deactivated'
+  end
+
+  # @return [Boolean]
+  def deletable?
+    uninvited? &&
+      distributions.none? &&
+      requests.none? &&
+      (profile.nil? || profile&.users&.none?)
   end
 
   #

--- a/app/views/partners/_statuses.html.erb
+++ b/app/views/partners/_statuses.html.erb
@@ -1,4 +1,4 @@
-<% icon_mapping = { 
+<% icon_mapping = {
     "uninvited": 'ban',
     "invited": 'envelope',
     "awaiting_review": 'question-circle',
@@ -9,7 +9,7 @@
 %>
 
 <ul id="partner-status">
-  <% partners.statuses.each do |status, _| 
+  <% partners.statuses.each do |status, _|
     selector = (status + "?").to_sym
     partner_count = partners.select(&selector).size %>
   <li>
@@ -19,6 +19,6 @@
   <% end %>
   <li>
     <%= fa_icon 'list-alt' %>
-    <%= link_to "#{partners.size} Total", partners_path, class: ("filtering" if current_filtered_status.nil?) %>
+    <%= link_to "#{partners.active.size} Active", partners_path, class: ("filtering" if current_filtered_status.nil?) %>
   </li>
 </ul>

--- a/app/views/partners/_uninvited_header.html.erb
+++ b/app/views/partners/_uninvited_header.html.erb
@@ -7,6 +7,9 @@
   <!-- /.card-body -->
   <div class="card-footer">
     <%= edit_button_to edit_partner_path(partner) %>
+    <% if partner.deletable? %>
+      <%= delete_button_to partner_path(partner), {confirm: confirm_delete_msg(partner.name)} %>
+    <% end %>
     <span class="float-right">
     </span>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
     get :dashboard
     resources :base_items
     resources :organizations
-    resources :partners, except: %i[new create destroy]
+    resources :partners, except: %i[new create]
     resources :users
     resources :barcode_items
     resources :account_requests, only: [:index] do

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -101,6 +101,7 @@ FactoryBot.define do
       status { :uninvited }
 
       transient do
+        without_profile { false }
         without_partner_users { true }
       end
     end
@@ -110,6 +111,8 @@ FactoryBot.define do
     end
 
     after(:create) do |partner, evaluator|
+      next if evaluator.try(:without_profile)
+
       # Create associated records on partnerbase DB
       partners_partner = create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
       create(:partners_user, email: partner.email, name: partner.name, partner: partners_partner)

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -101,6 +101,56 @@ RSpec.describe Partner, type: :model, skip_seed: true do
     end
   end
 
+  describe '#deletable?' do
+
+    context 'when status is not uninvited' do
+      it 'should return false' do
+        expect(build(:partner, status: :invited)).not_to be_deletable
+        expect(build(:partner, status: :awaiting_review)).not_to be_deletable
+        expect(build(:partner, status: :approved)).not_to be_deletable
+        expect(build(:partner, status: :error)).not_to be_deletable
+        expect(build(:partner, status: :recertification_required)).not_to be_deletable
+        expect(build(:partner, status: :deactivated)).not_to be_deletable
+      end
+    end
+
+    context 'when status is uninvited' do
+      let(:partner) { create(:partner, :uninvited, without_profile: true) }
+
+      context 'when it has no other associations' do
+        it 'should return true' do
+          expect(partner).to be_deletable
+        end
+      end
+
+      context 'when it has a request' do
+        it 'should return false' do
+          create(:request, partner: partner)
+          expect(partner.reload).not_to be_deletable
+        end
+      end
+      context 'when it has a distribution' do
+        it 'should return false' do
+          create(:distribution, partner: partner)
+          expect(partner.reload).not_to be_deletable
+        end
+      end
+      context 'when it has a profile but no users' do
+        it 'should return true' do
+          create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
+          expect(partner.reload).to be_deletable
+        end
+      end
+      context 'when it has a profile and users' do
+        it 'should return false' do
+          partners_partner = create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
+          create(:partners_user, email: partner.email, name: partner.name, partner: partners_partner)
+          expect(partner.reload).not_to be_deletable
+        end
+      end
+    end
+  end
+
   describe '#invite_new_partner' do
     let(:partner) { create(:partner) }
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe Partner, type: :model, skip_seed: true do
   end
 
   describe '#deletable?' do
-
     context 'when status is not uninvited' do
       it 'should return false' do
         expect(build(:partner, status: :invited)).not_to be_deletable

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -136,9 +136,7 @@ RSpec.describe "Partners", type: :request do
             expect(subject.body).to include('Delete')
           end
         end
-
       end
-
     end
 
     context "csv" do

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -124,7 +124,21 @@ RSpec.describe "Partners", type: :request do
           subject
           expect(assigns[:impact_metrics]).not_to be_present
         end
+
+        it 'does not show the delete button' do
+          expect(subject).not_to include('Delete')
+        end
+
+        context 'when the partner has no users' do
+          # see the deletable? method which is tested separately in the partner model spec
+          it 'shows the delete button' do
+            partner.profile.users.delete_all
+            expect(subject.body).to include('Delete')
+          end
+        end
+
       end
+
     end
 
     context "csv" do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -139,6 +139,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         @uninvited = create(:partner, name: "Bcd", status: :uninvited)
         @invited = create(:partner, name: "Abc", status: :invited)
         @approved = create(:partner, :approved, name: "Cde", status: :approved)
+        @deactivated = create(:partner, name: "Def", status: :deactivated)
         visit url_prefix + "/partners"
       end
 
@@ -146,6 +147,8 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         expect(page).to have_css("table tr", count: 5, wait: page_content_wait)
         expect(page.find(:xpath, "//table/tbody/tr[1]/td[1]")).to have_content(@invited.name)
         expect(page.find(:xpath, "//table/tbody/tr[3]/td[1]")).to have_content(@approved.name)
+        expect(page.find(:xpath, %(//*[@id="partner-status"]))).to have_content("4 Active")
+        expect(page.find(:xpath, %(//*[@id="partner-status"]))).to have_content("1 Deactivated")
       end
 
       it "allows a user to invite a partner", js: true do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -177,7 +177,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         it "allows the user to click on one of the statuses at the top to filter the results" do
           approved_count = Partner.approved.count
           within "table tbody" do
-            expect(page).to have_css("tr", count: Partner.count)
+            expect(page).to have_css("tr", count: Partner.active.count)
           end
           within "#partner-status" do
             click_on "Approved"


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2747 

### Description
This PR has two changes in it:

1. The partner index page will now only show active partners by default. Deactivates partners are only shown if the Deactivated status is clicked. The text has changed from "N Total" to "N Active".
2. The partner edit page for uninvited partners will now have a delete button if that partner can be deleted (i.e. it has no users, requests or distributions).
   
Note that the original feature mentioned a "deactive/delete" button. However, since only uninvited users can be deleted, and uninvited users have a different header used for the edit page, I instead just added the delete button to that header if the partner can be deleted.

### Type of change

* Change to functionality as requested

### How Has This Been Tested?

Local and unit tests

### Screenshots
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/1986893/154865844-78b701d3-3fb8-4792-8721-da8743ed9946.png">

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/1986893/154865851-79c5335c-444c-4484-9783-8f97a9b50652.png">
