### PR TITLE
Adds comment to distribution report csv

### DIFF
--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -77,6 +77,9 @@ module Exports
         },
         "Agency Representative" => ->(distribution) {
           distribution.agency_rep
+        },
+        "Comments" => ->(distribution) {
+          distribution.comment
         }
       }
     end

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -69,7 +69,8 @@ describe Exports::ExportDistributionsCSVService do
         "Total Value",
         "Delivery Method",
         "State",
-        "Agency Representative"
+        "Agency Representative",
+        "Comments"
       ] + expected_item_headers
     end
 
@@ -91,7 +92,8 @@ describe Exports::ExportDistributionsCSVService do
           distribution.cents_to_dollar(distribution.line_items.total_value),
           distribution.delivery_method,
           distribution.state,
-          distribution.agency_rep
+          distribution.agency_rep,
+          distribution.comment
         ]
 
         row += total_item_quantity


### PR DESCRIPTION
Resolves #3153 

### Description
Comments column is added to the distributions report.
   
I have added this new column after the Agency Rep column, hoping the order is fine.

### Type of change

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

Existing Rspec has been fixed to test this change.

Create a distribution report csv for a partner and the comments column will now be included in the report.

### Screenshots
![dist_report](https://user-images.githubusercontent.com/15196830/191891466-3adc1d01-c395-419b-af5e-b28d6c589aeb.png)


