### PR TITLE
Fix issue in which itemized breakdown of donations & distributions were identical

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -687,4 +687,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.6
+   2.3.19

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,7 +13,9 @@ class DashboardController < ApplicationController
     distributions = current_organization.distributions.includes(:partner).during(helpers.selected_range)
     @recent_distributions = distributions.recent
 
+    @itemized_donation_data = DonationItemizedBreakdownService.new(organization: current_organization, donation_ids: @donations.pluck(:id)).fetch
     @itemized_distribution_data = DistributionItemizedBreakdownService.new(organization: current_organization, distribution_ids: distributions.pluck(:id)).fetch
+
     @total_inventory = current_organization.total_inventory
 
     @org_stats = OrganizationStats.new(current_organization)

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -8,7 +8,6 @@
 #  address2                       :string
 #  agency_mission                 :text
 #  agency_type                    :string
-#  ages_served                    :string
 #  application_data               :text
 #  at_fpl_or_below                :integer
 #  case_management                :boolean
@@ -22,7 +21,6 @@
 #  essentials_funding_source      :string
 #  essentials_use                 :string
 #  evidence_based                 :boolean
-#  evidence_based_description     :text
 #  executive_director_email       :string
 #  executive_director_name        :string
 #  executive_director_phone       :string
@@ -32,16 +30,12 @@
 #  greater_2_times_fpl            :integer
 #  income_requirement_desc        :boolean
 #  income_verification            :boolean
-#  incorporate_plan               :text
-#  internal_db                    :boolean
-#  maac                           :boolean
 #  more_docs_required             :string
 #  name                           :string
 #  new_client_times               :string
 #  other_agency_type              :string
 #  partner_status                 :string           default("pending")
 #  pick_up_email                  :string
-#  pick_up_method                 :string
 #  pick_up_name                   :string
 #  pick_up_phone                  :string
 #  population_american_indian     :integer
@@ -61,21 +55,16 @@
 #  program_address2               :string
 #  program_age                    :string
 #  program_city                   :string
-#  program_client_improvement     :text
 #  program_description            :text
 #  program_name                   :string
 #  program_state                  :string
 #  program_zip_code               :integer
 #  receives_essentials_from_other :string
-#  responsible_staff_position     :boolean
-#  serve_income_circumstances     :boolean
 #  sources_of_diapers             :string
 #  sources_of_funding             :string
 #  state                          :string
 #  status_in_diaper_base          :string
 #  storage_space                  :boolean
-#  trusted_pickup                 :boolean
-#  turn_away_child_care           :boolean
 #  twitter                        :string
 #  website                        :string
 #  zip_code                       :string

--- a/app/services/donation_itemized_breakdown_service.rb
+++ b/app/services/donation_itemized_breakdown_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class DonationItemizedBreakdownService
+  #
+  # Initialize the DonationItemizedBreakdownService
+  #
+  # @param organization [Organization]
+  # @param donation_ids [Array<Integer>]
+  # @return [DonationItemizedBreakdownService]
+  def initialize(organization:, donation_ids:)
+    @organization = organization
+    @donation_ids = donation_ids
+  end
+
+  def fetch
+    items_donated_hash.map do |item_name, hash|
+      { 
+        current_onhand: current_onhand_quantities[item_name],
+        name: item_name, 
+        donated: hash[:donated] 
+      }
+    end
+  end
+
+  private
+
+  attr_reader :organization, :donation_ids
+
+  def donations
+    @donations ||= Donation.where(id: donation_ids).includes(line_items: :item)
+  end
+
+  def current_onhand_quantities
+    @current_onhand_quantities ||= organization.inventory_items.group("items.name").sum(:quantity)
+  end
+
+  def items_donated_hash
+    item_distribution_hash = donations.each_with_object({}) do |d, acc|
+      d.line_items.each do |i|
+        key = i.item.name
+        acc[key] ||= { donated: 0 }
+        acc[key][:donated] += i.quantity
+      end
+    end
+  end
+
+end

--- a/app/services/donation_itemized_breakdown_service.rb
+++ b/app/services/donation_itemized_breakdown_service.rb
@@ -14,10 +14,10 @@ class DonationItemizedBreakdownService
 
   def fetch
     items_donated_hash.map do |item_name, hash|
