### PR TITLE
2807: Add default storage location to partners

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -168,7 +168,8 @@ class PartnersController < ApplicationController
   private
 
   def partner_params
-    params.require(:partner).permit(:name, :email, :send_reminders, :quota, :notes, :partner_group_id, documents: [])
+    params.require(:partner).permit(:name, :email, :send_reminders, :quota,
+      :notes, :partner_group_id, :default_storage_location_id, documents: [])
   end
 
   helper_method \

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,4 +132,16 @@ module ApplicationHelper
       <script>#{base_script}</script>
     HTML
   end
+
+  # @param source_object [ApplicationRecord]
+  # @return [Integer]
+  def storage_location_for_source(source_object)
+    if source_object.storage_location
+      return source_object.storage_location.id
+    end
+    if source_object.respond_to?(:partner) && source_object.partner&.default_storage_location_id
+      return source_object.partner.default_storage_location_id
+    end
+    current_organization.default_storage_location
+  end
 end

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -17,21 +17,27 @@
                 <span class="input-group-text"><i class="fa fa-envelope"></i></span>
                 <%= f.input_field :email, class: "form-control"%>
               <% end %>
+              <%= f.input :default_storage_location_id, :collection => current_organization.storage_locations.alphabetized,
+                          :label_method => :name,
+                          :value_method => :id,
+                          :label => "Default Storage Location",
+                          :include_blank => true,
+                          wrapper: :input_group %>
               <div class='w-50'>
                 <%= f.input :partner_group_id, label: "Group", wrapper: :input_group do %>
                   <%= f.input_field :partner_group_id, collection: @partner_groups, class: "form-control", include_blank: "None" %>
                 <% end %>
               </div>
-                  
+
               <div data-partner-reminder-form>
                 <%= f.input :send_reminders, label: "Do you want this partner to receive emails for distributions and reminders from the system?", wrapper: :input_group do %>
                   <%= f.check_box :send_reminders, {class: "input-group-text", id: "send_reminders", data: { 'partner-reminder-form-checkbox': '' } }, "true", "false" %>
-                 <% end %> 
-                  
+                 <% end %>
+
                 <div class='mb-2' data-partner-reminder-form-nested-form>
                   <div class="flex items-center bg-yellow-300 text-sm font-bold px-4 py-3" role="alert">
                     <p>Please note that reminders will be sent out according to the settings of their partner group OR organization. This won't work unless you've set up at least one.</p>
-                  </div> 
+                  </div>
                 </div>
               </div>
 

--- a/app/views/storage_locations/_source.html.erb
+++ b/app/views/storage_locations/_source.html.erb
@@ -10,7 +10,7 @@
   collection: storage_locations,
   label: label,
   error: error,
-  selected: source.object.storage_location&.id || current_organization.default_storage_location,
+  selected: storage_location_for_source(source.object),
   include_blank: true,
   input_html: {
     data: {

--- a/db/migrate/20220320202506_add_default_storage_location_to_partners.rb
+++ b/db/migrate/20220320202506_add_default_storage_location_to_partners.rb
@@ -1,0 +1,7 @@
+class AddDefaultStorageLocationToPartners < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :partners, :default_storage_location, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20220320202902_add_foreign_key_to_default_storage_locations.rb
+++ b/db/migrate/20220320202902_add_foreign_key_to_default_storage_locations.rb
@@ -1,0 +1,7 @@
+class AddForeignKeyToDefaultStorageLocations < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :partners, :storage_locations,
+                    column: :default_storage_location_id,
+                    validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_26_173715) do
+ActiveRecord::Schema.define(version: 2022_03_20_202902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -381,6 +381,8 @@ ActiveRecord::Schema.define(version: 2022_02_26_173715) do
     t.text "notes"
     t.integer "quota"
     t.bigint "partner_group_id"
+    t.bigint "default_storage_location_id"
+    t.index ["default_storage_location_id"], name: "index_partners_on_default_storage_location_id"
     t.index ["organization_id"], name: "index_partners_on_organization_id"
     t.index ["partner_group_id"], name: "index_partners_on_partner_group_id"
   end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2807 <!--fill issue number-->

### Description
Adds a default storage location for partners which will override the default location for organizations if set.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Local and request tests.

### Screenshots
<img width="1259" alt="image" src="https://user-images.githubusercontent.com/1986893/159186421-e8e6c432-e4e0-47ce-b877-8d932bb205eb.png">