### PR TITLE
fix filtering for product drive participant on donations

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -28,7 +28,7 @@ class DonationsController < ApplicationController
     @donation_sites = @donations.collect(&:donation_site).compact.uniq.sort_by { |site| site.name.downcase }
     @selected_donation_site = filter_params[:from_donation_site]
     @selected_product_drive = filter_params[:by_product_drive]
-    @selected_diaper_participant_drive = filter_params[:by_product_drive_participant]
+    @selected_product_drive_participant = filter_params[:by_product_drive_participant]
     @manufacturers = @donations.collect(&:manufacturer).compact.uniq.sort
     @selected_manufacturer = filter_params[:from_manufacturer]
 

--- a/app/views/donations/index.html.erb
+++ b/app/views/donations/index.html.erb
@@ -55,7 +55,7 @@
                 <% end %>
                 <% if @product_drive_participants.present? %>
                   <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
-                    <%= filter_select(scope: :by_product_drive_participant, collection: @product_drive_participants, value: :business_name, selected: @selected_product_drive) %>
+                    <%= filter_select(scope: :by_product_drive_participant, collection: @product_drive_participants, value: :business_name, selected: @selected_product_drive_participant) %>
                   </div>
                 <% end %>
                 <% if @manufacturers.present? %>

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe "Donations", type: :system, js: true do
         click_button "Filter"
         expect(page).to have_css("table tbody tr", count: 1)
       end
+
+      it "Filter by product drive participant sticks around" do
+        x = create(:product_drive, name: 'x')
+        a = create(:product_drive_participant, business_name: "A")
+        b = create(:product_drive_participant, business_name: "B")
+        create(:product_drive_donation, product_drive: x, product_drive_participant: a)
+        create(:product_drive_donation, product_drive: x, product_drive_participant: b)
+        visit subject
+        expect(page).to have_css("table tbody tr", count: 2)
+        select a.business_name, from: "filters_by_product_drive_participant"
+        click_button "Filter"
+        expect(page).to have_select("filters_by_product_drive_participant", selected: a.business_name)
+      end
+
       it "Filters by manufacturer" do
         a = create(:manufacturer, name: "A")
         b = create(:manufacturer, name: "B")


### PR DESCRIPTION


-->

Resolves #2888 

### Description
<!-- Please include a summary of the change and which issue is fixed. 

When I was looking at the diaper language, I unearthed a minor issue where the filtering for product drive and product drive participant on the donations page behaves oddly -- in that the filter selection on the product drive participant is linked to the product drive selection.

There was also a mis-naming of the selection variable in the controller, which is why this wasn't caught on the first go-round

So - changed those to be consistent and work!


### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 

Visual verification
Added test to donations system spec
All current  tests pass
