### PR TITLE
Add 20220116010945 migration changes

### DIFF
--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -8,7 +8,9 @@
 #  name                 :string           not null
 #  organization_name    :string           not null
 #  organization_website :string
+#  rejection_reason     :string
 #  request_details      :text             not null
+#  status               :string           default("started"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -8,7 +8,9 @@
 #  name                 :string           not null
 #  organization_name    :string           not null
 #  organization_website :string
+#  rejection_reason     :string
 #  request_details      :text             not null
+#  status               :string           default("started"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #


### PR DESCRIPTION
Running migration
`20220116010945_add_rejection_reason_to_account_requests.rb`
(added 4a13aaf0) adds these lines

Yah, they're just auto-generated comments, but saving others the confusion of seeing
changes after running migration(s)

![image](https://user-images.githubusercontent.com/2031462/155028969-5f2858be-d570-48cd-9e4c-c69f752e14d4.png)

![image](https://user-images.githubusercontent.com/2031462/155029062-8ea00bff-4eaf-4069-bb81-307b19019c03.png)
