### PR TITLE
3063 - add partner name to individual distribution view

### DIFF
--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -5,7 +5,7 @@
         <% content_for :title, "#{@distribution.storage_location.name} - Distributions - #{current_organization.name}" %>
         <h1>
           Distribution
-          <small>for <%= @distribution.storage_location.name %></small>
+          <small>from <%= @distribution.storage_location.name %> to <%=@distribution.partner.name %></small>
         </h1>
       </div>
       <div class="col-sm-6">

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -5,7 +5,7 @@
         <% content_for :title, "#{@distribution.storage_location.name} - Distributions - #{current_organization.name}" %>
         <h1>
           Distribution
-          <small>from <%= @distribution.storage_location.name %> to <%=@distribution.partner.name %></small>
+          <small>from <%= @distribution.storage_location.name %> to <b><%=@distribution.partner.name %></b></small>
         </h1>
       </div>
       <div class="col-sm-6">

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -278,6 +278,16 @@ RSpec.feature "Distributions", type: :system, skip_seed: true do
     end
   end
 
+  context "When showing a individual distribution" do
+    let!(:distribution) { create(:distribution, :with_items, agency_rep: "A Person", organization: @user.organization, issued_at: Time.zone.today, state: :complete) }
+
+    before { visit @url_prefix + "/distributions/#{distribution.id}" }
+
+    it "Show partner name in title" do
+      expect(page).to have_content("Distribution from #{distribution.storage_location.name} to #{distribution.partner.name}")
+    end
+  end
+
   context "When creating a distribution from a donation" do
     let(:donation) { create :donation, :with_items }
     before do


### PR DESCRIPTION

Resolves #3063 

### Description

Stakeholder request to put partner name close to individual distribution title page

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- sign in as [user_1@example.com](mailto:user_1@example.com) (password: password!)
- Click on Distributions in the left menu
- click on ""view" for any of the shown distributions.
- In title page will be appear something like this "Distribution from Bulk Storage Location **to Pawnee Senior Citizens Center**"

![image](https://user-images.githubusercontent.com/836472/182269669-e561ed85-b6a7-43c9-a191-3fe4d2c69f8f.png)
