### PR TITLE
#2840: Fix bug where scrollbar eclipses expand arrows

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -158,3 +158,7 @@ body a {
 #copy-calendar-button {
   margin-left: 10px;
 }
+
+.main-sidebar, .main-sidebar::before {
+  width: 280px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -162,3 +162,6 @@ body a {
 .main-sidebar, .main-sidebar::before {
   width: 280px;
 }
+body:not(.sidebar-mini-md) .content-wrapper, body:not(.sidebar-mini-md) .main-footer, body:not(.sidebar-mini-md) .main-header {
+  margin-left: 280px;
+}


### PR DESCRIPTION
Resolves #2840 .

### Description

This widens the sidebar by 30 pixels. This fixes the bug where the arrows that indicate expansion disappear when you expand the "Inventory" menu item. This is because of the "Inventory Adjustments" text, which is longer than most other entries and widens the sidebar too much when it's expanded.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Local testing

### Screenshots

<img width="464" alt="image" src="https://user-images.githubusercontent.com/1986893/166059808-ff79457c-322d-4bdd-9691-da1c0a05596c.png">
