### PR TITLE
2545: Add and fix text e-mail templates

### DIFF
--- a/app/views/account_request_mailer/approval_request.text.erb
+++ b/app/views/account_request_mailer/approval_request.text.erb
@@ -1,0 +1,9 @@
+We've just received a confirmed account request from <%= @account_request.organization_name %>
+
+Here are their details:
+<% @account_request.attributes.each do |ar, val| %>
+* <%= ar.humanize %>: <%= val %>
+<% end %>
+
+Create This Organization: <%=new_admin_organization_url(token: @account_request.identity_token) %>
+Reject This Organization: <%=for_rejection_admin_account_requests_url(token: @account_request.identity_token) %>

--- a/app/views/account_request_mailer/confirmation.text.erb
+++ b/app/views/account_request_mailer/confirmation.text.erb
@@ -1,0 +1,29 @@
+Greetings from the Human Essentials Team,
+
+Visit the following URL when you want to continue requesting an account with us: <%= confirmation_account_requests_url(token: @account_request.identity_token) %>
+
+We're delighted to hear from you and hope you're all staying well!
+
+First, and most importantly, Human Essentials is 100% free! We're supported by the non-profit Code for Good and Microsoft sponsors the servers!
+
+If you'd like to experience the app, please log in to the sandbox/demo sites and test it out using the information below.
+
+***The details below allow you to log into a demo site. All data on the demo site is reset every day at 6 AM EST.***
+
+Human Essentials:
+Link: https://staging.humanessentials.app/users/sign_in
+Username: org_admin1@example.com
+Password: password!
+
+PartnerBase:
+Link: https://staging.humanessentials.app/partner_users/sign_in
+Username: verified@example.com
+Password: password!
+
+A couple things to know about the sandbox servers before you start using them:
+  The development team uses the servers for testing our new features and upgrades before putting them on the live site to ensure that no bugs get pushed through to the live site, so if something looks different than the (real) humanessentials.app site that is probably why! Please don’t enter any sensitive information into the demo servers, several users have access to the demo servers and it will be visible to all users.
+
+Finally, we made a getting started video with detailed directions on setting up your diaper bank in Human Essentials, check it out here: https://www.youtube.com/watch?v=fwo3WKMGM_4&feature=youtu.be
+Please let us know when you would like to begin using Human Essentials and we will set you up and send you a welcome email.
+
+Human Essentials Team

--- a/app/views/account_request_mailer/rejection.text.erb
+++ b/app/views/account_request_mailer/rejection.text.erb
@@ -1,0 +1,11 @@
+Greetings from the Human Essentials Team,
+
+***Your account request has been rejected.***
+
+Unfortunately, we were unable to process your account request at this time. The reason for this decision is as follows:
+
+<%= @account_request.rejection_reason %>
+
+If you have any questions, please don't hesitate to reach out to us.
+
+Human Essential Team

--- a/app/views/distribution_mailer/partner_mailer.text.erb
+++ b/app/views/distribution_mailer/partner_mailer.text.erb
@@ -1,3 +1,19 @@
-Distribution#partner_mailer
+Your essentials request has been approved.
+From: <%= @from_email %>
 
-<%= @greeting %>, find me in app/views/distribution_mailer/partner_mailer.text.erb
+<%= @default_email_text_interpolated %>
+<% if @distribution_changes.present? %>
+  Here are some Items that we need change based on Human Essentials
+  <% if !@distribution_changes[:updates].empty? %>
+    Items Updated:
+    <% @distribution_changes[:updates].each do |item| %>
+    * <%= "#{item[:name]} from #{item[:old_quantity]} to #{item[:new_quantity]}" %>
+    <% end %>
+  <% end %>
+  <% if !@distribution_changes[:removed].empty? %>
+    Items Removed:
+    <% @distribution_changes[:removed].each do |item| %>
+    * <%= item[:name] %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/distribution_mailer/reminder_email.text.erb
+++ b/app/views/distribution_mailer/reminder_email.text.erb
@@ -1,0 +1,5 @@
+<% delivery_method = (@distribution.delivery?) ? "delivery" : "pick up"%>
+Hello <%= @partner.name %>,
+This is a friendly reminder that tomorrow, <%= @distribution.issued_at.strftime("%A, %B #{@distribution.issued_at.day.ordinalize} %Y at %I:%M%p") %>, is your distribution <%= delivery_method %> date.
+
+For more information: <%= @distribution.organization.email %>

--- a/app/views/organization_mailer/partner_approval_request.text.erb
+++ b/app/views/organization_mailer/partner_approval_request.text.erb
@@ -1,0 +1,3 @@
+You've received a request to approve the account for <%= @partner.name %>.
+
+Review This Organization: <%=partner_url(organization_id: @organization.short_name, id: @partner.id, anchor: "partner-information") %>

