### PR TITLE
refactory test and move logic to model - partner user invite service

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -108,12 +108,8 @@ class PartnersController < ApplicationController
 
   def invite_partner_user
     partner = current_organization.partners.find(params[:partner])
-    existing_partner_user = PartnerUser.find_by(email: params[:email], partner: partner.profile)
-    if existing_partner_user
-      existing_partner_user.invite!
-    else
-      PartnerUser.invite!(email: params[:email], partner: partner.profile)
-    end
+    partner_user_invite_service = PartnerUserInviteService.new(partner: partner, email: params[:email])
+    partner_user_invite_service.call
 
     redirect_to partner_path(partner), notice: "We have invited #{params[:email]} to #{partner.name}!"
   rescue StandardError => e

--- a/app/services/partner_user_invite_service.rb
+++ b/app/services/partner_user_invite_service.rb
@@ -8,7 +8,7 @@ class PartnerUserInviteService
 
   def call
     if existing_partner_user.present?
-      partner_user.invite!
+      existing_partner_user.invite!
     else
       PartnerUser.invite!(email: email, partner: partner.profile)
     end

--- a/app/services/partner_user_invite_service.rb
+++ b/app/services/partner_user_invite_service.rb
@@ -1,0 +1,24 @@
+class PartnerUserInviteService
+  include ServiceObjectErrorsMixin
+
+  def initialize(partner:, email:)
+    @partner = partner
+    @email = email
+  end
+
+  def call
+    if existing_partner_user.present?
+      partner_user.invite!
+    else
+      PartnerUser.invite!(email: email, partner: partner.profile)
+    end
+  end
+
+  private
+
+  attr_reader :partner, :email
+
+  def existing_partner_user
+    @existing_partner_user ||= PartnerUser.find_by(email: email, partner: partner.profile)
+  end
+end

--- a/spec/factories/partner_user.rb
+++ b/spec/factories/partner_user.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :partner_user, class: PartnerUser do
+    name { "Partner User" }
+    sequence(:email) { |n| "partner__user_#{n}@example.com" }
+    partner { Partners::Partner.first || create(:partners_partner) }
+    password { "password!" }
+    password_confirmation { "password!" }
+    invitation_sent_at { Time.current - 1.day }
+    last_sign_in_at { Time.current }
+  end
+end

--- a/spec/factories/partner_user.rb
+++ b/spec/factories/partner_user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :partner_user, class: PartnerUser do
     name { "Partner User" }
-    sequence(:email) { |n| "partner__user_#{n}@example.com" }
+    sequence(:email) { |n| "partner___user_#{n}@example.com" }
     partner { Partners::Partner.first || create(:partners_partner) }
     password { "password!" }
     password_confirmation { "password!" }

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -296,11 +296,12 @@ RSpec.describe "Partners", type: :request do
       end
     end
 
-    context 'when there is error in invite' do
+    context 'when there is an error in invite' do
       let(:error_message) { 'Error message' }
       before do
         allow(PartnerUserInviteService).to receive(:new).and_raise(StandardError.new(error_message))
       end
+
       it 'redirect to partner url with error message' do
         subject.call
         expect(response).to redirect_to(partner_path(partner))

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -277,6 +277,38 @@ RSpec.describe "Partners", type: :request do
     end
   end
 
+  describe "POST #invite_partner_user" do
+    subject { -> { post invite_partner_user_partner_path(default_params.merge(id: partner.id, partner: partner.id, email: email)) } }
+    let(:partner) { create(:partner, organization: @organization) }
+    let(:email) { Faker::Internet.email }
+    let(:fake_partner_user_invite_service) { instance_double(PartnerUserInviteService, call: -> {}) }
+
+    before do
+      allow(PartnerUserInviteService).to receive(:new).with(partner: partner, email: email).and_return(fake_partner_user_invite_service)
+    end
+
+    context 'when the invite successfully' do
+      it "send the invite" do
+        subject.call
+        expect(fake_partner_user_invite_service).to have_received(:call)
+        expect(response).to redirect_to(partner_path(partner))
+        expect(flash[:notice]).to eq("We have invited #{email} to #{partner.name}!")
+      end
+    end
+
+    context 'when there is error in invite' do
+      let(:error_message) { 'Error message' }
+      before do
+        allow(PartnerUserInviteService).to receive(:new).and_raise(StandardError.new(error_message))
+      end
+      it 'redirect to partner url with error message' do
+        subject.call
+        expect(response).to redirect_to(partner_path(partner))
+        expect(flash[:error]).to eq("Failed to invite #{email} to #{partner.name} due to: #{error_message}")
+      end
+    end
+  end
+
   describe "PUT #deactivate" do
     let(:partner) { create(:partner, organization: @organization, status: "approved") }
 

--- a/spec/services/partner_user_invite_service_spec.rb
+++ b/spec/services/partner_user_invite_service_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe PartnerUserInviteService, skip_seed: true do
+  let(:partner) { create(:partner) }
+  let(:email) { Faker::Internet.email }
+  let!(:partner_user) { instance_spy(PartnerUser) }
+
+  describe "#call" do
+    subject { described_class.new(partner: partner, email: email).call }
+
+    context "when partner user exist in database" do
+      before do
+        allow(PartnerUser).to receive(:find_by).with(email: email, partner: partner.profile).and_return(partner_user)
+      end
+
+      it "calls invite! partner user method" do
+        subject
+        expect(partner_user).to have_received(:invite!)
+      end
+    end
+
+    context "when partner user doesnt exist in database" do
+      before do
+        allow(PartnerUser).to receive(:invite!)
+        allow(PartnerUser).to receive(:find_by).with(email: email, partner: partner.profile)
+      end
+
+      it "calls invite! PartnerUser class method" do
+        subject
+        expect(PartnerUser).to have_received(:invite!).with(email: email, partner: partner.profile)
+      end
+    end
+  end
+end

--- a/spec/services/partner_user_invite_service_spec.rb
+++ b/spec/services/partner_user_invite_service_spec.rb
@@ -8,7 +8,7 @@ describe PartnerUserInviteService, skip_seed: true do
   describe "#call" do
     subject { described_class.new(partner: partner, email: email).call }
 
-    context "when partner user exist in database" do
+    context "when the partner user exist in database" do
       before do
         allow(PartnerUser).to receive(:find_by).with(email: email, partner: partner.profile).and_return(partner_user)
       end
@@ -19,7 +19,7 @@ describe PartnerUserInviteService, skip_seed: true do
       end
     end
 
-    context "when partner user doesnt exist in database" do
+    context "when the partner user doesnt exist in database" do
       before do
         allow(PartnerUser).to receive(:invite!)
         allow(PartnerUser).to receive(:find_by).with(email: email, partner: partner.profile)


### PR DESCRIPTION
### Description

This PR has a goal to move partner user invite logic from controller to new service,  and improve test coverage.

### Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?
- login as Organization Admin
- go to partner detail page
- click on "Add user to partner" button

### Screenshots
#Before refactory
![image](https://user-images.githubusercontent.com/836472/180626137-8ebbc2df-16d7-4392-a611-55671663408f.png)

#After refactory
![image](https://user-images.githubusercontent.com/836472/180626058-47363686-5620-4924-81e9-98c4ad668309.png)

