### PR TITLE
Fix invite flow for org admins

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -576,7 +576,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
-    webmock (3.16.0)
+    webmock (3.17.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/app/services/partner_invite_service.rb
+++ b/app/services/partner_invite_service.rb
@@ -10,7 +10,7 @@ class PartnerInviteService
 
     existing_user = User.find_by(email: partner.email)
     if existing_user && existing_user.partner_id.nil?
-      existing_user.update!(partner_id: partner.id)
+      existing_user.update!(partner_id: partner.profile.id)
       return
     end
 

--- a/app/services/partner_invite_service.rb
+++ b/app/services/partner_invite_service.rb
@@ -9,7 +9,7 @@ class PartnerInviteService
     return self unless valid?
 
     existing_user = User.find_by(email: partner.email)
-    if existing_user
+    if existing_user && existing_user.partner_id.nil?
       existing_user.update!(partner_id: partner.id)
       return
     end

--- a/app/services/partner_invite_service.rb
+++ b/app/services/partner_invite_service.rb
@@ -8,6 +8,12 @@ class PartnerInviteService
   def call
     return self unless valid?
 
+    existing_user = User.find_by(email: partner.email)
+    if existing_user
+      existing_user.update!(partner_id: partner.id)
+      return
+    end
+
     partner.update!(status: 'invited')
     # skip invitation is necessary because when email will be send for this situation needs partner reference updated,
     # and, in this case, we create invite, reload object and send invitation email.

--- a/app/services/partner_user_invite_service.rb
+++ b/app/services/partner_user_invite_service.rb
@@ -10,6 +10,11 @@ class PartnerUserInviteService
     if existing_partner_user.present?
       existing_partner_user.invite!
     else
+      existing_user = User.find_by(email: email)
+      if existing_user && existing_user.partner_id.nil?
+        existing_user.update!(partner_id: partner.profile.id)
+        return
+      end
       User.invite!(email: email, partner: partner.profile)
     end
   end

--- a/spec/services/partner_user_invite_service_spec.rb
+++ b/spec/services/partner_user_invite_service_spec.rb
@@ -22,6 +22,7 @@ describe PartnerUserInviteService, skip_seed: true do
     context "when the partner user doesnt exist in database" do
       before do
         allow(User).to receive(:invite!)
+        allow(User).to receive(:find_by).with(email: email)
         allow(User).to receive(:find_by).with(email: email, partner: partner.profile)
       end
 


### PR DESCRIPTION
When a new partner user is created with an e-mail that already exists (i.e. we are adding a partner account to an existing organization user), the invite flow no longer works. This is likely because Devise invites the user blindly, but when it goes to create it, it can't because it already exists and therefore the partner_id isn't updated.

This change makes it so if the user already exists in the system, it will simply add the partner_id to that user and return immediately.