### PR TITLE
Adds filtering on distributions by item_id

### DIFF
--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -17,4 +17,12 @@ module DistributionHelper
     crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secret_key_base[0..31])
     distributions_calendar_url(hash: crypt.encrypt_and_sign(current_organization.id))
   end
+
+  def quantity_by_item_id(distribution, item_id)
+    item_id = Integer(item_id)
+    quantities = distribution.line_items.quantities_by_name
+
+    single_item = quantities.values.find { |li| item_id == li[:item_id] } || {}
+    single_item[:quantity]
+  end
 end

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -3,7 +3,15 @@
   <td><%= distribution_row.partner.name %></td>
   <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %> </td>
   <td><%= distribution_row.storage_location.name %></td>
-  <td class="numeric"><%= distribution_row.line_items.total %></td>
+
+  <!-- Quantity -->
+  <% if filter_params[:by_item_id].present? %>
+    <td class="numeric"><%= quantity_by_item_id(distribution_row, filter_params[:by_item_id]) %></td>
+  <% else %>
+    <td class="numeric"><%= distribution_row.line_items.total %></td>
+  <% end %>
+  <!-- End Quantity -->
+
   <td class="numeric"><%= dollar_value(distribution_row.value_per_itemizable) %></td>
   <td><%= distribution_row.delivery_method.humanize %></td>
   <td><%= distribution_row.comment %></td>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -98,6 +98,7 @@
                 <th>Source Inventory</th>
 
                 <!-- Quantity -->
+                
                 <% if filter_params[:by_item_id].present? %>
                   <th class="numeric">Total <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
                 <% else %>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -96,7 +96,16 @@
                 <th>Partner</th>
                 <th class="date">Date of Distribution</th>
                 <th>Source Inventory</th>
-                <th class="numeric">Total items</th>
+
+                <!-- Quantity -->
+                <% if filter_params[:by_item_id].present? %>
+                  <th class="numeric">Total <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
+                <% else %>
+                  <th class="numeric">Total items</th>
+                <% end %>
+                
+                <!-- End Quantity -->
+
                 <th class="numeric">Total value</th>
                 <th>Delivery method</th>
                 <th>Comments</th>

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -446,6 +446,12 @@ RSpec.feature "Distributions", type: :system do
       click_button("Filter")
       # check for filtered distributions
       expect(page).to have_css("table tbody tr", count: 1)
+
+      # check for heading text
+      expect(page).to have_css("table thead tr th", text: "Total #{item1.name}")
+      # check for count update
+      stored_item1_total = @storage_location.item_total(item1.id)
+      expect(page).to have_css("table tbody tr td", text: stored_item1_total)
     end
 
     it "filters by partner" do


### PR DESCRIPTION
Resolves #3070

### Description
When filtering by an item type, it now displays all distributions that contain that item and however many of that item specifically are contained in the distribution.

The heading is now updated to display that quantity.

Some caveats:

  - the implementation is KLUNKY. It's using a basic if/else for both the table heading and also the table data
  - the helper being used is hyper-specific to quantity by item_id. This could maybe generalized later. or not. whatever you feel like :)
  - I did test it with a non-existent item ID and it gracefully displayed nothing

I modified the existing filter system spec to also verify that the TH and TD tags both display the new text, correctly.

While fixing this, I identified a bug in the date-range params. I will push up a separate PR for that.

### Type of change

<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

  1. Log in as an org admin
  2. View the distributions list
  3. Filter by an item type
  4. Bask in the greatness :)

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
![Screen Shot 2022-10-31 at 1 30 18 AM](https://user-images.githubusercontent.com/502363/198938043-65f8d822-26a1-4527-97e9-d80c8dd781e7.png)
