### PR TITLE
Adds back in bootstrap select

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "strong_migrations", "0.8.0"
 
 ##### JAVSCRIPT/CSS/ASSETS #######
 
+gem 'bootstrap-select-rails'
 # Bootstrap is a library for HTML, CSS and JS.
 gem 'bootstrap', '~> 4.6.0'
 # jQuery framework (DOM methods, Ajax, chaining, etc.)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
+    bootstrap-select-rails (1.13.8)
     brakeman (5.2.3)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
@@ -607,6 +608,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap (~> 4.6.0)
+  bootstrap-select-rails
   brakeman
   bugsnag
   bullet

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery
 //= require popper
 //= require bootstrap
+//= require bootstrap-select
 // require jquery_ujs
 //= require filterrific/filterrific-jquery
 //= require bootstrap/alert

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@
 @import 'AdminLTE';
 @import 'bootstrap';
 @import 'simple_form-bootstrap/simple_form-bootstrap';
+@import 'bootstrap-select';
 @import 'progress_stepper';
 @import 'audits';
 @import 'modal-dialog';

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -69,7 +69,8 @@
                 <%= f.input :intake_location, :collection => current_organization.storage_locations.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Intake Location", :include_blank => true, wrapper: :input_group %>
 
                 <%= f.label :partner_form_fields, "Required Partner Fields" %>
-                <%= f.select(:partner_form_fields, Organization::ALL_PARTIALS, {include_hidden: false}, { multiple: true, class: 'form-control input_group' }) %>
+
+                <%= f.select(:partner_form_fields, Organization::ALL_PARTIALS, {include_hidden: false}, { multiple: true, class: 'form-control selectpicker input_group' }) %>
                 <br>
                 <%= f.input :default_storage_location, :collection => current_organization.storage_locations.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Storage Location", :include_blank => true, wrapper: :input_group %>
 


### PR DESCRIPTION
Bootstrap select was taken out by accident -- I don't think we realized it was being used. This puts it back in and allows the banks to once again select which form fields their partners need.

Before:
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/667909/173432053-41240013-2a20-4cad-883f-533bfd311ece.png">

After:
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/667909/173432179-ece0465c-e39a-401e-818b-92e48b89153e.png">
