### PR TITLE
build: skip factory_bot_lint & brakeman on docs

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'bin/*'
 
 jobs:
   brakeman:

--- a/.github/workflows/factory-bot-lint.yml
+++ b/.github/workflows/factory-bot-lint.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'bin/*'
 
 jobs:
   factory_bot_lint:


### PR DESCRIPTION
Copies path ignore patterns from our rspec workflow to the factory-bot-lint and brakeman workflows.