### PR TITLE
Ensure capybara waits till the new page loads before asserting on the new page

### DIFF
--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -77,6 +77,7 @@ RSpec.feature "Distributions", type: :system do
 
         click_button "Save"
 
+        expect(page).not_to have_content('New Distribution')
         expect(page).to have_content("The following items have fallen below the minimum on hand quantity: #{item.name}")
       end
     end

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -169,6 +169,8 @@ RSpec.describe "Requests", type: :system, js: true do
           select @storage_location.name, from: "From storage location"
           fill_in "Comment", with: "Take my wipes... please"
           click_on "Save"
+
+          expect(page).not_to have_content("New Distribution")
           expect(page).to have_content "Distributions"
           expect(page).to have_content "Distribution created"
           expect(request.reload.distribution_id).to eq Distribution.last.id


### PR DESCRIPTION
Resolves some flaky specs introduced by applying turbo on distributions_controller

### Description

A few new flaky tests were introduced after turbo was added to the distributions_controller. It appears that due to the async nature of TURBO_STREAM the assertions that are meant for a page are being done on the previous page. This PR adds some safe guards to ensure the page has been fully redirected to the new page.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Specs should pass successfully and consistently.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
