### PR TITLE
2762: show $0 on dashboard

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -8,11 +8,11 @@ module ItemsHelper
     ActionController::Base.helpers.number_to_currency dollars, precision: precision
   end
 
-  def dollar_value(value, addition = '')
+  def dollar_value(value)
     if value.zero?
       ''
     else
-      addition + dollar_presentation(value)
+      dollar_presentation value
     end
   end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,10 +1,18 @@
 # Encapsulates methods that need some business logic
 module ItemsHelper
+  def dollar_presentation(value)
+    dollars = cents_to_dollar value
+    rounds_to_self = dollars.round == value
+    precision = rounds_to_self ? 0 : 2
+
+    ActionController::Base.helpers.number_to_currency dollars, precision: precision
+  end
+
   def dollar_value(value, addition = '')
     if value.zero?
       ''
     else
-      addition + ActionController::Base.helpers.number_to_currency(cents_to_dollar(value), precision: cents_to_dollar(value).round == value ? 0 : 2)
+      addition + dollar_presentation(value)
     end
   end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,18 +1,18 @@
 # Encapsulates methods that need some business logic
 module ItemsHelper
   def dollar_presentation(value)
-    dollars = cents_to_dollar value
+    dollars = cents_to_dollar(value)
     rounds_to_self = dollars.round == value
     precision = rounds_to_self ? 0 : 2
 
-    ActionController::Base.helpers.number_to_currency dollars, precision: precision
+    ActionController::Base.helpers.number_to_currency(dollars, precision: precision)
   end
 
   def dollar_value(value)
     if value.zero?
       ''
     else
-      dollar_presentation value
+      dollar_presentation(value)
     end
   end
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -189,7 +189,7 @@
                   </span>
                   items
                   received <%= @selected_date_range_label %></h3>
-                <h4 class="text-center"><%= dollar_value(total_received_money_donations) %>
+                <h4 class="text-center"><%= dollar_presentation(total_received_money_donations) %>
                   raised  <%= @selected_date_range_label %></h4>
                 <div class="box-body">
                   <h4>Recent Donations</h4>
@@ -220,7 +220,7 @@
                     <%= total_received_from_diaper_drives %>
                   </span> items
                   received <%= @selected_date_range_label %></h3>
-                <h4 class="text-center"><%= dollar_value(total_received_money_donations) %>
+                <h4 class="text-center"><%= dollar_presentation(total_received_money_donations) %>
                   raised  <%= @selected_date_range_label %></h4>
                 <div class="box-body">
                   <h4>Recent Donations from Diaper Drives</h4>
@@ -287,7 +287,7 @@
             <div class="position-relative mb-4">
               <div class="box-body text-center float-center">
                 <%= new_button_to new_purchase_path, {text: "New Purchase"} %>
-                <h3 class="text-center"><%= dollar_value(@purchases.sum(&:amount_spent_in_cents)) %>
+                <h3 class="text-center"><%= dollar_presentation(@purchases.sum(&:amount_spent_in_cents)) %>
                   spent
                   <%= @selected_date_range_label %></h3>
                 <div class="box-body">


### PR DESCRIPTION
Resolves #2762

### Description
Extract most of `ItemsHelper#dollar_value` into `#dollar_presentation` so both the dashboard and `#dollar_value` can use it without affecting `#dollar_value`'s callers.

Also removes `#dollar_value`'s unused `addition` parameter

**Suggestions for a name better than `dollar_presentation` welcome!**

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually

Happy to add examples/expectations if that would be interesting
See also #2783

### Screenshots
#### Before

![](https://user-images.githubusercontent.com/2031462/154371274-af780428-2ed9-4816-a0be-ea4386bda8c8.png)

#### After

![image](https://user-images.githubusercontent.com/2031462/155417970-0e9c4b79-0354-48d0-9a19-b57bcf048748.png)
