### PR TITLE
2764: Only show active items in new distribution drop-down

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -96,7 +96,7 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build
       @distribution.copy_from_donation(params[:donation_id], params[:storage_location_id])
     end
-    @items = current_organization.items.alphabetized
+    @items = current_organization.items.active.alphabetized
     @storage_locations = current_organization.storage_locations.has_inventory_items.alphabetized
   end
 

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -78,8 +78,13 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
 
     describe "GET #new" do
       it "returns http success" do
+        # for items drop-down
+        create(:item, :active, name: 'Active Item')
+        create(:item, :inactive, name: 'Inactive Item')
         get new_distribution_path(default_params)
         expect(response).to be_successful
+        expect(response.body).to include('Active Item')
+        expect(response.body).not_to include('Inactive Item')
       end
     end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2764.

### Description

Fixes the item drop down for new distributions so it does not show inactive items.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Local and unit tests.
