### PR TITLE
fix calendar timezone

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -54,6 +54,7 @@ document.addEventListener("DOMContentLoaded", function() {
   const calendarElement = document.getElementById('calendar');
   if (calendarElement) {
     new Calendar(calendarElement, {
+      timeZone: 'UTC',
       firstDay: 1,
       plugins: [luxonPlugin, dayGridPlugin, listPlugin],
       displayEventTime: true,

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -9,6 +9,20 @@ RSpec.feature "Distributions", type: :system, skip_seed: true do
     setup_storage_location(@storage_location)
   end
 
+  context "When go Pick Ups & Deliveries" do
+    let(:issued_at) { "2022-08-07 19:00:00".to_datetime }
+    before do
+      item1 = create(:item, value_in_cents: 1050)
+      @distribution = create(:distribution, :with_items, item: item1, agency_rep: "A Person", organization: @user.organization, issued_at: issued_at)
+    end
+
+    it "appears distribution in calendar with correct time" do
+      visit @url_prefix + "/distributions/schedule"
+      expect(page.find(".fc-event-time")).to have_content "7p"
+      expect(page.find(".fc-event-title")).to have_content @distribution.partner.name
+    end
+  end
+
   context "When creating a new distribution manually" do
     it "Allows a distribution to be created" do
       # update items to check for inactive ones

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -9,14 +9,14 @@ RSpec.feature "Distributions", type: :system, skip_seed: true do
     setup_storage_location(@storage_location)
   end
 
-  context "When go Pick Ups & Deliveries" do
+  context "When going to the Pick Ups & Deliveries page" do
     let(:issued_at) { "2022-08-07 19:00:00".to_datetime }
     before do
       item1 = create(:item, value_in_cents: 1050)
       @distribution = create(:distribution, :with_items, item: item1, agency_rep: "A Person", organization: @user.organization, issued_at: issued_at)
     end
 
-    it "appears distribution in calendar with correct time" do
+    it "appears distribution in calendar with correct time & timezone" do
       visit @url_prefix + "/distributions/schedule"
       expect(page.find(".fc-event-time")).to have_content "7p"
       expect(page.find(".fc-event-title")).to have_content @distribution.partner.name


### PR DESCRIPTION

Resolves #3078

### Description

This PR has a goal to fix javascript calendar timezone.
This component uses local timezone ( default ) , but we save our dates in database using UTC timezone.


### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Enter a new distribution. Specify the date and time
- Then go into "Pick Ups and Deliveries", the date/time is not what was entered.

### Screenshots

After correction

![image](https://user-images.githubusercontent.com/836472/183771720-97a9e261-6188-4140-8d5c-9e0111b159c0.png)

![image](https://user-images.githubusercontent.com/836472/183771770-d8043e63-4461-4a82-a61c-60d8898f5c98.png)


