### PR TITLE
3093 product drive export

### DIFF
--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -10,6 +10,13 @@ class ProductDrivesController < ApplicationController
                      .within_date_range(@selected_date_range)
                      .order(created_at: :desc)
     @selected_name_filter = filter_params[:by_name]
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        send_data Exports::ExportProductDrivesCSVService.generate_csv(@product_drives), filename: "Product-Drives-#{Time.zone.today}.csv"
+      end
+    end
   end
 
   # GET /product_drives/1
@@ -84,6 +91,7 @@ class ProductDrivesController < ApplicationController
     params.require(:filters)[:date_range]
   end
 
+  helper_method \
   def filter_params
     return {} unless params.key?(:filters)
 

--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -92,7 +92,7 @@ class ProductDrivesController < ApplicationController
   end
 
   helper_method \
-  def filter_params
+    def filter_params
     return {} unless params.key?(:filters)
 
     params.require(:filters).slice(:by_name)

--- a/app/services/exports/export_product_drives_csv_service.rb
+++ b/app/services/exports/export_product_drives_csv_service.rb
@@ -1,7 +1,7 @@
 module Exports
   class ExportProductDrivesCSVService
     extend ItemsHelper
-    HEADERS = ['Product Drive Name','Start Date','End Date','Held Virtually?','Quantity of Items','Variety of Items','In Kind Value']
+    HEADERS = ["Product Drive Name", "Start Date", "End Date", "Held Virtually?", "Quantity of Items", "Variety of Items", "In Kind Value"]
 
     def self.generate_csv(product_drives)
       CSV.generate do |csv|
@@ -14,16 +14,16 @@ module Exports
     end
 
     private
-    
+
     def self.generate_row(drive)
-      [ 
-        "#{drive.name}", 
-        "#{drive.start_date.strftime("%m-%d-%Y")}", 
-        "#{drive.end_date&.strftime("%m-%d-%Y")}", 
-        "#{drive.virtual ? 'Yes' : 'No'}", 
-        "#{drive.donation_quantity}",
-        "#{drive.distinct_items_count}",
-        "#{dollar_value(drive.in_kind_value)}"
+      [
+        drive.name.to_s,
+        drive.start_date.strftime("%m-%d-%Y").to_s,
+        drive.end_date&.strftime("%m-%d-%Y").to_s,
+        (drive.virtual ? "Yes" : "No").to_s,
+        drive.donation_quantity.to_s,
+        drive.distinct_items_count.to_s,
+        dollar_value(drive.in_kind_value).to_s
       ]
     end
   end

--- a/app/services/exports/export_product_drives_csv_service.rb
+++ b/app/services/exports/export_product_drives_csv_service.rb
@@ -1,0 +1,30 @@
+module Exports
+  class ExportProductDrivesCSVService
+    extend ItemsHelper
+    HEADERS = ['Product Drive Name','Start Date','End Date','Held Virtually?','Quantity of Items','Variety of Items','In Kind Value']
+
+    def self.generate_csv(product_drives)
+      CSV.generate do |csv|
+        csv << HEADERS
+
+        product_drives.each do |drive|
+          csv << generate_row(drive)
+        end
+      end
+    end
+
+    private
+    
+    def self.generate_row(drive)
+      [ 
+        "#{drive.name}", 
+        "#{drive.start_date.strftime("%m-%d-%Y")}", 
+        "#{drive.end_date&.strftime("%m-%d-%Y")}", 
+        "#{drive.virtual ? 'Yes' : 'No'}", 
+        "#{drive.donation_quantity}",
+        "#{drive.distinct_items_count}",
+        "#{dollar_value(drive.in_kind_value)}"
+      ]
+    end
+  end
+end

--- a/app/services/exports/export_product_drives_csv_service.rb
+++ b/app/services/exports/export_product_drives_csv_service.rb
@@ -13,9 +13,9 @@ module Exports
       end
     end
 
-    private
-
-    def self.generate_row(drive)
+    private_class_method(
+      # The following indentation is idiotic, but it's what rubocop wants
+      def self.generate_row(drive)
       [
         drive.name.to_s,
         drive.start_date.strftime("%m-%d-%Y").to_s,
@@ -26,5 +26,6 @@ module Exports
         dollar_value(drive.in_kind_value).to_s
       ]
     end
+    )
   end
 end

--- a/app/views/product_drives/index.html.erb
+++ b/app/views/product_drives/index.html.erb
@@ -50,6 +50,14 @@
                 <%= filter_button %>
                 <%= clear_filter_button %>
                 <span class="float-right">
+                  <%=
+                    if @product_drives.length > 0
+                      download_button_to(
+                        product_drives_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)),
+                        text: "Export Product Drives"
+                      )
+                    end
+                  %>
                   <%= new_button_to new_product_drive_path(organization_id: current_organization), {text: "New Product Drive"} %>
                   </span>
               </div>

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
   end
 
   context "While signed in >" do
