### PR TITLE
Changed item_category factory to use paragraph_by_chars at a fixed 25…

### DIFF
--- a/spec/factories/item_categories.rb
+++ b/spec/factories/item_categories.rb
@@ -13,6 +13,6 @@ FactoryBot.define do
   factory :item_category do
     association :organization
     name { Faker::Appliance.unique.brand }
-    description { Faker::Lorem.sentence(word_count: 30) }
+    description { Faker::Lorem.paragraph_by_chars(number: 250) }
   end
 end


### PR DESCRIPTION
…0 chars instead of word count which could randomly break the 250 char valdiation limit

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description
Recently the seed process got stuck because the `:item_category` factory could randomly try to generate an instance with a description longer than 250 chars, which breaks the validation. 

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)