### PR TITLE
Modifies ExportDistributionsCSVService to get @distributions directly

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -62,7 +62,7 @@ class DistributionsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportDistributionsCSVService.new(distribution_ids: @distributions.map(&:id)).generate_csv, filename: "Distributions-#{Time.zone.today}.csv"
+        send_data Exports::ExportDistributionsCSVService.new(distributions: @distributions, filters: filter_params).generate_csv, filename: "Distributions-#{Time.zone.today}.csv"
       end
     end
   end

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -43,6 +43,8 @@ class DistributionsController < ApplicationController
 
     @distributions = current_organization
                      .distributions
+                     .includes(:partner, :storage_location, line_items: [:item])
+                     .order('issued_at DESC')
                      .apply_filters(filter_params, helpers.selected_range)
     @paginated_distributions = @distributions.page(params[:page])
     @total_value_all_distributions = total_value(@distributions)

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -51,7 +51,7 @@ class PartnersController < ApplicationController
   def show
     @partner = current_organization.partners.find(params[:id])
     @impact_metrics = @partner.profile.impact_metrics unless @partner.uninvited?
-    @partner_distributions = @partner.distributions.includes(:partner, :storage_location, line_items: [:item]).order('issued_at DESC')
+    @partner_distributions = @partner.distributions.includes(:partner, :storage_location, line_items: [:item]).order("issued_at DESC")
     @partner_profile_fields = current_organization.partner_form_fields
     @partner_users = @partner.profile.users.order(name: :asc)
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -58,7 +58,7 @@ class PartnersController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportDistributionsCSVService.new(distribution_ids: @partner_distributions.map(&:id)).generate_csv, filename: "PartnerDistributions-#{Time.zone.today}.csv"
+        send_data Exports::ExportDistributionsCSVService.new(distributions: @partner_distributions, filters: filter_params).generate_csv, filename: "PartnerDistributions-#{Time.zone.today}.csv"
       end
     end
   end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -51,7 +51,7 @@ class PartnersController < ApplicationController
   def show
     @partner = current_organization.partners.find(params[:id])
     @impact_metrics = @partner.profile.impact_metrics unless @partner.uninvited?
-    @partner_distributions = @partner.distributions.order(created_at: :desc)
+    @partner_distributions = @partner.distributions.includes(:partner, :storage_location, line_items: [:item]).order('issued_at DESC')
     @partner_profile_fields = current_organization.partner_form_fields
     @partner_users = @partner.profile.users.order(name: :asc)
 

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -1,10 +1,14 @@
 module Exports
   class ExportDistributionsCSVService
-    def initialize(distribution_ids:)
-      # Use a where lookup so that I can eager load all the resources needed
-      # rather than depending on external code to do it for me. This makes
-      # this code more self contained and efficient!
-      @distributions = Distribution.includes(:partner, :storage_location, line_items: [:item]).where(id: distribution_ids).order('issued_at DESC')
+    def initialize(distributions:, filters: [])
+      # Currently, the @distributions are already loaded by the controllers that are delegating exporting
+      # to this service object; this is happening within the same request/response cycle, so it's already
+      # in memory, so we can pass that collection in directly. Should this be moved to a background / async
+      # job, we will need to pass in a collection of IDs instead.
+      # Also, adding in a `filters` parameter to make the filters that have been used available to this
+      # service object.
+      @distributions = distributions
+      @filters = filters
     end
 
     def generate_csv

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -1,7 +1,7 @@
 describe Exports::ExportDistributionsCSVService do
   describe '#generate_csv_data' do
-    subject { described_class.new(distribution_ids: distribution_ids).generate_csv_data }
-    let(:distribution_ids) { distributions.map(&:id) }
+    subject { described_class.new(distributions: distributions).generate_csv_data }
+    let(:distributions) { distributions }
 
     let(:duplicate_item) do
       FactoryBot.create(


### PR DESCRIPTION
### Description
Previously, this was receiving a collection of ids from the controller, and then re-running the query. This would absolutely be the correct way to do it if/when this export is running from an async job (where we can only use primitives). With the current state, however, it results in running a semi-complex query twice.

We're only using the service object in two places, so the change has a small footprint.

I also added an optional "filters" parameter and passed in :filter_params to it on both controllers. This will be useful later when applying filters to the export set to get it to mirror what is seen on the index view.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested manually (load distributions, click on "export", confirm sane dataset)

Automated tests pass. 
