### PR TITLE
Undoing accidental change of earlier migration.  Mea culpa.  Mea maxi…

### DIFF
--- a/db/migrate/20220410141231_add_partner_tables.rb
+++ b/db/migrate/20220410141231_add_partner_tables.rb
@@ -127,7 +127,7 @@ class AddPartnerTables < ActiveRecord::Migration[7.0]
         t.text "evidence_based_description"
         t.text "program_client_improvement"
         t.string "diaper_use"
-        t.string "receives_essentials_from_other"
+        t.string "other_diaper_use"
         t.boolean "currently_provide_diapers"
         t.boolean "turn_away_child_care"
         t.string "program_address1"


### PR DESCRIPTION
### Description

I did a db:drop and then ran bin/setup - lo and behold, there was a problem,  and the problem was caused by me.  
This fixes an obviously careless change to the partner tables setup migration


### Type of change


* Bug fix (non-breaking change which fixes an issue)
### How Has This Been Tested?

Dropped the database and reran the db setup.   
I have not rerun the rspec