### PR TITLE
3034: Fix invalid transfers

### DIFF
--- a/db/migrate/20220805192937_fix_invalid_transfers.rb
+++ b/db/migrate/20220805192937_fix_invalid_transfers.rb
@@ -1,0 +1,7 @@
+class FixInvalidTransfers < ActiveRecord::Migration[7.0]
+  def change
+    Transfer.all.each do |transfer|
+      transfer.destroy if transfer.from.nil? || transfer.to.nil?
+    end
+  end
+end


### PR DESCRIPTION
Resolves #3034.

### Description
The underlying issue here is that there are a number of transfers for this organization that reference storage locations (ID 107, in particular) that no longer exist. Because these are defined as `dependent: destroy`, Rails *should* have deleted the transfers when the storage location was deleted. Unfortunately, because we don't seem to keep historical logs, I have no way of knowing how that location was deleted, so I don't know why the destroy action wasn't cascaded.

For now I've put in a migration that will delete all transfers that refer to invalid storage locations.

If this continues happening, I'm not sure how we can debug other than being able to view logs for a longer period of time to see what happened when the location was deleted.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

N/A