### PR TITLE
Setup to sync only the ADR folder to Gitbook

### DIFF
--- a/.gitbook.yml
+++ b/.gitbook.yml
@@ -1,0 +1,1 @@
+root: ./doc/architecture/decisions


### PR DESCRIPTION
### Description

Adds a configuration in to tell .gitbook to only show the ADR records in our sync. See https://docs.gitbook.com/getting-started/git-sync/content-configuration 

### Type of change
* Documentation update

### How Has This Been Tested?
Tested using Gitbook, view ADR in gitbook here - https://ruby-for-good.gitbook.io/architectural-decision-records/

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
