### PR TITLE
Change default name to "Unnamed"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@
 #  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string           default("Unnamed"), not null
+#  name                   :string           default("Name Not Provided"), not null
 #  organization_admin     :boolean
 #  provider               :string
 #  remember_created_at    :datetime

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@
 #  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string           default("CHANGEME"), not null
+#  name                   :string           default("Unnamed"), not null
 #  organization_admin     :boolean
 #  provider               :string
 #  remember_created_at    :datetime

--- a/db/migrate/20220819190425_change_default_user_name.rb
+++ b/db/migrate/20220819190425_change_default_user_name.rb
@@ -1,0 +1,6 @@
+class ChangeDefaultUserName < ActiveRecord::Migration[7.0]
+  def change
+    change_column :users, :name, :string, default: 'Unnamed'
+    User.where(name: 'CHANGEME').update_all(name: 'Unnamed', updated_at: Time.zone.now)
+  end
+end

--- a/db/migrate/20220819190425_change_default_user_name.rb
+++ b/db/migrate/20220819190425_change_default_user_name.rb
@@ -1,6 +1,6 @@
 class ChangeDefaultUserName < ActiveRecord::Migration[7.0]
   def change
-    change_column :users, :name, :string, default: 'Unnamed'
-    User.where(name: 'CHANGEME').update_all(name: 'Unnamed', updated_at: Time.zone.now)
+    change_column :users, :name, :string, default: 'Name Not Provided'
+    User.where(name: 'CHANGEME').update_all(name: 'Name Not Provided', updated_at: Time.zone.now)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_22_215911) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_19_190425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -403,6 +403,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_22_215911) do
     t.boolean "repackage_essentials", default: false, null: false
     t.boolean "distribute_monthly", default: false, null: false
     t.bigint "ndbn_member_id"
+    t.boolean "enable_child_based_requests", default: true, null: false
+    t.boolean "enable_individual_requests", default: true, null: false
     t.index ["latitude", "longitude"], name: "index_organizations_on_latitude_and_longitude"
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end
@@ -510,6 +512,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_22_215911) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "other_agency_type"
     t.string "status_in_diaper_base"
+    t.boolean "enable_child_based_requests", default: true, null: false
+    t.boolean "enable_individual_requests", default: true, null: false
     t.index ["essentials_bank_id"], name: "index_partners_on_essentials_bank_id"
   end
 
@@ -694,7 +698,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_22_215911) do
     t.integer "invited_by_id"
     t.integer "invitations_count", default: 0
     t.boolean "organization_admin"
-    t.string "name", default: "CHANGEME", null: false
+    t.string "name", default: "Unnamed", null: false
     t.boolean "super_admin", default: false
     t.datetime "last_request_at", precision: nil
     t.datetime "discarded_at", precision: nil

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_19_190425) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_19_192440) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -698,7 +698,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_190425) do
     t.integer "invited_by_id"
     t.integer "invitations_count", default: 0
     t.boolean "organization_admin"
-    t.string "name", default: "Unnamed", null: false
+    t.string "name", default: "Name Not Provided", null: false
     t.boolean "super_admin", default: false
     t.datetime "last_request_at", precision: nil
     t.datetime "discarded_at", precision: nil

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,7 +18,7 @@
 #  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string           default("Unnamed"), not null
+#  name                   :string           default("Name Not Provided"), not null
 #  organization_admin     :boolean
 #  provider               :string
 #  remember_created_at    :datetime

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,7 +18,7 @@
 #  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string           default("CHANGEME"), not null
+#  name                   :string           default("Unnamed"), not null
 #  organization_admin     :boolean
 #  provider               :string
 #  remember_created_at    :datetime

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,7 +18,7 @@
 #  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string           default("Unnamed"), not null
+#  name                   :string           default("Name Not Provided"), not null
 #  organization_admin     :boolean
 #  provider               :string
 #  remember_created_at    :datetime

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,7 +18,7 @@
 #  last_request_at        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
-#  name                   :string           default("CHANGEME"), not null
+#  name                   :string           default("Unnamed"), not null
 #  organization_admin     :boolean
 #  provider               :string
 #  remember_created_at    :datetime


### PR DESCRIPTION

### Description

Per Slack discussion: https://rubyforgood.slack.com/archives/G01APA16DT9/p1660650111971589

"CHANGEME" is a jarring value for default user name. Using "Unnamed" is a first step towards us fixing this in a more permanent fashion.