### PR TITLE
2866 Rails 7 Deprecations addressed.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,7 +95,7 @@ class ApplicationController < ActionController::Base
 
   def setup_date_range_picker
     @selected_date_interval = helpers.selected_interval
-    @selected_date_range = helpers.selected_interval.map { |d| d.to_s(:long) }.join(" - ")
+    @selected_date_range = helpers.selected_interval.map { |d| d.to_fs(:long) }.join(" - ")
     @selected_date_range_label = helpers.date_range_label
   end
 

--- a/app/helpers/date_range_helper.rb
+++ b/app/helpers/date_range_helper.rb
@@ -43,7 +43,7 @@ module DateRangeHelper
     elsif end_date == Time.zone.today
       "since #{start_date}"
     else
-      "during the period #{start_date.to_s(:short)} to #{end_date.to_s(:short)}"
+      "during the period #{start_date.to_fs(:short)} to #{end_date.to_fs(:short)}"
     end
   end
 end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -75,9 +75,9 @@ class Distribution < ApplicationRecord
 
   def distributed_at
     if is_midnight(issued_at)
-      issued_at.to_s(:distribution_date)
+      issued_at.to_fs(:distribution_date)
     else
-      issued_at.to_s(:distribution_date_time)
+      issued_at.to_fs(:distribution_date_time)
     end
   end
 

--- a/app/views/donations/edit.html.erb
+++ b/app/views/donations/edit.html.erb
@@ -16,7 +16,7 @@
           </li>
           <li class="breadcrumb-item"><%= link_to "Donations", (donations_path) %></li>
           <li class="breadcrumb-item">
-            <a href="#">Editing <%= @donation.source %> on <%= @donation.created_at.to_s(:distribution_date) %></a></li>
+            <a href="#">Editing <%= @donation.source %> on <%= @donation.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>
     </div>

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -15,7 +15,7 @@
             <% end %>
           </li>
           <li class="breadcrumb-item"><%= link_to "Donations", (donations_path) %></li>
-          <li class="breadcrumb-item"><a href="#"><%= @donation.source %> on <%= @donation.created_at.to_s(:distribution_date) %></a></li>
+          <li class="breadcrumb-item"><a href="#"><%= @donation.source %> on <%= @donation.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>
     </div>
@@ -39,7 +39,7 @@
               </tr>
               </thead>
               <tbody>
-              <td><%= @donation.created_at.to_s(:distribution_date) %></td>
+              <td><%= @donation.created_at.to_fs(:distribution_date) %></td>
               <td><%= @donation.source %></td>
               <td><%= @donation.donation_site_view %></td>
               <td><%= @donation.storage_view %></td>              </tbody>

--- a/app/views/product_drives/edit.html.erb
+++ b/app/views/product_drives/edit.html.erb
@@ -14,7 +14,7 @@
             <% end %>
           </li>
           <li class="breadcrumb-item"><%= link_to "Product Drives", (product_drives_path) %></li>
-          <li class="breadcrumb-item"><a href="#">Editing <%= @product_drive.name %> on <%= @product_drive.created_at.to_s(:distribution_date) %></a></li>
+          <li class="breadcrumb-item"><a href="#">Editing <%= @product_drive.name %> on <%= @product_drive.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>
     </div>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -16,7 +16,7 @@
           </li>
           <li class="breadcrumb-item"><%= link_to "Purchases", (purchases_path) %></li>
           <li class="breadcrumb-item"><a href="#">Editing <%= @purchase.purchased_from_view %>
-            on <%= @purchase.created_at.to_s(:distribution_date) %></a></li>
+            on <%= @purchase.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>
     </div>

--- a/app/views/purchases/show.html.erb
+++ b/app/views/purchases/show.html.erb
@@ -15,7 +15,7 @@
             <% end %>
           </li>
           <li class="breadcrumb-item"><%= link_to "Purchases", (purchases_path) %></li>