-    let(:product_drive) { create(:product_drive, organization: organization) }
     before do
       sign_in(user)
     end
@@ -110,6 +109,8 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
 
     describe "PUT#update" do
       it "returns redirect http status" do
+        product_drive = create(:product_drive, organization: organization)
+
         put product_drive_path(default_params.merge(id: product_drive.id, product_drive: attributes_for(:product_drive)))
         expect(response).to have_http_status(:redirect)
       end
@@ -117,6 +118,8 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
 
     describe "GET #edit" do
       it "returns http success" do
+        product_drive = create(:product_drive, organization: organization)
+
         get edit_product_drive_path(default_params.merge(id: product_drive.id))
         expect(response).to be_successful
       end
@@ -124,6 +127,8 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
 
     describe "GET #show" do
       it "returns http success" do
+        product_drive = create(:product_drive, organization: organization)
+
         get product_drive_path(default_params.merge(id: product_drive.id))
         expect(response).to be_successful
       end
@@ -131,6 +136,8 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
 
     describe "DELETE #destroy" do
       it "redirects to the index" do
+        product_drive = create(:product_drive, organization: organization)
+        
         delete product_drive_path(default_params.merge(id: product_drive.id))
         expect(response).to redirect_to(product_drives_path)
       end

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
     describe "DELETE #destroy" do
       it "redirects to the index" do
         product_drive = create(:product_drive, organization: organization)
-        
+
         delete product_drive_path(default_params.merge(id: product_drive.id))
         expect(response).to redirect_to(product_drives_path)
       end

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
         end
 
         it 'returns ONLY the product drives within a selected date range (inclusive)' do
-          default_params.merge!(filters: { date_range: date_range_picker_params(Date.parse('30/01/1979'), Date.parse('30/01/1982')) })
+          default_params[:filters] = { date_range: date_range_picker_params(Date.parse('30/01/1979'), Date.parse('30/01/1982')) }
 
           FactoryBot.create(
             :product_drive,

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
 
           expect(response).to be_successful
           expect(response.header['Content-Type']).to include 'text/csv'
-          
+
           expected_headers = "Product Drive Name,Start Date,End Date,Held Virtually?,Quantity of Items,Variety of Items,In Kind Value\n"
           expect(response.body).to eq(expected_headers)
         end
@@ -46,7 +46,7 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
           FactoryBot.create(:product_drive, name: 'unassociated_product_drive', organization: FactoryBot.create(:organization))
 
           subject
-          
+
           expect(response.body).to include('product_drive')
           expect(response.body).not_to include('unassociated_product_drive')
         end
@@ -55,21 +55,21 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
           default_params.merge!(filters: { date_range: date_range_picker_params(Date.parse('30/01/1979'), Date.parse('30/01/1982')) })
 
           FactoryBot.create(
-            :product_drive, 
+            :product_drive,
             name: 'early_product_drive',
             start_date: '30/01/1970',
             end_date: '30/01/1971',
             organization: organization
           )
           FactoryBot.create(
-            :product_drive, 
+            :product_drive,
             name: 'product_drive_within_date_range',
             start_date: '30/01/1980',
             end_date: '30/01/1981',
             organization: organization
           )
           FactoryBot.create(
-            :product_drive, 
+            :product_drive,
             name: 'product_drive_on_date_range',
             start_date: '30/01/1979',
             end_date: '30/01/1982',
@@ -77,7 +77,7 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
           )
 
           FactoryBot.create(
-            :product_drive, 
+            :product_drive,
             name: 'late_product_drive',
             start_date: '30/01/1990',
             end_date: '30/01/1991',
@@ -85,12 +85,12 @@ RSpec.describe "ProductDrives", type: :request, skip_seed: true do
           )
 
           subject
-          
+
           expect(response.body).to include('product_drive_within_date_range')
           expect(response.body).to include('product_drive_on_date_range')
           expect(response.body).not_to include('early_product_drive')
           expect(response.body).not_to include('late_product_drive')
-        end       
+        end
       end
     end
 

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -1,20 +1,96 @@
 require 'rails_helper'
 
-RSpec.describe "ProductDrives", type: :request do
-  let(:default_params) do
-    { organization_id: @organization.id.to_param }
+RSpec.describe "ProductDrives", type: :request, skip_seed: true do
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:user) { FactoryBot.create(:user, organization: organization) }
+  let(:default_params) { { organization_id: organization.to_param } }
+
+  context "while not signed in" do
+    it "is unsuccessful" do
+      get product_drives_path(default_params)
+
+      expect(response).not_to be_successful
+    end
   end
 
   context "While signed in >" do
