### PR TITLE
2818 disaggregate purchases export

### DIFF
--- a/app/controllers/partners/helps_controller.rb
+++ b/app/controllers/partners/helps_controller.rb
@@ -3,7 +3,17 @@ module Partners
     layout 'partners/application'
 
     def show
-      @partner_questions = Question.for_partners
+      @filterrific = initialize_filterrific(
+        Question.for_partners,
+        params[:filterrific]
+      ) || return
+
+      @partner_questions = @filterrific.find.page(params[:page])
+
+      respond_to do |format|
+        format.html
+        format.js
+      end
     end
   end
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -23,7 +23,10 @@ class PurchasesController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.csv { send_data Purchase.generate_csv(@purchases), filename: "Purchases-#{Time.zone.today}.csv" }
+      #  format.csv { send_data Purchase.generate_csv(@purchases), filename: "Purchases-#{Time.zone.today}.csv" }
+      format.csv do
+        send_data Exports::ExportPurchasesCSVService.new(purchase_ids: @purchases.map(&:id)).generate_csv, filename: "Purchases-#{Time.zone.today}.csv"
+      end
     end
   end
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -2,17 +2,18 @@
 #
 # Table name: partners
 #
-#  id               :integer          not null, primary key
-#  email            :string
-#  name             :string
-#  notes            :text
-#  quota            :integer
-#  send_reminders   :boolean          default(FALSE), not null
-#  status           :integer          default("uninvited")
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  organization_id  :integer
-#  partner_group_id :bigint
+#  id                          :integer          not null, primary key
+#  email                       :string
+#  name                        :string
+#  notes                       :text
+#  quota                       :integer
+#  send_reminders              :boolean          default(FALSE), not null
+#  status                      :integer          default("uninvited")
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  default_storage_location_id :bigint
+#  organization_id             :integer
+#  partner_group_id            :bigint
 #
 
 class Partner < ApplicationRecord

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -102,21 +102,6 @@ class Purchase < ApplicationRecord
     false
   end
 
-  def self.csv_export_headers
-    ["Purchases from", "Storage Location", "Purchased Date", "Quantity of Items", "Variety of Items", "Amount Spent"]
-  end
-
-  def csv_export_attributes
-    [
-      purchased_from_view,
-      storage_location.name,
-      issued_at.strftime("%Y-%m-%d"),
-      line_items.total,
-      line_items.size,
-      amount_spent_in_dollars
-    ]
-  end
-
   private
 
   def combine_duplicates

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -8,6 +8,7 @@
 #  longitude       :float
 #  name            :string
 #  square_footage  :integer
+#  time_zone       :string           default("America/Los_Angeles"), not null
 #  warehouse_type  :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/services/exports/export_purchases_csv_service.rb
+++ b/app/services/exports/export_purchases_csv_service.rb
@@ -9,7 +9,7 @@ module Exports
         :vendor,
         line_items: [:item]
       ).where(
-        id: purchase_ids,
+        id: purchase_ids
       ).order(created_at: :asc)
     end
 
@@ -76,7 +76,19 @@ module Exports
         "Variety of Items" => ->(purchase) {
           purchase.line_items.map(&:name).uniq.size
         },
-        "Comments" => ->(purchase) {
+        "Amount Spent" => ->(purchase) {
+          purchase.amount_spent
+        },
+        "Spent on Diapers" => ->(purchase) {
+          purchase.amount_spent_on_diapers
+        },
+        "Spent on Adult Incontinence" => ->(purchase) {
+          purchase.amount_spent_on_adult_incontinence
+        },
+        "Spent on Other" => ->(purchase) {
+          purchase.amount_spent_on_other
+        },
+        "Comment" => ->(purchase) {
           purchase.comment
         }
       }

