### PR TITLE
2895: Show inventory for storage location

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -45,10 +45,7 @@ class RequestsController < ApplicationController
   def load_items
     return unless @request.request_items
 
-    location_id = @request.partner.default_storage_location_id ||
-      current_organization.default_storage_location
-    location = StorageLocation.find_by(id: location_id)
-    @request.request_items.map { |json| RequestItem.from_json(json, current_organization, location) }
+    @request.request_items.map { |json| RequestItem.from_json(json, @request) }
   end
 
   helper_method \

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -45,7 +45,10 @@ class RequestsController < ApplicationController
   def load_items
     return unless @request.request_items
 
-    @request.request_items.map { |json| RequestItem.from_json(json, current_organization) }
+    location_id = @request.partner.default_storage_location_id ||
+      current_organization.default_storage_location
+    location = StorageLocation.find_by(id: location_id)
+    @request.request_items.map { |json| RequestItem.from_json(json, current_organization, location) }
   end
 
   helper_method \

--- a/app/models/request_item.rb
+++ b/app/models/request_item.rb
@@ -1,10 +1,14 @@
 class RequestItem
   attr_accessor :name, :quantity, :on_hand, :on_hand_for_location
 
-  def self.from_json(json, organization, location)
+  def self.from_json(json, request)
+    location_id = request.partner.default_storage_location_id ||
+      request.organization.default_storage_location
+    location = StorageLocation.find_by(id: location_id)
+
     item = Item.find(json['item_id'])
     quantity = json['quantity']
-    on_hand = organization.inventory_items.where(item_id: item.id).sum(:quantity)
+    on_hand = request.organization.inventory_items.where(item_id: item.id).sum(:quantity)
     on_hand_for_location = if location
       location.inventory_items.where(item_id: item.id).sum(:quantity)
     else

--- a/app/models/request_item.rb
+++ b/app/models/request_item.rb
@@ -1,17 +1,22 @@
 class RequestItem
-  attr_accessor :name, :quantity, :on_hand
+  attr_accessor :name, :quantity, :on_hand, :on_hand_for_location
 
-  def self.from_json(json, organization)
+  def self.from_json(json, organization, location)
     item = Item.find(json['item_id'])
     quantity = json['quantity']
     on_hand = organization.inventory_items.where(item_id: item.id).sum(:quantity)
-
-    new(item.name, quantity, on_hand)
+    on_hand_for_location = if location
+      location.inventory_items.where(item_id: item.id).sum(:quantity)
+    else
+      'N/A'
+    end
+    new(item.name, quantity, on_hand, on_hand_for_location)
   end
 
-  def initialize(name, quantity, on_hand)
+  def initialize(name, quantity, on_hand, on_hand_for_location)
     @name = name
     @quantity = quantity
     @on_hand = on_hand
+    @on_hand_for_location = on_hand_for_location
   end
 end

--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -18,7 +18,7 @@
           </td>
           <td class="p-4"><%= request.total_items %></td>
           <td class="p-4">
-            <%request_item = request.request_items.map { |json| RequestItem.from_json(json, @parent_org) } %>
+            <%request_item = request.request_items.map { |json| RequestItem.from_json(json, request) } %>
 
             <% request_item.map do |item| %>
               <span class="inline-block p-1 mr-1 mb-2 lg:mb-0 bg-white border border-gray-600 rounded-sm">

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -65,7 +65,8 @@
               <tr>
                 <th>Item</th>
                 <th>Quantity</th>
-                <th>Estimated on-hand</th>
+                <th>Fulfillment Location Inventory</th>
+                <th>Total Inventory</th>
               </tr>
               </thead>
               <tbody>
@@ -73,6 +74,7 @@
                 <tr>
                   <td><%= item.name %></td>
                   <td><%= item.quantity %></td>
+                  <td><%= item.on_hand_for_location %></td>
                   <td><%= item.on_hand %></td>
                 </tr>
               <% end %>

--- a/spec/models/request_item_spec.rb
+++ b/spec/models/request_item_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RequestItem, type: :model do
       end
 
       subject do