-      { 
+      {
         current_onhand: current_onhand_quantities[item_name],
-        name: item_name, 
-        donated: hash[:donated] 
+        name: item_name,
+        donated: hash[:donated]
       }
     end
   end
@@ -35,13 +35,12 @@ class DonationItemizedBreakdownService
   end
 
   def items_donated_hash
-    item_distribution_hash = donations.each_with_object({}) do |d, acc|
+    donations.each_with_object({}) do |d, acc|
       d.line_items.each do |i|
         key = i.item.name
-        acc[key] ||= { donated: 0 }
+        acc[key] ||= {donated: 0}
         acc[key][:donated] += i.quantity
       end
     end
   end
-
 end

--- a/app/views/dashboard/_itemized_distributions_partial.html.erb
+++ b/app/views/dashboard/_itemized_distributions_partial.html.erb
@@ -1,0 +1,21 @@
+<table class="table table-hover striped">
+  <thead>
+  <tr>
+    <th>&nbsp&nbsp&nbspItem</th>
+    <th>Total Distributed</th>
+    <th>Total On Hand</th>
+  </tr>
+  </thead>
+  <% # Ordering from highest distributed to lowest %>
+  <% (local_assigns[:itemized_breakdown] || []).each do |item| %>
+    <tbody>
+      <tr>
+        <td>&nbsp&nbsp&nbsp<%= item[:name] %></td>
+        <td><%= item[:distributed] %></td>
+        <td class="<%= 'table-danger' if item[:below_onhand_minimum] %>">
+          <%= item[:current_onhand] || "Unknown" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/dashboard/_itemized_donations_partial.html.erb
+++ b/app/views/dashboard/_itemized_donations_partial.html.erb
@@ -2,19 +2,17 @@
   <thead>
   <tr>
     <th>&nbsp&nbsp&nbspItem</th>
-    <th>Total Distributed</th>
+    <th>Total Donated</th>
     <th>Total On Hand</th>
   </tr>
   </thead>
   <% # Ordering from highest distributed to lowest %>
-  <% @itemized_distribution_data.each do |item| %>
+  <% (local_assigns[:itemized_breakdown] || []).each do |item| %>
     <tbody>
       <tr>
         <td>&nbsp&nbsp&nbsp<%= item[:name] %></td>
-        <td><%= item[:distributed] %></td>
-        <td class="<%= 'table-danger' if item[:below_onhand_minimum] %>">
-          <%= item[:current_onhand] || "Unknown" %>
-        </td>
+        <td><%= item[:donated] %></td>
+        <td><%= item[:current_onhand] || "Unknown" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -140,7 +140,7 @@
               <%= download_button_to(itemized_breakdown_distributions_path(format: :csv, filters: { date_range: date_range_params }), {text: "Export To CSV"}) %>
             </div>
             
-            <%= render partial: "itemized_partial" %>
+            <%= render partial: "itemized_distributions_partial", locals: { itemized_breakdown: @itemized_distribution_data } %>
           </div>
         </div>
 
@@ -313,7 +313,7 @@
             </div>
           </div>
           <div class="box-body table-responsive no-padding">
-            <%= render partial: "itemized_partial", object: @donations, as: :item_to_itemize %>
+            <%= render partial: "itemized_donations_partial", locals: { itemized_breakdown: @itemized_donation_data } %>
           </div>
         </div>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -767,7 +767,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_22_215911) do
   add_foreign_key "partner_users", "partner_profiles", column: "partner_id"
   add_foreign_key "partners", "storage_locations", column: "default_storage_location_id"
   add_foreign_key "product_drives", "organizations"
-  add_foreign_key "product_drives", "organizations"
   add_foreign_key "requests", "distributions"
   add_foreign_key "requests", "organizations"
   add_foreign_key "requests", "partners"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -767,6 +767,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_22_215911) do
   add_foreign_key "partner_users", "partner_profiles", column: "partner_id"
   add_foreign_key "partners", "storage_locations", column: "default_storage_location_id"
   add_foreign_key "product_drives", "organizations"
+  add_foreign_key "product_drives", "organizations"
   add_foreign_key "requests", "distributions"
   add_foreign_key "requests", "organizations"
   add_foreign_key "requests", "partners"

--- a/spec/models/partners/partner_spec.rb
+++ b/spec/models/partners/partner_spec.rb
@@ -8,7 +8,6 @@
 #  address2                       :string
 #  agency_mission                 :text
 #  agency_type                    :string
-#  ages_served                    :string
 #  application_data               :text
 #  at_fpl_or_below                :integer
 #  case_management                :boolean
@@ -22,7 +21,6 @@
 #  essentials_funding_source      :string
 #  essentials_use                 :string
 #  evidence_based                 :boolean
-#  evidence_based_description     :text
 #  executive_director_email       :string
 #  executive_director_name        :string
 #  executive_director_phone       :string
@@ -32,16 +30,12 @@
 #  greater_2_times_fpl            :integer
 #  income_requirement_desc        :boolean
 #  income_verification            :boolean
-#  incorporate_plan               :text
-#  internal_db                    :boolean
-#  maac                           :boolean
 #  more_docs_required             :string
 #  name                           :string
 #  new_client_times               :string
 #  other_agency_type              :string
 #  partner_status                 :string           default("pending")
 #  pick_up_email                  :string
