### PR TITLE
2813 Update Annual Report

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -94,7 +94,8 @@ class PurchasesController < ApplicationController
   def purchase_params
     params = compact_line_items
     params.require(:purchase).permit(:comment, :amount_spent, :purchased_from,
-      :amount_spent_on_diapers, :amount_spent_on_adult_incontinence, :amount_spent_on_other,
+      :amount_spent_on_diapers, :amount_spent_on_adult_incontinence, :amount_spent_on_period_supplies,
+      :amount_spent_on_other,
       :storage_location_id, :issued_at, :vendor_id,
       line_items_attributes: %i(id item_id quantity _destroy))
       .merge(organization: current_organization)

--- a/app/controllers/reports/annual_reports_controller.rb
+++ b/app/controllers/reports/annual_reports_controller.rb
@@ -2,7 +2,10 @@ class Reports::AnnualReportsController < ApplicationController
   before_action :validate_show_params, only: [:show, :recalculate]
 
   def index
-    foundation_year = current_organization.created_at.year
+    # 2813_update_annual_report -- changed to earliest_reporting_year
+    # so that we can do system tests and staging
+    foundation_year = current_organization.earliest_reporting_year
+
     @actual_year = Time.current.year
 
     @years = (foundation_year...@actual_year).to_a

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -74,9 +74,15 @@ class Item < ApplicationRecord
       .or(where("items.partner_key LIKE '%adult%' AND items.partner_key NOT LIKE '%cloth%'"))
   }
 
+  scope :period_supplies, -> {
+    joins(:base_item)
+      .where(items: { partner_key: %w(tampons pads) })
+      .or(where("base_items.category = 'Period Supplies'"))
+  }
+
   scope :other_categories, -> {
     joins(:base_item)
-      .where(items: { partner_key: %w(pads tampons cloth_training_pants wipes adult_wipes) })
+      .where(items: { partner_key: %w(cloth_training_pants wipes adult_wipes) })
       .or(where("base_items.category = 'Miscellaneous'"))
   }
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -232,6 +232,22 @@ class Organization < ApplicationRecord
     email
   end
 
+  # re 2813 update annual report -- allowing an earliest reporting year will let us do system testing and staging for annual reports
+  def earliest_reporting_year
+    year = created_at.year
+    if donations.any?
+      year = [year, donations.minimum(:issued_at).year].min
+    end
+
+    if purchases.any?
+      year = [year, purchases.minimum(:issued_at).year].min
+    end
+    if distributions.any?
+      year = [year, distributions.minimum(:issued_at).year].min
+    end
+    year
+  end
+
   private
 
   def sync_visible_partner_form_sections

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -7,6 +7,7 @@
 #  amount_spent_on_adult_incontinence_cents :integer          default(0), not null
 #  amount_spent_on_diapers_cents            :integer          default(0), not null
 #  amount_spent_on_other_cents              :integer          default(0), not null
+#  amount_spent_on_period_supplies_cents    :integer          default(0), not null
 #  comment                                  :text
 #  issued_at                                :datetime
 #  purchased_from                           :string
@@ -32,6 +33,7 @@ class Purchase < ApplicationRecord
   monetize :amount_spent_in_cents, as: :amount_spent
   monetize :amount_spent_on_diapers_cents
   monetize :amount_spent_on_adult_incontinence_cents
+  monetize :amount_spent_on_period_supplies_cents
   monetize :amount_spent_on_other_cents
 
   before_save :strip_symbols_from_money
@@ -110,7 +112,7 @@ class Purchase < ApplicationRecord
   end
 
   def strip_symbols_from_money
-    %w[amount_spent amount_spent_on_diapers amount_spent_on_adult_incontinence amount_spent_on_other].each do |field|
+    %w[amount_spent amount_spent_on_diapers amount_spent_on_adult_incontinence amount_spent_on_period_supplies amount_spent_on_other].each do |field|
       if self[field].is_a?(String)
         self[field] = self[field].tr("$", "").tr(",", "").to_i
       end
@@ -121,9 +123,10 @@ class Purchase < ApplicationRecord
     return unless amount_spent&.nonzero?
     return if !amount_spent_on_diapers&.nonzero? &&
       !amount_spent_on_adult_incontinence&.nonzero? &&