-    let(:product_drive) { create(:product_drive) }
+    let(:product_drive) { create(:product_drive, organization: organization) }
     before do
-      sign_in(@user)
+      sign_in(user)
     end
 
     describe "GET #index" do
+      subject { get product_drives_path(default_params) }
+
       it "returns http success" do
-        get product_drives_path(default_params)
+        subject
+
         expect(response).to be_successful
+      end
+
+      context "csv" do
+        before { default_params.merge!(format: :csv) }
+
+        it 'is successful' do
+          subject
+
+          expect(response).to be_successful
+          expect(response.header['Content-Type']).to include 'text/csv'
+          
+          expected_headers = "Product Drive Name,Start Date,End Date,Held Virtually?,Quantity of Items,Variety of Items,In Kind Value\n"
+          expect(response.body).to eq(expected_headers)
+        end
+
+        it 'returns ONLY the associated product drives' do
+          FactoryBot.create(:product_drive, name: 'product_drive', organization: organization)
+          FactoryBot.create(:product_drive, name: 'unassociated_product_drive', organization: FactoryBot.create(:organization))
+
+          subject
+          
+          expect(response.body).to include('product_drive')
+          expect(response.body).not_to include('unassociated_product_drive')
+        end
+
+        it 'returns ONLY the product drives within a selected date range (inclusive)' do
+          default_params.merge!(filters: { date_range: date_range_picker_params(Date.parse('30/01/1979'), Date.parse('30/01/1982')) })
+
+          FactoryBot.create(
+            :product_drive, 
+            name: 'early_product_drive',
+            start_date: '30/01/1970',
+            end_date: '30/01/1971',
+            organization: organization
+          )
+          FactoryBot.create(
+            :product_drive, 
+            name: 'product_drive_within_date_range',
+            start_date: '30/01/1980',
+            end_date: '30/01/1981',
+            organization: organization
+          )
+          FactoryBot.create(
+            :product_drive, 
+            name: 'product_drive_on_date_range',
+            start_date: '30/01/1979',
+            end_date: '30/01/1982',
+            organization: organization
+          )
+
+          FactoryBot.create(
+            :product_drive, 
+            name: 'late_product_drive',
+            start_date: '30/01/1990',
+            end_date: '30/01/1991',
+            organization: organization
+          )
+
+          subject
+          
+          expect(response.body).to include('product_drive_within_date_range')
+          expect(response.body).to include('product_drive_on_date_range')
+          expect(response.body).not_to include('early_product_drive')
+          expect(response.body).not_to include('late_product_drive')
+        end       
       end
     end
 


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/human-essentials/issues/3093

### Description
Adds a button to the product drives page to give the user the ability to download a csv of product drives, filtered by date.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Request specs added.
I have also tested the feature locally (see screenshots) 

### Screenshots
Product Drives page now includes an "Export Product Drives" button:
![image](https://user-images.githubusercontent.com/27900457/189502944-19310963-d9fe-4d1b-b347-32db886b0839.png)

When button is clicked on the above page, the following csv is downloaded:
![image](https://user-images.githubusercontent.com/27900457/189502972-3ee24978-3ced-47b6-ac04-4926368ecf77.png)
   