### PR TITLE
[#3059] downcase partner email

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -47,6 +47,7 @@ class Partner < ApplicationRecord
 
   validate :correct_document_mime_type
 
+  before_save { email&.downcase! }
   before_update :invite_new_partner, if: :should_invite_because_email_changed?
 
   scope :for_csv_export, ->(organization, *) {

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe Partner, type: :model, skip_seed: true do
     end
   end
 
+  context "callbacks" do
+    it "properly downcases email" do
+      partner = create(:partner, name: "Foo", email: "Foo@example.com")
+      expect(partner.email).to eq("foo@example.com")
+    end
+  end
+
   describe "Filters" do
     describe "by_status" do
       it "yields partners with the provided status" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3059 

### Description
In order to always ensure the email is properly down case if felt right to leverage an activerecord callback. In this case, I was between `before_save` vs. `before_validation`. In my opinion, since there was a case insensitivity check in the email uniqueness, it felt right to put it in `before_save` since I generally like to group data manipulations in a small set of callbacks (generally `before_save`). I can also be persuaded to place this as a `before_validation` and to drop the case sensitivity specific search, but that assumes that no emails have slipped through the cracks and it becomes less safe.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Peformed functional testing as a bank adding and editing partner.
2. Added in new context for callbacks and tested downcasing there.

