### PR TITLE
Set user-role based on seed config

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -140,6 +140,10 @@ end
     password_confirmation: 'password!'
   )
 
+  if user_data[:organization]
+    user.add_role(:org_user, user_data[:organization])
+  end
+
   if user_data[:organization_admin]
     user.add_role(:org_admin, user_data[:organization])
   end


### PR DESCRIPTION
A local clean DB build with this change lets the Org admin see the org settings page.