--- a/app/services/exports/export_purchases_csv_service.rb
+++ b/app/services/exports/export_purchases_csv_service.rb
@@ -1,0 +1,113 @@
+module Exports
+  class ExportPurchasesCSVService
+    def initialize(purchase_ids:)
+      # Use a where lookup so that I can eager load all the resources
+      # needed rather than depending on external code to do it for me.
+      # This makes this code more self contained and efficient!
+      @purchases = Purchase.includes(
+        :storage_location,
+        :vendor,
+        line_items: [:item]
+      ).where(
+        id: purchase_ids,
+      ).order(created_at: :asc)
+    end
+
+    def generate_csv
+      csv_data = generate_csv_data
+
+      CSV.generate(headers: true) do |csv|
+        csv_data.each { |row| csv << row }
+      end
+    end
+
+    def generate_csv_data
+      csv_data = []
+
+      csv_data << headers
+      purchases.each do |purchase|
+        csv_data << build_row_data(purchase)
+      end
+
+      csv_data
+    end
+
+    private
+
+    attr_reader :purchases
+
+    def headers
+      # Build the headers in the correct order
+      base_headers + item_headers
+    end
+
+    # Returns a Hash of keys to indexes so that obtaining the index
+    # doesn't require a linear scan.
+    def headers_with_indexes
+      @headers_with_indexes ||= headers.each_with_index.to_h
+    end
+
+    # This method keeps the base headers associated with the lambdas
+    # for extracting the values for the base columns from the given
+    # purchase.
+    #
+    # Doing so (as opposed to expressing them in distinct methods) makes
+    # it less likely that a future edit will inadvertently modify the
+    # order of the headers in a way that isn't also reflected in the
+    # values for the these base columns.
+    #
+    # Reminder: Since Ruby 1.9, Hashes are ordered based on insertion
+    # (or on the order of the literal).
+    def base_table
+      {
+
+        "Purchases from" => ->(purchase) {
+          purchase.vendor.try(:business_name)
+        },
+        "Storage Location" => ->(purchase) {
+          purchase.storage_view
+        },
+        "Purchased Date" => ->(purchase) {
+          purchase.issued_at.strftime("%F")
+        },
+        "Quantity of Items" => ->(purchase) {
+          purchase.line_items.total
+        },
+        "Variety of Items" => ->(purchase) {
+          purchase.line_items.map(&:name).uniq.size
+        },
+        "Comments" => ->(purchase) {
+          purchase.comment
+        }
+      }
+    end
+
+    def base_headers
+      base_table.keys
+    end
+
+    def item_headers
+      # Define the item_headers by taking each item name
+      # and sort them alphabetically
+      item_names = purchases.map do |purchase|
+        purchase.line_items.map(&:item).map(&:name)
+      end.flatten
+
+      item_names.sort.uniq
+    end
+
+    def build_row_data(purchase)
+      row = base_table.values.map { |closure| closure.call(purchase) }
+
+      row += Array.new(item_headers.size, 0)
+
+      purchase.line_items.each do |line_item|
+        item_name = line_item.item.name
+        item_column_idx = headers_with_indexes[item_name]
+        row[item_column_idx] += line_item.quantity
+      end
+
+      row
+    end
+  end
+end

--- a/app/views/help/_bank_questions.html.erb
+++ b/app/views/help/_bank_questions.html.erb
@@ -1,17 +1,15 @@
 <% @bank_questions.each do |bank_question| %>
-  <div class="accordion" id="accordion">
-    <div class="card">
-      <div class="card-header" id="heading">
-        <h2 class="mb-0">
-          <button class="text-2xl font-bold list-none" type="button" data-toggle="collapse" data-target="#collapse<%= bank_question.id %>" aria-expanded="false" aria-controls="collapse<%= bank_question.id %>">
-            <%= bank_question.title %>
-          </button>
-        </h2>
+  <div class="card">
+    <a class="d-block w-100" data-toggle="collapse" href="#question<%= bank_question.id %>">
+      <div class="card-header">
+        <h4 class="card-title w-100">
+          <%= bank_question.title %>
+        </h4>
       </div>
-      <div id="collapse<%= bank_question.id %>" class="collapse" aria-labelledby="heading" data-parent="#accordion">
-        <div class="card-body">
-          <%= bank_question.answer %>
-        </div>
+    </a>
+    <div id="question<%= bank_question.id %>" class="collapse" data-parent="#accordion">
+      <div class="card-body">
+        <%= bank_question.answer %>
       </div>
     </div>
   </div>