-        organization.update!(default_storage_location: location)
+        organization.update!(default_storage_location: location.id)
         described_class.from_json(request_item_json.first, request)
       end
 

--- a/spec/models/request_item_spec.rb
+++ b/spec/models/request_item_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe RequestItem, type: :model do
         ]
       end
 
-      subject { described_class.from_json(request_item_json.first, organization, location) }
+      subject do
+        organization.update!(default_storage_location: location)
+        described_class.from_json(request_item_json.first, request)
+      end
 
       before(:each) do
         create(:inventory_item,

--- a/spec/models/request_item_spec.rb
+++ b/spec/models/request_item_spec.rb
@@ -4,24 +4,54 @@
 RSpec.describe RequestItem, type: :model do
   context "Methods >" do
     describe "#from_json" do
-      let(:organization) { build :organization }
-      let(:request) { build :request, organization: organization }
-      let(:request_item_json) { request.request_items.first }
-      let(:item) { Item.find(request_item_json['item_id']) }
+      let(:organization) { create :organization }
+      let(:location) { create :storage_location, organization: organization }
+      let(:other_location) { create :storage_location, organization: organization }
+      let(:request) { build :request, organization: organization, request_items: request_item_json }
+      let(:item1) { create(:item, organization: organization) }
+      let(:item2) { create(:item, organization: organization) }
+      let(:request_item_json) do
+        [
+          {item_id: item1.id, quantity: 15}.stringify_keys,
+          {item_id: item2.id, quantity: 18}.stringify_keys
+        ]
+      end
 
-      subject { described_class.from_json(request_item_json, organization) }
+      subject { described_class.from_json(request_item_json.first, organization, location) }
+
+      before(:each) do
+        create(:inventory_item,
+          storage_location: other_location,
+          item_id: item1.id,
+          quantity: 10)
+        create(:inventory_item,
+          storage_location: location,
+          item_id: item1.id,
+          quantity: 20)
+        create(:inventory_item,
+          storage_location: other_location,
+          item_id: item2.id,
+          quantity: 30)
+        create(:inventory_item,
+          storage_location: location,
+          item_id: item2.id,
+          quantity: 40)
+      end
 
       it 'has the correct name' do
-        expect(subject.name).to eq(item.name)
+        expect(subject.name).to eq(item1.name)
       end
 
       it 'has the correct quantity' do
-        expect(subject.quantity).to eq(request_item_json['quantity'])
+        expect(subject.quantity).to eq(15)
       end
 
       it 'has the correct amount on hand' do
-        # NOTE: this is an unpersisted organization that shouldn't have anything on hand
-        expect(subject.on_hand).to eq(0)
+        expect(subject.on_hand).to eq(30)
+      end
+
+      it 'has the correct amount on hand for location' do
+        expect(subject.on_hand_for_location).to eq(20)
       end
     end
   end

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "Requests", type: :system, js: true do
     it "should show the request with a request sender if a partner user is set" do
       visit subject
       expect(page).to have_content("Request from #{request.partner.name}")
-      expect(page).to have_content("Estimated on-hand")
+      expect(page).to have_content("Fulfillment Location Inventory")
       expect(page).to have_content("Request Sender:")
       partner_user = request.partner_user
       expect(page).to have_content("#{partner_user.name} <#{partner_user.email}>")
@@ -132,7 +132,7 @@ RSpec.describe "Requests", type: :system, js: true do
       request.save!
       visit subject
       expect(page).to have_content("Request from #{request.partner.name}")
-      expect(page).to have_content("Estimated on-hand")
+      expect(page).to have_content("Fulfillment Location Inventory")
       expect(page).to have_content("Request Sender:")
       expect(page).not_to have_content("#{partner_user.name} <#{partner_user.email}>")
     end


### PR DESCRIPTION
Resolves #2895.

### Description
Adds the current inventory of the default storage location (if provided) for a request in additional to the total inventory for the organization.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Local and unit tests. Note that I haven't had time to do more in-depth tests, but both the request and item specs are passing, so I'm reasonably confident this should work.

### Screenshots
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/1986893/170788599-10ac5781-f2cd-4831-a90c-15cda1e3487b.png">