### PR TITLE
Avoid erroring out when missing inventory data

### DIFF
--- a/app/services/distribution_itemized_breakdown_service.rb
+++ b/app/services/distribution_itemized_breakdown_service.rb
@@ -20,14 +20,21 @@ class DistributionItemizedBreakdownService
   def fetch
     items_distributed = fetch_items_distributed
 
+
     # Inject the "onhand" data
     items_distributed.map! do |item|
       item_name = item[:name]
 
+      below_onhand_minimum = if current_onhand_quantities[item_name] && current_onhand_minimums[item_name]
+                               current_onhand_quantities[item_name] < current_onhand_minimums[item_name]
+                             else
+                               nil
+                             end
+
       item.merge({
         current_onhand: current_onhand_quantities[item_name],
         onhand_minimum: current_onhand_minimums[item_name],
-        below_onhand_minimum: current_onhand_quantities[item_name] < current_onhand_minimums[item_name]
+        below_onhand_minimum: below_onhand_minimum
       })
     end
 

--- a/app/services/distribution_itemized_breakdown_service.rb
+++ b/app/services/distribution_itemized_breakdown_service.rb
@@ -20,16 +20,13 @@ class DistributionItemizedBreakdownService
   def fetch
     items_distributed = fetch_items_distributed
 
-
     # Inject the "onhand" data
     items_distributed.map! do |item|
       item_name = item[:name]
 
       below_onhand_minimum = if current_onhand_quantities[item_name] && current_onhand_minimums[item_name]
-                               current_onhand_quantities[item_name] < current_onhand_minimums[item_name]
-                             else
-                               nil
-                             end
+        current_onhand_quantities[item_name] < current_onhand_minimums[item_name]
+      end
 
       item.merge({
         current_onhand: current_onhand_quantities[item_name],

--- a/app/views/dashboard/_itemized_partial.html.erb
+++ b/app/views/dashboard/_itemized_partial.html.erb
@@ -13,7 +13,7 @@
         <td>&nbsp&nbsp&nbsp<%= item[:name] %></td>
         <td><%= item[:distributed] %></td>
         <td class="<%= 'table-danger' if item[:below_onhand_minimum] %>">
-          <%= item[:current_onhand] %>
+          <%= item[:current_onhand] || "Unknown" %>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
### Description

Fix issue in `DistributionItemizedBreakdownService` which leads to raising 500 errors when inventory data is missing for an item. This is causing users to not be able to access their dashboard.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested locally

### Screenshots
<img width="956" alt="Captura de Pantalla 2022-06-14 a la(s) 9 34 33 p m" src="https://user-images.githubusercontent.com/11335191/173724422-1e3e4d24-9a94-4ad0-913b-5169d444297b.png">