--- a/app/views/help/show.html.erb
+++ b/app/views/help/show.html.erb
@@ -1,36 +1,75 @@
+<style>
+    .trix-content, ol {
+        list-style: auto;
+    }
+    .trix-content, ul {
+        list-style: inside;
+    }
+</style>
 <section class="content">
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-12">
-        <!-- Default box -->
-        <div class="card card-info mt-2">
-          <div class="card-header">
-            <h2 class="card-title">Frequently Asked Questions</h2>
-          </div>
-          <div class="card-body p-4">
-            <ul class="list-inside my-2 list-decimal space-y-5">
-              <%= form_for_filterrific @filterrific, remote: true do |f| %>
-                <div class="row flex-row justify-content-between align-items-center">
-                  <div class='col-3'>
-                    <%= f.label :search_title, "Search By Question" %>
-                    <%= f.text_field(:search_title, class: 'filterrific-periodically-observed form-control') %>
-                  </div>
-                  <div class="col-3">
-                    <%= render_filterrific_spinner %>
-                  </div>
-                </div>
-              <% end %>
-              <div id="filterrific_results">
-                <%= render(partial: 'bank_questions', locals: { bank_questions: @bank_questions }) %>
-              </div>
-              <li class='text-2xl font-bold list-none'>Have suggestions to help improve the app or other questions about the app? Please <a href="https://human-essential.slack.com/archives/CG1NL2MRC"><u class='text-blue-400'>reach out on Slack.</u></a></li>
-              <li class='text-2xl font-bold list-none'>Not a member of the Human Essentials Slack group? <a href="https://join.slack.com/t/human-essential/shared_invite/zt-bfa8tymd-d8Ks3Mq000COcRe~nfs~zg"><u class='text-blue-400'>Request a login.</u></a></li>
-              <li class='text-2xl font-bold list-none'>Still need help? Submit a support ticket <u><%= link_to 'here', support_ticket_form_url, target: '_blank', class: 'text-blue-400' %></u> and we will do our best to follow up with you via email.</li>
-            </ul>
-          </div>
-          <!-- /.card-footer-->
+  <div class="row">
+    <div class="col-12">
+      <div class="card card-primary mt-2">
+        <div class="card-header">
+          <h2 class="card-title">Frequently Asked Questions</h2>
         </div>
-        <!-- /.card -->
+        <div class="card-body p-4">
+          <ul class="list-inside my-2 list-decimal space-y-5">
+            <%= form_for_filterrific @filterrific, remote: true do |f| %>
+              <div class="row flex-row justify-content-between align-items-center">
+                <div class='col-3'>
+                  <%= f.label :search_title, "Search By Question" %>
+                  <%= f.text_field(:search_title, class: 'filterrific-periodically-observed form-control') %>
+                </div>
+                <div class="col-3">
+                  <%= render_filterrific_spinner %>
+                </div>
+              </div>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="row">
+    <div class="col-12" id="accordion">
+      <div id="filterrific_results">
+        <%= render(partial: 'bank_questions', locals: { bank_questions: @bank_questions }) %>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="row">
+    <div class="col-12">
+      <div class="card card-primary mt-2">
+        <div class="col-12 mt-3 text-center">
+          <p class="lead">
+            Have suggestions to help improve the app or other questions about the app? Please
+            <a href="https://human-essential.slack.com/archives/CG1NL2MRC"><u>reach out on Slack.</u></a>
+          </p>
+        </div>
+        <div class="col-12 mt-3 text-center">
+          <p class="lead">
+            Not a member of the Human Essentials Slack group?
+            <a href="https://join.slack.com/t/human-essential/shared_invite/zt-bfa8tymd-d8Ks3Mq000COcRe~nfs~zg"><u>Request
+              a
+              login.</u></a>
+          </p>
+        </div>
+        <div class="col-12 mt-3 text-center">
+          <p class="lead">
+            Still need help? Submit a support ticket
+            <u><%= link_to 'here', support_ticket_form_url, target: '_blank' %></u>
+            and we will do our best to follow up with you via email. Please note that our team meets and triages email
+            on
+            Saturdays.
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/partners/helps/_partner_questions.html.erb
+++ b/app/views/partners/helps/_partner_questions.html.erb
@@ -1,0 +1,16 @@
+<% @partner_questions.each do |partner_question| %>
+  <div class="card">
+    <a class="d-block w-100" data-toggle="collapse" href="#question<%= partner_question.id %>">
+      <div class="card-header">
+        <h4 class="card-title w-100">
+          <%= partner_question.title %>
+        </h4>
+      </div>
+    </a>
+    <div id="question<%= partner_question.id %>" class="collapse" data-parent="#accordion">
+      <div class="card-body">
+        <%= partner_question.answer %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/partners/helps/show.html.erb
+++ b/app/views/partners/helps/show.html.erb
@@ -1,40 +1,58 @@
+<style>
+    .trix-content, ol {
+        list-style: auto;
+    }
+    .trix-content, ul {
+        list-style: inside;
+    }
+</style>
 <section class="content">
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-12">
-        <!-- Default box -->
-        <div class="card card-info mt-2">
-          <div class="card-header">
-            <h2 class="card-title">Frequently Asked Questions</h2>
-          </div>
-          <div class="card-body p-4">
-            <ul class="list-inside my-2 list-decimal space-y-5">
-              <% @partner_questions.each do |partner_question| %>
-                <div class="accordion" id="accordion">
-                  <div class="card">
-                    <div class="card-header" id="heading">
-                      <h2 class="mb-0">
-                        <button class="text-2xl font-bold list-none" type="button" data-toggle="collapse" data-target="#collapse<%= partner_question.id %>" aria-expanded="false" aria-controls="collapse<%= partner_question.id %>">
-                          <%= partner_question.title %>
-                        </button>
-                      </h2>
-                    </div>
-                    <div id="collapse<%= partner_question.id %>" class="collapse" aria-labelledby="heading" data-parent="#accordion">
-                      <div class="card-body">
-                        <%= partner_question.answer %>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              <% end %>
-              <li class="text-2xl font-bold list-none">Have suggestions to help improve the app or other questions about the app? Please <a href="https://human-essential.slack.com/archives/CG1NL2MRC"><u class='text-blue-400'>reach out on Slack.</u></a></li>
-              <li class="text-2xl font-bold list-none">Not a member of the Human Essentials Slack group? <a href="https://join.slack.com/t/human-essential/shared_invite/zt-bfa8tymd-d8Ks3Mq000COcRe~nfs~zg"><u class='text-blue-400'>Request a login.</u></a></li>
-              <li class="text-2xl font-bold list-none">Still need help? Submit a support ticket <u><%= link_to 'here', support_ticket_form_url, target: '_blank', class: 'text-blue-400' %></u> and we will do our best to follow up with you via email.</li>
-            </ul>
-          </div>
-          <!-- /.card-footer-->
+  <div class="row">
+    <div class="col-12">
+      <!-- Default box -->
+      <div class="card card-primary mt-2">
+        <div class="card-header">
+          <h2 class="card-title">Frequently Asked Questions</h2>
         </div>
