### PR TITLE
Remove schema load from fetch_latest_db to avoid collision between lo…

### DIFF
--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -11,7 +11,7 @@ task :fetch_latest_db => :environment do
 
   puts "Recreating databases..."
   system("bin/rails db:environment:set RAILS_ENV=development")
-  system("rails db:drop db:create db:schema:load")
+  system("rails db:drop db:create")
 
   puts "Restoring the database with #{backup.name}"
   backup_filepath = fetch_file_path(backup)


### PR DESCRIPTION
### Description

Prevent collision between schema on production and local which causes migrations to not work as intended when running production set locally.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
