### PR TITLE
Fix fetch_latest_db task to pull from actual backup dump name

### DIFF
--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -41,7 +41,7 @@ def fetch_latest_backups
   #
   # Retrieve the most up to date version of the DB dump
   #
-  backup = backups.select { |b| b.name.match?("diaper.dump") }.sort do |a,b|
+  backup = backups.select { |b| b.name.match?(".dump") }.sort do |a,b|
     Time.parse(a.properties[:last_modified]) <=> Time.parse(b.properties[:last_modified])
   end.reverse.first
 


### PR DESCRIPTION
### Description

Whilst debugging an issue using production data, I noticed that the `rails fetch_latest_db` wasn't pulling the latest backup. On further inspection, this is because we've changed the name of the backup to exclude the word `diaper` and the current code is still looking to match backup names with `diaper`

This PR removes the reference to diaper so that the task now works.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally and I can confirm it is working!

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
