### PR TITLE
#2858: Download PDF button for partner distributions

### DIFF
--- a/app/controllers/partners/distributions_controller.rb
+++ b/app/controllers/partners/distributions_controller.rb
@@ -12,5 +12,18 @@ module Partners
 
       @parent_org = Organization.find(@partner.diaper_bank_id)
     end
+
+    def print
+      distribution = Distribution.find(params[:id])
+      respond_to do |format|
+        format.any do
+          pdf = DistributionPdf.new(distribution.organization, distribution)
+          send_data pdf.render,
+            filename: format("%s %s.pdf", distribution.partner.name, sortable_date(distribution.created_at)),
+            type: "application/pdf",
+            disposition: "inline"
+        end
+      end
+    end
   end
 end

--- a/app/views/partners/distributions/_distribution_section.html.erb
+++ b/app/views/partners/distributions/_distribution_section.html.erb
@@ -10,11 +10,13 @@
       </tr>
     </thead>
     <tbody>
-    <% distributions.each do |dist| %>
+      <% distributions.each do |dist| %>
         <tr class="hover:bg-gray-100 border-b border-gray-200 last:border-b-0">
           <td class="p-4 w-40">
             <i class="text-blue-900 far fa-file-alt mr-1"></i>
             <%= dist.issued_at.strftime("%m/%d/%Y") %>
+            <br/>
+            <%= print_button_to print_partners_distribution_path(dist, format: :pdf) %>
           </td>
           <td class="p-4"><%= dist.line_items.total %></td>
           <td class="p-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,9 @@ Rails.application.routes.draw do
     end
     resources :families
     resources :authorized_family_members
-    resources :distributions, only: [:index]
+    resources :distributions, only: [:index] do
+      get :print, on: :member
+    end
   end
 
   # This is where a superadmin CRUDs all the things

--- a/spec/requests/partners/distributions_spec.rb
+++ b/spec/requests/partners/distributions_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "/partners/distributions", type: :request do
+  let(:partner) { create(:partner) }
+  let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).primary_user }
+
   describe "GET #index" do
     subject { -> { get partners_distributions_path } }
-    let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).primary_user }
-    let(:partner) { create(:partner) }
 
     before do
       sign_in(partner_user, scope: :partner_user)
@@ -13,6 +14,27 @@ RSpec.describe "/partners/distributions", type: :request do
     it "should render without any issues" do
       subject.call
       expect(response).to render_template(:index)
+    end
+  end
+
+  describe "GET #print" do
+    before do
+      sign_in(partner_user, scope: :partner_user)
+    end
+
+    let(:distribution) { FactoryBot.create(:distribution, partner: partner) }
+    it "returns http success" do
+      get print_partners_distribution_path(distribution)
+      expect(response).to be_successful
+    end
+
+    context "with non-UTF8 characters" do
+      let(:non_utf8_partner) { create(:partner, name: "KOKA Keiki O Ka ‘Āina") }
+
+      it "returns http success" do
+        get print_partners_distribution_path(distribution)
+        expect(response).to be_successful
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #2858 

### Description
Adds a "print" button to distributions for partners, which works identically to the print button for organizations.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Local and unit tests.

### Screenshots
<img width="538" alt="image" src="https://user-images.githubusercontent.com/1986893/169608890-38ecab8b-4e88-4ea9-9042-c2c74f02a3fa.png">