+      !amount_spent_on_period_supplies&.nonzero? &&
       !amount_spent_on_other.nonzero?
 
-    category_total = amount_spent_on_diapers + amount_spent_on_adult_incontinence + amount_spent_on_other
+    category_total = amount_spent_on_diapers + amount_spent_on_adult_incontinence + amount_spent_on_period_supplies + amount_spent_on_other
     if category_total != amount_spent
       cat_total = humanized_money_with_symbol(category_total)
       total = humanized_money_with_symbol(amount_spent)

--- a/app/services/exports/export_purchases_csv_service.rb
+++ b/app/services/exports/export_purchases_csv_service.rb
@@ -85,6 +85,9 @@ module Exports
         "Spent on Adult Incontinence" => ->(purchase) {
           purchase.amount_spent_on_adult_incontinence
         },
+        "Spent on Period Supplies" => ->(purchase) {
+          purchase.amount_spent_on_period_supplies
+        },
         "Spent on Other" => ->(purchase) {
           purchase.amount_spent_on_other
         },

--- a/app/services/reports.rb
+++ b/app/services/reports.rb
@@ -8,6 +8,7 @@ module Reports
         Reports::AcquisitionReportService.new(year: year, organization: organization).report,
         Reports::WarehouseReportService.new(year: year, organization: organization).report,
         Reports::AdultIncontinenceReportService.new(year: year, organization: organization).report,
+        Reports::PeriodSupplyReportService.new(year: year, organization: organization).report,
         Reports::OtherProductsReportService.new(year: year, organization: organization).report,
         Reports::PartnerInfoReportService.new(year: year, organization: organization).report,
         Reports::ChildrenServedReportService.new(year: year, organization: organization).report,

--- a/app/services/reports/period_supply_report_service.rb
+++ b/app/services/reports/period_supply_report_service.rb
@@ -1,0 +1,95 @@
+module Reports
+  class PeriodSupplyReportService
+    include ActionView::Helpers::NumberHelper
+    attr_reader :year, :organization
+
+    # @param year [Integer]
+    # @param organization [Organization]
+    def initialize(year:, organization:)
+      @year = year
+      @organization = organization
+    end
+
+    # @return [Hash]
+    def report
+      @report ||= {name: "Period Supplies",
+                   entries: {
+                     "Period supplies distributed" => number_with_delimiter(distributed_supplies),
+                     "Period supplies per adult per month" => monthly_supplies&.round || 0,
+                     "Period supplies" => types_of_supplies,
+                     "% period supplies donated" => "#{percent_donated.round}%",
+                     "% period supplies bought" => "#{percent_bought.round}%",
+                     "Money spent purchasing period supplies" => number_to_currency(money_spent_on_supplies)
+                   }}
+    end
+
+    # @return [Integer]
+    def distributed_supplies
+      @distributed_supplies ||= organization
+        .distributions
+        .for_year(year)
+        .joins(line_items: :item)
+        .merge(Item.period_supplies)
+        .sum("line_items.quantity")
+    end
+
+    # @return [Integer]
+    def monthly_supplies
+      # NOTE: This is asking "per adult per month" but there doesn't seem to be much difference
+      # in calculating per month or per any other time frame, since all it's really asking
+      # is the value of the `distribution_quantity` field for the items we're giving out.
+      organization
+        .distributions
+        .for_year(year)
+        .joins(line_items: :item)
+        .merge(Item.period_supplies)
+        .average("COALESCE(items.distribution_quantity, 50)")
+    end
+
+    def types_of_supplies
+      organization.items.period_supplies.map(&:name).uniq.sort.join(", ")
+    end
+
+    # @return [Float]
+    def percent_donated
+      return 0.0 if total_supplies.zero?
+
+      (donated_supplies / total_supplies.to_f) * 100
+    end
+
+    # @return [Float]
+    def percent_bought
+      return 0.0 if total_supplies.zero?
+
+      (purchased_supplies / total_supplies.to_f) * 100
+    end
+
+    # @return [String]
+    def money_spent_on_supplies
+      organization.purchases.for_year(year).sum(:amount_spent_on_period_supplies_cents) / 100.0
+    end
+
+    ###### HELPER METHODS ######
+
+    # @return [Integer]
+    def purchased_supplies
+      @purchased_supplies ||= LineItem.joins(:item)
+        .merge(Item.period_supplies)
+        .where(itemizable: organization.purchases.for_year(year))
+        .sum(:quantity)
+    end
+
+    # @return [Integer]
+    def total_supplies
+      @total_supplies ||= purchased_supplies + donated_supplies
+    end
+
+    # @return [Integer]
+    def donated_supplies
+      @donated_supplies ||= LineItem.joins(:item)
+        .merge(Item.period_supplies)
+        .where(itemizable: organization.donations.for_year(year))
+        .sum(:quantity)
+    end
+  end
+end

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -47,6 +47,13 @@
     </div>
     <div class="row">
       <div class="col-xs-8 col-md-6">
