### PR TITLE
Remove Google login link from initial login page

### DIFF
--- a/app/views/consolidated_logins/new.html.erb
+++ b/app/views/consolidated_logins/new.html.erb
@@ -23,7 +23,3 @@
     </div>
   </div>
 <% end %>
-
-<%= link_to user_google_oauth2_omniauth_authorize_path, method: :post do %>
-  <img src="../img/btn_google_signin_dark_focus_web@2x.png" alt="Sign in with Google"/>
-<% end %>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description

As per discussion over Slack, this removes the Google login link from the first login page. This is to reduce confusion for users who have both a bank and partner login, since the Google link only works for bank logins right now. The link on the bank login page is still there, so they can still use this feature.

I will be filing a new issue to discuss better handling of user accounts than what we have right now.

### Type of change

Fix / improvement

### How Has This Been Tested?

Local testing.

### Screenshots

<img width="577" alt="image" src="https://user-images.githubusercontent.com/1986893/155863601-c1255bfd-b0da-403f-ad7d-9e9140db7ccb.png">
<img width="530" alt="image" src="https://user-images.githubusercontent.com/1986893/155863605-468f6dd5-0774-465f-9558-59e2d15701f8.png">
<img width="678" alt="image" src="https://user-images.githubusercontent.com/1986893/155863607-99425f87-6e1e-4b68-a55d-45f176bea59e.png">
<img width="542" alt="image" src="https://user-images.githubusercontent.com/1986893/155863612-0792b844-8b93-4e54-8dff-992e0ce1eadf.png">
