### PR TITLE
Fix variety of items on product drive

### DIFF
--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -53,7 +53,7 @@ class ProductDrive < ApplicationRecord
         item_ids << line_item.item_id
       end
     end
-    item_ids.uniq().size
+    item_ids.uniq.size
   end
 
   def in_kind_value

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -47,7 +47,7 @@ class ProductDrive < ApplicationRecord
   end
 
   def distinct_items_count
-    self.donations. joins(:line_items). select('line_items.item_id'). distinct. count
+    donations.joins(:line_items).select('line_items.item_id').distinct.count
   end
 
   def in_kind_value

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -47,13 +47,7 @@ class ProductDrive < ApplicationRecord
   end
 
   def distinct_items_count
-    item_ids = []
-    donations.each do |donation|
-      donation.line_items.each do |line_item|
-        item_ids << line_item.item_id
-      end
-    end
-    item_ids.uniq.size
+    self.donations. joins(:line_items). select('line_items.item_id'). distinct. count
   end
 
   def in_kind_value

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -46,8 +46,14 @@ class ProductDrive < ApplicationRecord
     donations.joins(:line_items).sum('line_items.quantity')
   end
 
-  def distinct_items
-    donations.joins(:items).distinct(:item_id).count
+  def distinct_items_count
+    item_ids = []
+    donations.each do |donation|
+      donation.line_items.each do |line_item|
+        item_ids << line_item.item_id
+      end
+    end
+    item_ids.uniq().size
   end
 
   def in_kind_value

--- a/app/views/product_drives/index.html.erb
+++ b/app/views/product_drives/index.html.erb
@@ -94,7 +94,7 @@
                   <td><%= product_drive.end_date&.strftime("%m-%d-%Y") %></td>
                   <td><%= is_virtual(product_drive: product_drive) %></td>
                   <td class="text-right"><%= product_drive.donation_quantity %></td>
-                  <td class="text-right"><%= product_drive.distinct_items %></td>
+                  <td class="text-right"><%= product_drive.distinct_items_count %></td>
                   <td class="text-right"><strong><%= dollar_value(product_drive.in_kind_value) %></strong></td>
                   <td class="text-right"><%= view_button_to product_drive_path(product_drive.id) %></td>
                 </tr>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_22_215911) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_15_160156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/models/product_drive_spec.rb
+++ b/spec/models/product_drive_spec.rb
@@ -28,10 +28,6 @@ RSpec.describe ProductDrive, type: :model, skip_seed: true do
     expect(product_drive.in_kind_value).to be_a Integer
   end
 
-
-
-
-
   describe "validations" do
     it { expect(build(:product_drive, name: nil)).not_to be_valid }
     it { expect(build(:product_drive, start_date: nil)).not_to be_valid }
@@ -50,41 +46,35 @@ RSpec.describe ProductDrive, type: :model, skip_seed: true do
   end
 
   describe "distinct_items" do
-
     let!(:item_1) { create(:item, name: "item_1") }
     let!(:item_2) { create(:item, name: "item_2") }
     let!(:item_3) { create(:item, name: "item_3") }
     let!(:item_4) { create(:item, name: "item_4") }
 
     it("counts the items correctly for 1 donation with multiple items") do
-      product_drive =  create(:product_drive)
-      donation_1 =  create(:donation, product_drive: product_drive)
+      product_drive = create(:product_drive)
+      donation_1 = create(:donation, product_drive: product_drive)
 
-      line_item_1_1 = create(:line_item,  itemizable: donation_1, item: item_1, quantity: 4)
-      line_item_1_2 = create(:line_item,  itemizable: donation_1, item: item_2, quantity: 5)
-      line_item_1_3 = create(:line_item,  itemizable: donation_1, item: item_3, quantity: 6)
+      line_item_1_1 = create(:line_item, itemizable: donation_1, item: item_1, quantity: 4)
+      line_item_1_2 = create(:line_item, itemizable: donation_1, item: item_2, quantity: 5)
+      line_item_1_3 = create(:line_item, itemizable: donation_1, item: item_3, quantity: 6)
 
       print line_item_1_1.item_id
       print line_item_1_2.item_id
       print line_item_1_3.item_id
 
