### PR TITLE
Adds distribution filtering by item_category

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -50,9 +50,11 @@ class DistributionsController < ApplicationController
     @total_items_all_distributions = total_items(@distributions)
     @total_items_paginated_distributions = total_items(@paginated_distributions)
     @items = current_organization.items.alphabetized
+    @item_categories = current_organization.item_categories
     @storage_locations = current_organization.storage_locations.alphabetized
     @partners = @distributions.collect(&:partner).uniq.sort_by(&:name)
     @selected_item = filter_params[:by_item_id]
+    @selected_item_category = filter_params[:by_item_category_id]
     @selected_partner = filter_params[:by_partner]
     @selected_status = filter_params[:by_state]
     @selected_location = filter_params[:by_location]
@@ -254,7 +256,7 @@ class DistributionsController < ApplicationController
     def filter_params
     return {} unless params.key?(:filters)
 
-    params.require(:filters).permit(:by_item_id, :by_partner, :by_state, :by_location)
+    params.require(:filters).permit(:by_item_id, :by_item_category_id, :by_partner, :by_state, :by_location)
   end
 
   def perform_inventory_check

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -30,7 +30,6 @@ module DistributionHelper
     item_category_id = Integer(item_category_id)
     quantities = distribution.line_items.quantities_by_category
 
-    single_category = quantities.values.find { |li| item_category_id == li[:item_category_id] } || {}
-    single_category[:quantity]
+    quantities[item_category_id]
   end
 end

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -25,4 +25,12 @@ module DistributionHelper
     single_item = quantities.values.find { |li| item_id == li[:item_id] } || {}
     single_item[:quantity]
   end
+
+  def quantity_by_item_category_id(distribution, item_category_id)
+    item_category_id = Integer(item_category_id)
+    quantities = distribution.line_items.quantities_by_category
+
+    single_category = quantities.values.find { |li| item_category_id == li[:item_category_id] } || {}
+    single_category[:quantity]
+  end
 end

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -17,4 +17,12 @@ module DistributionHelper
     crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secret_key_base[0..31])
     distributions_calendar_url(hash: crypt.encrypt_and_sign(current_organization.id))
   end
+
+  def quantity_by_item_id(distribution, item_id)
+    item_id = Integer(item_id)
+    quantities = distribution.line_items.quantities_by_name
+
+    single_item = quantities.values.find { |li| item_id == li[:item_id] } || {}
+    single_item[:quantity]
+  end
 end

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -47,7 +47,17 @@ module Itemizable
       end
 
       def quantities_by_category
-        includes(:item).group("items.category").sum(:quantity)
+        results = {}
+
+        # Gather the quantities first
+        each do |li|
+          next if li.quantity.zero?
+
+          results[li.item.item_category_id] ||= 0
+          results[li.item.item_category_id] += li.quantity
+        end
+
+        results
       end
 
       def quantities_by_name
@@ -72,10 +82,13 @@ module Itemizable
         sum(&:value_per_line_item)
       end
     end
+
     has_many :items, through: :line_items
     accepts_nested_attributes_for :line_items,
                                   allow_destroy: true,
                                   reject_if: proc { |l| l[:item_id].blank? || l[:quantity].blank? }
