### PR TITLE
2870 changing family guardian country to family guardian county

### DIFF
--- a/app/controllers/partners/families_controller.rb
+++ b/app/controllers/partners/families_controller.rb
@@ -70,7 +70,7 @@ module Partners
       params.require(:partners_family).permit(
         :agency_guardian_id,
         :comments,
-        :guardian_country,
+        :guardian_county,
         :guardian_employed,
         :guardian_employment_type,
         :guardian_first_name,

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -12,6 +12,7 @@ require 'time_util'
 #  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  event_id               :string
 #  organization_id        :integer
 #  partner_id             :integer
 #  storage_location_id    :integer

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -2,88 +2,18 @@
 #
 # Table name: partners
 #
-#  id                         :bigint           not null, primary key
-#  above_1_2_times_fpl        :integer
-#  address1                   :string
-#  address2                   :string
-#  agency_mission             :text
-#  agency_type                :string
-#  ages_served                :string
-#  application_data           :text
-#  at_fpl_or_below            :integer
-#  case_management            :boolean
-#  city                       :string
-#  currently_provide_diapers  :boolean
-#  describe_storage_space     :text
-#  diaper_budget              :string
-#  diaper_funding_source      :string
-#  diaper_use                 :string
-#  distribution_times         :string
-#  distributor_type           :string
-#  evidence_based             :boolean
-#  evidence_based_description :text
-#  executive_director_email   :string
-#  executive_director_name    :string
-#  executive_director_phone   :string
-#  facebook                   :string
-#  form_990                   :boolean
-#  founded                    :integer
-#  greater_2_times_fpl        :integer
-#  income_requirement_desc    :boolean
-#  income_verification        :boolean
-#  incorporate_plan           :text
-#  internal_db                :boolean
-#  maac                       :boolean
-#  max_serve                  :string
-#  more_docs_required         :string
-#  name                       :string
-#  new_client_times           :string
-#  other_agency_type          :string
-#  other_diaper_use           :string
-#  partner_status             :string           default("pending")
-#  pick_up_email              :string
-#  pick_up_method             :string
-#  pick_up_name               :string
-#  pick_up_phone              :string
-#  population_american_indian :integer
-#  population_asian           :integer
-#  population_black           :integer
-#  population_hispanic        :integer
-#  population_island          :integer
-#  population_multi_racial    :integer
-#  population_other           :integer
-#  population_white           :integer
-#  poverty_unknown            :integer
-#  program_address1           :string
-#  program_address2           :string
-#  program_age                :string
-#  program_city               :string
-#  program_client_improvement :text
-#  program_contact_email      :string
-#  program_contact_mobile     :string
-#  program_contact_name       :string
-#  program_contact_phone      :string
-#  program_description        :text
-#  program_name               :string
-#  program_state              :string
-#  program_zip_code           :integer
-#  responsible_staff_position :boolean
-#  serve_income_circumstances :boolean
-#  sources_of_diapers         :string
-#  sources_of_funding         :string
-#  state                      :string
-#  status_in_diaper_base      :string
-#  storage_space              :boolean
-#  trusted_pickup             :boolean
-#  turn_away_child_care       :boolean
-#  twitter                    :string
-#  website                    :string
-#  zip_code                   :string
-#  zips_served                :string
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  diaper_bank_id             :bigint
-#  diaper_partner_id          :integer
+#  id                          :integer          not null, primary key
+#  email                       :string
+#  name                        :string
+#  notes                       :text
+#  quota                       :integer
+#  send_reminders              :boolean          default(FALSE), not null
+#  status                      :integer          default("uninvited")
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  default_storage_location_id :bigint
+#  organization_id             :integer
+#  partner_group_id            :bigint
 #
 
 class Partner < ApplicationRecord

--- a/app/models/partners/family.rb
+++ b/app/models/partners/family.rb
@@ -4,7 +4,7 @@
 #
 #  id                        :bigint           not null, primary key
 #  comments                  :text
-#  guardian_country          :string
+#  guardian_county           :string
 #  guardian_employed         :boolean
 #  guardian_employment_type  :jsonb
 #  guardian_first_name       :string
@@ -67,7 +67,7 @@ module Partners
 
     def self.csv_export_headers
       %w[
-        id guardian_first_name guardian_last_name guardian_zip_code guardian_country
+        id guardian_first_name guardian_last_name guardian_zip_code guardian_county
         guardian_phone agency_guardian_id home_adult_count home_child_count home_young_child_count
         sources_of_income guardian_employed guardian_employment_type guardian_monthly_pay
         guardian_health_insurance comments created_at updated_at partner_id military
@@ -80,7 +80,7 @@ module Partners
         guardian_first_name,
         guardian_last_name,
         guardian_zip_code,
-        guardian_country,
+        guardian_county,
         guardian_phone,
         agency_guardian_id,
         home_adult_count,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,10 @@
 #
 # Table name: users
 #
-#  id                     :bigint           not null, primary key
+#  id                     :integer          not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
+#  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  invitation_accepted_at :datetime
@@ -14,17 +15,22 @@
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
+#  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string
+#  name                   :string           default("CHANGEME"), not null
+#  organization_admin     :boolean
+#  provider               :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0), not null
+#  super_admin            :boolean          default(FALSE)
+#  uid                    :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  invited_by_id          :bigint
-#  partner_id             :bigint
+#  invited_by_id          :integer
+#  organization_id        :integer
 #
 
 class User < ApplicationRecord

--- a/app/views/partners/families/_form.html.erb
+++ b/app/views/partners/families/_form.html.erb
@@ -15,9 +15,9 @@
 
               <%= f.input :guardian_zip_code, label: "Guardian Zip Code", class: "form-control", wrapper: :input_group %>
 
-              <%= f.label :guardian_country, "Guardian County" %>
+              <%= f.label :guardian_county, "Guardian County" %>
               <%# <i class="fa fa-question-circle" style="color:blue" data-toggle="tooltip" title="Hooray!"></i> %>
-              <%= f.text_field :guardian_country, class: "form-control" %>
+              <%= f.text_field :guardian_county, class: "form-control" %>
 
               <%= f.label :guardian_phone, "Guardian Phone" %>
               <%# <i class="fa fa-question-circle" style="color:blue" data-toggle="tooltip" title="Hooray!"></i> %>

--- a/app/views/partners/families/show.html.erb
+++ b/app/views/partners/families/show.html.erb
@@ -43,7 +43,7 @@
               <dd><%= @family.guardian_zip_code %></dd>
 
               <dt>Guardian County:</dt>
-              <dd><%= @family.guardian_country %></dd>
+              <dd><%= @family.guardian_county %></dd>
 
               <dt>Guardian Phone:</dt>
               <dd><%= @family.guardian_phone %></dd>

--- a/db/partners_migrate/20220428165803_rename_guardian_country_to_guardian_county.rb
+++ b/db/partners_migrate/20220428165803_rename_guardian_country_to_guardian_county.rb
@@ -1,0 +1,7 @@
+class RenameGuardianCountryToGuardianCounty < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured {
+      rename_column :families, :guardian_country, :guardian_county
+    }
+  end
+end

--- a/db/partners_schema.rb
+++ b/db/partners_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2021_09_24_155700) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_28_165803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -83,7 +83,7 @@ ActiveRecord::Schema[7.0].define(version: 2021_09_24_155700) do
     t.string "guardian_first_name"
     t.string "guardian_last_name"
     t.string "guardian_zip_code"
-    t.string "guardian_country"
+    t.string "guardian_county"
     t.string "guardian_phone"
     t.string "agency_guardian_id"
     t.integer "home_adult_count"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -270,7 +270,7 @@ note = [
       guardian_first_name: Faker::Name.first_name,
       guardian_last_name: Faker::Name.last_name,
       guardian_zip_code: Faker::Address.zip_code,
-      guardian_country: "United States",
+      guardian_county: Faker::Address.community, # Faker doesn't have county, this has same flavor, and isn't country
       guardian_phone: Faker::PhoneNumber.phone_number,
       agency_guardian_id: Faker::Name.name,
       home_adult_count: [1, 2, 3].sample,

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -11,6 +11,7 @@
 #  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  event_id               :string
 #  organization_id        :integer
 #  partner_id             :integer
 #  storage_location_id    :integer

--- a/spec/factories/partners/family.rb
+++ b/spec/factories/partners/family.rb
@@ -3,7 +3,8 @@ FactoryBot.define do
     association :partner, factory: :partners_partner
 
     comments                  { Faker::Lorem.paragraph }
-    guardian_country          { Faker::Address.country }
+    # Faker doesn't have county, community is same flavour, we don't use it, and it is not country.
+    guardian_county          { Faker::Address.community }
     guardian_employed         { false }
     guardian_employment_type  { nil }
     guardian_first_name       { Faker::Name.first_name }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,9 +2,10 @@
 #
 # Table name: users
 #
-#  id                     :bigint           not null, primary key
+#  id                     :integer          not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
+#  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  invitation_accepted_at :datetime
@@ -14,17 +15,22 @@
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
+#  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string
+#  name                   :string           default("CHANGEME"), not null
+#  organization_admin     :boolean
+#  provider               :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0), not null
+#  super_admin            :boolean          default(FALSE)
+#  uid                    :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  invited_by_id          :bigint
-#  partner_id             :bigint
+#  invited_by_id          :integer
+#  organization_id        :integer
 #
 
 FactoryBot.define do

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -11,6 +11,7 @@
 #  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  event_id               :string
 #  organization_id        :integer
 #  partner_id             :integer
 #  storage_location_id    :integer

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -2,88 +2,18 @@
 #
 # Table name: partners
 #
-#  id                         :bigint           not null, primary key
-#  above_1_2_times_fpl        :integer
-#  address1                   :string
-#  address2                   :string
-#  agency_mission             :text
-#  agency_type                :string
-#  ages_served                :string
-#  application_data           :text
-#  at_fpl_or_below            :integer
-#  case_management            :boolean
-#  city                       :string
-#  currently_provide_diapers  :boolean
-#  describe_storage_space     :text
-#  diaper_budget              :string
-#  diaper_funding_source      :string
-#  diaper_use                 :string
-#  distribution_times         :string
-#  distributor_type           :string
-#  evidence_based             :boolean
-#  evidence_based_description :text
-#  executive_director_email   :string
-#  executive_director_name    :string
-#  executive_director_phone   :string
-#  facebook                   :string
-#  form_990                   :boolean
-#  founded                    :integer
-#  greater_2_times_fpl        :integer
-#  income_requirement_desc    :boolean
-#  income_verification        :boolean
-#  incorporate_plan           :text
-#  internal_db                :boolean
-#  maac                       :boolean
-#  max_serve                  :string
-#  more_docs_required         :string
-#  name                       :string
-#  new_client_times           :string
-#  other_agency_type          :string
-#  other_diaper_use           :string
-#  partner_status             :string           default("pending")
-#  pick_up_email              :string
-#  pick_up_method             :string
-#  pick_up_name               :string
-#  pick_up_phone              :string
-#  population_american_indian :integer
-#  population_asian           :integer
-#  population_black           :integer
-#  population_hispanic        :integer
-#  population_island          :integer
-#  population_multi_racial    :integer
-#  population_other           :integer
-#  population_white           :integer
-#  poverty_unknown            :integer
-#  program_address1           :string
-#  program_address2           :string
-#  program_age                :string
-#  program_city               :string
-#  program_client_improvement :text
-#  program_contact_email      :string
-#  program_contact_mobile     :string
-#  program_contact_name       :string
-#  program_contact_phone      :string
-#  program_description        :text
-#  program_name               :string
-#  program_state              :string
-#  program_zip_code           :integer
-#  responsible_staff_position :boolean
-#  serve_income_circumstances :boolean
-#  sources_of_diapers         :string
-#  sources_of_funding         :string
-#  state                      :string
-#  status_in_diaper_base      :string
-#  storage_space              :boolean
-#  trusted_pickup             :boolean
-#  turn_away_child_care       :boolean
-#  twitter                    :string
-#  website                    :string
-#  zip_code                   :string
-#  zips_served                :string
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  diaper_bank_id             :bigint
-#  diaper_partner_id          :integer
+#  id                          :integer          not null, primary key
+#  email                       :string
+#  name                        :string
+#  notes                       :text
+#  quota                       :integer
+#  send_reminders              :boolean          default(FALSE), not null
+#  status                      :integer          default("uninvited")
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  default_storage_location_id :bigint
+#  organization_id             :integer
+#  partner_group_id            :bigint
 #
 
 RSpec.describe Partner, type: :model, skip_seed: true do

--- a/spec/models/partners/family_spec.rb
+++ b/spec/models/partners/family_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id                        :bigint           not null, primary key
 #  comments                  :text
-#  guardian_country          :string
+#  guardian_county           :string
 #  guardian_employed         :boolean
 #  guardian_employment_type  :jsonb
 #  guardian_first_name       :string

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,9 +2,10 @@
 #
 # Table name: users
 #
-#  id                     :bigint           not null, primary key
+#  id                     :integer          not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
+#  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  invitation_accepted_at :datetime
@@ -14,17 +15,22 @@
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
+#  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string
+#  name                   :string           default("CHANGEME"), not null
+#  organization_admin     :boolean
+#  provider               :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0), not null
+#  super_admin            :boolean          default(FALSE)
+#  uid                    :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  invited_by_id          :bigint
-#  partner_id             :bigint
+#  invited_by_id          :integer
+#  organization_id        :integer
 #
 
 RSpec.describe User, type: :model do

--- a/spec/requests/partners/family_requests_spec.rb
+++ b/spec/requests/partners/family_requests_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "/partners/family", type: :request do
       guardian_first_name: "John",
       guardian_last_name: "Smith",
       guardian_zip_code: "90210",
-      guardian_country: "United States",
+      guardian_county: "Franklin",
       guardian_phone: "416-555-2345",
       agency_guardian_id: "Jane Smith",
       home_adult_count: 2,
@@ -29,7 +29,7 @@ RSpec.describe "/partners/family", type: :request do
       guardian_first_name: "Mark",
       guardian_last_name: "Smith",
       guardian_zip_code: "90210",
-      guardian_country: "United States",
+      guardian_county: "Jefferson",
       guardian_phone: "416-555-0987",
       agency_guardian_id: "Jane Smith",
       home_adult_count: 1,
@@ -59,9 +59,9 @@ RSpec.describe "/partners/family", type: :request do
       headers = {"Accept" => "text/csv", "Content-Type" => "text/csv"}
       get partners_families_path, headers: headers
       csv = <<~CSV
-        id,guardian_first_name,guardian_last_name,guardian_zip_code,guardian_country,guardian_phone,agency_guardian_id,home_adult_count,home_child_count,home_young_child_count,sources_of_income,guardian_employed,guardian_employment_type,guardian_monthly_pay,guardian_health_insurance,comments,created_at,updated_at,partner_id,military
-        #{family1.id},John,Smith,90210,United States,416-555-2345,Jane Smith,2,3,1,"SSI,TANF",true,Part-time,4.0,Medicaid,Some comment,#{family1.created_at},#{family1.updated_at},2,false
-        #{family2.id},Mark,Smith,90210,United States,416-555-0987,Jane Smith,1,2,2,TANF,false,Part-time,4.0,Medicaid,Some comment 2,#{family2.created_at},#{family2.updated_at},2,true
+        id,guardian_first_name,guardian_last_name,guardian_zip_code,guardian_county,guardian_phone,agency_guardian_id,home_adult_count,home_child_count,home_young_child_count,sources_of_income,guardian_employed,guardian_employment_type,guardian_monthly_pay,guardian_health_insurance,comments,created_at,updated_at,partner_id,military
+        #{family1.id},John,Smith,90210,Franklin,416-555-2345,Jane Smith,2,3,1,"SSI,TANF",true,Part-time,4.0,Medicaid,Some comment,#{family1.created_at},#{family1.updated_at},2,false
+        #{family2.id},Mark,Smith,90210,Jefferson,416-555-0987,Jane Smith,1,2,2,TANF,false,Part-time,4.0,Medicaid,Some comment 2,#{family2.created_at},#{family2.updated_at},2,true
       CSV
       expect(response.body).to eq(csv)
     end


### PR DESCRIPTION
Resolves #2870 <!--fill issue number-->

### Description
Fixes #2870 Family guardian country->guardian county

This is a case where the name of the field did not match the intent.  Per Sean, it is indeed supposed to be county.

Include anything else we should know about. -->

Note that the Faker Address doesn't have county.  I used community because it has the same flavour -- ish, and at least will be an alpha string.

Note that there is a migration --a column rename

This should be invisible to the end-user, except for the export, which had a header for guardian country, which has been changed to guardian county.


### Type of change

* Bug fix  (non-breaking change which fixes an issue)
* Tech Debt

### How Has This Been Tested?

The current tests were updated, and all run.
I also added a new family on local, and checked that the county shows appropriately.

Note that there aren't a lot of tests directly around the family.  The full test suite passed before I made the changes to the views/controller.   This seems to be our pattern, though, so I didn't add any new tests.   Am certainly up for doing so if we're trying to address those lacks.

