### PR TITLE
2839 Flipper cleanup.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -11,13 +11,12 @@ class DashboardController < ApplicationController
     @recent_purchases = @purchases.recent.includes(:vendor)
     @recent_distributions = current_organization.distributions.includes(:partner).during(helpers.selected_range).recent
 
-    if Flipper.enabled?(:itemized_distributions, current_user)
-      @itemized_distributions = current_organization.distributions.includes(:line_items).during(helpers.selected_range)
-      @onhand_quantities = current_organization.inventory_items.group("items.name").sum(:quantity)
-      @onhand_minimums = current_organization.inventory_items
-                                             .group("items.name")
-                                             .maximum("items.on_hand_minimum_quantity")
-    end
+    @itemized_distributions = current_organization.distributions.includes(:line_items).during(helpers.selected_range)
+    @onhand_quantities = current_organization.inventory_items.group("items.name").sum(:quantity)
+    @onhand_minimums = current_organization.inventory_items
+                                           .group("items.name")
+                                           .maximum("items.on_hand_minimum_quantity")
+
     @total_inventory = current_organization.total_inventory
 
     @org_stats = OrganizationStats.new(current_organization)

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -125,22 +125,20 @@
           </div>
         </div>
 
-        <% if Flipper.enabled?(:itemized_distributions, current_user) %>
-          <div class="card">
-            <div class="card-header border-0 bg-gradient-success">
-              <h3 class="card-title">Itemized Distributions
-                <small><%= @selected_date_range %></small></h3>
-              <div class="card-tools">
-                <button type="button" class="btn btn-tool" data-card-widget="remove">
-                  <i class="fas fa-times"></i>
-                </button>
-              </div>
-            </div>
-            <div class="box-body table-responsive no-padding">
-              <%= render partial: "itemized_partial", object: @itemized_distributions, as: :item_to_itemize %>
+        <div class="card">
+          <div class="card-header border-0 bg-gradient-success">
+            <h3 class="card-title">Itemized Distributions
+              <small><%= @selected_date_range %></small></h3>
+            <div class="card-tools">
+              <button type="button" class="btn btn-tool" data-card-widget="remove">
+                <i class="fas fa-times"></i>
+              </button>
             </div>
           </div>
-        <% end %>
+          <div class="box-body table-responsive no-padding">
+            <%= render partial: "itemized_partial", object: @itemized_distributions, as: :item_to_itemize %>
+          </div>
+        </div>
 
         <div class="card">
           <div class="card-header border-0 bg-gradient-warning">
@@ -303,19 +301,17 @@
         </div>
 
 
-        <% if Flipper.enabled?(:itemized_donations, current_user) %>
-          <div class="card">
-            <div class="card-header border-0 bg-gradient-warning">
-              <h3 class="card-title">Itemized Donations
-                <small><%= @selected_date_range %></small></h3>
-              <div class="card-tools">
-              </div>
-            </div>
-            <div class="box-body table-responsive no-padding">
-              <%= render partial: "itemized_partial", object: @donations, as: :item_to_itemize %>
+      <div class="card">
+          <div class="card-header border-0 bg-gradient-warning">
+            <h3 class="card-title">Itemized Donations
+              <small><%= @selected_date_range %></small></h3>
+            <div class="card-tools">
             </div>
           </div>
-        <% end %>
+          <div class="box-body table-responsive no-padding">
+            <%= render partial: "itemized_partial", object: @donations, as: :item_to_itemize %>
+          </div>
+        </div>
 
       </div>
     </div>

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -171,17 +171,14 @@
             <i class="nav-icon fa fa-circle-o"></i> Inventory Audit
           <% end %>
         </li>
-        <% if Flipper.enabled?(:reports, current_user) %>
-          <li class="nav-item <%= active_class(['reports']) %>">
-            <%= link_to(reports_annual_reports_path(organization_id: current_user.organization), class: "nav-link #{active_class(['reports'])}") do %>
-              <i class="nav-icon fa fa-circle-o"></i> Annual Survey
-            <% end %>
-          </li>
-        <% end %>
+        <li class="nav-item <%= active_class(['reports']) %>">
+          <%= link_to(reports_annual_reports_path(organization_id: current_user.organization), class: "nav-link #{active_class(['reports'])}") do %>
+            <i class="nav-icon fa fa-circle-o"></i> Annual Survey
+          <% end %>
+        </li>
       </ul>
     </li>
   <% end %>
-  <% if Flipper.enabled?(:forecasting, current_user) %>
     <li class="nav-item has-treeview <%= menu_open?(['forecasting/distributions', 'forecasting/donations', 'forecasting/purchases']) %>">
       <a href="#" class="nav-link <%= active_class(['forecasting/distributions', 'forecasting/donations', 'forecasting/purchases']) %>">
         <i class="nav-icon fa fa-bar-chart"></i>
@@ -206,7 +203,6 @@
         </li>
       </ul>
     </li>
-  <% end %>
   <% if current_user.organization_admin %>
     <li class="nav-item">
       <%= link_to(organization_path, class: "nav-link") do %>

--- a/spec/system/navigation_system_spec.rb
+++ b/spec/system/navigation_system_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "Navigation", type: :system, js: true, skip_seed: true do
 
     context "with organization user" do
       let(:user) { create(:organization_admin) }
-      let(:links) { ["Dashboard", "Donations", "Purchases", "Requests", "Product Drives", "Distributions", "Pick Ups & Deliveries", "Partner Agencies", "Inventory", "Community", "Reporting & Auditing", "My Organization"] }
+      # 2389 Links was missing Forecasting, which is available to an organization admin
+      let(:links) { ["Dashboard", "Donations", "Purchases", "Requests", "Product Drives", "Distributions", "Pick Ups & Deliveries", "Partner Agencies", "Inventory", "Community", "Reporting & Auditing", "Forecasting", "My Organization"] }
 
       it "shows navigation options" do
         sidebar = page.find(".sidebar")


### PR DESCRIPTION
Resolves #2389

### Description

Per the issue, several items were being controlled with Flipper. As they are now fully in production, that control is no longer necessary.

I simply removed all the checks for Flipper being enabled around those elements (which were all the checks for Flipper being enabled in the system).

I needed to update 1 test -- which was not taking into account the addition of Forecasting.

### Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

I ran the existing tests.   There was 1 test in the navigation system specs  that did not work when I just removed the flipper controls.  As the test had not taken into account the forecasting feature, I added it the forecasting feature in.