+        <%= f.input :amount_spent_on_period_supplies,
+                    label: "Purchase Total for Period Supplies",
+                    wrapper: :input_group %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-8 col-md-6">
         <%= f.input :amount_spent_on_other,
                     label: "Purchase Total for Other Products",
                     wrapper: :input_group %>

--- a/db/base_items.json
+++ b/db/base_items.json
@@ -42,7 +42,7 @@
     { "key": "adult_incontinence", "name": "Adult Incontinence Pads", "qty": { "arbor": 0, "pdxdb": 2304 } },
     { "key": "underpads", "name": "Underpads (Pack)", "qty": { "arbor": 0, "pdxdb": 2 } }
   ],
-  "Menstrual Supplies/Items": [
+  "Period Supplies": [
     { "key": "pads", "name": "Pads", "qty": { "arbor": 0, "pdxdb": 1232 } },
     { "key": "tampons", "name": "Tampons", "qty": { "arbor": 0, "pdxdb": 5162 } },
     { "key": "liners", "name": "Adult Liners", "qty": { "arbor": 0, "pdxdb": 5162 } }

--- a/db/migrate/20220328220318_add_amount_spent_on_period_supplies_to_purchases.rb
+++ b/db/migrate/20220328220318_add_amount_spent_on_period_supplies_to_purchases.rb
@@ -1,0 +1,6 @@
+class AddAmountSpentOnPeriodSuppliesToPurchases < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { add_monetize :purchases, :amount_spent_on_period_supplies, currency: { present: false } }
+    change_column_default :purchases, :amount_spent_on_period_supplies_cents, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_20_202902) do
+ActiveRecord::Schema.define(version: 2022_03_28_220318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -400,6 +400,7 @@ ActiveRecord::Schema.define(version: 2022_03_20_202902) do
     t.integer "amount_spent_on_diapers_cents", default: 0, null: false
     t.integer "amount_spent_on_adult_incontinence_cents", default: 0, null: false
     t.integer "amount_spent_on_other_cents", default: 0, null: false
+    t.integer "amount_spent_on_period_supplies_cents", default: 0, null: false
     t.index ["organization_id"], name: "index_purchases_on_organization_id"
     t.index ["storage_location_id"], name: "index_purchases_on_storage_location_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -638,6 +638,24 @@ comments = [
   )
 end
 
+#re 2813_update_annual_report add some data for last year (enables system testing of reports)
+5.times do
+  storage_location = random_record_for_org(pdx_org, StorageLocation)
+  vendor = random_record_for_org(pdx_org, Vendor)
+  Purchase.create(
+    purchased_from: suppliers.sample,
+    comment: comments.sample,
+    organization_id: pdx_org.id,
+    storage_location_id: storage_location.id,
+    amount_spent_in_cents: rand(200..10_000),
+    issued_at: (Time.zone.today - 1.year),
+    created_at: (Time.zone.today - 1.year),
+    updated_at: (Time.zone.today - 1.year),
+    vendor_id: vendor.id
+  )
+end
+
+
 # ----------------------------------------------------------------------------
 # Flipper
 # ----------------------------------------------------------------------------

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -7,6 +7,7 @@
 #  amount_spent_on_adult_incontinence_cents :integer          default(0), not null
 #  amount_spent_on_diapers_cents            :integer          default(0), not null
 #  amount_spent_on_other_cents              :integer          default(0), not null
+#  amount_spent_on_period_supplies_cents    :integer          default(0), not null
 #  comment                                  :text
 #  issued_at                                :datetime
 #  purchased_from                           :string

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -434,4 +434,25 @@ RSpec.describe Organization, type: :model do
       expect(build(:organization, reminder_day: 28, deadline_day: 14)).to_not be_valid
     end
   end
+
+  describe 'earliest reporting year' do
+    # re 2813 update annual report -- allowing an earliest reporting year will let us do system testing and staging for annual reports
+    it 'is the organization created year if no associated data' do
+      org = create(:organization)
+      expect(org.earliest_reporting_year).to eq(org.created_at.year)
+    end
+    it 'is the year of the earliest of donation, purchase, or distribution if they are earlier ' do
+      org = create(:organization)
+      create(:donation, organization: org, issued_at: 1.year.from_now)
+      create(:purchase, organization: org, issued_at: 1.year.from_now)
+      create(:distribution, organization: org, issued_at: 1.year.from_now)
+      expect(org.earliest_reporting_year).to eq(org.created_at.year)
+      create(:donation, organization: org, issued_at: 5.years.ago)
+      expect(org.earliest_reporting_year).to eq(5.years.ago.year)
+      create(:purchase, organization: org, issued_at: 6.years.ago)
+      expect(org.earliest_reporting_year).to eq(6.years.ago.year)
+      create(:purchase, organization: org, issued_at: 7.years.ago)
+      expect(org.earliest_reporting_year).to eq(7.years.ago.year)
+    end
+  end
 end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe Purchase, type: :model, skip_seed: true do
       expect(d).to be_valid
     end
 
+    # 2813 update annual reports -- this covers off making sure it's checking the case of period supplies only (which it won't be before we make it so)
+
+    it "is not valid if period supplies is non-zero but no other category is " do
+      d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_diapers_cents: 0,
+                amount_spent_on_adult_incontinence_cents: 00,
+                amount_spent_on_period_supplies_cents: 350,
+                amount_spent_on_other_cents: 0)
+      expect(d).not_to be_valid
+      expect(d.errors.full_messages)
+        .to eq(["Amount spent does not equal all categories - categories add to $3.50 but given total is $4.50"])
+    end
+
     it "is not valid if categories do not add up" do
       d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_diapers_cents: 200,
         amount_spent_on_adult_incontinence_cents: 250,

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe Purchase, type: :model, skip_seed: true do
 
     it "is not valid if period supplies is non-zero but no other category is " do
       d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_diapers_cents: 0,
