### PR TITLE
Fix the restore script and add documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,19 @@ The most recent test coverage statistics are available online at the Code Climat
 * [aggregate, including other kinds of information](https://codeclimate.com/github/rubyforgood/human-essentials)
 
 Of the two (local and cloud), the local page is better organized and has more test coverage information. Sample screenshots can be seen in the simplecov [readme](https://github.com/colszowka/simplecov#example-output).
+
+## Production Data
+
+If for whatever reason you need to work with a production data set, you can follow these steps:
+
+1. Shout out in the #human-essentials Slack channel that you need the data.
+2. You will be given the credentials for the Azure account for Human Essentials. Add these to your `.env` file, along with a fourth line which is needed for `pg_restore` to work:
+
+```
+AZURE_STORAGE_ACCOUNT_NAME="diaperbase"
+AZURE_STORAGE_ACCESS_KEY="****REDACTED****"
+AZURE_STORAGE_CONTAINER="development"
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+```
+3. Run `rake fetch_latest_db`. ***Note that this will wipe away your local DB and replace it with the prod data.***
+4. Once done, *remove* the last line (`DISABLE_DATABASE_ENVIRONMENT_CHECK`) from your `.env` file, as it is dangerous to keep it there.

--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -6,13 +6,13 @@ task :fetch_latest_db => :environment do
   diaper_backup, partner_backup = fetch_latest_backups
 
   puts "Recreating databases..."
-  system("rails db:drop && rails db:create")
+  system("rails db:migrate db:drop db:create")
 
   puts "Restoring the diaper_dev database with #{diaper_backup.name}..."
   diaper_backup_filepath = fetch_file_path(diaper_backup)
   system("pg_restore --clean --no-acl --no-owner -h localhost -d diaper_dev #{diaper_backup_filepath}")
   puts "Done! Next up is the partner database"
-  
+
   puts "Restoring the diaper_dev database with #{partner_backup.name}..."
   partner_backup_filepath = fetch_file_path(partner_backup)
   system("pg_restore --clean --no-acl --no-owner -h localhost -d partner_dev #{partner_backup_filepath}")
@@ -20,7 +20,7 @@ task :fetch_latest_db => :environment do
 
   puts "Replacing all the passwords with the replacement: '#{PASSWORD_REPLACEMENT}'"
   replace_user_passwords
-  
+
   puts "DONE!"
 end
 
@@ -78,7 +78,7 @@ def fetch_file_path(backup)
 end
 
 def replace_user_passwords
-  # Generate the encrypted password so that we can quickly update 
+  # Generate the encrypted password so that we can quickly update
   # all users with `update_all`
 
   u = User.new(password: PASSWORD_REPLACEMENT)


### PR DESCRIPTION
### Description

This fixes the restore script for prod data (it was missing a `db:migrate` which caused it to fail on my local) and adds documentation for how to use it to the contributing guidelines.

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* Documentation update

### How Has This Been Tested?

Local testing