-#  pick_up_method                 :string
 #  pick_up_name                   :string
 #  pick_up_phone                  :string
 #  population_american_indian     :integer
@@ -61,21 +55,16 @@
 #  program_address2               :string
 #  program_age                    :string
 #  program_city                   :string
-#  program_client_improvement     :text
 #  program_description            :text
 #  program_name                   :string
 #  program_state                  :string
 #  program_zip_code               :integer
 #  receives_essentials_from_other :string
-#  responsible_staff_position     :boolean
-#  serve_income_circumstances     :boolean
 #  sources_of_diapers             :string
 #  sources_of_funding             :string
 #  state                          :string
 #  status_in_diaper_base          :string
 #  storage_space                  :boolean
-#  trusted_pickup                 :boolean
-#  turn_away_child_care           :boolean
 #  twitter                        :string
 #  website                        :string
 #  zip_code                       :string

--- a/spec/services/donation_itemized_breakdown_service_spec.rb
+++ b/spec/services/donation_itemized_breakdown_service_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+RSpec.describe DonationItemizedBreakdownService, type: :service, skip_seed: true do
+  let(:organization) { create(:organization) }
+  let(:donation_ids) { [donation_1, donation_2, donation_3].map(&:id) }
+  let(:item_a) { create(:item, organization: organization) }
+  let(:item_b) { create(:item, organization: organization) }
+  let(:donation_1) { create(:donation, :with_items, item: item_a, item_quantity: 500, organization: organization) }
+  let(:donation_2) { create(:donation, :with_items, item: item_a, item_quantity: 500, organization: organization) }
+  let(:donation_3) { create(:donation, :with_items, item: item_b, item_quantity: 500, organization: organization) }
+
+  let(:expected_output) do
+    [
+      { name: item_a.name, donated: 1200, current_onhand: 1100 },
+      { name: item_b.name, donated: 500, current_onhand: 600 }
+    ]
+  end
+
+  describe '#fetch' do
+    subject { described_class.new(organization: organization, donation_ids: donation_ids).fetch }
+
+    it 'return the list of items donated with distributed' do
+      expect(subject).to eq(expected_output)
+    end
+  end
+
+
+end

--- a/spec/services/donation_itemized_breakdown_service_spec.rb
+++ b/spec/services/donation_itemized_breakdown_service_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe DonationItemizedBreakdownService, type: :service, skip_seed: true do
   let(:organization) { create(:organization) }
   let(:donation_ids) { [donation_1, donation_2, donation_3].map(&:id) }
@@ -10,18 +11,16 @@ RSpec.describe DonationItemizedBreakdownService, type: :service, skip_seed: true
 
   let(:expected_output) do
     [
-      { name: item_a.name, donated: 1200, current_onhand: 1100 },
-      { name: item_b.name, donated: 500, current_onhand: 600 }
+      {name: item_a.name, donated: 1200, current_onhand: 1100},
+      {name: item_b.name, donated: 500, current_onhand: 600}
     ]
   end
 
-  describe '#fetch' do
+  describe "#fetch" do
     subject { described_class.new(organization: organization, donation_ids: donation_ids).fetch }
 
-    it 'return the list of items donated with distributed' do
+    it "return the list of items donated with distributed" do
       expect(subject).to eq(expected_output)
     end
   end
-
-
 end

--- a/spec/services/donation_itemized_breakdown_service_spec.rb
+++ b/spec/services/donation_itemized_breakdown_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DonationItemizedBreakdownService, type: :service, skip_seed: true
 
   let(:expected_output) do
     [
-      {name: item_a.name, donated: 1200, current_onhand: 1100},
+      {name: item_a.name, donated: 1000, current_onhand: 1200},
       {name: item_b.name, donated: 500, current_onhand: 600}
     ]
   end


### PR DESCRIPTION
Resolves #3057 

### Description

This PR fixes the issue reported in #3057 in which the dashboard partial for itemized distribution & donations was identical. The problem stems from not properly separating the two partials and the locals that get passed into it. It is addressed in this PR by:
- Add new service object for generating itemized breakdown of donations /w spec.
- Utilize two different partials for itemized donation & distribution and pass down inputs into them.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested locally

### Screenshots
Noticed that both the partials are different now:
![Captura de Pantalla 2022-07-30 a la(s) 4 54 43 p m](https://user-images.githubusercontent.com/11335191/181995950-3e7f7c7e-1b25-4cac-960a-917f79c5bf2f.png)
![Captura de Pantalla 2022-07-30 a la(s) 4 54 46 p m](https://user-images.githubusercontent.com/11335191/181995951-533f0364-7766-41e4-8f8d-ce5f3823393b.png)