-                amount_spent_on_adult_incontinence_cents: 00,
-                amount_spent_on_period_supplies_cents: 350,
-                amount_spent_on_other_cents: 0)
+        amount_spent_on_adult_incontinence_cents: 0,
+        amount_spent_on_period_supplies_cents: 350,
+        amount_spent_on_other_cents: 0)
       expect(d).not_to be_valid
       expect(d.errors.full_messages)
         .to eq(["Amount spent does not equal all categories - categories add to $3.50 but given total is $4.50"])

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -7,6 +7,7 @@
 #  amount_spent_on_adult_incontinence_cents :integer          default(0), not null
 #  amount_spent_on_diapers_cents            :integer          default(0), not null
 #  amount_spent_on_other_cents              :integer          default(0), not null
+#  amount_spent_on_period_supplies_cents    :integer          default(0), not null
 #  comment                                  :text
 #  issued_at                                :datetime
 #  purchased_from                           :string
@@ -37,16 +38,37 @@ RSpec.describe Purchase, type: :model, skip_seed: true do
       expect(d).to be_valid
     end
 
+    # re 2813_update_annual_report, adding in amount_spent_on_period_supplies_cents to test.
+    # also adding in amount_spend_on_incontinence_cents because it was missing.
+
+    it "is not valid if any category is non-zero but does not add up to the total" do
+      d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_diapers_cents: 300)
+      expect(d).not_to be_valid
+      d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_adult_incontinence_cents: 300)
+      expect(d).not_to be_valid
+      d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_period_supplies_cents: 300)
+      expect(d).not_to be_valid
+      d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_other_cents: 300)
+      expect(d).not_to be_valid
+    end
+
     it "is valid if all categories add up to total" do
-      d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_diapers_cents: 200, amount_spent_on_other_cents: 250)
+      d = build(:purchase, amount_spent_in_cents: 1150,
+        amount_spent_on_diapers_cents: 200,
+        amount_spent_on_adult_incontinence_cents: 300,
+        amount_spent_on_period_supplies_cents: 400,
+        amount_spent_on_other_cents: 250)
       expect(d).to be_valid
     end
 
     it "is not valid if categories do not add up" do
