### PR TITLE
Seed change for ensuring verified@example.com can always request *something* 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -687,4 +687,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.19
+   2.3.20

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,7 +115,7 @@ Organization.all.each do |org|
   # Setup the Partner Group & their item categories
   partner_group = FactoryBot.create(:partner_group, organization: org)
 
-  total_item_categories_to_add = Faker::Number.between(from: 0, to: 2)
+  total_item_categories_to_add = Faker::Number.between(from: 1, to: 2)
   org.item_categories.sample(total_item_categories_to_add).each do |item_category|
     partner_group.item_categories << item_category
   end


### PR DESCRIPTION
Resolves #3076 

### Description

verified@example.com wasn't always able to request something on staging.   This should fix that.
Changed so that the partner group always has at least one category

  

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Visual confirmation.    Existing automated tests passed.