--- a/app/views/partner_mailer/application_approved.text.erb
+++ b/app/views/partner_mailer/application_approved.text.erb
@@ -1,0 +1,5 @@
+Hi <%= @partner.name %>
+
+<%= @organization.name %> has approved your application.
+
+Check out your dashboard: <%=partners_dashboard_url %>

--- a/app/views/reminder_deadline_mailer/notify_deadline.text.erb
+++ b/app/views/reminder_deadline_mailer/notify_deadline.text.erb
@@ -1,0 +1,9 @@
+Hello <%= @partner.name %>,
+
+This is a friendly reminder that <%= @organization.name %> requires your human essentials requests to be submitted by <%= @deadline.strftime('%a, %d %b %Y') %>
+if you would like to receive a distribution next month.
+
+Please log into PartnerBase at https://humanessentials.app before this date and submit your request if you are intending to submit a diaper request.
+
+Please contact <%= @organization.name %> at <%= @organization.email %>
+if you have any questions about this!

--- a/app/views/request_mailer/request_cancel_partner_notification.text.erb
+++ b/app/views/request_mailer/request_cancel_partner_notification.text.erb
@@ -1,0 +1,16 @@
+***One of your essentials requests (#<%= @request.id %>) have been canceled.***
+
+Hello there, <%= @partner.name %>:
+
+We are emailing you to notify you that a essentials request you've made to <%= @organization.name %> has been canceled. See below for details:
+
+Request ID: <%= @request.id %>
+Reason Provided: <%= @request.discard_reason || 'N/A' %>
+Items requested:
+<% @formatted_requested_items.each do |rt| %>
+* <%= rt[:quantity] %> x <%= rt[:name] %>
+<% end %>
+
+If you need any help, don’t hesitate to reach out to us at <%= @organization.email %> !
+
+Supported By HumanEssentials.app

--- a/spec/mailers/account_request_mailer_spec.rb
+++ b/spec/mailers/account_request_mailer_spec.rb
@@ -24,24 +24,50 @@ RSpec.describe AccountRequestMailer, type: :mailer, skip_seed: true do
       expect(mail.subject).to eq('[Action Required] Human Essential Account Request')
     end
 
-    it 'should include the staging/demo account information' do
-      expect(mail.body.encoded).to match(%r{<a href='https://staging.humanessentials.app/users/sign_in'>Human Essentials</a>})
-      expect(mail.body.encoded).to match('Username: org_admin1@example.com')
-      expect(mail.body.encoded).to match('Password: password!')
+    context 'HTML format' do
+      it 'should include the staging/demo account information' do
+        html = html_body(mail)
+        expect(html).to match(%r{<a href='https://staging.humanessentials.app/users/sign_in'>Human Essentials</a>})
+        expect(html).to match('Username: org_admin1@example.com')
+        expect(html).to match('Password: password!')
 
-      expect(mail.body.encoded).to match(%r{<a href='https://staging.humanessentials.app/partner_users/sign_in'>PartnerBase</a>})
-      expect(mail.body.encoded).to match('Username: verified@example.com')
-      expect(mail.body.encoded).to match('Password: password!')
+        expect(html).to match(%r{<a href='https://staging.humanessentials.app/partner_users/sign_in'>PartnerBase</a>})
+        expect(html).to match('Username: verified@example.com')
+        expect(html).to match('Password: password!')
+      end
+
+      it 'should include the instruction video link' do
+        expect(html_body(mail)).to include('https://www.youtube.com/watch?v=fwo3WKMGM_4&feature=youtu.be')
+      end
+
+      it 'should include the button to confirm the request' do
+        expect(html_body(mail)).to include(
+          confirmation_account_requests_url(token: account_request.identity_token)
+        )
+      end
     end
 
-    it 'should include the instruction video link' do
-      expect(mail.body.encoded).to include('https://www.youtube.com/watch?v=fwo3WKMGM_4&feature=youtu.be')
-    end
+    context 'Text format' do
+      it 'should include the staging/demo account information' do
+        text = text_body(mail)
+        expect(text).to match(%r{https://staging.humanessentials.app/users/sign_in})
+        expect(text).to match('Username: org_admin1@example.com')
+        expect(text).to match('Password: password!')
 
-    it 'should include the button to confirm the request' do
-      expect(mail.body.encoded).to include(
-        confirmation_account_requests_url(token: account_request.identity_token)
-      )
+        expect(text).to match(%r{https://staging.humanessentials.app/partner_users/sign_in})
+        expect(text).to match('Username: verified@example.com')
+        expect(text).to match('Password: password!')
+      end
+
+      it 'should include the instruction video link' do
+        expect(text_body(mail)).to include('https://www.youtube.com/watch?v=fwo3WKMGM_4&feature=youtu.be')
+      end
+
+      it 'should include the button to confirm the request' do
+        expect(text_body(mail)).to include(
+          confirmation_account_requests_url(token: account_request.identity_token)
+        )
+      end
     end
   end
 

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -66,11 +66,24 @@ RSpec.describe DistributionMailer, type: :mailer, needs_users: true do
   describe "#reminder_email" do
     let(:mail) { DistributionMailer.reminder_email(@distribution.id) }
 
-    it "renders the body with organization's email text" do
-      expect(mail.body.encoded).to match("This is a friendly reminder")
-      expect(mail.body).to match(%(For more information: <a href="mailto:me@org.com">me@org.com</a>))
-      expect(mail.from).to eq(["info@humanessentials.app"])
-      expect(mail.subject).to eq("PARTNER Distribution Reminder")
+    context 'HTML format' do
+      it "renders the body with organization's email text" do
+        html = html_body(mail)
+        expect(html).to match("This is a friendly reminder")
+        expect(html).to match(%(For more information: <a href="mailto:me@org.com">me@org.com</a>))
+        expect(mail.from).to eq(["info@humanessentials.app"])
+        expect(mail.subject).to eq("PARTNER Distribution Reminder")
+      end
+    end
+
+    context 'Text format' do
+      it "renders the body with organization's email text" do
+        text = text_body(mail)
+        expect(text).to match("This is a friendly reminder")
+        expect(text).to match(%(For more information: me@org.com))
+        expect(mail.from).to eq(["info@humanessentials.app"])
+        expect(mail.subject).to eq("PARTNER Distribution Reminder")
+      end
     end
 
     context "with deliver_method: :pick_up" do

--- a/spec/mailers/organization_mailer_spec.rb
+++ b/spec/mailers/organization_mailer_spec.rb
@@ -5,9 +5,14 @@ RSpec.describe OrganizationMailer, type: :mailer, skip_seed: true do
     let(:organization) { partner.organization }
 
     it "renders the body with correct text with partner information" do
-      expect(subject.body.encoded).to include("<h1> You've received a request to approve the account for #{partner.name}. </h1>")
-      expect(subject.body.encoded).to include("Review This Organization")
-      expect(subject.body.encoded).to include("#{organization.short_name}/partners/#{partner.id}#partner-information\">Review This Organization</a>")
+      html = html_body(subject)
+      expect(html).to include("<h1> You've received a request to approve the account for #{partner.name}. </h1>")
+      expect(html).to include("Review This Organization")
+      expect(html).to include("#{organization.short_name}/partners/#{partner.id}#partner-information\">Review This Organization</a>")
+      text = text_body(subject)
+      expect(text).to include("You've received a request to approve the account for #{partner.name}.")
+      expect(text).to include("Review This Organization")
+      expect(text).to include("#{organization.short_name}/partners/#{partner.id}#partner-information")
     end
 
     it "includes a link to the relevant partner" do

--- a/spec/mailers/reminder_deadline_mailer_spec.rb
+++ b/spec/mailers/reminder_deadline_mailer_spec.rb
@@ -23,7 +23,10 @@ describe ReminderDeadlineMailer, type: :job, skip_seed: true do
 
     it 'renders the body' do
       travel_to today do
-        expect(subject.body)
+        expect(html_body(subject))
+          .to include("This is a friendly reminder that #{@organization.name} requires your human essentials requests to "\
+                       "be submitted by Tue, 01 Feb 2022")
+        expect(text_body(subject))
           .to include("This is a friendly reminder that #{@organization.name} requires your human essentials requests to "\
                        "be submitted by Tue, 01 Feb 2022")
       end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -4,8 +4,12 @@ RSpec.describe RequestMailer, type: :mailer, skip_seed: true do
     let(:request) { create(:request) }
 
     it "renders the body with correct text with partner information" do
-      expect(subject.body.encoded).to include("Hello there, <strong>#{request.partner.name}</strong>")
-      expect(subject.body.encoded).to include("One of your essentials requests (##{request.id}) have been canceled.")
+      html = html_body(subject)
+      expect(html).to include("Hello there, <strong>#{request.partner.name}</strong>")
+      expect(html).to include("One of your essentials requests (##{request.id}) have been canceled.")
+      text = text_body(subject)
+      expect(text).to include("Hello there, #{request.partner.name}")
+      expect(text).to include("One of your essentials requests (##{request.id}) have been canceled.")
     end
 
     it "should be sent to the partner main email with the correct subject line" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -257,6 +257,14 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+def html_body(mail)
+  mail.body.parts.find { |p| p.content_type =~ /html/ }.body.encoded
+end
+
+def text_body(mail)
+  mail.body.parts.find { |p| p.content_type =~ /text/ }.body.encoded
+end
+
 def create_default_users
   Rails.logger.info "\n\n-~=> Creating DEFAULT admins & user"
   @organization_admin = create(:organization_admin, name: "DEFAULT ORG ADMIN", organization: @organization)


### PR DESCRIPTION
Resolves #2545

### Description

This adds and/or fixes all current HTML templates to add text/plain templates which mirror the HTML ones.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Unit tests.