-      d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_diapers_cents: 200)
+      d = build(:purchase, amount_spent_in_cents: 450, amount_spent_on_diapers_cents: 200,
+        amount_spent_on_adult_incontinence_cents: 250,
+        amount_spent_on_period_supplies_cents: 350,
+        amount_spent_on_other_cents: 725)
       expect(d).not_to be_valid
       expect(d.errors.full_messages)
-        .to eq(["Amount spent does not equal all categories - categories add to $2.00 but given total is $4.50"])
+        .to eq(["Amount spent does not equal all categories - categories add to $15.25 but given total is $4.50"])
     end
   end
 

--- a/spec/services/exports/export_purchases_csv_service_spec.rb
+++ b/spec/services/exports/export_purchases_csv_service_spec.rb
@@ -40,9 +40,10 @@ describe Exports::ExportPurchasesCSVService, skip_seed: true do
           ),
           issued_at: start_time + i.days,
           comment: "This is the #{i}-th purchase in the test.",
-          amount_spent_in_cents: i * 3 + 425,
+          amount_spent_in_cents: i * 4 + 555,
           amount_spent_on_diapers_cents: i + 100,
           amount_spent_on_adult_incontinence_cents: i + 125,
+          amount_spent_on_period_supplies_cents: i + 130,
           amount_spent_on_other_cents: i + 200
         )
 
@@ -66,6 +67,7 @@ describe Exports::ExportPurchasesCSVService, skip_seed: true do
         "Amount Spent",
         "Spent on Diapers",
         "Spent on Adult Incontinence",
+        "Spent on Period Supplies",
         "Spent on Other",
         "Comment"
       ] + expected_item_headers
@@ -102,6 +104,7 @@ describe Exports::ExportPurchasesCSVService, skip_seed: true do
           purchase.amount_spent,
           purchase.amount_spent_on_diapers,
           purchase.amount_spent_on_adult_incontinence,
+          purchase.amount_spent_on_period_supplies,
           purchase.amount_spent_on_other,
           purchase.comment
         ]

--- a/spec/services/reports/period_supply_report_service_spec.rb
+++ b/spec/services/reports/period_supply_report_service_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe Reports::PeriodSupplyReportService, type: :service, skip_seed: true do
+  let(:year) { 2020 }
+  let(:organization) { create(:organization) }
+
+  subject(:report) do
+    described_class.new(organization: organization, year: year)
+  end
+
+  describe "#report" do
+    it "should report zero values" do
+      expect(report.report[:entries]).to match(hash_including({
+        "% period supplies bought" => "0%",
+        "% period supplies donated" => "0%",
+        "Period supplies distributed" => "0",
+        "Period supplies per adult per month" => 0,
+        "Money spent purchasing period supplies" => "$0.00"
+      }))
+      expect(report.report[:entries]["Period supplies"].split(", "))
+        .to contain_exactly("Tampons", "Pads", "Adult Liners")
+    end
+
+    describe "with values" do
+      before(:each) do
+        seed_base_items_for_tests
+        Organization.seed_items(organization)
+
+        within_time = Time.zone.parse("2020-05-31 14:00:00")
+        outside_time = Time.zone.parse("2019-05-31 14:00:00")
+
+        period_supplies_item = organization.items.period_supplies.first
+        non_period_supplies_item = organization.items.where.not(id: organization.items.period_supplies).first
+
+        # We will create data both within and outside our date range, and both period_supplies and non period_supplies.
+        # Spec will ensure that only the required data is included.
+
+        # Distributions
+        distributions = create_list(:distribution, 2, issued_at: within_time, organization: organization)
+        outside_distributions = create_list(:distribution, 2, issued_at: outside_time, organization: organization)
+        (distributions + outside_distributions).each do |dist|
+          create_list(:line_item, 5, :distribution, quantity: 200, item: period_supplies_item, itemizable: dist)
+          create_list(:line_item, 5, :distribution, quantity: 30, item: non_period_supplies_item, itemizable: dist)
+        end
+
+        # Donations
+        donations = create_list(:donation, 2,
+          product_drive: nil,
+          issued_at: within_time,
+          money_raised: 1000,
+          organization: organization)
+
+        donations += create_list(:donation, 2,
+          product_drive: nil,
+          issued_at: outside_time,
+          money_raised: 1000,
+          organization: organization)
+
+        donations.each do |donation|
+          create_list(:line_item, 3, :donation, quantity: 20, item: period_supplies_item, itemizable: donation)
+          create_list(:line_item, 3, :donation, quantity: 10, item: non_period_supplies_item, itemizable: donation)
+        end
+
+        # Purchases
+        purchases = [
+          create(:purchase,
+            issued_at: within_time,
+            organization: organization,
+            purchased_from: "Google",
+            amount_spent_in_cents: 1000,
+            amount_spent_on_period_supplies_cents: 1000),
+          create(:purchase,
+            issued_at: within_time,
+            organization: organization,
+            purchased_from: "Walmart",
+            amount_spent_in_cents: 2000,
+            amount_spent_on_period_supplies_cents: 2000)
+        ]
+        purchases += create_list(:purchase, 2,
+          issued_at: outside_time,
+          amount_spent_in_cents: 20_000,
+          amount_spent_on_period_supplies_cents: 20_000,
+          organization: organization)
+        purchases.each do |purchase|
+          create_list(:line_item, 3, :purchase, quantity: 30, item: period_supplies_item, itemizable: purchase)
+          create_list(:line_item, 3, :purchase, quantity: 40, item: non_period_supplies_item, itemizable: purchase)
+        end
+      end
+
+      it "should report normal values" do
+        organization.items.period_supplies.first.update!(distribution_quantity: 20)
+
+        expect(report.report[:name]).to eq("Period Supplies")
+        expect(report.report[:entries]).to match(hash_including({
+          "% period supplies bought" => "60%",
+          "% period supplies donated" => "40%",
+          "Period supplies distributed" => "2,000",
+          "Period supplies per adult per month" => 20,
+          "Money spent purchasing period supplies" => "$30.00"
+        }))
+        expect(report.report[:entries]["Period supplies"].split(", "))
+          .to contain_exactly("Tampons", "Pads", "Adult Liners")
+      end
+    end
+  end
+end

