### PR TITLE
Add matrix gem to Gemfile 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem "omniauth-rails_csrf_protection"
 # Allow login via Google.
 gem "omniauth-google-oauth2"
 
+gem "matrix"
 # Generate PDFs as views.
 gem "prawn-rails"
 # Reduces boilerplate HTML code when writing forms.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -643,6 +643,7 @@ DEPENDENCIES
   listen (~> 3.7.0)
   lograge
   magic_test
+  matrix
   mini_racer (~> 0.6.0)
   money-rails
   nokogiri (>= 1.10.4)


### PR DESCRIPTION
The matrix gem was removed from Ruby core with ruby 3.1 and prawn requires it. Until there is a new version of prawn released we need to add the gem to the gem file so we can deploy to heroic.