### PR TITLE
Speed up & unflake specs in CI

### DIFF
--- a/.github/workflows/rspec-system.yml
+++ b/.github/workflows/rspec-system.yml
@@ -13,7 +13,7 @@ on:
       - 'bin/*'
 
 jobs:
-  rspec:
+  rspec-system:
 
     runs-on: ubuntu-latest
 
@@ -36,10 +36,10 @@ jobs:
         # Set N number of parallel jobs you want to run tests on.
         # Use higher number if you have slow tests to split them on more parallel jobs.
         # Remember to update ci_node_index below to 0..N-1
-        ci_node_total: [2]
+        ci_node_total: [4]
         # set N-1 indexes for parallel jobs
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
-        ci_node_index: [0, 1]
+        ci_node_index: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/rspec-system.yml
+++ b/.github/workflows/rspec-system.yml
@@ -36,10 +36,10 @@ jobs:
         # Set N number of parallel jobs you want to run tests on.
         # Use higher number if you have slow tests to split them on more parallel jobs.
         # Remember to update ci_node_index below to 0..N-1
-        ci_node_total: [6]
+        ci_node_total: [2]
         # set N-1 indexes for parallel jobs
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
-        ci_node_index: [0, 1, 2, 3, 4, 5]
+        ci_node_index: [0, 1]
     steps:
       - uses: actions/checkout@v2
 
@@ -51,7 +51,7 @@ jobs:
       - name: Install PostgreSQL client
         run: |
           sudo apt-get -yqq install libpq-dev
-      - name: Build App
+      - name: Build App with asset compilation
         env:
           POSTGRES_HOST: localhost
           DATABASE_HOST: localhost
@@ -62,8 +62,10 @@ jobs:
           RAILS_ENV: test
         run: |
           bundle exec skylight disable_dev_warning
+          yarn
           bundle exec rake db:create
           bundle exec rake db:schema:load
+          bundle exec rails assets:precompile
       - name: Run rspec
         env:
           POSTGRES_HOST: localhost
