### PR TITLE
[BUG-3212]: Fix buttons position in `partners#show` page

### DIFF
--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -218,7 +218,7 @@
 
         <section class="card card-info card-outline" id='partner-information'>
           <div class="card-header">
-            <div>
+            <div class="clearfix">
               <h2 class="card-title">Application & Information</h2>
             </div>
             <div class='pull-right'>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3212 

### Description

- In this case, the header is having class `card-title`
- This class is having `float: left` style applied
- All the other headers don't have buttons along with it
- Since, we have added buttons as part of the header,
- We have to introduce another div wrapper for the header card title
- And we have to apply class `clearfix` to clear the floating elements

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Tested this locally. Attaching the same screenshot in the next section.

### Screenshots

<img width="747" alt="Screenshot 2022-10-31 at 12 33 08 PM" src="https://user-images.githubusercontent.com/16205473/198950276-b6f4c1ef-b061-4120-bc07-be9d047213ee.png">
