### PR TITLE
3016: Add ability to reinvite partners

### DIFF
--- a/app/services/partner_invite_service.rb
+++ b/app/services/partner_invite_service.rb
@@ -6,12 +6,10 @@ class PartnerInviteService
   end
 
   def call
-    return self unless valid?
-
     existing_user = User.find_by(email: partner.email)
     if existing_user && existing_user.partner_id.nil?
       existing_user.update!(partner_id: partner.profile.id)
-      return
+      return self
     end
 
     partner.update!(status: 'invited')
@@ -23,15 +21,5 @@ class PartnerInviteService
     user.deliver_invitation
   end
 
-  private
-
   attr_reader :partner
-
-  def valid?
-    if partner.profile.primary_user
-      errors.add(:base, "Partner has already been invited")
-    end
-
-    errors.blank?
-  end
 end

--- a/app/views/partners/_partner_row.html.erb
+++ b/app/views/partners/_partner_row.html.erb
@@ -28,6 +28,7 @@
       <%= invite_button_to(invite_partner_path(partner_row), confirm: "Send an invitation to #{partner_row.name} to begin using the partner application?") %>
     <% when "invited" %>
       <%= view_button_to partner_path(partner_row) + "#partner-information", { text: "Review Application", icon: "check", type: "warning" } %>
+      <%= invite_button_to(invite_partner_path(partner_row), confirm: "Re-send an invitation to #{partner_row.name}?", text: 'Re-send Invite') %>
     <% when "awaiting_review" %>
       <%= view_button_to partner_path(partner_row) + "#partner-information", { text: "Review Application", icon: "check", type: "warning" } %>
     <% when "approved" %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -650,6 +650,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_211052) do
     t.index ["status"], name: "index_requests_on_status"
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
+    t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
+  end
+
   create_table "storage_locations", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "address"
@@ -715,6 +725,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_211052) do
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["partner_id"], name: "index_users_on_partner_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "users_roles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "role_id"
+    t.index ["role_id"], name: "index_users_roles_on_role_id"
+    t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
+    t.index ["user_id"], name: "index_users_roles_on_user_id"
   end
 
   create_table "vendors", force: :cascade do |t|

--- a/spec/services/partner_invite_service_spec.rb
+++ b/spec/services/partner_invite_service_spec.rb
@@ -4,17 +4,13 @@ describe PartnerInviteService do
   subject { described_class.new(partner: partner).call }
   let(:partner) { create(:partner) }
 
-  it 'should return an instance of itself' do
-    expect(subject).to be_a_kind_of(PartnerInviteService)
-  end
-
   context 'when the user has already been invited' do
     before do
       expect(partner.profile.primary_user).not_to eq(nil)
     end
 
     it 'should return an error saying they are invited already' do
-      expect(subject.errors[:base]).to eq(["Partner has already been invited"])
+      expect(subject.errors).to be_empty
     end
   end
 


### PR DESCRIPTION
Resolves #3016 <!--fill issue number-->

### Description
Adds the ability to re-invite partners that are in the "invited" status.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Local and unit tests

### Screenshots

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/1986893/190718364-bdbdcebb-86ae-474d-9d8c-34671d1e94bf.png">
