### PR TITLE
2876 diaper language continued

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ There are numerous other folks that can chime in and answer questions -- please 
 
 ## About
 
-This application is an inventory management system that is built to address the needs of [Diaper Banks](https://nationaldiaperbanknetwork.org/diaper-need/) as directly and explicitly as possible. Diaper Banks maintain inventory, receive donations and other means of intaking diapers (and related supplies), and issue Distributions to community partner organizations. Like any non-profit, they also need to perform reports on this data, and have day-to-day operational information they need as well. This application aims to serve all those needs, as well as facilitate, wherever possible the general operations of the Diaper Bank themselves (eg. through using barcode readers, scale weighing, inventory audits).
+This application is an inventory management system that is built to address the needs of [Diaper Banks](https://nationaldiaperbanknetwork.org/diaper-need/) as directly and explicitly as possible, and later adapted to meet the need of other Essentials Banks.  Essentials Banks maintain inventory, receive donations and other means of intaking human essentials supplies (e.g. diapers, period supplies), and issue Distributions to community partner organizations. Like any non-profit, they also need to perform reports on this data, and have day-to-day operational information they need as well. This application aims to serve all those needs, as well as facilitate, wherever possible the general operations of the Diaper Bank themselves (eg. through using barcode readers, scale weighing, inventory audits).
 
 For a general overview of the application, please see the [Application Overview](https://github.com/rubyforgood/human-essentials/wiki/Application-Overview) wiki article.
 
 ### Origins
 
 
-This project took what we built for the [Portland Diaper Bank in 2016](https://github.com/rubyforgood/pdx_diaper) and turned it into a multitenant application, something that all diaper banks can use. We re-used models, code and other documentation where applicable as well as implemented new features and functionality requested by the prime stakeholder (PDXDB). We're super excited to have had Rachel Alston, the director of the Portland Diaper Bank, attending our event in 2017, providing guidance and giving us the best chance of success!
+This project took what we built for the [Portland Diaper Bank in 2016](https://github.com/rubyforgood/pdx_diaper) and turned it into a multitenant application, something that all essentials banks can use. We re-used models, code and other documentation where applicable as well as implemented new features and functionality requested by the prime stakeholder (PDXDB). We're super excited to have had Rachel Alston, the director of the Portland Diaper Bank, attending our event in 2017, providing guidance and giving us the best chance of success!
 
 
 ## Development

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -1,4 +1,4 @@
-# Provides limited CRUD for Adjustments, which are the way that Diaper Banks fix incorrect inventory totals at Storage Locations
+# Provides limited CRUD for Adjustments, which are the way that Essentials Banks fix incorrect inventory totals at Storage Locations
 class AdjustmentsController < ApplicationController
   # GET /adjustments
   # GET /adjustments.json

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -109,7 +109,7 @@ class Organization < ApplicationRecord
     ['Sources of Funding', 'sources_of_funding'],
     ['Population Served', 'population_served'],
     ['Executive Director', 'executive_director'],
-    ['Diaper Pickup Person', 'diaper_pick_up_person'],
+    ['Pickup Person', 'diaper_pick_up_person'],
     ['Agency Distribution Information', 'agency_distribution_information'],
     ['Attached Documents', 'attached_documents']
   ].freeze

--- a/app/views/account_request_mailer/confirmation.html.erb
+++ b/app/views/account_request_mailer/confirmation.html.erb
@@ -42,7 +42,7 @@
 </p>
 
 <p>
-    Finally, we made a getting started video with detailed directions on setting up your diaper bank in Human Essentials, check it out
+    Finally, we made a getting started video with detailed directions on setting up your essentials bank in Human Essentials, check it out
     <a href='https://www.youtube.com/watch?v=fwo3WKMGM_4&feature=youtu.be'>here</a>! Please let us know when you would like to begin using Human Essentials and we will set you up and send you a welcome email.
 </p>
 

--- a/app/views/account_request_mailer/confirmation.text.erb
+++ b/app/views/account_request_mailer/confirmation.text.erb
@@ -23,7 +23,7 @@ Password: password!
 A couple things to know about the sandbox servers before you start using them:
   The development team uses the servers for testing our new features and upgrades before putting them on the live site to ensure that no bugs get pushed through to the live site, so if something looks different than the (real) humanessentials.app site that is probably why! Please don’t enter any sensitive information into the demo servers, several users have access to the demo servers and it will be visible to all users.
 
-Finally, we made a getting started video with detailed directions on setting up your diaper bank in Human Essentials, check it out here: https://www.youtube.com/watch?v=fwo3WKMGM_4&feature=youtu.be
+Finally, we made a getting started video with detailed directions on setting up your essentials bank in Human Essentials, check it out here: https://www.youtube.com/watch?v=fwo3WKMGM_4&feature=youtu.be
 Please let us know when you would like to begin using Human Essentials and we will set you up and send you a welcome email.
 
 Human Essentials Team

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -88,7 +88,7 @@
       </div>
 
       <div class='card-text'>
-        <p> Hey there, it looks like you're trying to request an account, but you're not currently on the live version of Diaper Base </p>
+        <p> Hey there, it looks like you're trying to request an account, but you're not currently on the live version of Human Essentials </p>
         <p> To request an account, <%= link_to 'click here', 'https://humanessentials.app/account_requests/new' %> to head on over to the Human Essentials website</p>
       </div>
     </div>

--- a/app/views/admin/partners/show.html.erb
+++ b/app/views/admin/partners/show.html.erb
@@ -35,7 +35,7 @@
               <thead>
               <tr>
                 <th>Partner Name</th>
-                <th>Diaper Bank</th>
+                <th>Essentials Bank</th>
                 <th>Partner Email</th>
               </tr>
               </thead>

--- a/app/views/dashboard/_getting_started_prompt.html.erb
+++ b/app/views/dashboard/_getting_started_prompt.html.erb
@@ -112,7 +112,7 @@
 
               <div class="org-stats-desc">
                 <p>
-                  As a diaper bank, you might already have inventory on hand. These items might have come from previous donations/purchases. If you have multiple sources or want to add inventory to multiple storage locations, you can create multiple donations or purchases while specifying the correct date, source, and location.
+                  As an essentials bank, you might already have inventory on hand. These items might have come from previous donations/purchases. If you have multiple sources or want to add inventory to multiple storage locations, you can create multiple donations or purchases while specifying the correct date, source, and location.
                 </p>
               </div >
 

--- a/app/views/layouts/_lte_navbar.html.erb
+++ b/app/views/layouts/_lte_navbar.html.erb
@@ -49,7 +49,7 @@
   <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
     <%= link_to(requests_path, class: "dropdown-item") do %>
     <i class="fa fa-file-text text-aqua"></i> <%= current_organization&.requests.status_pending.size rescue "0" %>
-    Diaper Requests
+    Requests
     <% end %>
     <div class="dropdown-divider"></div>
     <%= link_to(partners_path, class: "dropdown-item") do %>

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -31,7 +31,7 @@
                            class: "form-control", wrapper: :input_group %>
             <%= form.input :program_client_improvement, label: "Verified Successes of Program", as: :text,
                            class: "form-control", wrapper: :input_group %>
-            <%= form.input :diaper_use, label: "Diaper Use", as: :text,
+            <%= form.input :diaper_use, label: "Essentials Item Use", as: :text,
                            class: "form-control", wrapper: :input_group %>
             <%= form.input :other_diaper_use, label: "Do You Receive Diapers From Other Sources",
                            class: "form-control", wrapper: :input_group %>

--- a/app/views/partners/profiles/edit/_diaper_pick_up_person.html.erb
+++ b/app/views/partners/profiles/edit/_diaper_pick_up_person.html.erb
@@ -4,7 +4,7 @@
       <div class="col-md-12">
         <div class="card">
           <div class="card-header bg-white">
-            <h3 class="card-title"><strong>Diaper Pick Up Person</strong></h3>
+            <h3 class="card-title"><strong>Pick Up Person</strong></h3>
           </div>
           <div class="card-body">
             <%= form.input :pick_up_method, label: "Pick Up Method", class: "form-control", wrapper: :input_group %>

--- a/app/views/partners/profiles/edit/_sources_of_funding.html.erb
+++ b/app/views/partners/profiles/edit/_sources_of_funding.html.erb
@@ -10,7 +10,7 @@
             <%= form.input :sources_of_funding, label: "Sources Of Funding", class: "form-control", wrapper: :input_group %>
             <%= form.input :sources_of_diapers, label: "How do you currently obtain diapers?",
                            class: "form-control", wrapper: :input_group %>
-            <%= form.input :diaper_budget, label: "Diaper Budget", class: "form-control", wrapper: :input_group %>
+            <%= form.input :diaper_budget, label: "Essentials Budget", class: "form-control", wrapper: :input_group %>
             <%= form.input :diaper_funding_source, label: "Diaper Funding Source", class: "form-control", wrapper: :input_group %>
           </div>
         </div>

--- a/app/views/partners/profiles/edit/_sources_of_funding.html.erb
+++ b/app/views/partners/profiles/edit/_sources_of_funding.html.erb
@@ -11,7 +11,7 @@
             <%= form.input :sources_of_diapers, label: "How do you currently obtain diapers?",
                            class: "form-control", wrapper: :input_group %>
             <%= form.input :diaper_budget, label: "Essentials Budget", class: "form-control", wrapper: :input_group %>
-            <%= form.input :diaper_funding_source, label: "Diaper Funding Source", class: "form-control", wrapper: :input_group %>
+            <%= form.input :diaper_funding_source, label: "Essentials Funding Source", class: "form-control", wrapper: :input_group %>
           </div>
         </div>
       </div>

--- a/app/views/partners/profiles/show/_agency_stability.html.erb
+++ b/app/views/partners/profiles/show/_agency_stability.html.erb
@@ -37,7 +37,7 @@
       <dt>Verified Successes of Program</dt>
       <dd><%= partner.program_client_improvement %></dd>
 
-      <dt>Diaper Use</dt>
+      <dt>Essentials Item Use</dt>
       <dd><%= partner.diaper_use %></dd>
 
       <dt>Do You Receive Diapers From Other Sources</dt>

--- a/app/views/partners/profiles/show/_diaper_pick_up_person.html.erb
+++ b/app/views/partners/profiles/show/_diaper_pick_up_person.html.erb
@@ -1,5 +1,5 @@
 <div class="card mb-4">
-  <h5 class="card-header bg-primary text-white">Diaper Pick Up Person</h5>
+  <h5 class="card-header bg-primary text-white">Pick Up Person</h5>
   <div class="card-body">
     <dl>
       <dt>Pick Up Method</dt>

--- a/app/views/partners/profiles/show/_sources_of_funding.html.erb
+++ b/app/views/partners/profiles/show/_sources_of_funding.html.erb
@@ -11,7 +11,7 @@
       <dt>Essentials Budget</dt>
       <dd><%= partner.diaper_budget %></dd>
 
-      <dt>Diaper Funding Source</dt>
+      <dt>Essentials Funding Source</dt>
       <dd><%= partner.diaper_funding_source %></dd>
     </dl>
   </div>

--- a/app/views/partners/profiles/show/_sources_of_funding.html.erb
+++ b/app/views/partners/profiles/show/_sources_of_funding.html.erb
@@ -8,7 +8,7 @@
       <dt>How do you currently obtain diapers?</dt>
       <dd><%= partner.sources_of_diapers %></dd>
 
-      <dt>Diaper Budget</dt>
+      <dt>Essentials Budget</dt>
       <dd><%= partner.diaper_budget %></dd>
 
       <dt>Diaper Funding Source</dt>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -136,7 +136,7 @@
       <p>Sources of Funding: <%= partner_profile.sources_of_funding %></p>
       <p>Sources of Diapers: <%= partner_profile.sources_of_diapers %> </p>
       <p>Essentials Budget:<%= partner_profile.diaper_budget %></p>
-      <p>Diaper Funding Source: <%= partner_profile.diaper_funding_source %></p>
+      <p>Essentials Funding Source: <%= partner_profile.diaper_funding_source %></p>
     <% end %>
     <% if partner_profile_fields.include?('attached_documents') || partner_profile_fields.empty? %>
       <h2 class='text-2xl underline'>Other Documents</h2>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -117,7 +117,7 @@
       <br>
     <% end %>
     <% if partner_profile_fields.include?('diaper_pick_up_person') || partner_profile_fields.empty? %>
-      <h2 class='text-2xl underline'>Diaper Pick Up Person</h2>
+      <h2 class='text-2xl underline'>Pick Up Person</h2>
       <p>Pick Up Method: <%= partner_profile.pick_up_method %></p>
       <p>Pick Up Name: <%= partner_profile.pick_up_name %></p>
       <p>Pick Up Phone: <%= partner_profile.pick_up_phone %></p>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -135,7 +135,7 @@
       <h2 class='text-2xl underline'>Sources of Funding</h2>
       <p>Sources of Funding: <%= partner_profile.sources_of_funding %></p>
       <p>Sources of Diapers: <%= partner_profile.sources_of_diapers %> </p>
-      <p>Diaper Budget:<%= partner_profile.diaper_budget %></p>
+      <p>Essentials Budget:<%= partner_profile.diaper_budget %></p>
       <p>Diaper Funding Source: <%= partner_profile.diaper_funding_source %></p>
     <% end %>
     <% if partner_profile_fields.include?('attached_documents') || partner_profile_fields.empty? %>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -42,8 +42,8 @@
       <p>Evidence Based: <%= partner_profile.evidence_based %></p>
       <p>Evidence Based Description: <%= partner_profile.evidence_based_description %></p>
       <p>Program Client Improvement: <%= partner_profile.program_client_improvement %></p>
-      <p>Diaper Use: <%= partner_profile.diaper_use %></p>
-      <p>Other Diaper Use: <%= partner_profile.other_diaper_use %></p>
+      <p>Essentials Item Use: <%= partner_profile.diaper_use %></p>
+      <p>Other Essentials Item Use: <%= partner_profile.other_diaper_use %></p>
       <p>Currently Provide Diapers: <%= partner_profile.currently_provide_diapers %></p>
       <p>Turn Away Child Care: <%= partner_profile.turn_away_child_care %></p>
       <br>

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -17,7 +17,7 @@ en:
         submit_button: "Set my password"
     mailer:
       invitation_instructions:
-        subject: "Your Diaper App Account Approval"
+        subject: "Your Human Essentials App Account Approval"
         hello: "Hello %{email}"
         someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
         accept: "Accept invitation"

--- a/doc/architecture/decisions/0003-multitenancy-instead-of-multiple-instances.md
+++ b/doc/architecture/decisions/0003-multitenancy-instead-of-multiple-instances.md
@@ -8,11 +8,11 @@ Accepted
 
 ## Context
 
-Discussion about whether to make this application a multi-tenant (single instance with many Diaper Banks) or single-tenant (each Diaper Bank gets their own instance).
+Discussion about whether to make this application a multi-tenant (single instance with many Essentials Banks) or single-tenant (each Essentials Bank gets their own instance).
 
 ## Decision
 
-We've decided to go with a multi-tenancy. Rails has good support for this, with some initial configuration. This will help keep costs down and allow us to provide it as a cheap/free service. This will require ongoing support by us, to maintain the production instance, but since this is intended to be an ongoing project that was implied anyways. This will also ensure that all Diaper Banks have access to the same version of the software, universally.
+We've decided to go with a multi-tenancy. Rails has good support for this, with some initial configuration. This will help keep costs down and allow us to provide it as a cheap/free service. This will require ongoing support by us, to maintain the production instance, but since this is intended to be an ongoing project that was implied anyways. This will also ensure that all Essentials Banks have access to the same version of the software, universally.
 
 ## Consequences
 

--- a/doc/architecture/decisions/0005-extract-all-partner-operations-into-a-separate-application-intended-for-partners.md
+++ b/doc/architecture/decisions/0005-extract-all-partner-operations-into-a-separate-application-intended-for-partners.md
@@ -16,4 +16,4 @@ A new application, Partnerbase, will be created to handle the CRM aspects. It wi
 
 ## Consequences
 
-Depending on the future features required, this may or may not be the right decision. We now have 2 applications to maintain and there will be duplicated efforts when we have to do updates, as well as a division of labor and domain knowledge. Diaper Banks will not be able to see Partner data, which is both a feature and a liability (since they need some of that for reporting).
+Depending on the future features required, this may or may not be the right decision. We now have 2 applications to maintain and there will be duplicated efforts when we have to do updates, as well as a division of labor and domain knowledge. Essentials Banks will not be able to see Partner data, which is both a feature and a liability (since they need some of that for reporting).

--- a/doc/architecture/decisions/0006-instantiating-items-from-base-items.md
+++ b/doc/architecture/decisions/0006-instantiating-items-from-base-items.md
@@ -8,11 +8,11 @@ Accepted
 
 ## Context
 
-We encountered a bug where one Diaper Bank edited / deleted Items from the Item list (they weren't using specific Item types). Because Item types were shared globally, this deleted those types for everyone. That needs to not be the case.
+We encountered a bug where one Essentials Bank edited / deleted Items from the Item list (they weren't using specific Item types). Because Item types were shared globally, this deleted those types for everyone. That needs to not be the case.
 
 ## Decision
 
-We've decided to have all items be sandboxed on a per-organization basis. There is a list of templated starting items ("Base Items") that will be created for every new organization when they are first added. Each of those starting items (and all other items) will all be connected back to a Base Item (a generic type). This will allow the Diaper Banks to rename and customize the items to their heart's content without (a) affecting other Diaper Banks and (b) while keeping it possible for Partner Base to request items without needing to know specifically what kinds of items they have on-hand. An "Other" base item will accommodate any items we've not factored in already.
+We've decided to have all items be sandboxed on a per-organization basis. There is a list of templated starting items ("Base Items") that will be created for every new organization when they are first added. Each of those starting items (and all other items) will all be connected back to a Base Item (a generic type). This will allow the Essentials Banks to rename and customize the items to their heart's content without (a) affecting other Essentials Banks and (b) while keeping it possible for Partner Base to request items without needing to know specifically what kinds of items they have on-hand. An "Other" base item will accommodate any items we've not factored in already.
 
 ## Consequences
 

--- a/doc/architecture/decisions/0007-barcode-querying.md
+++ b/doc/architecture/decisions/0007-barcode-querying.md
@@ -8,7 +8,7 @@ Accepted
 
 ## Context
 
-We've been using Barcode values that have been recorded as either private (associated only with an organization) or global (available to all organizations). The idea was that Diaper Banks could decide to "Share" a barcode with everyone by making it global, and that this barcode could then be used by others. The implementation, as well as the actual use-cases by Diaper Banks in beta testing, has contraindicated this utility. Additionally, it's unclear how Barcode lookup happens with regard to Base Items.
+We've been using Barcode values that have been recorded as either private (associated only with an organization) or global (available to all organizations). The idea was that Essentials Banks could decide to "Share" a barcode with everyone by making it global, and that this barcode could then be used by others. The implementation, as well as the actual use-cases by Essentials Banks in beta testing, has contraindicated this utility. Additionally, it's unclear how Barcode lookup happens with regard to Base Items.
 
 ## Decision
 

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
       skip_items { false }
     end
 
-    sequence(:name) { |n| "Diaper Bank #{n}" } # 037000863427
+    sequence(:name) { |n| "Essentials Bank #{n}" } # 037000863427
     sequence(:short_name) { |n| "db_#{n}" } # 037000863427
     sequence(:email) { |n| "email#{n}@example.com" } # 037000863427
     sequence(:url) { |n| "https://organization#{n}.org" } # 037000863427

--- a/spec/models/partners/partner_spec.rb
+++ b/spec/models/partners/partner_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Partners::Partner, type: :model, skip_seed: true do
     subject { partner.organization }
     let(:partner) { FactoryBot.create(:partners_partner) }
 
-    it 'should return the associated organization using its diaper bank id' do
+    it 'should return the associated organization using its essentials bank id' do
       expect(subject).to eq(Organization.find_by!(id: partner.diaper_bank_id))
     end
   end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
 RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
-  context "With a new Diaper bank" do
+  context "With a new essentials bank" do
     before :each do
       @new_organization = create(:organization)
       @user = create(:user, organization: @new_organization)
@@ -66,7 +66,7 @@ RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
     end
   end
 
-  context "With an existing Diaper bank" do
+  context "With an existing essentials bank" do
     before do
       sign_in(@user)
     end


### PR DESCRIPTION
Partial #2876<!--fill issue number-->

### Description

Continuation of addressing diaper language.   

  This should pretty much handle generalizing the user-facing diaper language, with the exception of the "non-diaper item" references in the annual report (#2865  )

  - change message on staging account request to "Human Essentials" instead of "Diaper Base" 
  - change partner email "Your Diaper App Account Approval" to "Your Human Essentials App Account Approval" 
  - change user-facing text "Diaper Funding Source" to "Essentials Funding Source" 
  - change user-facing text "Diaper Budget" to "Essentials Budget"
  - change user-facing text "Diaper Use" to "Essentials Item Use"
  - change drop-down text (from alert icon) 'Diaper Requests' to 'Requests' 
  - changing visible test for 'Diaper Pickup Person' to 'Pickup Person' 
  - text and comment references to Diaper Bank changed to Essentials Bank,  excluding  names and quotes. 
   
  Outstanding:  variable, field name, routing  changes.    
  Am considering postponing field name changes until after databases are combined.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* Documentation update

### How Has This Been Tested?

All current tests pass.
Visual confirmation of changes on screens.
Have *not*  tested partner mail message change.