-          <li class="breadcrumb-item"><a href="#"><%= @purchase.purchased_from_view %> on <%= @purchase.created_at.to_s(:distribution_date) %></a></li>
+          <li class="breadcrumb-item"><a href="#"><%= @purchase.purchased_from_view %> on <%= @purchase.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>
     </div>
@@ -39,7 +39,7 @@
               </thead>
               <tbody>
               <tr>
-              <td><%= @purchase.created_at.to_s(:distribution_date) %></td>
+              <td><%= @purchase.created_at.to_fs(:distribution_date) %></td>
               <td><%= @purchase.purchased_from_view %></td>
               <td><%= @purchase.storage_view %></td>
               </tr>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -16,7 +16,7 @@
           </li>
           <li class="breadcrumb-item"><%= link_to "Requests", (requests_path) %></li>
           <li class="breadcrumb-item"><a href="#"> Request from <%= @request.partner.name %>
-            at <%= @request.created_at.to_s(:distribution_date) %></a></li>
+            at <%= @request.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>
     </div>
@@ -29,7 +29,7 @@
       <div class="col-12">
         <div class="card">
           <div class="card-header">
-            <h3 class="card-title">This request was sent on <%= @request.created_at.to_s(:distribution_date) %></h3>
+            <h3 class="card-title">This request was sent on <%= @request.created_at.to_fs(:distribution_date) %></h3>
           </div>
           <div class="card-body p-0">
             <table class="table">

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -2,7 +2,7 @@
 # we're storing date & time but ignoring the timezone. So use this
 # format to NOT show the time zone.
 #
-# Usage: @distribution.issued_at.to_s(:distribution_date_time)
+# Usage: @distribution.issued_at.to_fs(:distribution_date_time)
 #
 Time::DATE_FORMATS[:distribution_date_time] = "%B %-d %Y %-l:%M%P"
 Time::DATE_FORMATS[:distribution_date] = "%B %-d %Y"

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Distribution, type: :model, skip_seed: true do
       it "displays explicit issued_at date" do
         two_days_ago = 2.days.ago.midnight
         distribution.issued_at = Time.zone.parse("2014-03-01 14:30:00")
-        expect(create(:distribution, issued_at: two_days_ago).distributed_at).to eq(two_days_ago.to_s(:distribution_date))
+        expect(create(:distribution, issued_at: two_days_ago).distributed_at).to eq(two_days_ago.to_fs(:distribution_date))
       end
 
       it "shows the hour and minutes if it has been provided" do

--- a/spec/requests/storage_locations_requests_spec.rb
+++ b/spec/requests/storage_locations_requests_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "StorageLocations", type: :request do
               end
               travel 2.weeks do
                 get storage_location_path(storage_location, default_params.merge(format: response_format,
-                  version_date: 9.days.ago.to_date.to_s(:db)))
+                  version_date: 9.days.ago.to_date.to_fs(:db)))
                 expect(response).to be_successful
                 expect(response.body).to include("Smithsonian")
                 expect(response.body).to include("Test Item")
@@ -134,7 +134,7 @@ RSpec.describe "StorageLocations", type: :request do
           context "with no version found" do
             it "should show N/A" do
               get storage_location_path(storage_location, default_params.merge(format: response_format,
-                version_date: 1.week.ago.to_date.to_s(:db)))
+                version_date: 1.week.ago.to_date.to_fs(:db)))
               expect(response).to be_successful
               expect(response.body).to include("Smithsonian")
               expect(response.body).to include("Test Item")


### PR DESCRIPTION

Resolves #2866 <!--fill issue number-->

### Description
With the upgrade to Rails 7, we started getting a lot of deprecation warnings.   This clears them up.

All the warnings were in cases where we were using Date.to_s or TimeZone.to_s.  These had to be changed to to_fs.  That was done throughout (it is possible there are cases that are not tested).

I also looked through the release notes for Rails 7, and did text searches for  the other deprecations.  We should be clear.

I did this by hand rather than by finding/using a deprecation gem because it just wasn't a big enough job to merit the work.


### Type of change


* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran the full Rspec on local.  It all passed.