--- a/spec/system/annual_reports_system_spec.rb
+++ b/spec/system/annual_reports_system_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe "Annual Reports", type: :system, js: true do
+  let(:url_prefix) { "/#{@organization.short_name}" }
+
+  context "while signed in as an organization admin" do
+    subject { url_prefix + "/reports/annual_reports" }
+    let!(:purchase) { create(:purchase, :with_items, item_quantity: 10, issued_at: 1.year.ago) }
+
+    before do
+      sign_in @organization_admin
+      visit subject.to_s
+    end
+
+    it("exists") do
+      expect(page).to have_content("Reports are available")
+    end
+
+    it("has the report from last year, if there is a purchase from last year") do
+      year = 1.year.ago.year
+      expect(page).to have_content(year)
+    end
+
+    it "has all the sub-reports we expect" do
+      visit subject.to_s
+      year = 1.year.ago.year
+      click_on(year.to_s)
+      expect(page).to have_content("Diaper Acquisition")
+      expect(page).to have_content("Warehouse and Storage")
+      expect(page).to have_content("Adult Incontinence")
+      expect(page).to have_content("Other Items")
+      expect(page).to have_content("Partner Agencies and Service Area")
+      expect(page).to have_content("Children Served")
+      expect(page).to have_content("Year End Summary")
+      expect(page).to have_content("Period Supplies")
+    end
+  end
+end

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -187,7 +187,6 @@ RSpec.describe "Purchases", type: :system, js: true do
             click_button "Save"
             expect(page).to have_content('Failed to create purchase due to: ["Vendor must exist", "Amount spent is not a number", "Amount spent in cents must be greater than 0"]')
           end
-
         end
       end
 

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -170,30 +170,6 @@ RSpec.describe "Purchases", type: :system, js: true do
           expect(Purchase.last.line_items.first.quantity).to eq(16)
         end
 
