### PR TITLE
2961 - Updated readme.md to install Yarn project dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ This app uses Ruby version 3.0.2, indicated in `/.ruby-version` and `Gemfile`, w
 ### Yarn Installation
 If you don't have Yarn installed, you can install with Homebrew on macOS `brew install yarn` or visit [https://yarnpkg.com/en/docs/install](https://yarnpkg.com/en/docs/install). Be sure to run `yarn install` after installing Yarn. NOTE: It's possible that Node version 12 may cause you problems, see issue #751. Node 10 or 11 seem to be fine.
 
+### Install dependencies using Yarn
+Run `yarn` to install project dependencies.
+
 ### Create your .env with database credentials
 Be sure to create a `.env` file in the root of the app that includes the following lines (change to whatever is appropriate for your system):
 ```


### PR DESCRIPTION
Resolves #2961

### Description
This change addresses the error returned indicating that `webpack-dev-server` is not found when trying to start the application with the command `bin/start`. 

This change is only to update the `README.md` file with a step to run the `yarn` command after installing Yarn. Running `yarn` will install all the project dependencies specified in the `yarn.lock` file.

### Type of change
* Documentation update

### How Has This Been Tested?
To test this change, the `yarn` command was run and verified the app started up successfully with `bin/start`.
