### PR TITLE
Ensure compilation of all assets occur only once for each test suite run

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -66,7 +66,7 @@ jobs:
           yarn
           bundle exec rake db:create
           bundle exec rake db:schema:load
-          bundle exec rails webpacker:compile
+          bundle exec rails assets:precompile
       - name: Run rspec
         env:
           POSTGRES_HOST: localhost

--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -7,7 +7,7 @@ if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
     bundle exec rake knapsack_pro:rspec # use Regular Mode here always
 else
     # Regular Mode
-    bundle exec rake knapsack_pro:rspec
+    bundle exec rake knapsack_pro:queue:rspec
 
     # or you can use Queue Mode instead of Regular Mode if you like
     # bundle exec rake knapsack_pro:queue:rspec

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -283,48 +283,6 @@ def seed_base_items_for_tests
   Rails.logger.info "~-=> Done creating Base Items!"
 end
 
-def __start_db_cleaning_with_log
-  Rails.logger.info "======> SISYPHUS, PUSH THAT BOULDER BACK UP THE HILL <========"
-  Rails.logger.info <<~ASCIIART
-        ,-'"""`-.
-      ,'         `.
-      /        `    \\
-    (    /          \)
-    |             " |
-    (               \)
-    `.\\\\          \\ /
-      `:.      , \\ ,\\ _
-    hh  `:-.___,-`-.{\\\)
-          `.         |/ \\
-            `.         \\ \\
-              `-.      _\\,|
-                `.   |,-||
-                  `..|| ||
-  ASCIIART
-
-  DatabaseCleaner.start
-end
-
-def __sweep_up_db_with_log
-  DatabaseCleaner.clean
-  Rails.logger.info "========= ONE MUST IMAGINE SISYPHUS HAPPY ===================="
-  Rails.logger.info <<~ASCIIART
-                  /             _
-        ,-'"""`-.    /         _ |
-      ,'         `.      ;    {\\\)|
-    /        `    \\   :. :   /\\ \\
-    (    /          | .     _/  \\ \\
-    |             " |;  .-``.   _\\,|
-    (               |.-`     `-|,-||
-    \\\\            /.`         ||.||
-      :.     ,   ,`               |.
-    amh  :-.___,-``
-            .`
-          .`
-      .-`
-  ASCIIART
-end
-
 def create_organization
   Rails.logger.info "\n\n-~=> Creating DEFAULT organization"
   @organization = create(:organization, name: "DEFAULT", skip_items: true)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,11 +92,6 @@ def stub_addresses
   end
 end
 
-# Create global var for use in
-# config.before(:each, type: :system)
-# below
-# have_run_webpacker_for_specs = false
-
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
@@ -142,6 +137,11 @@ RSpec.configure do |config|
 
   # Preparatifyication
   config.before(:suite) do
+    unless File.exist?(Rails.root.join("public", "packs-task"))
+      Rails.logger.info "Detected missing webpack assets for testing. Running compilation step"
+      `NODE_ENV=test bin/webpack`
+    end
+
     Rails.logger.info <<~ASCIIART
       -~~==]}>        ######## ###########  ####      ########    ###########
       -~~==]}>      #+#    #+#    #+#     #+# #+#    #+#     #+#     #+#

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,7 +95,7 @@ end
 # Create global var for use in
 # config.before(:each, type: :system)
 # below
-have_run_webpacker_for_specs = false
+# have_run_webpacker_for_specs = false
 
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
@@ -171,15 +171,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do
-    unless have_run_webpacker_for_specs
-      Rails.logger.info "** Running webpack"
-
-      # Compile assets neccessary for browser tests to pass
-      `NODE_ENV=test bin/webpack`
-
-      have_run_webpacker_for_specs = true
-    end
-
     # Use truncation in the case of doing `browser` tests because it
     # appears that transactions won't work since it really does
     # depend on the database to have records.


### PR DESCRIPTION

### Description

This updates the section of testing suite setup that aimed to ensure `webpack` runs once per suite run. Under closer inspection, it appears that the original code wasn't working, and webpack compiling was occurring on every test suite unnecessarily. Individual tests aren't affected by this but the time adds up when running the whole test suite.

Another addition: Use `queue` mode for knapsack so that our tests are better distributed.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
This has been tested locally & via CI

### Screenshots
Here is a snapshot of before & after the use of `queue` mode. Notice that with queue mode the time between the first node passing and the last has decreased by alot!

Before queue mode:
![Captura de Pantalla 2022-07-17 a la(s) 7 33 39 a m](https://user-images.githubusercontent.com/11335191/179398541-ec8be2e3-00e4-423b-9e55-e443d33c4e74.png)

After queue mode:
![Captura de Pantalla 2022-07-17 a la(s) 7 33 45 a m](https://user-images.githubusercontent.com/11335191/179398550-7f15e492-d81e-42e7-883d-fecd0c0c09c3.png)