-        # Issue 2318 -- adding in tests to confirm that the category sum checks work properly.
-        # In support of change to add period supply category for annual reports
-
-        it "should allow all zero category totals" do
-          select Vendor.first.business_name, from: "purchase_vendor_id"
-          select StorageLocation.first.name, from: "purchase_storage_location_id"
-          fill_in "purchase_amount_spent", with: "10"
-          expect do
-            click_button "Save"
-          end.to change { Purchase.count }.by(1)
-        end
-        it "should save if the category totals sum to the grand total" do
-          select Vendor.first.business_name, from: "purchase_vendor_id"
-          select StorageLocation.first.name, from: "purchase_storage_location_id"
-          fill_in "purchase_amount_spent", with: "10"
-          fill_in "purchase_amount_spent_on_diapers", with: "1"
-          fill_in "purchase_amount_spent_on_adult_incontinence", with: "2"
-          fill_in "purchase_amount_spent_on_period_supplies", with: "3"
-          fill_in "purchase_amount_spent_on_other", with: "4"
-          expect do
-            click_button "Save"
-          end.to change { Purchase.count }.by(1)
-        end
-
         context 'when creating a purchase incorrectly' do
           # Bug fix -- Issue #71
           # When a user creates a purchase without it passing validation, the items
@@ -212,28 +188,6 @@ RSpec.describe "Purchases", type: :system, js: true do
             expect(page).to have_content('Failed to create purchase due to: ["Vendor must exist", "Amount spent is not a number", "Amount spent in cents must be greater than 0"]')
           end
 
-          # Issue 2318 -- adding in tests to confirm that the category sum checks work properly.
-          # In support of change to add period supply category for annual reports
-          it "should display appropriate message if non-zero category totals does not equal purchase total" do
-            select Vendor.first.business_name, from: "purchase_vendor_id"
-            select StorageLocation.first.name, from: "purchase_storage_location_id"
-            fill_in "purchase_amount_spent", with: "10"
-            fill_in "purchase_amount_spent_on_diapers", with: "1"
-            fill_in "purchase_amount_spent_on_adult_incontinence", with: "2"
-            fill_in "purchase_amount_spent_on_period_supplies", with: "3"
-            fill_in "purchase_amount_spent_on_other", with: "5"
-            click_button "Save"
-            expect(page).to have_content('Failed to create purchase due to: ["Amount spent does not equal all categories - categories add to $11.00 but given total is $10.00"]')
-          end
-          # this covers off making sure it's checking the case of period supplies only (which it won't be before we make it so)
-          it "should display appropriate message if non-zero category totals does not equal purchase total, period supplies only case" do
-            select Vendor.first.business_name, from: "purchase_vendor_id"
-            select StorageLocation.first.name, from: "purchase_storage_location_id"
-            fill_in "purchase_amount_spent", with: "10"
-            fill_in "purchase_amount_spent_on_period_supplies", with: "3"
-            click_button "Save"
-            expect(page).to have_content('Failed to create purchase due to: ["Amount spent does not equal all categories - categories add to $3.00 but given total is $10.00"]')
-          end
         end
       end
 

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -170,6 +170,30 @@ RSpec.describe "Purchases", type: :system, js: true do
           expect(Purchase.last.line_items.first.quantity).to eq(16)
         end
 
+        # Issue 2318 -- adding in tests to confirm that the category sum checks work properly.
+        # In support of change to add period supply category for annual reports
+
+        it "should allow all zero category totals" do
+          select Vendor.first.business_name, from: "purchase_vendor_id"
+          select StorageLocation.first.name, from: "purchase_storage_location_id"
+          fill_in "purchase_amount_spent", with: "10"
+          expect do
+            click_button "Save"
+          end.to change { Purchase.count }.by(1)
+        end
+        it "should save if the category totals sum to the grand total" do
+          select Vendor.first.business_name, from: "purchase_vendor_id"
+          select StorageLocation.first.name, from: "purchase_storage_location_id"
+          fill_in "purchase_amount_spent", with: "10"
+          fill_in "purchase_amount_spent_on_diapers", with: "1"
+          fill_in "purchase_amount_spent_on_adult_incontinence", with: "2"
+          fill_in "purchase_amount_spent_on_period_supplies", with: "3"
+          fill_in "purchase_amount_spent_on_other", with: "4"
+          expect do
+            click_button "Save"
+          end.to change { Purchase.count }.by(1)
+        end
+
         context 'when creating a purchase incorrectly' do
           # Bug fix -- Issue #71
           # When a user creates a purchase without it passing validation, the items