-        <!-- /.card -->
+        <div class="card-body p-4">
+          <ul class="list-inside my-2 list-decimal space-y-5">
+            <%= form_for_filterrific @filterrific, remote: true do |f| %>
+              <div class="row flex-row justify-content-between align-items-center">
+                <div class='col-3'>
+                  <%= f.label :search_title, "Search By Question" %>
+                  <%= f.text_field(:search_title, class: 'filterrific-periodically-observed form-control') %>
+                </div>
+                <div class="col-3">
+                  <%= render_filterrific_spinner %>
+                </div>
+              </div>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="row">
+    <div class="col-12" id="accordion">
+      <div id="filterrific_results">
+        <%= render(partial: 'partner_questions', locals: { partner_questions: @partner_questions }) %>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="row">
+    <div class="col-12">
+      <div class="card card-primary mt-2">
+        <div class="col-12 mt-3 text-center">
+          <p class="lead">
+            Still need help? Reach out to your sponsoring bank with any unanswered questions.
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/partners/helps/show.js.erb
+++ b/app/views/partners/helps/show.js.erb
@@ -1,0 +1,4 @@
+<% js = escape_javascript(
+  render(partial: 'partner_questions', locals: { partner_questions: @partner_questions })
+) %>
+$("#filterrific_results").html("<%= js %>")

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -540,6 +540,7 @@ ActiveRecord::Schema.define(version: 2022_03_20_202902) do
   add_foreign_key "organizations", "account_requests"
   add_foreign_key "organizations", "ndbn_members", primary_key: "ndbn_member_id"
   add_foreign_key "partner_groups", "organizations"
+  add_foreign_key "partners", "storage_locations", column: "default_storage_location_id"
   add_foreign_key "product_drives", "organizations"
   add_foreign_key "requests", "distributions"
   add_foreign_key "requests", "organizations"

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -8,6 +8,7 @@
 #  longitude       :float
 #  name            :string
 #  square_footage  :integer
+#  time_zone       :string           default("America/Los_Angeles"), not null
 #  warehouse_type  :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -2,17 +2,18 @@
 #
 # Table name: partners
 #
