### PR TITLE
re: 2790 Fixing error on showing a product drive with no end date

### DIFF
--- a/app/views/diaper_drives/show.html.erb
+++ b/app/views/diaper_drives/show.html.erb
@@ -41,7 +41,7 @@
               <tr>
               <td><%= @diaper_drive.name %></td>
               <td class="text-left" class="date"><%= @diaper_drive.start_date.strftime("%m-%d-%Y") %></td>
-              <td class="text-left"><%= @diaper_drive.end_date.strftime("%m-%d-%Y") %></td>
+              <td class="text-left"><%= @diaper_drive.end_date&.strftime("%m-%d-%Y") %></td>
               </tr>
               </tbody>
             </table>

--- a/spec/system/diaper_drive_system_spec.rb
+++ b/spec/system/diaper_drive_system_spec.rb
@@ -112,4 +112,14 @@ RSpec.describe "Product Drives", type: :system, js: true, skip_seed: true do
       expect(page.find('.alert')).to have_content('added')
     end
   end
+
+  context 'when showing a Product Drive with no end date' do
+    let(:new_diaper_drive) { create(:diaper_drive, name: 'Endless drive', start_date: 3.weeks.ago, end_date: '') }
+    let(:subject) { @url_prefix + "/diaper_drives/#{new_diaper_drive.id}" }
+
+    it 'must be able to show the product drive' do
+      visit subject
+      expect(page).to have_content 'Endless drive'
+    end
+  end
 end


### PR DESCRIPTION

Resolves #2790 

### Description

Before this fix, if  you went to "All Product Drives", and clicked "View" on a product drive that has no end date,  you would receive an error.  Now, it shows the product drive.

The fix is adding an "&' to the end_drive object in the diaper_drives/show.html.erb  view,  thereby making it check if it exists before calling strftime on it.

              <td class="text-left" class="date"><%= @diaper_drive.start_date.strftime("%m-%d-%Y") %></td>
              <td class="text-left"><%= @diaper_drive.end_date&.strftime("%m-%d-%Y") %></td>

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* 
### How Has This Been Tested?

1/   Added a test to spec/system/diaper_drive_system_spec.rb  

     when showing a Product Drive with no end date
        it must be able to show the product drive.
2/  Visual confirmation
3/  Ran the full test suite 

### Screenshots
<img width="1693" alt="Screen Shot 2022-03-06 at 11 29 07 AM" src="https://user-images.githubusercontent.com/10157589/156932188-0f1f4485-d721-48ad-9bbe-795dc093a03d.png">

