### PR TITLE
BUGFIX: date range params on distribution was using label for value

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -7,7 +7,7 @@ class DistributionsController < ApplicationController
   include DateRangeHelper
   include DistributionHelper
 
-  before_action :enable_turbo!, only: %i[index new show]
+  before_action :enable_turbo!, only: %i[new show]
   skip_before_action :authenticate_user!, only: %i(calendar)
   skip_before_action :authorize_user, only: %i(calendar)
 

--- a/app/views/shared/_date_range_picker.html.erb
+++ b/app/views/shared/_date_range_picker.html.erb
@@ -1,7 +1,7 @@
 <%
   css_class ||= ""
 %>
-<%= text_field_tag 'filters[date_range]', @selected_date_range_label,
+<%= text_field_tag 'filters[date_range]', date_range_params,
                    placeholder: 'January 1, 2011 - December 31, 2011',
                    class: "#{css_class}",
                    data: { initial_start_date: @selected_date_interval.first.strftime('%B %d, %Y'),

--- a/app/views/shared/_date_range_picker.html.erb
+++ b/app/views/shared/_date_range_picker.html.erb
@@ -1,7 +1,7 @@
 <%
   css_class ||= ""
 %>
-<%= text_field_tag 'filters[date_range]', date_range_params,
+<%= text_field_tag 'filters[date_range]', @selected_date_range_label,
                    placeholder: 'January 1, 2011 - December 31, 2011',
                    class: "#{css_class}",
                    data: { initial_start_date: @selected_date_interval.first.strftime('%B %d, %Y'),


### PR DESCRIPTION
### Description
I found this bug while on a different feature.

The partial for app/views/shared/_date_range_picker.html.erb was using @selected_date_range_label for the second parameter of the text_field_tag. This is the value used for the actual value of the field, and is not what the form is expecting. (The label is stored in a hidden field tag, presumably to be used by other stuff).


I am not able to consistently get the helper UI JS thingy to display, but it does display sometimes? The lack of displaying is _probably_ unrelated? I'm not seeing JS errors show up in the console. I'm not sure how it's wired up.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

To reproduce the error, normally:

  1. Go to distributions#index
  2. Apply a filter (to seed filter_params); note the new value in the date-range field
  3. Click "Filter" again, you should see an error

By changing the field to use the :date_range_params helper method (already existing), this restores the behavior to what is expected.

### Screenshots
#### After clicking filter the first time
![Screen Shot 2022-10-31 at 1 32 36 AM](https://user-images.githubusercontent.com/502363/198939384-ee986d36-ca92-457e-a15e-523d72f2a592.png)

#### After clicking filter the second time
![Screen Shot 2022-10-31 at 1 34 29 AM](https://user-images.githubusercontent.com/502363/198939395-ed6b3242-c5a7-42d1-8b93-3f2121a43c38.png)

#### Same, but after the fix is applied
![Screen Shot 2022-10-31 at 1 42 04 AM](https://user-images.githubusercontent.com/502363/198939466-7e8a6b43-c50d-42b0-b86a-024664ed97d8.png)

