### PR TITLE
Remove unused/incorrect JS code to prevent fading out of flash messages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,14 +23,6 @@
 //= require quagga
 //= require_tree .
 
-window.setTimeout(function() {
-  // When the user is given an error message, we should not auto-hide it so that
-  // they can fully read it and potentially copy/paste it into an issue.
-  $(".alert").not(".error").fadeTo(1000, 0).slideUp(1000, function() {
-    $(this).remove();
-  });
-}, 2500);
-
 $(document).ready(function() {
   Filterrific.init();
 });


### PR DESCRIPTION
### Description

I noticed that the JS code here doesn't appear to be affecting any error messages as the comment mentions. This code that is being erased only seems to serve to prevent a success/notification message from fading out which makes sense to me.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally :)

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
