### PR TITLE
Replace the data-partner-reminder-form JS with stimulus controller

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -106,26 +106,3 @@ $(document).ready(function () {
     window.location.hash = e.target.hash;
   })
 })
-
-/**
- * Handles toggling the visiblity of reminder options depending on
- * if reminders are even enabled.
- */
-$(document).ready(function() {
-  $('[data-partner-reminder-form]').each(function(idx, formEle) {
-    let nestedForm = $(formEle).find('[data-partner-reminder-form-nested-form]');
-    let checkBox = $(formEle).find('[data-partner-reminder-form-checkbox]');
-
-    function toggleNestedFormVisibility(nestedForm, checkBox) {
-      let shouldBeVisible = !checkBox.get(0).checked;
-      nestedForm.toggleClass('hidden', shouldBeVisible);
-    }
-
-    $(checkBox).change(function(ele) {
-      toggleNestedFormVisibility(nestedForm, checkBox);
-    })
-
-    toggleNestedFormVisibility(nestedForm, checkBox);
-  })
-})
-

--- a/app/javascript/controllers/checkbox_with_nested_element_controller.js
+++ b/app/javascript/controllers/checkbox_with_nested_element_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+/*
+ * CheckboxWithNestedElementController is a Stimulus controller that
+ * shows/hides a nested element when a checkbox is checked/unchecked.
+ */
+export default class extends Controller {
+  static targets = [ "nestedElement", "checkbox" ]
+
+  connect() {
+    this.toggleNestedElementVisiblity()
+  }
+
+  toggleNestedElementVisiblity() {
+    if (this.checkboxTarget.checked) {
+      this.nestedElementTarget.classList.remove("hidden")
+    } else {
+      this.nestedElementTarget.classList.add("hidden")
+    }
+  }
+
+}
+

--- a/app/javascript/controllers/checkbox_with_nested_element_controller.js
+++ b/app/javascript/controllers/checkbox_with_nested_element_controller.js
@@ -11,12 +11,12 @@ export default class extends Controller {
     this.toggleNestedElementVisiblity()
   }
 
+  /**
+   * Toggles the visibility of the nested element depending
+   * on wither the checkbox is checked or not.
+   */
   toggleNestedElementVisiblity() {
-    if (this.checkboxTarget.checked) {
-      this.nestedElementTarget.classList.remove("hidden")
-    } else {
-      this.nestedElementTarget.classList.add("hidden")
-    }
+    this.nestedElementTarget.classList.toggle("hidden", !this.checkboxTarget.checked)
   }
 
 }

--- a/app/views/partner_groups/_form.html.erb
+++ b/app/views/partner_groups/_form.html.erb
@@ -22,7 +22,7 @@
 
               <div class='mt-3' data-controller='checkbox-with-nested-element'>
                 <h2 class='text-bold text-lg'>Do you want to send deadline reminders to them every month?</h2>
-                <%= f.input :send_reminders, as: :boolean, label: "Yes", input_html: { data: { action: 'click->checkbox-with-nested-element#toggleNestedElementVisiblity' } } %>
+                <%= f.input :send_reminders, as: :boolean, label: "Yes", input_html: { data: { action: 'click->checkbox-with-nested-element#toggleNestedElementVisiblity', 'checkbox-with-nested-element-target': 'checkbox' } } %>
 
                 <div class='pl-4 w-3/4 hidden' data-checkbox-with-nested-element-target='nestedElement'>
 

--- a/app/views/partner_groups/_form.html.erb
+++ b/app/views/partner_groups/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @partner_group, html: {class: 'form-horizontal' } do |f| %>
+<%= simple_form_for @partner_group, html: { class: 'form-horizontal' } do |f| %>
   <section class="content">
     <div class="container-fluid">
       <div class="row">
@@ -20,11 +20,12 @@
                 <%= f.association :item_categories, collection: @item_categories, as: :check_boxes, label: '' %>
               </div>
 
-              <div class='mt-3' data-partner-reminder-form>
+              <div class='mt-3' data-controller='checkbox-with-nested-element'>
                 <h2 class='text-bold text-lg'>Do you want to send deadline reminders to them every month?</h2>
-                <%= f.input :send_reminders, as: :boolean, label: "Yes", input_html: { data: { 'partner-reminder-form-checkbox': '' } } %>
+                <%= f.input :send_reminders, as: :boolean, label: "Yes", input_html: { data: { action: 'click->checkbox-with-nested-element#toggleNestedElementVisiblity' } } %>
 
-                <div class='pl-4 w-3/4' data-partner-reminder-form-nested-form>
+                <div class='pl-4 w-3/4 hidden' data-checkbox-with-nested-element-target='nestedElement'>
+
                   <div class="bg-yellow-200 border-l-4 border-orange-500 text-orange-700 p-4 mb-2" role="alert">
                     <p class="font-bold text-red-800">That's great! You must fill out the details below to send reminders. </p>
                   </div>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for form, html: {class: 'form-horizontal'} do |f| %>
+<%= simple_form_for form, html: { class: 'form-horizontal' } do |f| %>
   <section class="content">
     <div class="container-fluid">
       <div class="row">
@@ -29,12 +29,12 @@
                 <% end %>
               </div>
 
-              <div data-partner-reminder-form>
+              <div data-controller='checkbox-with-nested-element'>
                 <%= f.input :send_reminders, label: "Do you want this partner to receive emails for distributions and reminders from the system?", wrapper: :input_group do %>
-                  <%= f.check_box :send_reminders, {class: "input-group-text", id: "send_reminders", data: { 'partner-reminder-form-checkbox': '' } }, "true", "false" %>
+                  <%= f.check_box :send_reminders, { class: "input-group-text", id: "send_reminders", data: { action: 'click->checkbox-with-nested-element#toggleNestedElementVisiblity' } }, "true", "false" %>
                  <% end %>
 
-                <div class='mb-2' data-partner-reminder-form-nested-form>
+                <div class='mb-2 hidden' data-checkbox-with-nested-element-target='nestedElement'>
                   <div class="flex items-center bg-yellow-300 text-sm font-bold px-4 py-3" role="alert">
                     <p>Please note that reminders will be sent out according to the settings of their partner group OR organization. This won't work unless you've set up at least one.</p>
                   </div>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -31,7 +31,7 @@
 
               <div data-controller='checkbox-with-nested-element'>
                 <%= f.input :send_reminders, label: "Do you want this partner to receive emails for distributions and reminders from the system?", wrapper: :input_group do %>
-                  <%= f.check_box :send_reminders, { class: "input-group-text", id: "send_reminders", data: { action: 'click->checkbox-with-nested-element#toggleNestedElementVisiblity' } }, "true", "false" %>
+                  <%= f.check_box :send_reminders, { class: "input-group-text", id: "send_reminders", data: { action: 'click->checkbox-with-nested-element#toggleNestedElementVisiblity', 'checkbox-with-nested-element-target': 'checkbox' } }, "true", "false" %>
                  <% end %>
 
                 <div class='mb-2 hidden' data-checkbox-with-nested-element-target='nestedElement'>


### PR DESCRIPTION
### Description

Replaces the legacy custom JS used to handle showing nested forms depending on the checkbox. Migrating away from old JS with using StimulusJS.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally

### Screenshots
![form1](https://user-images.githubusercontent.com/11335191/196310207-8fb3f3c5-799a-477c-9ef5-47907eb2117f.gif)
![form2](https://user-images.githubusercontent.com/11335191/196310209-d5c68279-ed9b-4a7c-a1bd-ea7d8c689d92.gif)