@@ -81,7 +83,7 @@ jobs:
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_LOG_LEVEL: info
-          KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN: "{spec/system/**{,/*/**}/*_spec.rb,spec/requests/**{,/*/**}/*_spec.rb}"
+          KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/system/**{,/*/**}/*_spec.rb,spec/requests/**{,/*/**}/*_spec.rb}"
         run: |
           RUBYOPT='-W:no-deprecated -W:no-experimental' bin/knapsack_pro_rspec
       - name: Upload artifacts

--- a/.github/workflows/rspec-system.yml
+++ b/.github/workflows/rspec-system.yml
@@ -1,4 +1,4 @@
-name: rspec
+name: rspec-system
 
 on:
   push:
@@ -80,7 +80,6 @@ jobs:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_LOG_LEVEL: info
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/system/**{,/*/**}/*_spec.rb,spec/requests/**{,/*/**}/*_spec.rb}"

--- a/.github/workflows/rspec-system.yml
+++ b/.github/workflows/rspec-system.yml
@@ -36,10 +36,10 @@ jobs:
         # Set N number of parallel jobs you want to run tests on.
         # Use higher number if you have slow tests to split them on more parallel jobs.
         # Remember to update ci_node_index below to 0..N-1
-        ci_node_total: [4]
+        ci_node_total: [6]
         # set N-1 indexes for parallel jobs
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
-        ci_node_index: [0, 1, 2, 3]
+        ci_node_index: [0, 1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/rspec-system.yml
+++ b/.github/workflows/rspec-system.yml
@@ -60,6 +60,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
           RAILS_ENV: test
+          NODE_ENV: test
         run: |
           bundle exec skylight disable_dev_warning
           yarn
@@ -77,6 +78,7 @@ jobs:
           PGHOST: localhost
           PGUSER: postgres
           RAILS_ENV: test
+          NODE_ENV: test
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -36,10 +36,10 @@ jobs:
         # Set N number of parallel jobs you want to run tests on.
         # Use higher number if you have slow tests to split them on more parallel jobs.
         # Remember to update ci_node_index below to 0..N-1
-        ci_node_total: [4]
+        ci_node_total: [2]
         # set N-1 indexes for parallel jobs
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
-        ci_node_index: [0, 1, 2, 3]
+        ci_node_index: [0, 1]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -78,7 +78,6 @@ jobs:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_LOG_LEVEL: info
           KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN: "{spec/system/**{,/*/**}/*_spec.rb,spec/requests/**{,/*/**}/*_spec.rb}"

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -36,10 +36,10 @@ jobs:
         # Set N number of parallel jobs you want to run tests on.
         # Use higher number if you have slow tests to split them on more parallel jobs.
         # Remember to update ci_node_index below to 0..N-1
-        ci_node_total: [6]
+        ci_node_total: [4]
         # set N-1 indexes for parallel jobs
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
-        ci_node_index: [0, 1, 2, 3, 4, 5]
+        ci_node_index: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -36,10 +36,10 @@ jobs:
         # Set N number of parallel jobs you want to run tests on.
         # Use higher number if you have slow tests to split them on more parallel jobs.
         # Remember to update ci_node_index below to 0..N-1
-        ci_node_total: [12]
+        ci_node_total: [6]
         # set N-1 indexes for parallel jobs
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        ci_node_index: [0, 1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v2
 

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -33,6 +33,7 @@ module Partners
         flash[:success] = 'Request was successfully created.'
         redirect_to partners_request_path(create_service.partner_request.id)
       else
+
         @partner_request = create_service.partner_request
         @errors = create_service.errors
         @formatted_requestable_items = Organization.find(current_partner.essentials_bank_id).valid_items.map do |item|

--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -1,14 +1,3 @@
 #!/bin/bash
 
-if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
-  KNAPSACK_PRO_ENDPOINT=https://api-disabled-for-fork.knapsackpro.com \
-    KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
-    KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
-    bundle exec rake knapsack_pro:rspec # use Regular Mode here always
-else
-    # Regular Mode
-    bundle exec rake knapsack_pro:queue:rspec
-
-    # or you can use Queue Mode instead of Regular Mode if you like
-    # bundle exec rake knapsack_pro:queue:rspec
-fi
+bundle exec rake knapsack_pro:rspec

--- a/spec/controllers/donation_sites_controller_spec.rb
+++ b/spec/controllers/donation_sites_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DonationSitesController, type: :controller, skip_seed: true do
+RSpec.describe DonationSitesController, type: :controller do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DonationsController, type: :controller, skip_seed: true do
+RSpec.describe DonationsController, type: :controller do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe HelpController, type: :controller, skip_seed: true do
+RSpec.describe HelpController, type: :controller do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ItemsController, type: :controller, skip_seed: true do
+RSpec.describe ItemsController, type: :controller do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe TransfersController, type: :controller, skip_seed: true do
+RSpec.describe TransfersController, type: :controller do
   context "While signed in" do
     before do
       sign_in(@user)

--- a/spec/factories/partners/child.rb
+++ b/spec/factories/partners/child.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
     first_name           { Faker::Name.first_name }
     last_name            { Faker::Name.last_name }
     gender               { Faker::Gender.binary_type }
-    item_needed_diaperid { rand(1..10) }
+    item_needed_diaperid { Item.all.sample.id }
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ApplicationHelper, type: :helper, skip_seed: true do
+RSpec.describe ApplicationHelper, type: :helper do
   describe "dashboard_path_from_user" do
     before(:each) do
       allow(helper).to receive(:current_user).and_return(user)

--- a/spec/helpers/product_drive_helper_spec.rb
+++ b/spec/helpers/product_drive_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ProductDriveHelper, type: :helper, skip_seed: true do
+RSpec.describe ProductDriveHelper, type: :helper do
   describe '#is_virtual' do
     context 'when the product drive was held virtually' do
       let(:product_drive) { build(:product_drive, virtual: true) }

--- a/spec/helpers/ui_helper_spec.rb
+++ b/spec/helpers/ui_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe UiHelper, type: :helper, skip_seed: true do
+RSpec.describe UiHelper, type: :helper do
   describe 'optional_data_text' do
     subject { helper.optional_data_text(field) }
 

--- a/spec/jobs/notify_partner_job_spec.rb
+++ b/spec/jobs/notify_partner_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe NotifyPartnerJob, job: true, skip_seed: true do
+RSpec.describe NotifyPartnerJob, job: true do
   describe "#perform" do
     let(:request) { create(:request) }
     let(:mailer) { double(:mailer) }

--- a/spec/jobs/partner_mailer_job_spec.rb
+++ b/spec/jobs/partner_mailer_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PartnerMailerJob, type: :job, skip_seed: true do
+RSpec.describe PartnerMailerJob, type: :job do
   describe "conditionally sending the emails" do
     let(:organization) { create :organization }
     let(:mailer_subject) { 'PartnerMailerJob subject' }

--- a/spec/jobs/reminder_deadline_job_spec.rb
+++ b/spec/jobs/reminder_deadline_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ReminderDeadlineJob, type: :job, skip_seed: true do
+describe ReminderDeadlineJob, type: :job do
   describe '#perform' do
     subject { -> { described_class.perform_now } }
     let(:partner) { create(:partner) }

--- a/spec/mailers/account_request_mailer_spec.rb
+++ b/spec/mailers/account_request_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AccountRequestMailer, type: :mailer, skip_seed: true do
+RSpec.describe AccountRequestMailer, type: :mailer do
   describe '#confirmation' do
     let(:mail) { AccountRequestMailer.confirmation(account_request_id: account_request_id) }
     let(:account_request_id) { account_request.id }

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe CustomDeviseMailer, type: :mailer, skip_seed: true do
+RSpec.describe CustomDeviseMailer, type: :mailer do
   describe "#invitation_instructions" do
     let(:user) { create(:user) }
     let(:mail) { described_class.invitation_instructions(user, SecureRandom.uuid) }

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionMailer, type: :mailer, needs_users: true do
+RSpec.describe DistributionMailer, type: :mailer do
   before do
     @organization.default_email_text = "Default email text example\n\n%{delivery_method} %{distribution_date}\n\n%{partner_name}\n\n%{comment}"
     @partner = create(:partner, name: 'PARTNER')

--- a/spec/mailers/organization_mailer_spec.rb
+++ b/spec/mailers/organization_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe OrganizationMailer, type: :mailer, skip_seed: true do
+RSpec.describe OrganizationMailer, type: :mailer do
   describe "#partner_approval_request" do
     subject { described_class.partner_approval_request(organization: organization, partner: partner) }
     let(:partner) { create(:partner) }

--- a/spec/mailers/partner_mailer_spec.rb
+++ b/spec/mailers/partner_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PartnerMailer, type: :mailer, skip_seed: true do
+RSpec.describe PartnerMailer, type: :mailer do
   describe "#recertification_request" do
     subject { PartnerMailer.recertification_request(partner: partner) }
     let(:partner) { create(:partner) }

--- a/spec/mailers/reminder_deadline_mailer_spec.rb
+++ b/spec/mailers/reminder_deadline_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe ReminderDeadlineMailer, type: :job, skip_seed: true do
+describe ReminderDeadlineMailer, type: :job do
   describe 'notify deadline' do
     let(:today) { Date.new(2022, 1, 10) }
     let(:partner) { create(:partner) }

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RequestMailer, type: :mailer, skip_seed: true do
+RSpec.describe RequestMailer, type: :mailer do
   describe "#request_cancel_partner_notification" do
     subject { described_class.request_cancel_partner_notification(request_id: request.id) }
     let(:request) { create(:request) }

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RequestsConfirmationMailer, type: :mailer, skip_seed: true do
+RSpec.describe RequestsConfirmationMailer, type: :mailer do
   let(:request) { create(:request) }
 
   describe "#confirmation_email" do

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -16,7 +16,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe AccountRequest, type: :model, skip_seed: true do
+RSpec.describe AccountRequest, type: :model do
   let(:account_request) { FactoryBot.create(:account_request) }
 
   describe 'associations' do

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -13,7 +13,8 @@
 
 RSpec.describe Adjustment, type: :model, needs_users: true do
   it_behaves_like "itemizable"
-  it_behaves_like "pagination"
+  # This mixes feature specs with model specs... idealy we do not want to do this
+  # it_behaves_like "pagination"
 
   context "Validations >" do
     it "must belong to an organization" do

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -11,7 +11,7 @@
 #  user_id             :bigint
 #
 
-RSpec.describe Adjustment, type: :model, needs_users: true do
+RSpec.describe Adjustment, type: :model do
   it_behaves_like "itemizable"
   # This mixes feature specs with model specs... idealy we do not want to do this
   # it_behaves_like "pagination"

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -14,7 +14,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Audit, type: :model, needs_users: true do
+RSpec.describe Audit, type: :model do
   it_behaves_like "itemizable"
 
   context "Validations >" do

--- a/spec/models/barcode_item_spec.rb
+++ b/spec/models/barcode_item_spec.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples "common barcode tests" do |barcode_item_factory|
   end
 end
 
-RSpec.describe BarcodeItem, type: :model, skip_seed: true do
+RSpec.describe BarcodeItem, type: :model do
   context "Barcodes of BaseItems ('Global')" do
     let(:base_item) { create(:base_item) }
     let(:global_barcode_item) { create(:global_barcode_item, barcodeable: base_item) }

--- a/spec/models/concerns/deadlinable_spec.rb
+++ b/spec/models/concerns/deadlinable_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Deadlinable, type: :model, skip_seed: true do
+RSpec.describe Deadlinable, type: :model do
   let(:dummy_class) do
     Class.new do
       def self.name

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -16,7 +16,7 @@
 #  storage_location_id    :integer
 #
 
-RSpec.describe Distribution, type: :model, skip_seed: true do
+RSpec.describe Distribution, type: :model do
   it_behaves_like "itemizable"
 
   context "Validations >" do

--- a/spec/models/donation_site_spec.rb
+++ b/spec/models/donation_site_spec.rb
@@ -12,7 +12,7 @@
 #  organization_id :integer
 #
 
-RSpec.describe DonationSite, type: :model, skip_seed: true do
+RSpec.describe DonationSite, type: :model do
   context "Validations >" do
     it "must belong to an organization" do
       expect(build(:donation_site, organization_id: nil)).not_to be_valid

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -19,7 +19,8 @@
 
 RSpec.describe Donation, type: :model, needs_users: true do
   it_behaves_like "itemizable"
-  it_behaves_like "pagination"
+  # This mixes feature specs with model specs... idealy we do not want to do this
+  # it_behaves_like "pagination"
 
   context "Validations >" do
     it "must belong to an organization" do

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -17,7 +17,7 @@
 #  storage_location_id          :integer
 #
 
-RSpec.describe Donation, type: :model, needs_users: true do
+RSpec.describe Donation, type: :model do
   it_behaves_like "itemizable"
   # This mixes feature specs with model specs... idealy we do not want to do this
   # it_behaves_like "pagination"

--- a/spec/models/inventory_item_spec.rb
+++ b/spec/models/inventory_item_spec.rb
@@ -10,7 +10,7 @@
 #  storage_location_id :integer
 #
 
-RSpec.describe InventoryItem, type: :model, skip_seed: true do
+RSpec.describe InventoryItem, type: :model do
   context "Validations >" do
     describe "quantity >" do
       it "is required" do

--- a/spec/models/item_category_spec.rb
+++ b/spec/models/item_category_spec.rb
@@ -11,7 +11,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe ItemCategory, type: :model, skip_seed: true do
+RSpec.describe ItemCategory, type: :model do
   describe 'validations' do
     subject { build(:item_category) }
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -21,7 +21,7 @@
 #  organization_id              :integer
 #
 
-RSpec.describe Item, type: :model, skip_seed: true do
+RSpec.describe Item, type: :model do
   describe 'Assocations >' do
     it { should belong_to(:item_category).optional }
   end

--- a/spec/models/kit_spec.rb
+++ b/spec/models/kit_spec.rb
@@ -13,7 +13,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe Kit, type: :model, skip_seed: true do
+RSpec.describe Kit, type: :model do
   let(:kit) { build(:kit, name: "Test Kit") }
 
   context "Validations >" do

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -11,7 +11,7 @@
 #  itemizable_id   :integer
 #
 
-RSpec.describe LineItem, type: :model, skip_seed: true do
+RSpec.describe LineItem, type: :model do
   let(:line_item) { build :line_item }
 
   context "Validations >" do

--- a/spec/models/manufacturer_spec.rb
+++ b/spec/models/manufacturer_spec.rb
@@ -11,7 +11,7 @@
 
 require "rails_helper"
 
-RSpec.describe Manufacturer, type: :model, skip_seed: true do
+RSpec.describe Manufacturer, type: :model do
   context "Validations" do
     it "must belong to an organization" do
       expect(build(:manufacturer, organization: nil)).not_to be_valid

--- a/spec/models/organization_stats_spec.rb
+++ b/spec/models/organization_stats_spec.rb
@@ -1,7 +1,7 @@
 # == No Schema Information
 #
 
-RSpec.describe OrganizationStats, type: :model, skip_seed: true do
+RSpec.describe OrganizationStats, type: :model do
   let(:partners) { [] }
   let(:storage_locations) { [] }
   let(:donation_sites) { [] }

--- a/spec/models/partner_group_spec.rb
+++ b/spec/models/partner_group_spec.rb
@@ -11,7 +11,7 @@
 #  updated_at      :datetime         not null
 #  organization_id :bigint
 #
-RSpec.describe PartnerGroup, type: :model, skip_seed: true do
+RSpec.describe PartnerGroup, type: :model do
   describe 'associations' do
     it { should belong_to(:organization) }
     it { should have_many(:partners) }

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -16,7 +16,7 @@
 #  partner_group_id            :bigint
 #
 
-RSpec.describe Partner, type: :model, skip_seed: true do
+RSpec.describe Partner, type: :model do
   describe 'associations' do
     it { should belong_to(:organization) }
     it { should belong_to(:partner_group).optional }

--- a/spec/models/partners/authorized_family_member_spec.rb
+++ b/spec/models/partners/authorized_family_member_spec.rb
@@ -14,7 +14,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::AuthorizedFamilyMember, type: :model, skip_seed: true do
+RSpec.describe Partners::AuthorizedFamilyMember, type: :model do
   describe 'associations' do
     it { should belong_to(:family) }
     it { should have_many(:child_item_requests).dependent(:nullify) }

--- a/spec/models/partners/child_item_request_spec.rb
+++ b/spec/models/partners/child_item_request_spec.rb
@@ -14,7 +14,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe Partners::ChildItemRequest, type: :model, skip_seed: true do
+RSpec.describe Partners::ChildItemRequest, type: :model do
   describe 'associations' do
     it { should belong_to(:item_request) }
     it { should belong_to(:child) }

--- a/spec/models/partners/child_spec.rb
+++ b/spec/models/partners/child_spec.rb
@@ -21,7 +21,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::Child, type: :model, skip_seed: true do
+RSpec.describe Partners::Child, type: :model do
   describe 'associations' do
     it { should belong_to(:family) }
     it { should have_many(:child_item_requests).dependent(:destroy) }

--- a/spec/models/partners/family_spec.rb
+++ b/spec/models/partners/family_spec.rb
@@ -26,7 +26,7 @@
 
 require "rails_helper"
 
-RSpec.describe Partners::Family, type: :model, skip_seed: true do
+RSpec.describe Partners::Family, type: :model do
   describe "associations" do
     it { should belong_to(:partner) }
     it { should have_many(:children).dependent(:destroy) }

--- a/spec/models/partners/item_request_spec.rb
+++ b/spec/models/partners/item_request_spec.rb
@@ -13,7 +13,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::ItemRequest, type: :model, skip_seed: true do
+RSpec.describe Partners::ItemRequest, type: :model do
   describe 'associations' do
     it { should belong_to(:request).class_name('Partners::Request').with_foreign_key(:partner_request_id) }
     it { should have_many(:child_item_requests).dependent(:destroy) }

--- a/spec/models/partners/partner_form_spec.rb
+++ b/spec/models/partners/partner_form_spec.rb
@@ -10,7 +10,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::PartnerForm, type: :model, skip_seed: true do
+RSpec.describe Partners::PartnerForm, type: :model do
   describe 'associations' do
     it { should have_one(:partner).with_primary_key(:essentials_bank_id).with_foreign_key(:essentials_bank_id) }
   end

--- a/spec/models/partners/partner_spec.rb
+++ b/spec/models/partners/partner_spec.rb
@@ -76,7 +76,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::Partner, type: :model, skip_seed: true do
+RSpec.describe Partners::Partner, type: :model do
   describe 'associations' do
     it { should have_many(:users).dependent(:destroy) }
     it { should have_many(:requests).dependent(:destroy) }

--- a/spec/models/partners/request_spec.rb
+++ b/spec/models/partners/request_spec.rb
@@ -14,7 +14,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::Request, type: :model, skip_seed: true do
+RSpec.describe Partners::Request, type: :model do
   describe 'associations' do
     it { should belong_to(:partner) }
     it { should have_many(:item_requests).dependent(:destroy) }

--- a/spec/models/product_drive_participant_spec.rb
+++ b/spec/models/product_drive_participant_spec.rb
@@ -18,7 +18,7 @@
 
 require "rails_helper"
 
-RSpec.describe ProductDriveParticipant, type: :model, skip_seed: true do
+RSpec.describe ProductDriveParticipant, type: :model do
   it_behaves_like "provideable"
 
   context "Validations" do

--- a/spec/models/product_drive_spec.rb
+++ b/spec/models/product_drive_spec.rb
@@ -14,7 +14,7 @@
 
 require "rails_helper"
 
-RSpec.describe ProductDrive, type: :model, skip_seed: true do
+RSpec.describe ProductDrive, type: :model do
   let!(:product_drive) { create(:product_drive) }
   let!(:donation) { create(:donation, :with_items, item_quantity: 7, product_drive: product_drive) }
   let!(:donation2) { create(:donation, :with_items, item_quantity: 9, product_drive: product_drive) }

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -18,7 +18,7 @@
 #  vendor_id                                :integer
 #
 
-RSpec.describe Purchase, type: :model, skip_seed: true do
+RSpec.describe Purchase, type: :model do
   it_behaves_like "itemizable"
 
   context "Validations >" do

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe StorageLocation, type: :model do
       end
     end
 
-    describe "import_inventory", needs_users: true do
+    describe "import_inventory" do
       it "imports storage locations from a csv file" do
         donations_count = Donation.count
         storage_location = create(:storage_location, organization_id: @organization.id)

--- a/spec/models/transfer_spec.rb
+++ b/spec/models/transfer_spec.rb
@@ -11,7 +11,7 @@
 #  to_id           :integer
 #
 
-RSpec.describe Transfer, type: :model, skip_seed: true do
+RSpec.describe Transfer, type: :model do
   it_behaves_like "itemizable"
 
   context "Validations >" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe User, type: :model do
       let!(:a_name_user) { create(:user, name: 'Amanda') }
 
       it "retrieves users in the correct order" do
-        create_default_users
         alphabetized_list = described_class.alphabetized
 
         expect(alphabetized_list.first).to eq(a_name_user)
@@ -82,7 +81,6 @@ RSpec.describe User, type: :model do
       let!(:deactivated_z_name_user) { create(:user, name: 'Zeke', discarded_at: discarded_at) }
 
       it "retrieves users in the correct order" do
-        create_default_users
         alphabetized_list = described_class.org_users.with_discarded.alphabetized
 
         expect(alphabetized_list).to eq(

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -18,7 +18,7 @@
 
 require "rails_helper"
 
-RSpec.describe Vendor, type: :model, skip_seed: true do
+RSpec.describe Vendor, type: :model do
   it_behaves_like "provideable"
 
   context "Methods" do

--- a/spec/queries/items_in_query_spec.rb
+++ b/spec/queries/items_in_query_spec.rb
@@ -1,6 +1,6 @@
 # Spec for /app/queries/items_in_query.rb
 
-RSpec.describe ItemsInQuery, skip_seed: true do
+RSpec.describe ItemsInQuery do
   let!(:storage_location) { create(:storage_location, organization: @organization) }
   let!(:other_storage_location) { create(:storage_location, :with_items, item: create(:item), item_quantity: 10, organization: @organization) }
   subject { ItemsInQuery.new(storage_location: storage_location, organization: @organization).call }

--- a/spec/queries/items_in_total_query_spec.rb
+++ b/spec/queries/items_in_total_query_spec.rb
@@ -1,6 +1,6 @@
 # Spec for /app/queries/items_in_total_query.rb
 
-RSpec.describe ItemsInTotalQuery, skip_seed: true do
+RSpec.describe ItemsInTotalQuery do
   let!(:storage_location) { create(:storage_location, organization: @organization) }
   let!(:other_storage_location) { create(:storage_location, :with_items, item: create(:item), item_quantity: 10, organization: @organization) }
   let!(:shared_item) { create(:item) }

--- a/spec/queries/items_out_query_spec.rb
+++ b/spec/queries/items_out_query_spec.rb
@@ -1,6 +1,6 @@
 # Spec for /app/queries/items_out_query.rb
 
-RSpec.describe ItemsOutQuery, skip_seed: true do
+RSpec.describe ItemsOutQuery do
   let!(:storage_location) { create(:storage_location, organization: @organization) }
   subject { ItemsOutQuery.new(storage_location: storage_location, organization: @organization).call }
 

--- a/spec/queries/items_out_total_query_spec.rb
+++ b/spec/queries/items_out_total_query_spec.rb
@@ -1,6 +1,6 @@
 # Spec for /app/queries/items_out_total_query.rb
 
-RSpec.describe ItemsOutTotalQuery, skip_seed: true do
+RSpec.describe ItemsOutTotalQuery do
   let!(:storage_location) { create(:storage_location, organization: @organization) }
   subject { ItemsOutTotalQuery.new(storage_location: storage_location, organization: @organization).call }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -137,14 +137,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    # Faker::Config.random = Random.new(42)
-
-    # DatabaseCleaner.strategy = :transaction
-  end
-
-
-  config.before(:each) do |example|
-    # seed_with_default_records unless example.metadata[:skip_seed]
+    seed_users
   end
 
   config.before(:each, type: proc { |v| %i[request system controller].include?(v) }) do
@@ -191,6 +184,20 @@ def text_body(mail)
   mail.body.parts.find { |p| p.content_type =~ /text/ }.body.encoded
 end
 
+def seed_users
+  @organization = FactoryBot.create(:organization, name: "DEFAULT", skip_items: true)
+  Organization.seed_items(@organization)
+
+  # Create default users
+  @organization_admin = FactoryBot.create(:organization_admin, name: "DEFAULT ORG ADMIN", organization: @organization)
+  @user = FactoryBot.create(:user, organization: @organization, name: "DEFAULT USER")
+  @super_admin = FactoryBot.create(:super_admin, name: "DEFAULT SUPERADMIN")
+  @super_admin_no_org = FactoryBot.create(:super_admin_no_org, name: "DEFAULT SUPERADMIN NO ORG")
+
+  # Seed with default partner record
+  @partner = FactoryBot.create(:partner, organization: @organization)
+end
+
 def seed_base_items_for_tests
   # Create base items that are used to handle seeding Organization with items
   base_items = File.read(Rails.root.join("db", "base_items.json"))
@@ -206,18 +213,6 @@ def seed_base_items_for_tests
       }
     end
   end.flatten
+
   BaseItem.create!(base_items_data)
-
-  # Create organization
-  @organization = FactoryBot.create(:organization, name: "DEFAULT", skip_items: true)
-  Organization.seed_items(@organization)
-
-  # Create default users
-  @organization_admin = FactoryBot.create(:organization_admin, name: "DEFAULT ORG ADMIN", organization: @organization)
-  @user = FactoryBot.create(:user, organization: @organization, name: "DEFAULT USER")
-  @super_admin = FactoryBot.create(:super_admin, name: "DEFAULT SUPERADMIN")
-  @super_admin_no_org = FactoryBot.create(:super_admin_no_org, name: "DEFAULT SUPERADMIN NO ORG")
-
-  # Seed with default partner record
-  @partner = FactoryBot.create(:partner, organization: @organization)
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= "test"
+ENV["RAILS_ENV"] = "test"
+ENV["NODE_ENV"] = "test"
+
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
@@ -198,11 +200,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do
-    unless File.exist?(Rails.root.join("public", "packs-task"))
-      Rails.logger.info "Detected missing webpack assets for testing. Running compilation step"
-      `NODE_ENV=test bin/webpack`
-    end
-
     clear_downloads
     driven_by :chrome
     Capybara.server = :puma, { Silent: true }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -99,11 +99,6 @@ RSpec.configure do |config|
 
   # Preparatifyication
   config.before(:suite) do
-    unless File.exist?(Rails.root.join("public", "packs-task"))
-      Rails.logger.info "Detected missing webpack assets for testing. Running compilation step"
-      `NODE_ENV=test bin/webpack`
-    end
-
     DatabaseCleaner.clean_with(:truncation, except: %w[ar_internal_metadata])
 
     # Stub out the Geocoder since we
@@ -131,6 +126,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do
+    unless File.exist?(Rails.root.join("public", "packs-task"))
+      Rails.logger.info "Detected missing webpack assets for testing. Running compilation step"
+      `NODE_ENV=test bin/webpack`
+    end
+
     clear_downloads
     driven_by :chrome
     Capybara.server = :puma, { Silent: true }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -173,7 +173,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation, except: %w[ar_internal_metadata])
 
-    # Stub out the Geocoder since we
+    # Stub out the Geocoder since we don't want to hit the API
     Geocoder.configure(lookup: :test)
 
     ["1500 Remount Road, Front Royal, VA 22630",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -105,11 +105,7 @@ RSpec.configure do |config|
     end
 
     DatabaseCleaner.clean_with(:truncation, except: %w(ar_internal_metadata))
-  end
 
-  # Run all the needed seeds and stubbing to 
-  # allow the tests to run without errors.
-  config.before(:all) do
     # Stub out the Geocoder since we
     Geocoder.configure(lookup: :test)
 
@@ -213,15 +209,15 @@ def seed_base_items_for_tests
   BaseItem.create!(base_items_data)
 
   # Create organization
-  @organization = create(:organization, name: "DEFAULT", skip_items: true)
+  @organization = FactoryBot.create(:organization, name: "DEFAULT", skip_items: true)
   Organization.seed_items(@organization)
 
   # Create default users
-  @organization_admin = create(:organization_admin, name: "DEFAULT ORG ADMIN", organization: @organization)
-  @user = create(:user, organization: @organization, name: "DEFAULT USER")
-  @super_admin = create(:super_admin, name: "DEFAULT SUPERADMIN")
-  @super_admin_no_org = create(:super_admin_no_org, name: "DEFAULT SUPERADMIN NO ORG")
+  @organization_admin = FactoryBot.create(:organization_admin, name: "DEFAULT ORG ADMIN", organization: @organization)
+  @user = FactoryBot.create(:user, organization: @organization, name: "DEFAULT USER")
+  @super_admin = FactoryBot.create(:super_admin, name: "DEFAULT SUPERADMIN")
+  @super_admin_no_org = FactoryBot.create(:super_admin_no_org, name: "DEFAULT SUPERADMIN NO ORG")
 
   # Seed with default partner record
-  @partner = create(:partner, organization: @organization)
+  @partner = FactoryBot.create(:partner, organization: @organization)
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -137,25 +137,9 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
+    # Seeding users in the `each` block because it makes the @ variables defined
+    # through the specs
     seed_users
-  end
-
-  config.before(:each, type: proc { |v| %i[request system controller].include?(v) }) do
-    # create_default_users
-  end
-
-  config.before(:each, :needs_users) do
-    # create_default_users
-  end
-
-  config.after(:each) do |example|
-    # Ensure to clean-up the database by whichever means
-    # were specified before the test ran
-    # DatabaseCleaner.clean unless example.metadata[:persisted_data]
-
-    # Remove any /tmp/storage files that might have been
-    # added as a consequence of the test.
-    # FileUtils.rm_rf(Dir["#{Rails.root}/tmp/storage"])
   end
 
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -104,7 +104,7 @@ RSpec.configure do |config|
       `NODE_ENV=test bin/webpack`
     end
 
-    DatabaseCleaner.clean_with(:truncation, except: %w(ar_internal_metadata))
+    DatabaseCleaner.clean_with(:truncation, except: %w[ar_internal_metadata])
 
     # Stub out the Geocoder since we
     Geocoder.configure(lookup: :test)
@@ -188,12 +188,12 @@ def seed_base_items_for_tests
   items_by_category = JSON.parse(base_items)
   base_items_data = items_by_category.map do |category, entries|
     entries.map do |entry|
-      { 
+      {
         name: entry["name"],
         category: category,
         partner_key: entry["key"],
         updated_at: Time.zone.now,
-        created_at: Time.zone.now 
+        created_at: Time.zone.now
       }
     end
   end.flatten

--- a/spec/requests/account_requests_spec.rb
+++ b/spec/requests/account_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "/account_requests", type: :request, skip_seed: true do
+RSpec.describe "/account_requests", type: :request do
   describe "GET #new" do
     it "renders a successful response" do
       get new_account_request_url

--- a/spec/requests/adjustments_requests_spec.rb
+++ b/spec/requests/adjustments_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Adjustments", type: :request, skip_seed: true do
+RSpec.describe "Adjustments", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/admin/account_requests_requests_spec.rb
+++ b/spec/requests/admin/account_requests_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Admin::AccountRequestsController', type: :request, skip_seed: true do
+RSpec.describe 'Admin::AccountRequestsController', type: :request do
   context 'while signed in as a super admin' do
     before do
       sign_in(@super_admin)

--- a/spec/requests/admin/base_items_requests_spec.rb
+++ b/spec/requests/admin/base_items_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Admin::BaseItems", type: :request, skip_seed: true do
+RSpec.describe "Admin::BaseItems", type: :request do
   context "while signed in as a super admin" do
     before do
       sign_in(@super_admin)

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin::Organizations", type: :request, skip_seed: true do
+RSpec.describe "Admin::Organizations", type: :request do
   let(:default_params) do
     { organization_id: @organization.id }
   end

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe "Admin::Organizations", type: :request do
     describe "DELETE #destroy" do
       it "redirects" do
         delete admin_organization_path({ id: @organization.id })
-        expect(response).to redirect_to(admin_organizations_path({ organization_id: @organization }))
+        expect(response).to redirect_to(admin_organizations_path({ organization_id: "admin" }))
       end
     end
   end

--- a/spec/requests/admin/partners_requests_spec.rb
+++ b/spec/requests/admin/partners_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Admin::Partners", type: :request, skip_seed: true do
+RSpec.describe "Admin::Partners", type: :request do
   context "When logged in as a super admin" do
     before do
       sign_in(@super_admin)

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Admin::UsersController", type: :request, skip_seed: true do
+RSpec.describe "Admin::UsersController", type: :request do
   let(:default_params) do
     { organization_id: @organization.id }
   end

--- a/spec/requests/admin_requests_spec.rb
+++ b/spec/requests/admin_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin", type: :request, skip_seed: true do
+RSpec.describe "Admin", type: :request do
   context "while signed in as a super admin" do
     before do
       sign_in(@super_admin_no_org)

--- a/spec/requests/attachments_requests_spec.rb
+++ b/spec/requests/attachments_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Attachments", type: :request, skip_seed: true do
+RSpec.describe "Attachments", type: :request do
   before do
     sign_in(@user)
   end

--- a/spec/requests/audits_requests_spec.rb
+++ b/spec/requests/audits_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Audits", type: :request, skip_seed: true do
+RSpec.describe "Audits", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/barcode_items_requests_spec.rb
+++ b/spec/requests/barcode_items_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "BarcodeItems", type: :request, skip_seed: true do
+RSpec.describe "BarcodeItems", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/dashboard_requests_spec.rb
+++ b/spec/requests/dashboard_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Dashboard", type: :request, skip_seed: true do
+RSpec.describe "Dashboard", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Distributions", type: :request, skip_seed: true do
+RSpec.describe "Distributions", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/donation_sites_requests_spec.rb
+++ b/spec/requests/donation_sites_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "DonationSites", type: :request, skip_seed: true do
+RSpec.describe "DonationSites", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Donations", type: :request, skip_seed: true do
+RSpec.describe "Donations", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Items", type: :request, skip_seed: true do
+RSpec.describe "Items", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/partners/family_requests_controller_spec.rb
+++ b/spec/requests/partners/family_requests_controller_spec.rb
@@ -3,10 +3,9 @@ require "rails_helper"
 RSpec.describe Partners::FamilyRequestsController, type: :request do
   let(:partner) { create(:partner) }
   let(:params) do
-    children.inject({}) do |hash, child|
-      hash["child-#{child.id}"] =  true
-      hash
-    end 
+    children.each_with_object({}) do |child, hash|
+      hash["child-#{child.id}"] = true
+    end
   end
   let(:partners_partner) { Partners::Partner.find_by(partner_id: partner.id) }
   let(:family) { create(:partners_family, partner_id: partners_partner.id) }

--- a/spec/requests/partners/family_requests_controller_spec.rb
+++ b/spec/requests/partners/family_requests_controller_spec.rb
@@ -2,10 +2,15 @@ require "rails_helper"
 
 RSpec.describe Partners::FamilyRequestsController, type: :request do
   let(:partner) { create(:partner) }
-  let(:params) { { 'child-1' => true, 'child-2' => true, 'child-3' => true } }
+  let(:params) do
+    children.inject({}) do |hash, child|
+      hash["child-#{child.id}"] =  true
+      hash
+    end 
+  end
   let(:partners_partner) { Partners::Partner.find_by(partner_id: partner.id) }
   let(:family) { create(:partners_family, partner_id: partners_partner.id) }
-  let(:children) { FactoryBot.create_list(:partners_child, 3, family: family) }
+  let!(:children) { FactoryBot.create_list(:partners_child, 3, family: family) }
   let(:partner_user) { partners_partner.primary_user }
 
   before { sign_in(partner_user) }

--- a/spec/requests/partners/family_requests_spec.rb
+++ b/spec/requests/partners/family_requests_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe "/partners/family", type: :request do
       get partners_families_path, headers: headers
       csv = <<~CSV
         id,guardian_first_name,guardian_last_name,guardian_zip_code,guardian_county,guardian_phone,case_manager,home_adult_count,home_child_count,home_young_child_count,sources_of_income,guardian_employed,guardian_employment_type,guardian_monthly_pay,guardian_health_insurance,comments,created_at,updated_at,partner_id,military
-        #{family1.id},John,Smith,90210,Franklin,416-555-2345,Jane Smith,2,3,1,"SSI,TANF",true,Part-time,4.0,Medicaid,Some comment,#{family1.created_at},#{family1.updated_at},2,false
-        #{family2.id},Mark,Smith,90210,Jefferson,416-555-0987,Jane Smith,1,2,2,TANF,false,Part-time,4.0,Medicaid,Some comment 2,#{family2.created_at},#{family2.updated_at},2,true
+        #{family1.id},John,Smith,90210,Franklin,416-555-2345,Jane Smith,2,3,1,"SSI,TANF",true,Part-time,4.0,Medicaid,Some comment,#{family1.created_at},#{family1.updated_at},#{partner.id},false
+        #{family2.id},Mark,Smith,90210,Jefferson,416-555-0987,Jane Smith,1,2,2,TANF,false,Part-time,4.0,Medicaid,Some comment 2,#{family2.created_at},#{family2.updated_at},#{partner.id},true
       CSV
       expect(response.body).to eq(csv)
     end

--- a/spec/requests/partners/family_requests_spec.rb
+++ b/spec/requests/partners/family_requests_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe "/partners/family", type: :request do
       get partners_families_path, headers: headers
       csv = <<~CSV
         id,guardian_first_name,guardian_last_name,guardian_zip_code,guardian_county,guardian_phone,case_manager,home_adult_count,home_child_count,home_young_child_count,sources_of_income,guardian_employed,guardian_employment_type,guardian_monthly_pay,guardian_health_insurance,comments,created_at,updated_at,partner_id,military
-        #{family1.id},John,Smith,90210,Franklin,416-555-2345,Jane Smith,2,3,1,"SSI,TANF",true,Part-time,4.0,Medicaid,Some comment,#{family1.created_at},#{family1.updated_at},#{partner.id},false
-        #{family2.id},Mark,Smith,90210,Jefferson,416-555-0987,Jane Smith,1,2,2,TANF,false,Part-time,4.0,Medicaid,Some comment 2,#{family2.created_at},#{family2.updated_at},#{partner.id},true
+        #{family1.id},John,Smith,90210,Franklin,416-555-2345,Jane Smith,2,3,1,"SSI,TANF",true,Part-time,4.0,Medicaid,Some comment,#{family1.created_at},#{family1.updated_at},#{partner.profile.id},false
+        #{family2.id},Mark,Smith,90210,Jefferson,416-555-0987,Jane Smith,1,2,2,TANF,false,Part-time,4.0,Medicaid,Some comment 2,#{family2.created_at},#{family2.updated_at},#{partner.profile.id},true
       CSV
       expect(response.body).to eq(csv)
     end

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe "/partners/requests", type: :request do
           }
         }
       end
-      it 'should redirect to the dashboard' do
+
+      it 'should redirect to the show page' do
         subject.call
-        expect(response).to redirect_to(partners_request_path(Request.last.id))
+        expect(response).to redirect_to(partners_request_path(partner.requests.last.id))
       end
     end
 

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "/partners/requests", type: :request do
 
       it 'should redirect to the show page' do
         subject.call
-        expect(response).to redirect_to(partners_request_path(Request.last.id))
+        expect(response).to redirect_to(partners_request_path(Partners::Request.last.id))
       end
     end
 

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "/partners/requests", type: :request do
 
       it 'should redirect to the show page' do
         subject.call
-        expect(response).to redirect_to(partners_request_path(partner.requests.last.id))
+        expect(response).to redirect_to(partners_request_path(Request.last.id))
       end
     end
 

--- a/spec/requests/product_drive_participants_requests_spec.rb
+++ b/spec/requests/product_drive_participants_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
+RSpec.describe "ProductDriveParticipants", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "ProductDrives", type: :request, skip_seed: true do
+RSpec.describe "ProductDrives", type: :request do
   let(:default_params) do
     { organization_id: @organization.id.to_param }
   end

--- a/spec/requests/profiles_requests_spec.rb
+++ b/spec/requests/profiles_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Profiles", type: :request, skip_seed: true do
+RSpec.describe "Profiles", type: :request do
   let(:partner) { FactoryBot.create(:partner, organization: @organization) }
 
   let(:default_params) do

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Purchases", type: :request, skip_seed: true do
+RSpec.describe "Purchases", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/reports/annual_reports_requests_spec.rb
+++ b/spec/requests/reports/annual_reports_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Annual Reports", type: :request, skip_seed: true do
+RSpec.describe "Annual Reports", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param, year: 2018 }
   end

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Requests', type: :request, skip_seed: true do
+RSpec.describe 'Requests', type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/requests/static_requests_spec.rb
+++ b/spec/requests/static_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Static", type: :request, skip_seed: true do
+RSpec.describe "Static", type: :request do
   describe "Not signed in" do
     describe "GET #index" do
       it "returns http success" do

--- a/spec/requests/transfers_requests_spec.rb
+++ b/spec/requests/transfers_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Transfers", type: :request, skip_seed: true do
+RSpec.describe "Transfers", type: :request do
   let(:valid_params) do
     { organization_id: @organization.short_name }
   end

--- a/spec/requests/transfers_requests_spec.rb
+++ b/spec/requests/transfers_requests_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe "Transfers", type: :request do
 
       around do |example|
         travel_to Time.zone.local(2019, 7, 1)
-        create(:transfer)
         example.run
         travel_back
       end

--- a/spec/requests/users/omniauth_callbacks_requests_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Users - Omniauth Callbacks", type: :request, skip_seed: true do
+RSpec.describe "Users - Omniauth Callbacks", type: :request do
   before do
     Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]
     OmniAuth.config.test_mode = true

--- a/spec/requests/users_requests_spec.rb
+++ b/spec/requests/users_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Users", type: :request, skip_seed: true do
+RSpec.describe "Users", type: :request do
   let(:partner) { create(:partner) }
   let(:default_params) do
     { organization_id: @organization.to_param }

--- a/spec/requests/vendors_requests_spec.rb
+++ b/spec/requests/vendors_requests_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Vendors", type: :request, skip_seed: true do
+RSpec.describe "Vendors", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end

--- a/spec/routing/account_requests_routing_spec.rb
+++ b/spec/routing/account_requests_routing_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AccountRequestsController, type: :routing, skip_seed: true do
+RSpec.describe AccountRequestsController, type: :routing do
   describe "routing" do
     it "routes to #new" do
       expect(get: "/account_requests/new").to route_to("account_requests#new")

--- a/spec/services/allocate_kit_inventory_service_spec.rb
+++ b/spec/services/allocate_kit_inventory_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AllocateKitInventoryService, type: :service, skip_seed: true do
+RSpec.describe AllocateKitInventoryService, type: :service do
   let(:organization) { create :organization }
   let(:item) { create(:item, name: "Item", organization: organization, on_hand_minimum_quantity: 5) }
   let(:item_out_of_stock) { create(:item, name: "Item out of stock", organization: organization, on_hand_minimum_quantity: 0) }

--- a/spec/services/deallocate_kit_inventory_service_spec.rb
+++ b/spec/services/deallocate_kit_inventory_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DeallocateKitInventoryService, type: :service, skip_seed: true do
+RSpec.describe DeallocateKitInventoryService, type: :service do
   let(:organization) { create :organization }
   let(:item1) { create(:item, name: "Item11", organization: organization, on_hand_minimum_quantity: 5) }
   let(:item2) { create(:item, name: "Item 2", organization: organization, on_hand_minimum_quantity: 1) }

--- a/spec/services/distribution_content_change_service_spec.rb
+++ b/spec/services/distribution_content_change_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionContentChangeService, type: :service, skip_seed: true do
+RSpec.describe DistributionContentChangeService, type: :service do
   let(:line_item1) { { active: true, item_id: 32, name: "Adult Incontinence Pads", quantity: 382 } }
   let(:line_item2) { { active: true, item_id: 38, name: "Bed Pads (Disposable)", quantity: 36 } }
   let(:line_item3) { { active: true, item_id: 43, name: "Wipes (Adult)", quantity: 88 } }

--- a/spec/services/distribution_destroy_service_spec.rb
+++ b/spec/services/distribution_destroy_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DistributionDestroyService, skip_seed: true do
+describe DistributionDestroyService do
   describe '#call' do
     subject { described_class.new(distribution_id).call }
     let(:distribution_id) { Faker::Number.number }

--- a/spec/services/distribution_itemized_breakdown_service_spec.rb
+++ b/spec/services/distribution_itemized_breakdown_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionItemizedBreakdownService, type: :service, skip_seed: true do
+RSpec.describe DistributionItemizedBreakdownService, type: :service do
   let(:organization) { create(:organization) }
   let(:distribution_ids) { [distribution_1, distribution_2, distribution_3].map(&:id) }
   let(:item_a) do

--- a/spec/services/distribution_reminder_spec.rb
+++ b/spec/services/distribution_reminder_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionReminder, skip_seed: true do
+RSpec.describe DistributionReminder do
   describe "conditionally sending the emails" do
     let(:organization) { create :organization }
 

--- a/spec/services/distribution_update_service_spec.rb
+++ b/spec/services/distribution_update_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionUpdateService, type: :service, skip_seed: true do
+RSpec.describe DistributionUpdateService, type: :service do
   describe "call" do
     # TODO: this function was extracted to the service object - do we need a parallel test?
 

--- a/spec/services/donation_destroy_service_spec.rb
+++ b/spec/services/donation_destroy_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DonationDestroyService, skip_seed: true do
+describe DonationDestroyService do
   describe '#call' do
     subject { described_class.new(organization_id: organization_id, donation_id: donation_id) }
     let(:organization_id) { Faker::Number.number }

--- a/spec/services/donation_itemized_breakdown_service_spec.rb
+++ b/spec/services/donation_itemized_breakdown_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe DonationItemizedBreakdownService, type: :service, skip_seed: true do
+RSpec.describe DonationItemizedBreakdownService, type: :service do
   let(:organization) { create(:organization) }
   let(:donation_ids) { [donation_1, donation_2, donation_3].map(&:id) }
   let(:item_a) { create(:item, organization: organization) }

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -1,4 +1,4 @@
-describe Exports::ExportDistributionsCSVService, skip_seed: true do
+describe Exports::ExportDistributionsCSVService do
   describe '#generate_csv_data' do
     subject { described_class.new(distribution_ids: distribution_ids).generate_csv_data }
     let(:distribution_ids) { distributions.map(&:id) }

--- a/spec/services/exports/export_donations_csv_service_spec.rb
+++ b/spec/services/exports/export_donations_csv_service_spec.rb
@@ -1,4 +1,4 @@
-describe Exports::ExportDonationsCSVService, skip_seed: true do
+describe Exports::ExportDonationsCSVService do
   describe '#generate_csv_data' do
     subject { described_class.new(donation_ids: donation_ids).generate_csv_data }
     let(:donation_ids) { donations.map(&:id) }

--- a/spec/services/exports/export_donations_csv_service_spec.rb
+++ b/spec/services/exports/export_donations_csv_service_spec.rb
@@ -21,7 +21,7 @@ describe Exports::ExportDonationsCSVService do
         ],
         *(Array.new(3) do |i|
           [[FactoryBot.create(
-            :item, name: Faker::Appliance.equipment
+            :item, name: "item_#{i}"
           ), i + 1]]
         end)
       ]

--- a/spec/services/exports/export_purchases_csv_service_spec.rb
+++ b/spec/services/exports/export_purchases_csv_service_spec.rb
@@ -1,4 +1,4 @@
-describe Exports::ExportPurchasesCSVService, skip_seed: true do
+describe Exports::ExportPurchasesCSVService do
   describe "#generate_csv_data" do
     subject { described_class.new(purchase_ids: purchase_ids).generate_csv_data }
     let(:purchase_ids) { purchases.map(&:id) }

--- a/spec/services/exports/export_report_csv_service_spec.rb
+++ b/spec/services/exports/export_report_csv_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Exports::ExportReportCSVService, skip_seed: true do
+describe Exports::ExportReportCSVService do
   describe ".generate_csv_data" do
     it "creates CSV data including headers" do
       report = {

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Exports::ExportRequestService, skip_seed: true do
+describe Exports::ExportRequestService do
   let(:org) { create(:organization) }
 
   let(:item_3t) { create :item, name: "3T Diapers" }

--- a/spec/services/inventory_check_service_spec.rb
+++ b/spec/services/inventory_check_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe InventoryCheckService, type: :service, skip_seed: true do
+RSpec.describe InventoryCheckService, type: :service do
   subject { InventoryCheckService }
   describe "call" do
     let(:item1) { create(:item, name: "Item 1", organization: @organization, on_hand_minimum_quantity: 5, on_hand_recommended_quantity: 10) }

--- a/spec/services/item_create_service_spec.rb
+++ b/spec/services/item_create_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ItemCreateService, type: :service, skip_seed: true do
+RSpec.describe ItemCreateService, type: :service do
   describe '#call' do
     subject { described_class.new(organization_id: organization_id, item_params: item_params).call }
     let(:organization_id) { organization.id }

--- a/spec/services/kit_create_service_spec.rb
+++ b/spec/services/kit_create_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe KitCreateService, skip_seed: true do
+describe KitCreateService do
   describe '#call' do
     subject { described_class.new(**args).call }
     let(:args) do

--- a/spec/services/partner_approval_service_spec.rb
+++ b/spec/services/partner_approval_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerApprovalService, skip_seed: true do
+describe PartnerApprovalService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
     let(:partner) { create(:partner) }

--- a/spec/services/partner_create_service_spec.rb
+++ b/spec/services/partner_create_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerCreateService, skip_seed: true do
+describe PartnerCreateService do
   describe '#call' do
     subject { described_class.new(organization: organization, partner_attrs: partner_attrs).call }
     let(:organization) { create(:organization) }

--- a/spec/services/partner_fetch_requestable_items_service_spec.rb
+++ b/spec/services/partner_fetch_requestable_items_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerFetchRequestableItemsService, skip_seed: true do
+describe PartnerFetchRequestableItemsService do
   describe '#call' do
     subject { described_class.new(partner_id: partner_id).call }
     let(:partner_id) { partner.id }

--- a/spec/services/partner_invite_service_spec.rb
+++ b/spec/services/partner_invite_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerInviteService, skip_seed: true do
+describe PartnerInviteService do
   subject { described_class.new(partner: partner).call }
   let(:partner) { create(:partner) }
 

--- a/spec/services/partner_request_recertification_service_spec.rb
+++ b/spec/services/partner_request_recertification_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PartnerRequestRecertificationService, skip_seed: true do
+describe PartnerRequestRecertificationService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
     let(:partner) { create(:partner) }

--- a/spec/services/partner_user_invite_service_spec.rb
+++ b/spec/services/partner_user_invite_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe PartnerUserInviteService, skip_seed: true do
+describe PartnerUserInviteService do
   let(:partner) { create(:partner) }
   let(:email) { Faker::Internet.email }
   let!(:partner_user) { instance_spy(User) }

--- a/spec/services/partners/request_approval_service_spec.rb
+++ b/spec/services/partners/request_approval_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Partners::RequestApprovalService, skip_seed: true do
+describe Partners::RequestApprovalService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
     let(:partner) { create(:partner) }

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Partners::RequestCreateService, skip_seed: true do
+describe Partners::RequestCreateService do
   describe '#call' do
     subject { described_class.new(**args).call }
     let(:args) do

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
   before(:all) do
     DatabaseCleaner.start
     create_organization
-    seed_base_items_for_tests
 
     Organization.seed_items(organization)
     disposable_item = organization.items.disposable.first

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -1,169 +1,149 @@
 RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data: true do
-  # can't use `let` since we are creating a bunch of data in before(:all)
-  def year
-    2020
-  end
+  describe "acquisition report" do
+    subject { described_class.new(organization: organization, year: year) }
 
-  def within_time
-    Time.zone.parse("2020-05-31 14:00:00")
-  end
+    let(:organization) { create(:organization) }
+    let(:within_time) { Time.zone.parse("2020-05-31 14:00:00") }
+    let(:outside_time) { Time.zone.parse("2019-05-31 14:00:00") }
+    let(:year) { 2020 }
 
-  def outside_time
-    Time.zone.parse("2019-05-31 14:00:00")
-  end
+    before do
+      disposable_item = organization.items.disposable.first
+      non_disposable_item = organization.items.where.not(id: organization.items.disposable).first
 
-  def organization
-    @organization ||= create(:organization)
-  end
+      # We will create data both within and outside our date range, and both disposable and non disposable.
+      # Spec will ensure that only the required data is included.
 
-  before(:all) do
-    DatabaseCleaner.start
-    create_organization
+      # Distributions
+      distributions = create_list(:distribution, 2, issued_at: within_time, organization: organization)
+      outside_distributions = create_list(:distribution, 2, issued_at: outside_time, organization: organization)
+      (distributions + outside_distributions).each do |dist|
+        create_list(:line_item, 5, :distribution, quantity: 20, item: disposable_item, itemizable: dist)
+        create_list(:line_item, 5, :distribution, quantity: 30, item: non_disposable_item, itemizable: dist)
+      end
 
-    Organization.seed_items(organization)
-    disposable_item = organization.items.disposable.first
-    non_disposable_item = organization.items.where.not(id: organization.items.disposable).first
+      # Donations outside drives
+      non_drive_donations = create_list(:donation, 2,
+                                        product_drive: nil,
+                                        issued_at: within_time,
+                                        money_raised: 1000,
+                                        organization: organization)
 
-    # We will create data both within and outside our date range, and both disposable and non disposable.
-    # Spec will ensure that only the required data is included.
+      non_drive_donations += create_list(:donation, 2,
+                                         product_drive: nil,
+                                         issued_at: outside_time,
+                                         money_raised: 1000,
+                                         organization: organization)
 
-    # Distributions
-    distributions = create_list(:distribution, 2, issued_at: within_time, organization: organization)
-    outside_distributions = create_list(:distribution, 2, issued_at: outside_time, organization: organization)
-    (distributions + outside_distributions).each do |dist|
-      create_list(:line_item, 5, :distribution, quantity: 20, item: disposable_item, itemizable: dist)
-      create_list(:line_item, 5, :distribution, quantity: 30, item: non_disposable_item, itemizable: dist)
-    end
+      non_drive_donations.each do |donation|
+        create_list(:line_item, 3, :donation, quantity: 20, item: disposable_item, itemizable: donation)
+        create_list(:line_item, 3, :donation, quantity: 10, item: non_disposable_item, itemizable: donation)
+      end
 
-    # Donations outside drives
-    non_drive_donations = create_list(:donation, 2,
-                                      product_drive: nil,
-                                      issued_at: within_time,
-                                      money_raised: 1000,
-                                      organization: organization)
+      # Product drives
+      drives = create_list(:product_drive, 2,
+                           start_date: within_time,
+                           end_date: nil,
+                           virtual: false,
+                           organization: organization)
+      outside_drives = create_list(:product_drive, 2,
+                                   start_date: outside_time - 1.month,
+                                   end_date: outside_time,
+                                   organization: organization,
+                                   virtual: false)
 
-    non_drive_donations += create_list(:donation, 2,
-                                       product_drive: nil,
-                                       issued_at: outside_time,
-                                       money_raised: 1000,
-                                       organization: organization)
+      donations = (drives + outside_drives).map do |drive|
+        create_list(:product_drive_donation, 3,
+                    product_drive: drive,
+                    issued_at: drive.start_date + 1.day,
+                    money_raised: 1000,
+                    organization: organization)
+      end
+      donations.flatten!
+      donations.each do |donation|
+        create_list(:line_item, 5, :donation, quantity: 20, item: disposable_item, itemizable: donation)
+        create_list(:line_item, 5, :donation, quantity: 30, item: non_disposable_item, itemizable: donation)
+      end
 
-    non_drive_donations.each do |donation|
-      create_list(:line_item, 3, :donation, quantity: 20, item: disposable_item, itemizable: donation)
-      create_list(:line_item, 3, :donation, quantity: 10, item: non_disposable_item, itemizable: donation)
-    end
+      # Virtual product drives
+      vdrives = create_list(:product_drive, 2,
+                            start_date: within_time,
+                            end_date: nil,
+                            virtual: true,
+                            organization: organization)
+      outside_vdrives = create_list(:product_drive, 2,
+                                    start_date: outside_time - 1.month,
+                                    end_date: outside_time,
+                                    organization: organization,
+                                    virtual: true)
 
-    # Product drives
-    drives = create_list(:product_drive, 2,
-                         start_date: within_time,
-                         end_date: nil,
-                         virtual: false,
-                         organization: organization)
-    outside_drives = create_list(:product_drive, 2,
-                                 start_date: outside_time - 1.month,
-                                 end_date: outside_time,
-                                 organization: organization,
-                                 virtual: false)
+      vdonations = (vdrives + outside_vdrives).map do |drive|
+        create(:product_drive_donation,
+               product_drive: drive,
+               money_raised: 1000,
+               issued_at: drive.start_date + 1.day,
+               organization: organization)
+      end
+      vdonations.flatten!
+      vdonations.each do |donation|
+        create_list(:line_item, 3, :donation, quantity: 20, item: disposable_item, itemizable: donation)
+        create_list(:line_item, 3, :donation, quantity: 10, item: non_disposable_item, itemizable: donation)
+      end
 
-    donations = (drives + outside_drives).map do |drive|
-      create_list(:product_drive_donation, 3,
-                  product_drive: drive,
-                  issued_at: drive.start_date + 1.day,
-                  money_raised: 1000,
-                  organization: organization)
-    end
-    donations.flatten!
-    donations.each do |donation|
-      create_list(:line_item, 5, :donation, quantity: 20, item: disposable_item, itemizable: donation)
-      create_list(:line_item, 5, :donation, quantity: 30, item: non_disposable_item, itemizable: donation)
-    end
-
-    # Virtual product drives
-    vdrives = create_list(:product_drive, 2,
-                          start_date: within_time,
-                          end_date: nil,
-                          virtual: true,
-                          organization: organization)
-    outside_vdrives = create_list(:product_drive, 2,
-                                  start_date: outside_time - 1.month,
-                                  end_date: outside_time,
-                                  organization: organization,
-                                  virtual: true)
-
-    vdonations = (vdrives + outside_vdrives).map do |drive|
-      create(:product_drive_donation,
-             product_drive: drive,
-             money_raised: 1000,
-             issued_at: drive.start_date + 1.day,
-             organization: organization)
-    end
-    vdonations.flatten!
-    vdonations.each do |donation|
-      create_list(:line_item, 3, :donation, quantity: 20, item: disposable_item, itemizable: donation)
-      create_list(:line_item, 3, :donation, quantity: 10, item: non_disposable_item, itemizable: donation)
-    end
-
-    # Vendors
-    vendors = [
-      create(:vendor, business_name: "Vendor 1", organization: organization),
-      create(:vendor, business_name: "Vendor 2", organization: organization),
-    ]
-
-    # Purchases
-    vendors.each do |vendor|
-      purchases = [
-        create(:purchase,
-               issued_at: within_time,
-               vendor: vendor,
-               organization: organization,
-               purchased_from: 'Google',
-               amount_spent_in_cents: 1000,
-               amount_spent_on_diapers_cents: 1000),
-        create(:purchase,
-               issued_at: within_time,
-               vendor: vendor,
-               organization: organization,
-               purchased_from: 'Walmart',
-               amount_spent_in_cents: 2000,
-               amount_spent_on_diapers_cents: 2000),
+      # Vendors
+      vendors = [
+        create(:vendor, business_name: "Vendor 1", organization: organization),
+        create(:vendor, business_name: "Vendor 2", organization: organization),
       ]
-      purchases += create_list(:purchase, 2,
-                               issued_at: outside_time,
-                               amount_spent_in_cents: 20_000,
-                               amount_spent_on_diapers_cents: 20_000,
-                               vendor: vendor,
-                               organization: organization)
-      purchases.each do |purchase|
-        create_list(:line_item, 3, :purchase, quantity: 20, item: disposable_item, itemizable: purchase)
-        create_list(:line_item, 3, :purchase, quantity: 10, item: non_disposable_item, itemizable: purchase)
+
+      # Purchases
+      vendors.each do |vendor|
+        purchases = [
+          create(:purchase,
+                 issued_at: within_time,
+                 vendor: vendor,
+                 organization: organization,
+                 purchased_from: 'Google',
+                 amount_spent_in_cents: 1000,
+                 amount_spent_on_diapers_cents: 1000),
+                 create(:purchase,
+                        issued_at: within_time,
+                        vendor: vendor,
+                        organization: organization,
+                        purchased_from: 'Walmart',
+                        amount_spent_in_cents: 2000,
+                        amount_spent_on_diapers_cents: 2000),
+        ]
+        purchases += create_list(:purchase, 2,
+                                 issued_at: outside_time,
+                                 amount_spent_in_cents: 20_000,
+                                 amount_spent_on_diapers_cents: 20_000,
+                                 vendor: vendor,
+                                 organization: organization)
+        purchases.each do |purchase|
+          create_list(:line_item, 3, :purchase, quantity: 20, item: disposable_item, itemizable: purchase)
+          create_list(:line_item, 3, :purchase, quantity: 10, item: non_disposable_item, itemizable: purchase)
+        end
       end
     end
-  end
 
-  after(:all) do
-    DatabaseCleaner.clean
-  end
-
-  subject(:report) do
-    described_class.new(organization: organization, year: year)
-  end
-
-  specify '#report' do
-    expect(report.report).to eq({
-                                  entries: { "% diapers bought" => "22%",
-                                             "% diapers donated" => "78%",
-                                             "Average monthly disposable diapers distributed" => "17",
-                                             "Disposable diapers collected from drives" => "600",
-                                             "Disposable diapers collected from drives (virtual)" => "120",
-                                             "Disposable diapers distributed" => "200",
-                                             "Money raised from product drives" => "$60.00",
-                                             "Money raised from product drives (virtual)" => "$20.00",
-                                             "Money spent purchasing diapers" => "$60.00",
-                                             "Purchased from" => "Google, Walmart",
-                                             "Total product drives" => 2,
-                                             "Total product drives (virtual)" => 2,
-                                             "Vendors diapers purchased through" => "Vendor 1, Vendor 2" },
-                                  name: "Diaper Acquisition"
-                                })
+    it 'should return the proper results on #report' do
+      expect(subject.report).to eq({
+        entries: { "% diapers bought" => "22%",
+                   "% diapers donated" => "78%",
+                   "Average monthly disposable diapers distributed" => "17",
+                   "Disposable diapers collected from drives" => "600",
+                   "Disposable diapers collected from drives (virtual)" => "120",
+                   "Disposable diapers distributed" => "200",
+                   "Money raised from product drives" => "$60.00",
+                   "Money raised from product drives (virtual)" => "$20.00",
+                   "Money spent purchasing diapers" => "$60.00",
+                   "Purchased from" => "Google, Walmart",
+                   "Total product drives" => 2,
+                   "Total product drives (virtual)" => 2,
+                   "Vendors diapers purchased through" => "Vendor 1, Vendor 2" },
+                   name: "Diaper Acquisition"
+      })
+    end
   end
 end

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -106,13 +106,13 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
                  purchased_from: 'Google',
                  amount_spent_in_cents: 1000,
                  amount_spent_on_diapers_cents: 1000),
-                 create(:purchase,
-                        issued_at: within_time,
-                        vendor: vendor,
-                        organization: organization,
-                        purchased_from: 'Walmart',
-                        amount_spent_in_cents: 2000,
-                        amount_spent_on_diapers_cents: 2000),
+          create(:purchase,
+                 issued_at: within_time,
+                 vendor: vendor,
+                 organization: organization,
+                 purchased_from: 'Walmart',
+                 amount_spent_in_cents: 2000,
+                 amount_spent_on_diapers_cents: 2000),
         ]
         purchases += create_list(:purchase, 2,
                                  issued_at: outside_time,
@@ -142,7 +142,7 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
                    "Total product drives" => 2,
                    "Total product drives (virtual)" => 2,
                    "Vendors diapers purchased through" => "Vendor 1, Vendor 2" },
-                   name: "Diaper Acquisition"
+        name: "Diaper Acquisition"
       })
     end
   end

--- a/spec/services/reports/adult_incontinence_report_service_spec.rb
+++ b/spec/services/reports/adult_incontinence_report_service_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Reports::AdultIncontinenceReportService, type: :service, skip_see
 
     describe 'with values' do
       before(:each) do
-        seed_base_items_for_tests
         Organization.seed_items(organization)
 
         within_time = Time.zone.parse("2020-05-31 14:00:00")

--- a/spec/services/reports/adult_incontinence_report_service_spec.rb
+++ b/spec/services/reports/adult_incontinence_report_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reports::AdultIncontinenceReportService, type: :service, skip_seed: true do
+RSpec.describe Reports::AdultIncontinenceReportService, type: :service do
   let(:year) { 2020 }
   let(:organization) { create(:organization) }
 

--- a/spec/services/reports/children_served_report_service_spec.rb
+++ b/spec/services/reports/children_served_report_service_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Reports::ChildrenServedReportService, type: :service, skip_seed: 
     end
 
     it 'should report normal values' do
-      seed_base_items_for_tests
       Organization.seed_items(organization)
       organization.update!(distribute_monthly: true, repackage_essentials: true)
 
@@ -53,7 +52,6 @@ RSpec.describe Reports::ChildrenServedReportService, type: :service, skip_seed: 
     end
 
     it 'should work with no distribution_quantity' do
-      seed_base_items_for_tests
       Organization.seed_items(organization)
       organization.update!(distribute_monthly: true, repackage_essentials: true)
 

--- a/spec/services/reports/children_served_report_service_spec.rb
+++ b/spec/services/reports/children_served_report_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reports::ChildrenServedReportService, type: :service, skip_seed: true do
+RSpec.describe Reports::ChildrenServedReportService, type: :service do
   let(:year) { 2020 }
   let(:organization) { create(:organization) }
 

--- a/spec/services/reports/other_products_report_service_spec.rb
+++ b/spec/services/reports/other_products_report_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reports::OtherProductsReportService, type: :service, skip_seed: true do
+RSpec.describe Reports::OtherProductsReportService, type: :service do
   let(:year) { 2020 }
   let(:organization) { create(:organization) }
 

--- a/spec/services/reports/other_products_report_service_spec.rb
+++ b/spec/services/reports/other_products_report_service_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Reports::OtherProductsReportService, type: :service, skip_seed: t
     end
 
     it 'should report normal values' do
-      seed_base_items_for_tests
       Organization.seed_items(organization)
 
       within_time = Time.zone.parse("2020-05-31 14:00:00")

--- a/spec/services/reports/partner_info_report_service_spec.rb
+++ b/spec/services/reports/partner_info_report_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reports::PartnerInfoReportService, type: :service, skip_seed: true do
+RSpec.describe Reports::PartnerInfoReportService, type: :service do
   let(:year) { 2020 }
   let(:organization) { create(:organization) }
   let(:another_organization) { create(:organization) }

--- a/spec/services/reports/period_supply_report_service_spec.rb
+++ b/spec/services/reports/period_supply_report_service_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Reports::PeriodSupplyReportService, type: :service, skip_seed: tr
 
     describe "with values" do
       before(:each) do
-        seed_base_items_for_tests
         Organization.seed_items(organization)
 
         within_time = Time.zone.parse("2020-05-31 14:00:00")

--- a/spec/services/reports/period_supply_report_service_spec.rb
+++ b/spec/services/reports/period_supply_report_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reports::PeriodSupplyReportService, type: :service, skip_seed: true do
+RSpec.describe Reports::PeriodSupplyReportService, type: :service do
   let(:year) { 2020 }
   let(:organization) { create(:organization) }
 

--- a/spec/services/reports/summary_report_service_spec.rb
+++ b/spec/services/reports/summary_report_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reports::SummaryReportService, type: :service, skip_seed: true do
+RSpec.describe Reports::SummaryReportService, type: :service do
   let(:year) { 2020 }
   let(:organization) { create(:organization) }
   let(:another_organization) { create(:organization) }

--- a/spec/services/reports/summary_report_service_spec.rb
+++ b/spec/services/reports/summary_report_service_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Reports::SummaryReportService, type: :service, skip_seed: true do
     end
 
     it 'should report positive values' do
-      seed_base_items_for_tests
       Organization.seed_items(organization)
       disposable_item = organization.items.disposable.first
       non_disposable_item = organization.items.where.not(id: organization.items.disposable).first
@@ -52,7 +51,6 @@ RSpec.describe Reports::SummaryReportService, type: :service, skip_seed: true do
     end
 
     it 'should report negative values' do
-      seed_base_items_for_tests
       Organization.seed_items(organization)
       disposable_item = organization.items.disposable.first
       non_disposable_item = organization.items.where.not(id: organization.items.disposable).first

--- a/spec/services/reports/warehouse_report_service_spec.rb
+++ b/spec/services/reports/warehouse_report_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Reports::WarehouseReportService, type: :service, skip_seed: true do
+RSpec.describe Reports::WarehouseReportService, type: :service do
   let(:year) { 2020 }
   let(:organization) { create(:organization) }
   let(:another_organization) { create(:organization) }

--- a/spec/services/request_destroy_service_spec.rb
+++ b/spec/services/request_destroy_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RequestDestroyService, type: :service, skip_seed: true do
+RSpec.describe RequestDestroyService, type: :service do
   describe '#call' do
     subject { described_class.new(request_id: request_id).call }
     let(:request_id) { request.id }

--- a/spec/services/service_object_errors_mixin_spec.rb
+++ b/spec/services/service_object_errors_mixin_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ServiceObjectErrorsMixin, skip_seed: true do
+describe ServiceObjectErrorsMixin do
   describe 'self.included' do
     before do
       stub_const 'TestClass', Class.new

--- a/spec/services/text_interpolator_service_spec.rb
+++ b/spec/services/text_interpolator_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TextInterpolatorService, type: :service, skip_seed: true do
+RSpec.describe TextInterpolatorService, type: :service do
   describe '#call' do
     subject { described_class.new(text, interpolations).call }
 

--- a/spec/services/transfer_destroy_service_spec.rb
+++ b/spec/services/transfer_destroy_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe TransferDestroyService, type: :service, skip_seed: true do
+RSpec.describe TransferDestroyService, type: :service do
   describe '#call' do
     subject { described_class.new(transfer_id: transfer_id).call }
     let(:transfer_id) { transfer.id }

--- a/spec/system/account_request_system_spec.rb
+++ b/spec/system/account_request_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Account request flow', type: :system, js: true, skip_seed: true do
+RSpec.describe 'Account request flow', type: :system, js: true do
   context 'when in staging' do
     before do
       allow(Rails.env).to receive(:staging?).and_return(true)

--- a/spec/system/account_system_spec.rb
+++ b/spec/system/account_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "User account management", type: :system, js: true, skip_seed: true do
+RSpec.describe "User account management", type: :system, js: true do
   subject { "/users/edit" }
 
   before do

--- a/spec/system/account_system_spec.rb
+++ b/spec/system/account_system_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "User account management", type: :system, js: true do
     it "should change an user name" do
       name = @user.name + "aaa"
       fill_in "Name", with: name
-      fill_in "user_current_password", with: @user.password
+      fill_in "user_current_password", with: DEFAULT_USER_PASSWORD
       click_button "Save"
 
       expect(page).to have_content(name)
@@ -38,7 +38,7 @@ RSpec.describe "User account management", type: :system, js: true do
     it "should change the email" do
       email = "example@example.com"
       fill_in "Email", with: email
-      fill_in "user_current_password", with: @user.password
+      fill_in "user_current_password", with: DEFAULT_USER_PASSWORD
       click_button "Save"
 
       expect(page).to have_content('Your account has been updated successfully.')
@@ -47,7 +47,7 @@ RSpec.describe "User account management", type: :system, js: true do
     it "should fail when the email is invalid" do
       invalid_email = "invalid email"
       fill_in "Email", with: invalid_email
-      fill_in "user_current_password", with: @user.password
+      fill_in "user_current_password", with: DEFAULT_USER_PASSWORD
       click_button "Save"
 
       expect(page).to have_content('is invalid')

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Adjustment management", type: :system, js: true, skip_seed: true do
+RSpec.describe "Adjustment management", type: :system, js: true do
   let!(:url_prefix) { "/#{@organization.to_param}" }
   let!(:storage_location) { create(:storage_location, :with_items, organization: @organization) }
   let(:add_quantity) { 10 }

--- a/spec/system/admin/account_requests_system_spec.rb
+++ b/spec/system/admin/account_requests_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Account Requests Admin", type: :system, skip_seed: true do
+RSpec.describe "Account Requests Admin", type: :system do
   context "while signed in as a super admin" do
     let!(:request1) { create(:account_request, confirmed_at: Time.zone.today, status: 'admin_approved') }
     let!(:request2) {

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Barcode Items Admin", type: :system, skip_seed: true do
+RSpec.describe "Barcode Items Admin", type: :system do
   context "while signed in as a super admin" do
     before do
       sign_in(@super_admin)

--- a/spec/system/admin/base_items_system_spec.rb
+++ b/spec/system/admin/base_items_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Base Item Admin", type: :system, js: true, skip_seed: true do
+RSpec.describe "Base Item Admin", type: :system, js: true do
   context "While signed in as an Administrative User (super admin)" do
     before do
       sign_in(@super_admin)

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin Organization Management", type: :system, js: true, skip_seed: true do
+RSpec.describe "Admin Organization Management", type: :system, js: true do
   let!(:foo_org) { create(:organization, name: 'foo') }
   let!(:bar_org) { create(:organization, name: 'bar') }
   let!(:baz_org) { create(:organization, name: 'baz') }

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin Users Management", type: :system, js: true, skip_seed: true do
+RSpec.describe "Admin Users Management", type: :system, js: true do
   context "While signed in as an Administrative User (super admin)" do
     before do
       sign_in(@super_admin)

--- a/spec/system/authorization_system_spec.rb
+++ b/spec/system/authorization_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Authorization", type: :system, js: true, skip_seed: true do
+RSpec.describe "Authorization", type: :system, js: true do
   it "redirects to the dashboard when unauthorized user attempts access" do
     sign_in(@user)
     visit "/admin/dashboard"

--- a/spec/system/barcode_item_system_spec.rb
+++ b/spec/system/barcode_item_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Barcode management", type: :system, js: true, skip_seed: true do
+RSpec.describe "Barcode management", type: :system, js: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -1,6 +1,6 @@
 require 'ostruct'
 
-RSpec.describe "Dashboard", type: :system, js: true, skip_seed: true do
+RSpec.describe "Dashboard", type: :system, js: true do
   context "With a new essentials bank" do
     before :each do
       @new_organization = create(:organization)

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature "Distributions", type: :system do
     @url_prefix = "/#{@organization.to_param}"
 
     @partner = create(:partner, organization: @organization)
-    allow_any_instance_of(Organization).to receive(:logo).and_return(instance_double('fake-logo', attached?: true, download: "logo"))
 
     @storage_location = create(:storage_location, organization: @organization)
     setup_storage_location(@storage_location)

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Distributions", type: :system, skip_seed: true do
+RSpec.feature "Distributions", type: :system do
   before do
     sign_in(@user)
     @url_prefix = "/#{@organization.to_param}"

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -4,10 +4,8 @@ RSpec.feature "Distributions", type: :system do
     @url_prefix = "/#{@organization.to_param}"
 
     @partner = create(:partner, organization: @organization)
-    @organization.logo = Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/logo.jpg"), "image/jpeg")
-    @organization.save!
+    allow_any_instance_of(Organization).to receive(:logo).and_return(instance_double('fake-logo', attached?: true, download: "logo"))
 
-    # allow_any_instance_of(StorageLocation).to receive(:geocode).and_return(true)
     @storage_location = create(:storage_location, organization: @organization)
     setup_storage_location(@storage_location)
   end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -4,6 +4,9 @@ RSpec.feature "Distributions", type: :system do
     @url_prefix = "/#{@organization.to_param}"
 
     @partner = create(:partner, organization: @organization)
+    @organization.logo = Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/logo.jpg"), "image/jpeg")
+    @organization.save!
+
     # allow_any_instance_of(StorageLocation).to receive(:geocode).and_return(true)
     @storage_location = create(:storage_location, organization: @organization)
     setup_storage_location(@storage_location)

--- a/spec/system/donation_site_system_spec.rb
+++ b/spec/system/donation_site_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Donation Site", type: :system, js: true, skip_seed: true do
+RSpec.describe "Donation Site", type: :system, js: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/kit_system_spec.rb
+++ b/spec/system/kit_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Kit management", type: :system, skip_seed: true do
+RSpec.describe "Kit management", type: :system do
   before do
     sign_in(@user)
   end

--- a/spec/system/layout_system_spec.rb
+++ b/spec/system/layout_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Layout", type: :system, skip_seed: true do
+RSpec.describe "Layout", type: :system do
   let!(:url_prefix) { "/#{@organization.to_param}" }
 
   describe "Body CSS Data" do

--- a/spec/system/log_in_system_spec.rb
+++ b/spec/system/log_in_system_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Authentication", type: :system, js: true do
     it "should not allow the user to log in" do
       visit "/users/sign_in"
       fill_in "user_email", with: "deactivated@example.com"
-      fill_in "user_password", with: "password!"
+      fill_in "user_password", with: DEFAULT_USER_PASSWORD
       find('input[name="commit"]').click
       expect(page).to have_content("Invalid Email or password")
     end

--- a/spec/system/log_in_system_spec.rb
+++ b/spec/system/log_in_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Authentication", type: :system, js: true, skip_seed: true do
+RSpec.describe "Authentication", type: :system, js: true do
   describe "Success" do
     it "should show dashboard upon signin" do
       sign_in(@user)

--- a/spec/system/manage_system_spec.rb
+++ b/spec/system/manage_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Organization Administration", type: :system, js: true, skip_seed: true do
+RSpec.describe "Organization Administration", type: :system, js: true do
   subject { "/#{@organization.to_param}/organization" }
 
   context "while signed in as a normal user" do

--- a/spec/system/manufacturer_system_spec.rb
+++ b/spec/system/manufacturer_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Manufacturer", type: :system, skip_seed: true do
+RSpec.describe "Manufacturer", type: :system do
   before do
     sign_in(@user)
   end

--- a/spec/system/navigation_system_spec.rb
+++ b/spec/system/navigation_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Navigation", type: :system, js: true, skip_seed: true do
+RSpec.describe "Navigation", type: :system, js: true do
   describe "sidebar on home" do
     before do
       sign_in(user)

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Organization management", type: :system, js: true, skip_seed: true do
+RSpec.describe "Organization management", type: :system, js: true do
   include ActionView::RecordIdentifier
   let!(:url_prefix) { "/#{@organization.to_param}" }
 

--- a/spec/system/partners/approval_process_spec.rb
+++ b/spec/system/partners/approval_process_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Approval process for partners", type: :system, js: true, skip_seed: true do
+RSpec.describe "Approval process for partners", type: :system, js: true do
   describe 'filling in organization details and requesting for approval' do
     let(:partner_user) { partner.primary_partner_user }
     let!(:partner) { FactoryBot.create(:partner) }

--- a/spec/system/partners/coworker_invitations_system_spec.rb
+++ b/spec/system/partners/coworker_invitations_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Coworking invitations", type: :system, js: true, skip_seed: true do
+RSpec.describe "Coworking invitations", type: :system, js: true do
   describe 'inviting a new user as a partner user' do
     let(:partner_user) { partner.primary_partner_user }
     let!(:partner) { FactoryBot.create(:partner) }

--- a/spec/system/partners/family_requests_system_spec.rb
+++ b/spec/system/partners/family_requests_system_spec.rb
@@ -10,12 +10,13 @@ RSpec.describe "Family requests", type: :system, js: true do
   end
 
   describe "for children with different items, from different families" do
+    let(:item_id) { Item.all.sample.id }
     let!(:children) do
       [
         create(:partners_child, family: family),
-        create(:partners_child, family: family, item_needed_diaperid: 2),
-        create(:partners_child, family: family, item_needed_diaperid: 2),
-        create(:partners_child, family: other_family, item_needed_diaperid: 2),
+        create(:partners_child, family: family, item_needed_diaperid: item_id),
+        create(:partners_child, family: family, item_needed_diaperid: item_id),
+        create(:partners_child, family: other_family, item_needed_diaperid: item_id),
         create(:partners_child, family: other_family)
       ]
     end

--- a/spec/system/partners/helps_system_spec.rb
+++ b/spec/system/partners/helps_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Help", type: :system, skip_seed: true do
+RSpec.describe "Help", type: :system do
   let(:partner) { FactoryBot.create(:partner) }
   let(:partner_user) { partner.primary_partner_user }
 

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe "Managing requests", type: :system, js: true do
           before do
             expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
 
-            expect(current_path).to eq(partners_request_path(Request.last.id))
+            expect(current_path).to eq(partners_request_path(partner.requests.last.id))
             expect(page).to have_content('Request has been successfully created!')
           end
 
           it 'AND the partner_user can view the details of the created individuals request in a seperate page' do
-            visit partners_request_path(id: Partners::Request.last.id)
+            visit partners_request_path(id: partner.requests.last.id)
 
             # Should have the proper quantity per each item.
             item_details.each do |item|
@@ -101,7 +101,7 @@ RSpec.describe "Managing requests", type: :system, js: true do
         it 'should be created without any issue' do
           expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
 
-          expect(current_path).to eq(partners_request_path(Request.last.id))
+          expect(current_path).to eq(partners_request_path(partner.requests.last.id))
           expect(page).to have_content('Request has been successfully created!')
           expect(page).to have_content("#{partner.organization.name} should have received the request.")
         end
@@ -140,13 +140,14 @@ RSpec.describe "Managing requests", type: :system, js: true do
           before do
             expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
 
-            expect(current_path).to eq(partners_request_path(Request.last.id))
+            expect(current_path).to eq(partners_request_path(partner.requests.last.id))
             expect(page).to have_content('Request has been successfully created!')
             expect(page).to have_content("#{partner.organization.name} should have received the request.")
           end
 
           it 'AND the partner_user can view the details of the created request in a seperate page' do
-            visit partners_request_path(id: Partners::Request.last.id)
+            visit partners_request_path(id: partner.requests.last.id)
+
 
             item_details.each do |item|
               expect(page).to have_content("#{item[:quantity]} of #{item[:name]}")

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe "Managing requests", type: :system, js: true do
           before do
             expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
 
-            expect(current_path).to eq(partners_request_path(partner.requests.last.id))
+            expect(current_path).to eq(partners_request_path(Partners::Request.last.id))
             expect(page).to have_content('Request has been successfully created!')
           end
 
           it 'AND the partner_user can view the details of the created individuals request in a seperate page' do
-            visit partners_request_path(id: partner.requests.last.id)
+            visit partners_request_path(id: Partners::Request.last.id)
 
             # Should have the proper quantity per each item.
             item_details.each do |item|
@@ -140,13 +140,13 @@ RSpec.describe "Managing requests", type: :system, js: true do
           before do
             expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
 
-            expect(current_path).to eq(partners_request_path(partner.requests.last.id))
+            expect(current_path).to eq(partners_request_path(Partners::Request.last.id))
             expect(page).to have_content('Request has been successfully created!')
             expect(page).to have_content("#{partner.organization.name} should have received the request.")
           end
 
           it 'AND the partner_user can view the details of the created request in a seperate page' do
-            visit partners_request_path(id: partner.requests.last.id)
+            visit partners_request_path(id: Partners::Request.last.id)
 
             item_details.each do |item|
               expect(page).to have_content("#{item[:quantity]} of #{item[:name]}")

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Managing requests", type: :system, js: true do
         it 'should be created without any issue' do
           expect { click_button 'Submit Essentials Request' }.to change { Partners::Request.count + Request.count }.by(2)
 
-          expect(current_path).to eq(partners_request_path(partner.requests.last.id))
+          expect(current_path).to eq(partners_request_path(Partners::Request.last.id))
           expect(page).to have_content('Request has been successfully created!')
           expect(page).to have_content("#{partner.organization.name} should have received the request.")
         end

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -148,7 +148,6 @@ RSpec.describe "Managing requests", type: :system, js: true do
           it 'AND the partner_user can view the details of the created request in a seperate page' do
             visit partners_request_path(id: partner.requests.last.id)
 
-
             item_details.each do |item|
               expect(page).to have_content("#{item[:quantity]} of #{item[:name]}")
             end

--- a/spec/system/partners/partner_distribution_system_spec.rb
+++ b/spec/system/partners/partner_distribution_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Partner Distributions", type: :system, js: true, skip_seed: true do
+RSpec.describe "Partner Distributions", type: :system, js: true do
   describe "Distributions" do
     let(:partner_user) { partner.primary_partner_user }
     let(:date) { 1.week.from_now }

--- a/spec/system/product_drive_participant_system_spec.rb
+++ b/spec/system/product_drive_participant_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe " Participant", type: :system, js: true, skip_seed: true do
+RSpec.describe " Participant", type: :system, js: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/product_drive_system_spec.rb
+++ b/spec/system/product_drive_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Product Drives", type: :system, js: true, skip_seed: true do
+RSpec.describe "Product Drives", type: :system, js: true do
   include DateRangeHelper
 
   before do

--- a/spec/system/question_system_spec.rb
+++ b/spec/system/question_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Question search", type: :system, js: true, skip_seed: true do
+RSpec.describe "Question search", type: :system, js: true do
   context "while logged in" do
     before do
       sign_in(@user)

--- a/spec/system/sign_in_system_spec.rb
+++ b/spec/system/sign_in_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "User sign-in handling", type: :system, js: true, skip_seed: true do
+RSpec.describe "User sign-in handling", type: :system, js: true do
   subject { new_user_session_path }
 
   before do

--- a/spec/system/sign_in_system_spec.rb
+++ b/spec/system/sign_in_system_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "User sign-in handling", type: :system, js: true do
   context "when users are valid and belong to an organization" do
     it "redirects to user's dashboard" do
       fill_in "Email", with: @user.email
-      fill_in "Password", with: @user.password
+      fill_in "Password", with: DEFAULT_USER_PASSWORD
       click_button "Log in"
 
       expect(page).to have_current_path(

--- a/spec/system/storage_location_system_spec.rb
+++ b/spec/system/storage_location_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Storage Locations", type: :system, js: true, skip_seed: true do
+RSpec.describe "Storage Locations", type: :system, js: true do
   before do
     sign_in(@user)
   end

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Transfer management", type: :system, skip_seed: true do
+RSpec.describe "Transfer management", type: :system do
   before do
     sign_in(@user)
   end

--- a/spec/system/vendor_system_spec.rb
+++ b/spec/system/vendor_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Vendor", type: :system, js: true, skip_seed: true do
+RSpec.describe "Vendor", type: :system, js: true do
   before do
     sign_in(@user)
   end


### PR DESCRIPTION
Resolves #3031

### Description

This PR adds some changes to speed up specs in CI and reduce flakiness on a number of specs. Here is a high level of changes:

- Utilize set `use_transactional_fixtures` to `true` again (it was removed when we had 2 DBs) so that changes to the DB are kept in a transaction and are quickly rolled back. This reduces the overhead of having to create & erase records from the DB.
- Turn off `queue` mode from Knapsack since we are likely taking a penalty from waiting for knapsack to tell us which specs to run. It would be very effective but I think our startup cost is pretty high for the application and we lose the benefits.
- Fixed flaky tests that used hardcoded OR wrong primary keys in assertions. Let's avoid using primary keys to make assertions, it isn't always 100% that the id of a record you are asserting against is the same
- Split system + request specs & non-system so we aren't precompiling assets for specs that don't need it.
- Cleaned up `rails_helper` so that we always create base required records before the suite. Moreover, simplify them!
- Removed the need to keep checking if Webpacker ran already to build assets by ensuring webpacker is running in `test` mode rather than the default `development`
- Silenced a spec that mixes a feature spec inside a model spec (see commit [aa95899](https://github.com/rubyforgood/human-essentials/pull/3130/commits/aa95899684590c4d827bd1716f933b12b442d7be))

### Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Ran locally & in CI. Tests should continue to function

### Screenshots
N/A
