### PR TITLE
fixed deactivated partner show issue, added test

### DIFF
--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -58,7 +58,7 @@
                   <h4 class='text-2xl underline'> Partner Status </h4>
                 </div>
                 <% if @partner.deactivated? %>
-                  <%= reactivate_button_to reactivate_partner_path(@partner), { confirm: confirm_reactivate_msg(partner.name), size: 'm' } %>
+                  <%= reactivate_button_to reactivate_partner_path(@partner), { confirm: confirm_reactivate_msg(@partner.name), size: 'm' } %>
                 <% else %>
                   <%= deactivate_button_to deactivate_partner_path(@partner), { text: "Deactivate Partner", confirm: confirm_deactivate_msg(@partner.name), size: 'm' } %>
                 <% end %>

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -226,6 +226,15 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         end
       end
 
+      context "when viewing a deactivated partner" do
+        let(:deactivated) { create(:partner, name: "Deactivated Partner", status: :deactivated) }
+        subject { url_prefix + "/partners/#{deactivated.id}" }
+        it 'allows reactivation ' do
+          visit subject
+          expect(page).to have_selector(:link_or_button, 'Reactivate')
+        end
+      end
+
       context "when exporting as CSV" do
         subject { url_prefix + "/partners/#{partner.id}" }
 


### PR DESCRIPTION
Resolves #3011

### Description
Fixed error in partner show that was causing deactivated partners not to be displayed.
Added a test 
  
Note:  this is blocking the final tests on another bug (issue 3009)
### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Manually checked that deactivated partners can be displayed .  See issue for details
- added  specific test for deactivated show
- ran all partner show tests