+    
+    has_many :item_categories, through: :items
 
     # Anything using line_items should not be OK with an invalid line_item
     validates_associated :line_items

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -48,6 +48,7 @@ class Distribution < ApplicationRecord
   # add item_id scope to allow filtering distributions by item
   scope :by_item_id, ->(item_id) { joins(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner
+  scope :by_item_category_id, ->(item_category_id) { joins(:items).where(items: { item_category_id: item_category_id }) }
   scope :by_partner, ->(partner_id) { where(partner_id: partner_id) }
   # location scope to allow filtering distributions by location
   scope :by_location, ->(storage_location_id) { where(storage_location_id: storage_location_id) }

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -7,6 +7,8 @@
   <!-- Quantity -->
   <% if filter_params[:by_item_id].present? %>
     <td class="numeric"><%= quantity_by_item_id(distribution_row, filter_params[:by_item_id]) %></td>
+  <% elsif filter_params[:by_item_category_id].present? %>
+    <td class="numeric"><%= quantity_by_item_category_id(distribution_row, filter_params[:by_item_category_id]) %></td>
   <% else %>
     <td class="numeric"><%= distribution_row.line_items.total %></td>
   <% end %>

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -3,7 +3,15 @@
   <td><%= distribution_row.partner.name %></td>
   <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %> </td>
   <td><%= distribution_row.storage_location.name %></td>
-  <td class="numeric"><%= distribution_row.line_items.total %></td>
+
+  <!-- Quantity -->
+  <% if filter_params[:by_item_id].present? %>
+    <td class="numeric"><%= quantity_by_item_id(distribution_row, filter_params[:by_item_id]) %></td>
+  <% else %>
+    <td class="numeric"><%= distribution_row.line_items.total %></td>
+  <% end %>
+  <!-- End Quantity -->
+
   <td class="numeric"><%= dollar_value(distribution_row.value_per_itemizable) %></td>
   <td><%= distribution_row.delivery_method.humanize %></td>
   <td><%= distribution_row.comment %></td>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -106,11 +106,10 @@
                 <% if filter_params[:by_item_id].present? %>
                   <th class="numeric">Total <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
                 <% elsif filter_params[:by_item_category_id].present? %>
-                  <th class="numeric">Total <%= @item_categories.find { |ic| ic.id == filter_params[:by_item_category_id].to_i }&.name %></th>
+                  <th class="numeric">Total in <%= @item_categories.find { |ic| ic.id == filter_params[:by_item_category_id].to_i }&.name %></th>
                 <% else %>
                   <th class="numeric">Total items</th>
                 <% end %>
-                <% console %>
                 <!-- End Quantity -->
 
                 <th class="numeric">Total value</th>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -41,6 +41,11 @@
                     <%= filter_select(label: "Filter by item", scope: :by_item_id, collection: @items, selected: @selected_item) %>
                   </div>
                 <% end %>
+                <% if @item_categories.present? %>
+                  <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
+                    <%= filter_select(label: "Filter by item category", scope: :by_item_category_id, collection: @item_categories, selected: @selected_item_category) %>
+                  </div>
+                <% end %>
                 <% if @partners.present? %>
                   <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
                     <%= filter_select(scope: :by_partner, collection: @partners, selected: @selected_partner) %>
@@ -100,10 +105,12 @@
                 <!-- Quantity -->
                 <% if filter_params[:by_item_id].present? %>
                   <th class="numeric">Total <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
+                <% elsif filter_params[:by_item_category_id].present? %>
+                  <th class="numeric">Total <%= @item_categories.find { |ic| ic.id == filter_params[:by_item_category_id].to_i }&.name %></th>
                 <% else %>
                   <th class="numeric">Total items</th>
                 <% end %>
-                
+                <% console %>
                 <!-- End Quantity -->
 
                 <th class="numeric">Total value</th>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -96,7 +96,16 @@
                 <th>Partner</th>
                 <th class="date">Date of Distribution</th>
                 <th>Source Inventory</th>
-                <th class="numeric">Total items</th>
+
+                <!-- Quantity -->
+                <% if filter_params[:by_item_id].present? %>
+                  <th class="numeric">Total <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
+                <% else %>
+                  <th class="numeric">Total items</th>
+                <% end %>
+                
+                <!-- End Quantity -->
+
                 <th class="numeric">Total value</th>
                 <th>Delivery method</th>
                 <th>Comments</th>

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -429,7 +429,8 @@ RSpec.feature "Distributions", type: :system do
 
   context "when filtering on the index page" do
     subject { @url_prefix + "/distributions" }
-    let(:item1) { create(:item, name: "Good item") }
+    let(:item_category) { create(:item_category) }
+    let(:item1) { create(:item, name: "Good item", item_category: item_category) }
     let(:item2) { create(:item, name: "Crap item") }
     let(:partner1) { create(:partner, name: "This Guy", email: "thisguy@example.com") }
     let(:partner2) { create(:partner, name: "Not This Guy", email: "ntg@example.com") }
@@ -453,6 +454,29 @@ RSpec.feature "Distributions", type: :system do
       stored_item1_total = @storage_location.item_total(item1.id)
       expect(page).to have_css("table tbody tr td", text: stored_item1_total)
     end
+
+
+    it "filters by item category id" do
+      @organization.item_categories << item_category
+      create(:distribution, :with_items, item: item1)
+      create(:distribution, :with_items, item: item2)
+
+      visit subject
+      # check for all distributions
+      expect(page).to have_css("table tbody tr", count: 2)
+      # filter
+      select(item_category.name, from: "filters_by_item_category_id")
+      click_button("Filter")
+      # check for filtered distributions
+      expect(page).to have_css("table tbody tr", count: 1)
+
+      # check for heading text
+      expect(page).to have_css("table thead tr th", text: "Total in #{item_category.name}")
+      # check for count update
+      stored_item1_total = @storage_location.item_total(item1.id)
+      expect(page).to have_css("table tbody tr td", text: stored_item1_total)
+    end
+
 
     it "filters by partner" do
       create(:distribution, partner: partner1)

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -446,6 +446,12 @@ RSpec.feature "Distributions", type: :system do
       click_button("Filter")
       # check for filtered distributions
       expect(page).to have_css("table tbody tr", count: 1)
+
+      # check for heading text
+      expect(page).to have_css("table thead tr th", text: "Total #{item1.name}")
+      # check for count update
+      stored_item1_total = @storage_location.item_total(item1.id)
+      expect(page).to have_css("table tbody tr td", text: stored_item1_total)
     end
 
     it "filters by partner" do


### PR DESCRIPTION
Resolves #3069

### Description
Similar to #3070.

The previous :quantities_by_category was actually using vestigial code
from the previous pass at categories (that was later stripped out, and
then later re-visioned). The new method uses the current ItemCategory
model as a basis.

I did my best to avoid N+1s but it's possible the queries could be improved further, and more computation done in SQL.

The additional filtering field _does_ bump the the fields down a bit in
the UI, but that felt out of scope for this issue (no guidance was
provided on how to address the UI) -- I presume someone will have
opinions on how to address that separately. :)

 I tested this both with a system spec, and also manually: I verified
 that by filtering a specific item category, it will show the correct quantity for each entry. The heading is also set correctly.

 Exporting needs to be tweaked but I'll add that separately.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

The first thing you'll need to do is to look at your items and check all your item categories. I think the seeds file is randomly assigning them (should probably change that). You'll go batty like I did if you try and make any inference about the association otherwise :D

My recommendation is to do this:
  
  1. Go through all the Items in the org and set the items for Period Supplies (the smallest subset)
  2. Find a distribution and eliminate all period supplies items from it; note the ID
  3. Find a different distribution and make it "Oops! All period supplies!"; note the ID
  4. Filter both with and without it and see that (a) the first distribution (from (2)) does not show up when you filter for period supplies, and (b) the second distribution (from (3)) does not show up when you filter for something else. Also note the totals.

### Screenshots
![Screen Shot 2022-10-31 at 3 26 17 AM](https://user-images.githubusercontent.com/502363/198954060-c94e4460-0943-44e1-ad39-6cf0a8669d54.png)
![Screen Shot 2022-10-31 at 3 26 40 AM](https://user-images.githubusercontent.com/502363/198954119-afbd5668-5079-47e7-8fe8-3c815e88bde5.png)
![Screen Shot 2022-10-31 at 3 26 59 AM](https://user-images.githubusercontent.com/502363/198954153-fc84e47f-750d-4510-b74e-912147e416ff.png)
![Screen Shot 2022-10-31 at 3 27 17 AM](https://user-images.githubusercontent.com/502363/198954218-6608558f-cc42-4f1a-b2bc-b5204fbd789a.png)

#### Specific test
![Screen Shot 2022-10-31 at 3 29 17 AM](https://user-images.githubusercontent.com/502363/198954567-fd37712a-ca9a-4ae3-bec5-b55d3f4174eb.png)
![Screen Shot 2022-10-31 at 3 29 51 AM](https://user-images.githubusercontent.com/502363/198954644-373d6c58-5383-4f73-8320-4a98e4fc1511.png)
![Screen Shot 2022-10-31 at 3 30 11 AM](https://user-images.githubusercontent.com/502363/198954706-f7b82663-6264-4665-8bbe-d5a8df05333b.png)
