### PR TITLE
grammar correction on account request form  

### DIFF
--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -7,7 +7,7 @@
 
       <div class="form-check">
         <%= radio_button_tag(:account, :bank, false, class: 'form-check-input account_type') %>
-        <%= label_tag(:account, "I am an Essentials Bank. I do NOT distribution diapers/period supplies directly to the public, I distribute them to partner agencies who distribute them to the public.", class: 'form-check-label') %>
+        <%= label_tag(:account, "I am an Essentials Bank. I do NOT distribute diapers/period supplies directly to the public, I distribute them to partner agencies who distribute them to the public.", class: 'form-check-label') %>
       </div>
       <div class="form-check">
         <%= radio_button_tag(:account, :partner, false, class: 'form-check-input account_type') %>


### PR DESCRIPTION
### Description

This just corrects the grammar on the account request form from "I do NOT distribution..." to "I do NOT distribute..."

Fixed for better early impression on users. 

### Type of change

* Bug fix
* This change requires a documentation update (if there is user documentation around this screen, it should be touched for the same reason)

### How Has This Been Tested?
All the automated tests still work 
Visual check on local

### Screenshots

Before:
<img width="631" alt="Screen Shot 2022-05-16 at 10 59 31 AM" src="https://user-images.githubusercontent.com/10157589/168630338-61cd72b1-ef4f-46ba-88eb-6b48fda03205.png">
After: 
![Screen Shot 2022-05-16 at 11 38 49 AM](https://user-images.githubusercontent.com/10157589/168631004-db332681-6d2f-4245-a8ee-bf57a5286493.png)