-#  id               :integer          not null, primary key
-#  email            :string
-#  name             :string
-#  notes            :text
-#  quota            :integer
-#  send_reminders   :boolean          default(FALSE), not null
-#  status           :integer          default("uninvited")
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  organization_id  :integer
-#  partner_group_id :bigint
+#  id                          :integer          not null, primary key
+#  email                       :string
+#  name                        :string
+#  notes                       :text
+#  quota                       :integer
+#  send_reminders              :boolean          default(FALSE), not null
+#  status                      :integer          default("uninvited")
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  default_storage_location_id :bigint
+#  organization_id             :integer
+#  partner_group_id            :bigint
 #
 
 RSpec.describe Partner, type: :model, skip_seed: true do

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -161,16 +161,5 @@ RSpec.describe Purchase, type: :model, skip_seed: true do
         end
       end
     end
-
-    describe "#csv_export_attributes" do
-      let(:purchase) { create(:purchase, :with_items) }
-
-      it "includes purchase information" do
-        expect(purchase.csv_export_attributes).to include(purchase.purchased_from_view)
-        expect(purchase.csv_export_attributes).to include(purchase.storage_location.name)
-        expect(purchase.csv_export_attributes).to include(purchase.issued_at.strftime("%Y-%m-%d"))
-        expect(purchase.csv_export_attributes).to include(purchase.amount_spent_in_dollars)
-      end
-    end
   end
 end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -8,6 +8,7 @@
 #  longitude       :float
 #  name            :string
 #  square_footage  :integer
+#  time_zone       :string           default("America/Los_Angeles"), not null
 #  warehouse_type  :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/services/calendar_service_spec.rb
+++ b/spec/services/calendar_service_spec.rb
@@ -8,17 +8,13 @@ describe CalendarService do
         partner1 = create(:partner, name: "Partner 1")
         partner2 = create(:partner, name: "Partner 2")
         create(:distribution, issued_at: time_zone.local(2022, 3, 17, 10, 0, 0),
-                       partner: partner1,
-                       storage_location: storage_location)
+          partner: partner1, storage_location: storage_location)
         create(:distribution, issued_at: time_zone.local(2022, 2, 17, 9, 0, 0),
-                       partner: partner1,
-                       storage_location: storage_location)
+          partner: partner1, storage_location: storage_location)
         create(:distribution, issued_at: time_zone.local(2019, 1, 1),
-                       partner: partner2,
-                       storage_location: storage_location)
+          partner: partner2, storage_location: storage_location)
         create(:distribution, issued_at: time_zone.local(2023, 3, 17),
-                       partner: partner2,
-                       storage_location: storage_location)
+          partner: partner2, storage_location: storage_location)
       end
       result = described_class.calendar(@organization.id)
       expected = <<~ICAL

--- a/spec/services/exports/export_purchases_csv_service_spec.rb
+++ b/spec/services/exports/export_purchases_csv_service_spec.rb
@@ -1,0 +1,103 @@
+describe Exports::ExportPurchasesCSVService, skip_seed: true do
+  describe '#generate_csv_data' do
+    subject { described_class.new(purchase_ids: purchase_ids).generate_csv_data }
+    let(:purchase_ids) { purchases.map(&:id) }
+    let(:duplicate_item) do
+      FactoryBot.create(
+        :item, name: Faker::Appliance.equipment
+      )
+    end
+    let(:items_lists) do
+      [
+        [
+          [duplicate_item, 5],
+          [
+            FactoryBot.create(
+              :item, name: Faker::Appliance.equipment
+            ),
+            7
+          ],
+          [duplicate_item, 3]
+        ],
+        *(Array.new(3) do |i|
+          [[FactoryBot.create(
+            :item, name: Faker::Appliance.equipment
+          ), i + 1]]
+        end)
+      ]
+    end
+
+    let(:item_names) { items_lists.flatten(1).map(&:first).map(&:name).sort.uniq }
+
+    let(:purchases) do
+      start_time = Time.current
+
+      items_lists.each_with_index.map do |items, i|
+        purchase = create(
+          :purchase,
+          vendor: create(
+            :vendor, business_name: "Vendor Name #{i}",
+          ),
+          issued_at: start_time + i.days,
+          comment: "This is the #{i}-th purchase in the test."
+        )
+
+        items.each do |(item, quantity)|
+          purchase.line_items << create(
+            :line_item, quantity: quantity, item: item
+          )
+        end
+
+        purchase
+      end
+    end
+
+    let(:expected_headers) do
+      [
+        "Purchases from",
+        "Storage Location",
+        "Purchased Date",
+        "Quantity of Items",
+        "Variety of Items",
+        "Comments"
+      ] + expected_item_headers
+    end
+
+    let(:total_item_quantities) do
+      template = item_names.index_with(0)
+
+      items_lists.map do |items_list|
+        row = template.dup
+        items_list.each do |(item, quantity)|
+          row[item.name] += quantity
+        end
+        row.values
+      end
+    end
+
+    let(:expected_item_headers) do
+      expect(item_names).not_to be_empty
+
+      item_names
+    end
+
+    it 'should match the expected content for the csv' do
+      expect(subject[0]).to eq(expected_headers)
+
+      purchases.zip(total_item_quantities).each_with_index do |(purchase, total_item_quantity), idx|
+        row = [
+          purchase.vendor.try(:business_name),
+          purchase.storage_view,
+          purchase.issued_at.strftime("%F"),
+          purchase.line_items.total,
+          total_item_quantity.count(&:positive?),
+          purchase.comment
+        ]
+
+        row += total_item_quantity
+
+        expect(subject[idx + 1]).to eq(row)
+      end
+    end
+  end
+end

