### PR TITLE
Bug fix for question form

### DIFF
--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -41,8 +41,8 @@ class Admin::QuestionsController < AdminController
   private
 
   def error_messages(errors)
-    errors.map { |attribute, message|
-      "#{attribute.to_s.humanize(capitalize: true)} #{message}. "
+    errors.to_a.map { |attribute, message|
+      "#{attribute.to_s.humanize(capitalize: true)}#{message}. "
     }.join("")
   end
 

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -13,7 +13,7 @@ class Admin::QuestionsController < AdminController
     if @question.save
       redirect_to admin_questions_path
     else
-      flash[:error] = "Failed to create question. #{error_messages(@question.errors)}"
+      flash[:error] = "Failed to create question. #{@question.punctuate(@question.errors.to_a)}"
       render :new
     end
   end
@@ -27,7 +27,7 @@ class Admin::QuestionsController < AdminController
     if @question.update(question_params)
       redirect_to admin_questions_path
     else
-      flash[:error] = "Failed to update question. #{error_messages(@question.errors)}"
+      flash[:error] = "Failed to update question. #{@question.punctuate(@question.errors.to_a)}"
       render :edit
     end
   end
@@ -39,12 +39,6 @@ class Admin::QuestionsController < AdminController
   end
 
   private
-
-  def error_messages(errors)
-    errors.to_a.map { |attribute, message|
-      "#{attribute.to_s.humanize(capitalize: true)}#{message}. "
-    }.join("")
-  end
 
   def current_question
     @current_question ||= Question.find(params[:id])

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -24,4 +24,15 @@ class Question < ApplicationRecord
       :search_title
     ]
   )
+
+  def punctuate(errors)
+    remove_redundant_error(errors).map { |error| error + ". " }.join("")
+  end
+
+  def remove_redundant_error(errors)
+    if errors.include?("For banks and for partners can't both be unchecked")
+      errors.delete("For banks and for partners can't both be unchecked")
+    end
+    errors
+  end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -67,4 +67,27 @@ RSpec.describe Question, type: :model do
       expect(question).to_not be_valid
     end
   end
+
+  describe "remove_redundant_error" do
+    it "should return an array with only one error message related to the checkboxes." do
+      question = build(:question)
+      errors = [
+        "For banks and for partners can't both be unchecked",
+        "For partners and for banks can't both be unchecked"
+      ]
+      expect(question.remove_redundant_error(errors)).to eq ["For partners and for banks can't both be unchecked"]
+    end
+  end
+
+  describe "punctuate" do
+    it "should punctuate each string in a given array" do
+      sentences = [
+        "This is a sentence",
+        "This is another sentence",
+        "This is a third sentence"
+      ]
+      question = build(:question)
+      expect(question.punctuate(sentences)).to eq "This is a sentence. This is another sentence. This is a third sentence. "
+    end
+  end
 end


### PR DESCRIPTION
### Description

This PR fixes a bug with the super admin question form. Validation messages are supposed to be displayed across the top of the screen, but this is no longer working correctly.

Before:
  
![Screenshot (493)](https://user-images.githubusercontent.com/42154066/171506957-b3c42c05-d8ee-44a7-ba75-336e1e58ef5c.png)

After:

![Screenshot (496)](https://user-images.githubusercontent.com/42154066/171507524-14d84671-29b7-4f0c-aaee-b84281c993ff.png)

I also made a change that removes some redundancy in the error messages.  If both checkboxes are not checked, two messages that mean the same thing would get displayed one after the other. Now only one of those messages gets shown.

Before:

![Screenshot (497)](https://user-images.githubusercontent.com/42154066/171509665-9a5a360c-0c01-4132-8d09-c12868a0a5df.png)

After:

![Screenshot (499)](https://user-images.githubusercontent.com/42154066/171510371-a2fb9ef3-f840-49b3-88a2-57e2ce8be2c2.png)


### Type of change

* Bug fix (non-breaking change which fixes an issue)
* Small optimization for the user interface

### How Has This Been Tested?

Visual confirmation and I wrote some tests.

If anything needs to change, please let me know.