-
       donation_1.line_items << line_item_1_1
       donation_1.line_items << line_item_1_2
       donation_1.line_items << line_item_1_3
-      donation_1.save()
-
-
       expect(product_drive.distinct_items_count).to eq 3
     end
 
-
     it("doesn't double_count the items if there are two donations for the same item") do
-      product_drive =  create(:product_drive)
-      donation_1 =  create(:donation, product_drive: product_drive)
-      donation_2 =  create(:donation, product_drive: product_drive)
-      line_item_1_1 = create(:line_item,  itemizable: donation_1, item: item_1, quantity: 4)
-      line_item_2_1 = create(:line_item,  itemizable: donation_2, item: item_1, quantity: 75)
+      product_drive = create(:product_drive)
+      donation_1 = create(:donation, product_drive: product_drive)
+      donation_2 = create(:donation, product_drive: product_drive)
+      line_item_1_1 = create(:line_item, itemizable: donation_1, item: item_1, quantity: 4)
+      line_item_2_1 = create(:line_item, itemizable: donation_2, item: item_1, quantity: 75)
 
       donation_1.line_items << line_item_1_1
       donation_2.line_items << line_item_2_1
@@ -92,29 +82,23 @@ RSpec.describe ProductDrive, type: :model, skip_seed: true do
     end
 
     it("counts the distinct items correctly in overlapping donations") do
+      product_drive = create(:product_drive)
+      donation_1 = create(:donation, product_drive: product_drive)
+      donation_2 = create(:donation, product_drive: product_drive)
+      line_item_1_1 = create(:line_item, itemizable: donation_1, item: item_1, quantity: 4)
+      line_item_1_2 = create(:line_item, itemizable: donation_1, item: item_2, quantity: 5)
+      line_item_2_1 = create(:line_item, itemizable: donation_2, item: item_1, quantity: 75)
+      line_item_2_4 = create(:line_item, itemizable: donation_2, item: item_4, quantity: 65)
 
-      product_drive =  create(:product_drive)
-      donation_1 =  create(:donation, product_drive: product_drive)
-      donation_2 =  create(:donation, product_drive: product_drive)
-      line_item_1_1 = create(:line_item,  itemizable: donation_1, item: item_1, quantity: 4)
-      line_item_1_2 = create(:line_item,  itemizable: donation_1, item: item_2, quantity: 5)
-      line_item_2_1 = create(:line_item,  itemizable: donation_2, item: item_1, quantity: 75)
-      line_item_2_4 = create(:line_item,  itemizable: donation_2, item: item_4, quantity: 65)
+      donation_1.line_items << line_item_1_1
+      donation_1.line_items << line_item_1_2
 
-      donation_1.line_items << line_item_1_1;
-      donation_1.line_items << line_item_1_2;
-
-      donation_2.line_items << line_item_2_1;
-      donation_2.line_items << line_item_2_4;
+      donation_2.line_items << line_item_2_1
+      donation_2.line_items << line_item_2_4
 
       expect(product_drive.distinct_items_count).to eq 3
     end
-
   end
-
-
-
-
 
   describe "scopes" do
     describe ".by_name" do


### PR DESCRIPTION
Resolves #3101 
### Description

"Variety of items" on product drives screen is wrong.   This came back to the "distinct_items" on product_drives being incorrect.   

- added tests
- change the name to distinct_items_count (because it doesn't return the items)
- made it work

It is, perhaps a naive solution.

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* 
### How Has This Been Tested?

Wrote automated tests to confirm that it works in the following cases:
- 1 donation with multiple items
- 2 donations with overlapping items
- 2 donations with same items

(truth to tell, we could probably just use the 2 donations with overlapping items)