### PR TITLE
updated language in other products report to reference other product …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ coverage
 yarn-debug.log*
 .yarn-integrity
 package-lock.json
+
+# plugin history
+.history/

--- a/app/services/reports/other_products_report_service.rb
+++ b/app/services/reports/other_products_report_service.rb
@@ -14,11 +14,11 @@ module Reports
     def report
       @report ||= { name: 'Other Items',
                     entries: {
-                      'Non-diaper products distributed' => number_with_delimiter(distributed_products),
-                      '% non-diaper products donated' => "#{percent_donated.round}%",
-                      '% non-diaper products bought' => "#{percent_bought.round}%",
-                      'Money spent on non-diaper products' => number_to_currency(money_spent),
-                      'List of non-diaper products' => product_list
+                      'Other products distributed' => number_with_delimiter(distributed_products),
+                      '% other products donated' => "#{percent_donated.round}%",
+                      '% other products bought' => "#{percent_bought.round}%",
+                      'Money spent on other products' => number_to_currency(money_spent),
+                      'List of other products' => product_list
                     } }
     end
 

--- a/spec/services/reports/other_products_report_service_spec.rb
+++ b/spec/services/reports/other_products_report_service_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Reports::OtherProductsReportService, type: :service, skip_seed: t
     it 'should report zero values' do
       expect(report.report).to eq({
                                     entries: {
-                                      'Non-diaper products distributed' => '0',
-                                      '% non-diaper products donated' => "0%",
-                                      '% non-diaper products bought' => "0%",
-                                      'Money spent on non-diaper products' => '$0.00',
-                                      'List of non-diaper products' => organization.items.other_categories.map(&:name).sort.uniq.join(', ')
+                                      'Other products distributed' => '0',
+                                      '% other products donated' => "0%",
+                                      '% other products bought' => "0%",
+                                      'Money spent on other products' => '$0.00',
+                                      'List of other products' => organization.items.other_categories.map(&:name).sort.uniq.join(', ')
                                     },
                                     name: "Other Items"
                                   })


### PR DESCRIPTION
This is my first pull request which was assigned during office hours. 

# Checklist:

- I have performed a self-review of my own code
  - done, not tested with rspec due to numerous failing error prior to changes made.
- I have commented my code, particularly in hard-to-understand areas
  - no comments, self explanatory word replacement
- I have made corresponding changes to the documentation,
  - no documentation regarding how to generate annual report
- I have added tests that prove my fix is effective or that my feature works
  - I have updated the corresponding tests with the same language in the other product report service
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
  - no not tested locally due to failing tests, prior to changes made
- Title include "WIP" if work is in progress.
   - n/a

Resolves #2865

### Description
 Changed the language in the other products annual report from "non-diaper products" to "other products" in that section.

Guide questions:
  - What motivated this change (if not already described in an issue)?
    - Team handles other items besides diapers, so more generic/inclusive language 
  - What alternative solutions did you consider?
    - n/a
  - What are the tradeoffs for your solution?
    - n/a
   
List any dependencies that are required for this change. (gems, js libraries, etc.)
- n/a

Include anything else we should know about.
Just a comment the instance variable report is a nested json/hash and the key value is name: 'Other Items' but the entries themself are 'other product'. Should the key be Other Products or change entries to 'other items' for consistency?

### Type of change
* Documentation update

### How Has This Been Tested?
Not tested as I was having issue with testing passing, will need to be verified, langauge in 

### Screenshots
n/a
