### PR TITLE
Run webpack only for first :system example

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,6 +95,11 @@ def stub_addresses
   end
 end
 
+# Create global var for use in
+# config.before(:each, type: :system)
+# below
+have_run_webpacker_for_specs = false
+
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
@@ -160,8 +165,6 @@ RSpec.configure do |config|
 
     raise if Partners::Partner.count > 0
     raise if Organization.count > 0
-
-    ENV["RSPEC_HAS_RUN_WEBPACKER"] = "false"
   end
 
   config.before(:each) do
@@ -171,13 +174,13 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do
-    unless ENV["RSPEC_HAS_RUN_WEBPACKER"] == "true"
+    unless have_run_webpacker_for_specs
       Rails.logger.info "** Running webpack"
 
       # Compile assets neccessary for browser tests to pass
       `NODE_ENV=test bin/webpack`
 
-      ENV["RSPEC_HAS_RUN_WEBPACKER"] = "true"
+      have_run_webpacker_for_specs = true
     end
 
     # Use truncation in the case of doing `browser` tests because it

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -140,9 +140,6 @@ RSpec.configure do |config|
 
   # Preparatifyication
   config.before(:suite) do
-    # Compile assets neccessary for browser tests to pass
-    `NODE_ENV=test bin/webpack`
-
     Rails.logger.info <<~ASCIIART
       -~~==]}>        ######## ###########  ####      ########    ###########
       -~~==]}>      #+#    #+#    #+#     #+# #+#    #+#     #+#     #+#
@@ -163,6 +160,8 @@ RSpec.configure do |config|
 
     raise if Partners::Partner.count > 0
     raise if Organization.count > 0
+
+    ENV["RSPEC_HAS_RUN_WEBPACKER"] = "false"
   end
 
   config.before(:each) do
@@ -172,6 +171,15 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do
+    unless ENV["RSPEC_HAS_RUN_WEBPACKER"] == "true"
+      Rails.logger.info "** Running webpack"
+
+      # Compile assets neccessary for browser tests to pass
+      `NODE_ENV=test bin/webpack`
+
+      ENV["RSPEC_HAS_RUN_WEBPACKER"] = "true"
+    end
+
     # Use truncation in the case of doing `browser` tests because it
     # appears that transactions won't work since it really does
     # depend on the database to have records.


### PR DESCRIPTION
Related to #2801

### Description
Run webpack only for first example that needs it, rather than for every suite run, independent of need

### Type of change

DevX improvement—speed up spec runs which don't include `type: :system`examples

### How Has This Been Tested?

Manual, CI
