### PR TITLE
Improve org. dashboard formatting consistency

### DIFF
--- a/app/views/dashboard/_diaper_drive.html.erb
+++ b/app/views/dashboard/_diaper_drive.html.erb
@@ -1,5 +1,5 @@
   <div class="float-center donation">
     <%= link_to donation do %>
-      <%= donation.line_items.total %> from <%= donation.diaper_drive&.name || donation.diaper_drive_participant.business_name %>
+      <%= number_with_delimiter donation.line_items.total %> from <%= donation.diaper_drive&.name || donation.diaper_drive_participant.business_name %>
     <% end %>
   </div>

--- a/app/views/dashboard/_distribution.html.erb
+++ b/app/views/dashboard/_distribution.html.erb
@@ -1,7 +1,7 @@
 <br>
 <div class="pull-left distribution">
   <%= link_to distribution do %>
-    <%= distribution.line_items.total %> items distributed to
+    <%= number_with_delimiter distribution.line_items.total %> items distributed to
     <%= distribution.partner_name %>
   <% end %>
 </div>

--- a/app/views/dashboard/_donation.html.erb
+++ b/app/views/dashboard/_donation.html.erb
@@ -1,7 +1,7 @@
 <br>
 <div class="pull-left donation">
   <%= link_to donation do %>
-    <%= donation.line_items.total %> items from <%= donation.source %>
+    <%= number_with_delimiter donation.line_items.total %> items from <%= donation.source %>
   <% end %>
 </div>
 <div class="pull-right">

--- a/app/views/dashboard/_purchase.html.erb
+++ b/app/views/dashboard/_purchase.html.erb
@@ -1,7 +1,7 @@
 <br>
 <div class="pull-left purchase">
   <%= link_to do %>
-    <%= purchase.line_items.total %> items from <%= purchase.purchased_from_view %>
+    <%= number_with_delimiter purchase.line_items.total %> items from <%= purchase.purchased_from_view %>
   <% end %>
 </div>
 <div class="pull-right">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -144,7 +144,9 @@
 
         <div class="card">
           <div class="card-header border-0 bg-gradient-warning">
-            <h3 class="card-title">Activity <%= @selected_date_range_label %></h3>
+            <h3 class="card-title">Activity
+              <small><%= @selected_date_range %></small>
+            </h3>
             <div class="card-tools">
               <button type="button" class="btn btn-tool" data-card-widget="collapse">
                 <i class="fas fa-minus"></i>

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -240,9 +240,9 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
 
               expect(recent_donation_links.count).to eq expected_recent_donation_links_count
 
-              # Expect the links to be something like "1 item...", "20 items from Manufacturer"
+              # Expect the links to be something like "1 item...", "4,000 items from Manufacturer"
               # Strip out the item counts
-              recent_quantities = recent_donation_links.map { _1.match(/\d+/).to_s.to_i }
+              recent_quantities = recent_donation_links.map { _1.match(/[0-9,]+/).to_s.delete(",").to_i }
 
               # By design, the setup may have created more Donations during the period than are visible in the Recent Donation links
               # Make sure each Recent Donation link uniquely matches a single Donation
@@ -370,9 +370,9 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
 
               expect(recent_purchase_links.count).to eq expected_recent_purchase_links_count
 
-              # Expect the links to be something like "1 item...", "20 items from Manufacturer"
+              # Expect the links to be something like "1 item...", "4,000 items from Manufacturer"
               # Strip out the item counts
-              recent_quantities = recent_purchase_links.map { _1.match(/\d+/).to_s.to_i }
+              recent_quantities = recent_purchase_links.map { _1.match(/[0-9,]+/).to_s.delete(",").to_i }
 
               # By design, the setup may have created more Purchases during the period than are visible in the Recent Purchase links
               # Make sure each Recent Purchase link uniquely matches a single Purchase
@@ -486,13 +486,13 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
 
               expect(recent_donation_links.count).to eq expected_recent_donation_links_count
 
-              # Expect the links to be something like "1 from Some Drive", "20 items from Another Drive"
+              # Expect the links to be something like "1 from Some Drive", "4,000 items from Another Drive"
               # Strip out the item counts & drive names
               recent_donations = recent_donation_links.map do
-                items_donated, drive_name = _1.match(/(\d+) from (.+)/).captures
+                items_donated, drive_name = _1.match(/([0-9,]+) from (.+)/).captures
 
                 # e.g., [1, "Some Drive"], [20, "Another Drive"]
-                OpenStruct.new quantity: items_donated.to_i, drive_name: drive_name
+                OpenStruct.new quantity: items_donated.delete(",").to_i, drive_name: drive_name
               end
 
               # By design, the setup may have created more Donations during the period than are visible in the Recent Donation links
@@ -641,7 +641,7 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
               # Expect the links to be something like "In-date-range Manufacturer 1 (21)", "In-date-range Manufacturer 2 (4,321)", etc.
               # Strip out the item counts & manufacturer names
               top_manufacturer_donations = top_manufacturer_donation_links.map do
-                manufacturer_name, total_donated = _1.match(/(.+) \((\d+)\)/).captures
+                manufacturer_name, total_donated = _1.match(/(.+) \(([0-9,]+)\)/).captures
 
                 OpenStruct.new manufacturer_name: manufacturer_name, total_quantity_donated: total_donated.delete(",").to_i
               end
@@ -782,13 +782,13 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
 
               expect(recent_distribution_links.count).to eq expected_recent_distribution_links_count
 
-              # Expect the links to be something like "1 from Some Drive", "20 items from Another Drive"
+              # Expect the links to be something like "1 items distributed to Some Shelter", "4,000 items distributed to Some Shelter"
               # Strip out the item counts & drive names
               recent_distributions = recent_distribution_links.map do
-                items_distributed, partner_name = _1.match(/(\d+) items distributed to (.+)/).captures
+                items_distributed, partner_name = _1.match(/([0-9,]+) items distributed to (.+)/).captures
 
                 # e.g., [1, "Some Drive"], [20, "Another Drive"]
-                OpenStruct.new quantity: items_distributed.to_i, partner_name: partner_name
+                OpenStruct.new quantity: items_distributed.delete(",").to_i, partner_name: partner_name
               end
 
               # By design, the setup may have created more Distributions during the period than are visible in the Recent Distribution links


### PR DESCRIPTION
### Description
Fixes some inconsistencies in how the org. dashboard presents a date and many counts.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Manually
- Updated `spec/system/dashboard_system_spec.rb`

### Screenshots
#### Before
![154862132-b9d8184d-03de-4275-b0ea-2de5f722f8c0](https://user-images.githubusercontent.com/2031462/155044056-3e7ddb4f-a5ce-4f4d-a360-7a4cc1d09c80.png)

![image](https://user-images.githubusercontent.com/2031462/155044072-69feb413-2917-4058-94ce-0e2fc4814b4a.png)

#### After
(different database state, so don't worry that the numbers & names are different)

![image](https://user-images.githubusercontent.com/2031462/155044184-9e5d35c9-12ec-49bf-91b7-15f06c9e7ea6.png)