--- a/spec/services/exports/export_purchases_csv_service_spec.rb
+++ b/spec/services/exports/export_purchases_csv_service_spec.rb
@@ -1,5 +1,5 @@
 describe Exports::ExportPurchasesCSVService, skip_seed: true do
-  describe '#generate_csv_data' do
+  describe "#generate_csv_data" do
     subject { described_class.new(purchase_ids: purchase_ids).generate_csv_data }
     let(:purchase_ids) { purchases.map(&:id) }
     let(:duplicate_item) do
@@ -36,10 +36,14 @@ describe Exports::ExportPurchasesCSVService, skip_seed: true do
         purchase = create(
           :purchase,
           vendor: create(
-            :vendor, business_name: "Vendor Name #{i}",
+            :vendor, business_name: "Vendor Name #{i}"
           ),
           issued_at: start_time + i.days,
-          comment: "This is the #{i}-th purchase in the test."
+          comment: "This is the #{i}-th purchase in the test.",
+          amount_spent_in_cents: i * 3 + 425,
+          amount_spent_on_diapers_cents: i + 100,
+          amount_spent_on_adult_incontinence_cents: i + 125,
+          amount_spent_on_other_cents: i + 200
         )
 
         items.each do |(item, quantity)|
@@ -59,7 +63,11 @@ describe Exports::ExportPurchasesCSVService, skip_seed: true do
         "Purchased Date",
         "Quantity of Items",
         "Variety of Items",
-        "Comments"
+        "Amount Spent",
+        "Spent on Diapers",
+        "Spent on Adult Incontinence",
+        "Spent on Other",
+        "Comment"
       ] + expected_item_headers
     end
 
@@ -81,7 +89,7 @@ describe Exports::ExportPurchasesCSVService, skip_seed: true do
       item_names
     end
 
-    it 'should match the expected content for the csv' do
+    it "should match the expected content for the csv" do
       expect(subject[0]).to eq(expected_headers)
 
       purchases.zip(total_item_quantities).each_with_index do |(purchase, total_item_quantity), idx|
@@ -91,6 +99,10 @@ describe Exports::ExportPurchasesCSVService, skip_seed: true do
           purchase.issued_at.strftime("%F"),
           purchase.line_items.total,
           total_item_quantity.count(&:positive?),
+          purchase.amount_spent,
+          purchase.amount_spent_on_diapers,
+          purchase.amount_spent_on_adult_incontinence,
+          purchase.amount_spent_on_other,
           purchase.comment
         ]
 


### PR DESCRIPTION

Resolves #2818

### Description
Addresses #2818 Disaggregate Purchase Export
- Added columns for line items, following the donation pattern.
- Also added column for comments and for the breakdown of spend by major category

- changed the mechanism for the purchase to an export service matching how the donations export was done -- because the pattern was already there.

- cleaned up the csv export infrastructure in the purchases record, as no longer needed.  Deleted the accompanying spec.

Note:  At migration, several files were changed -- the schema, plus several files that annotate touched.   I was a little surprised by this -- that step is in a separate commit, in case of need .

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I added a new set of tests in spec/services/exports/export_purchases_csv_service_spec.rb.    These are directly modelled on the existing tets in export_donations_csv_service_spec.rb
In addition, I did a simple manual test -- adding a purchase with a breakdown by major category and 3 line items.  It appeared as I expected it to in the export.


### Screenshot
<img width="1473" alt="Screen Shot 2022-03-22 at 7 33 25 PM" src="https://user-images.githubusercontent.com/10157589/159593287-7fb2515b-ccc6-43e1-a97a-fcee107ef4df.png">
s