@@ -186,6 +210,29 @@ RSpec.describe "Purchases", type: :system, js: true do
           it "should display failure with error messages" do
             click_button "Save"
             expect(page).to have_content('Failed to create purchase due to: ["Vendor must exist", "Amount spent is not a number", "Amount spent in cents must be greater than 0"]')
+          end
+
+          # Issue 2318 -- adding in tests to confirm that the category sum checks work properly.
+          # In support of change to add period supply category for annual reports
+          it "should display appropriate message if non-zero category totals does not equal purchase total" do
+            select Vendor.first.business_name, from: "purchase_vendor_id"
+            select StorageLocation.first.name, from: "purchase_storage_location_id"
+            fill_in "purchase_amount_spent", with: "10"
+            fill_in "purchase_amount_spent_on_diapers", with: "1"
+            fill_in "purchase_amount_spent_on_adult_incontinence", with: "2"
+            fill_in "purchase_amount_spent_on_period_supplies", with: "3"
+            fill_in "purchase_amount_spent_on_other", with: "5"
+            click_button "Save"
+            expect(page).to have_content('Failed to create purchase due to: ["Amount spent does not equal all categories - categories add to $11.00 but given total is $10.00"]')
+          end
+          # this covers off making sure it's checking the case of period supplies only (which it won't be before we make it so)
+          it "should display appropriate message if non-zero category totals does not equal purchase total, period supplies only case" do
+            select Vendor.first.business_name, from: "purchase_vendor_id"
+            select StorageLocation.first.name, from: "purchase_storage_location_id"
+            fill_in "purchase_amount_spent", with: "10"
+            fill_in "purchase_amount_spent_on_period_supplies", with: "3"
+            click_button "Save"
+            expect(page).to have_content('Failed to create purchase due to: ["Amount spent does not equal all categories - categories add to $3.00 but given total is $10.00"]')
           end
         end
       end
@@ -264,7 +311,7 @@ RSpec.describe "Purchases", type: :system, js: true do
     end
   end
 
-  context "while singed in as an organization admin" do
+  context "while signed in as an organization admin" do
     let!(:purchase) { create(:purchase, :with_items, item_quantity: 10) }
     subject { url_prefix + "/purchases" }
 


### PR DESCRIPTION
Addition of period supplies category to purchase screens, to purchase…export, and to annual report

Adjusting foundation_year to allow for more testing of annual report (system testing and acceptance testing on staging)
System testing of annual report

Resolves #2813  

### Description
[] Addition of period supplies category to purchase model, screens, export
[] Splitting period supplies off from "other items" in annual report
[] Added method for "earliest reporting year" to organization - which is the year the organization was created, or, if that is the current year, the earliest year that we have donations, purchases, or distributions for.   This change is solely to enable system testing and easier acceptance testing on staging.    Changed annual reports controller to use this value instead of the organization reporting year to control the available reports.
[] added period_supplies scope to item (required for report)
[] Added some 1 year ago purchase data to seeds
[] Changed Menstrual Supplies/Items in base_items.json to Period Supplies.  
[] Addition of some System testing of annual report
[] changed /added specs to support the above.

Please note that the reports are currently hidden in staging.

The period supplies section is basically the same as the adult incontinence section.  I considered making it one piece of parameterized code.   However, 1/  I doubt we'll get a lot of new categories and 2/ the sooner we get the period supply category on the purchases out to our users, the less rework they would have to do accurate period supply 2022 reports.

Caveat:
* Accuracy of the period supply and other items sections of the reports is dependent on the proper entry of the amounts for each category in the purchase records.   N.B.  This applies to reports from earlier years, if recalculated, as well.   We can probably mitigate that through a warning on recalculation, but there is no mitigation in this pull request.
* I noticed that the terminology in the Other items section is all "non-diaper".  This should (probably) be updated - possibly bring up at the next stakeholder meeting?

### Type of change

<!-- Please delete options that are not relevant. -->

* Breaking change (fix or feature that would cause existing functionality to not work as expected)   

### How Has This Been Tested?

* Additional or modified tests in models/organization_spec, models/purchase_spec, services/exports/export_purchases_csv_service_spec, services/reports/period_supply_report_service_spec, system/annual_reports_system_spec, purchase_system_spec 
* All automated tests run successfully
* visually confirmed against a copy of production data that recalculating reports adds the period supply section, and that the export includes the period headers

