### PR TITLE
Added copying of .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You must install postgres and run the database locally. Instructions differ depe
 
 Follow one of these guides to install postgres:
 This app uses PostgreSQL for all environments. You'll also need to create the `dev` and `test` databases, the app is expecting them to be named `diaper_dev` and `diaper_test` respectively. This should all be handled with `rails db:setup`.
-Create a `database.yml` file on `config/` directory with your database configurations. You can also copy the existing file called [`database.yml.example`](config/database.yml.example) as an example and just change the credentials.
+Create a `database.yml` file on `config/` directory with your database configurations. You can also copy the existing files called [`database.yml.example`](config/database.yml.example) and [`.env.example`](.env.example) as an example and just change the credentials.
 
 - MacOSX - https://www.digitalocean.com/community/tutorials/how-to-use-postgresql-with-your-ruby-on-rails-application-on-macos
 - Ubuntu - TODO


### PR DESCRIPTION
### Description

I saw that copying of .env.example was not included. So I'm proposing this change.

### Type of change

* Documentation update

### How Has This Been Tested?

I saw the readme markdown is working and is linked to the correct file.

