### PR TITLE
fix(csv): correct totals for multiple line items for same item

### DIFF
--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -103,7 +103,7 @@ module Exports
       distribution.line_items.each do |line_item|
         item_name = line_item.item.name
         item_column_idx = headers_with_indexes[item_name]
-        row[item_column_idx] = line_item.quantity
+        row[item_column_idx] += line_item.quantity
       end
 
       row

--- a/app/services/exports/export_donations_csv_service.rb
+++ b/app/services/exports/export_donations_csv_service.rb
@@ -78,7 +78,7 @@ module Exports
           donation.line_items.total
         },
         "Variety of Items" => ->(donation) {
-          donation.line_items.size
+          donation.line_items.map(&:name).uniq.size
         },
         "Comments" => ->(donation) {
           donation.comment
@@ -108,7 +108,7 @@ module Exports
       donation.line_items.each do |line_item|
         item_name = line_item.item.name
         item_column_idx = headers_with_indexes[item_name]
-        row[item_column_idx] = line_item.quantity
+        row[item_column_idx] += line_item.quantity
       end
 
       row

--- a/app/services/exports/export_request_service.rb
+++ b/app/services/exports/export_request_service.rb
@@ -79,10 +79,8 @@ module Exports
           # Add to the deleted column for every item that
           # does not match any existing Item.
           row[item_column_idx] ||= 0
-          row[item_column_idx] += request_item['quantity']
-        else
-          row[item_column_idx] = request_item['quantity']
         end
+        row[item_column_idx] += request_item['quantity']
       end
 
       row

--- a/spec/services/exports/export_donations_csv_service_spec.rb
+++ b/spec/services/exports/export_donations_csv_service_spec.rb
@@ -2,23 +2,56 @@ describe Exports::ExportDonationsCSVService, skip_seed: true do
   describe '#generate_csv_data' do
     subject { described_class.new(donation_ids: donation_ids).generate_csv_data }
     let(:donation_ids) { donations.map(&:id) }
+    let(:duplicate_item) do
+      FactoryBot.create(
+        :item, name: Faker::Appliance.equipment
+      )
+    end
+    let(:items_lists) do
+      [
+        [
+          [duplicate_item, 5],
+          [
+            FactoryBot.create(
+              :item, name: Faker::Appliance.equipment
+            ),
+            7
+          ],
+          [duplicate_item, 3]
+        ],
+        *(Array.new(3) do |i|
+          [[FactoryBot.create(
+            :item, name: Faker::Appliance.equipment
+          ), i + 1]]
+        end)
+      ]
+    end
+
+    let(:item_names) { items_lists.flatten(1).map(&:first).map(&:name).sort.uniq }
+
     let(:donations) do
       start_time = Time.current
-      Array.new(3) do |i|
-        create(
+
+      items_lists.each_with_index.map do |items, i|
+        donation = create(
           :donation,
-          :with_items,
           donation_site: create(
             :donation_site, name: "Space Needle #{i}",
-          ),
-          item: FactoryBot.create(
-            :item, name: Faker::Appliance.equipment
           ),
           issued_at: start_time + i.days,
           comment: "This is the #{i}-th donation in the test."
         )
+
+        items.each do |(item, quantity)|
+          donation.line_items << create(
+            :line_item, quantity: quantity, item: item
+          )
+        end
+
+        donation
       end
     end
+
     let(:expected_headers) do
       [
         "Source",
@@ -30,37 +63,40 @@ describe Exports::ExportDonationsCSVService, skip_seed: true do
         "Comments"
       ] + expected_item_headers
     end
-    let(:expected_item_headers) do
-      item_names = donations.map do |donation|
-        donation.line_items.map(&:item).map(&:name)
-      end.flatten
 
+    let(:total_item_quantities) do
+      template = item_names.index_with(0)
+
+      items_lists.map do |items_list|
+        row = template.dup
+        items_list.each do |(item, quantity)|
+          row[item.name] += quantity
+        end
+        row.values
+      end
+    end
+
+    let(:expected_item_headers) do
       expect(item_names).not_to be_empty
 
-      item_names.sort.uniq
+      item_names
     end
 
     it 'should match the expected content for the csv' do
       expect(subject[0]).to eq(expected_headers)
 
-      donations.each_with_index do |donation, idx|
+      donations.zip(total_item_quantities).each_with_index do |(donation, total_item_quantity), idx|
         row = [
           donation.source_view,
           donation.issued_at.strftime("%F"),
           donation.donation_site.try(:name),
           donation.storage_view,
           donation.line_items.total,
-          donation.line_items.size,
+          total_item_quantity.count(&:positive?),
           donation.comment
         ]
 
-        row += Array.new(expected_item_headers.size, 0)
-
-        donation.line_items.includes(:item).each do |line_item|
-          item_name = line_item.item.name
-          item_column_idx = expected_headers.index(item_name)
-          row[item_column_idx] = line_item.quantity
-        end
+        row += total_item_quantity
 
         expect(subject[idx + 1]).to eq(row)
       end

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -25,6 +25,29 @@ describe Exports::ExportRequestService, skip_seed: true do
            request_items: [{ item_id: 0, quantity: 200 }, { item_id: -1, quantity: 200 }])
   end
 
+  let!(:duplicate_items) do
+    [
+      {item_id: item_3t.id, quantity: 2},
+      {item_id: item_2t.id, quantity: 3},
+      {item_id: item_3t.id, quantity: 5}
+    ]
+  end
+
+  let!(:duplicate_item_quantities) do
+    duplicate_items.each_with_object(Hash.new(0)) do |item, hsh|
+      hsh[item[:item_id]] += item[:quantity]
+    end
+  end
+
+  let!(:request_with_duplicate_items) do
+    create(
+      :request,
+      :started,
+      organization: org,
+      request_items: duplicate_items
+    )
+  end
+
   subject do
     described_class.new(Request.all).generate_csv_data
   end
@@ -43,16 +66,20 @@ describe Exports::ExportRequestService, skip_seed: true do
     it "includes rows for each request with correct columns of item quantity" do
       expect(subject.second).to include(request_3t.created_at.strftime("%m/%d/%Y").to_s)
 
-      item_column_idx = expected_headers.each_with_index.to_h[item_3t.name]
-      expect(subject.second[item_column_idx]).to eq(150)
+      item_2t_column_idx = expected_headers.each_with_index.to_h[item_2t.name]
+      item_3t_column_idx = expected_headers.each_with_index.to_h[item_3t.name]
+
+      expect(subject.second[item_3t_column_idx]).to eq(150)
 
       expect(subject.third).to include(request_2t.created_at.strftime("%m/%d/%Y").to_s)
-      item_column_idx = expected_headers.each_with_index.to_h[item_2t.name]
-      expect(subject.third[item_column_idx]).to eq(100)
+      expect(subject.third[item_2t_column_idx]).to eq(100)
 
       expect(subject.fourth).to include(request_3t.created_at.strftime("%m/%d/%Y").to_s)
       item_column_idx = expected_headers.each_with_index.to_h[Exports::ExportRequestService::DELETED_ITEMS_COLUMN_HEADER]
       expect(subject.fourth[item_column_idx]).to eq(400)
+
+      expect(subject.fifth[item_2t_column_idx]).to eq(duplicate_item_quantities[item_2t.id])
+      expect(subject.fifth[item_3t_column_idx]).to eq(duplicate_item_quantities[item_3t.id])
     end
   end
 end


### PR DESCRIPTION
### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
See modified specs. Note: I kept the commits separate in dev+review to make it easier for me to verify that they (correctly) fail before the addition of the commit modifying the export services

### Screenshots
With same example as in [#2605](https://github.com/rubyforgood/human-essentials/issues/2605#issuecomment-1052438115), the exported CSV is now correct:
```
> bat ~/Downloads/Donations-2022-03-02.csv | xsv table  --pad 1
Source                           Date       Donation Site Storage Location          Quantity of Items Variety of Items Comments               Pads Swimmers
Deirdre Breathnach (participant) 2022-02-26               Pawnee Main Bank (Office) 10                2                Testing item summation 7    3
```

- - -

### last commit message

fix(csv): correct totals for multiple line items for same item

Fixes #2605

Note: Also verified and fixed the same issue for distribution and
request CSV exports

Was setting the line item to the given item quantity in a hash with
item id/name as key, which resulted in subsequent item quantities
over-writing rather than adding to the total.