### PR TITLE
Remove some unused JS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,11 +27,6 @@ updates:
   - dependency-name: knapsack_pro
     versions:
     - 2.13.0
-  - dependency-name: chartkick
-    versions:
-    - 4.0.0
-    - 4.0.2
-    - 4.0.3
   - dependency-name: mini_racer
     versions:
     - 0.5.0

--- a/Gemfile
+++ b/Gemfile
@@ -41,10 +41,6 @@ gem 'bootstrap', '~> 4.6.0'
 # Displays a date range picker, i.e. a way for a user to select a start and end date in
 # a single widget.
 gem 'bootstrap-daterangepicker-rails'
-# Delivers assets for a superpowered dropdown using Bootstrap.
-gem 'bootstrap-select-rails'
-# Creates JavaScript graphs.
-gem "chartkick"
 # Installs fonts for Rails frontend.
 gem "font-awesome-rails"
 # A jQuery calendar widget.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,6 @@ GEM
       sassc-rails (>= 2.0.0)
     bootstrap-daterangepicker-rails (3.0.4)
       railties (>= 4.0)
-    bootstrap-select-rails (1.13.8)
     brakeman (5.2.2)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
@@ -117,7 +116,6 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    chartkick (4.1.3)
     childprocess (4.1.0)
     choice (0.2.0)
     cocoon (1.2.15)
@@ -622,13 +620,11 @@ DEPENDENCIES
   binding_of_caller
   bootstrap (~> 4.6.0)
   bootstrap-daterangepicker-rails
-  bootstrap-select-rails
   brakeman
   bugsnag
   bullet
   capybara (~> 3.0)
   capybara-screenshot
-  chartkick
   cocoon
   database_cleaner (= 1.8.5)
   delayed_job_active_record

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,14 +16,11 @@
 //= require bootstrap
 // require jquery_ujs
 //= require filterrific/filterrific-jquery
-//= require bootstrap-select
 //= require bootstrap/alert
 //= require fastclick
 //= require adminlte.min
 //= require cocoon
 //= require toastr
-//= require Chart.bundle
-//= require chartkick
 //= require moment
 //= require fullcalendar
 //= require quagga

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,7 +27,6 @@
  // import other stylesheets after variables
 @import 'AdminLTE';
 @import 'bootstrap';
-@import 'bootstrap-select';
 @import 'simple_form-bootstrap/simple_form-bootstrap';
 @import 'font-awesome';
 @import 'progress_stepper';

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -157,7 +157,7 @@
                 <div class="box-body">
                   <div class="box-body text-center">
                     <h5 class="text-center"></h5>
-                    <%= bar_chart received_distributed_data %>
+                    <div id="received-data-chart"></div>
                   </div>
                 </div>
               </div>
@@ -317,3 +317,34 @@
     </div>
   </div>
 </div>
+
+<script>
+
+<% data = received_distributed_data %>
+$(() => {
+  Highcharts.chart('received-data-chart', {
+    chart: {
+      type: 'bar'
+    },
+    title: '',
+    xAxis: {
+      categories: <%= data.keys.to_json.html_safe %>,
+      title: {
+        text: null
+      }
+    },
+    yAxis: {
+      title: {
+        text: null
+      }
+    },
+    legend: {
+      enabled: false
+    },
+    series: [
+      { data: <%= data.values.to_json.html_safe %> }
+    ]
+  })
+  $('#received-data-chart')
+});
+</script>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -69,7 +69,7 @@
                 <%= f.input :intake_location, :collection => current_organization.storage_locations.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Intake Location", :include_blank => true, wrapper: :input_group %>
 
                 <%= f.label :partner_form_fields, "Required Partner Fields" %>
-                <%= f.select(:partner_form_fields, Organization::ALL_PARTIALS, {include_hidden: false}, { multiple: true, class: 'form-control selectpicker input_group' }) %>
+                <%= f.select(:partner_form_fields, Organization::ALL_PARTIALS, {include_hidden: false}, { multiple: true, class: 'form-control input_group' }) %>
                 <br>
                 <%= f.input :default_storage_location, :collection => current_organization.storage_locations.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Storage Location", :include_blank => true, wrapper: :input_group %>
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@babel/plugin-transform-regenerator": "^7.17.9",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
-    "chartkick": "^3.2.1",
     "fstream": "^1.0.12",
     "highcharts": "^9.0.0",
     "js-yaml": "^3.13.1",


### PR DESCRIPTION
Partially resolves #2860 .

### Description

This PR includes the following:
* Remove the bootstrap-select-rails gem. This was only used on a single page to style the select box slightly differently.
* Remove the chartkick gem and associated libraries. This was only used on one page and we already have Highcharts which accomplishes the same thing. Replaced the bar graph on the dashboard with a Highcharts graph. 

### Type of change

* Internal change

### How Has This Been Tested?

Local testing. I've searched as much as I can but can't 100% guarantee I didn't miss something. Unfortunately all these similar PRs will have the same caveat.

### Screenshots

<img width="685" alt="image" src="https://user-images.githubusercontent.com/1986893/166066463-b8b24182-f67b-4575-aff9-9a6fb51e649b.png">
