### PR TITLE
Add back in 'My Profile' nav item for partners to set their name

### DIFF
--- a/app/views/layouts/partners/navigation/_navbar.html.erb
+++ b/app/views/layouts/partners/navigation/_navbar.html.erb
@@ -14,6 +14,10 @@
       <i class="fa fa-users mr-2"></i> My Co-Workers
     <% end %>
 
+    <%= link_to edit_partners_user_path(current_user), class:"dropdown-item" do %>
+      <i class="fa fa-users mr-2"></i> My Profile
+    <% end %>
+
     <div class="dropdown-divider"></div>
     <% current_user.switchable_roles.each do |role| %>
       <% next if role == current_role %>


### PR DESCRIPTION
### Description

Whoops! We had a merge incident in which we removed the "My Profile" link that would allow Partners to change their names. See instructions that I've crafted to demonstrate the flow - https://scribehow.com/shared/Workflow__frxtD0mKTaOCYqeXDQtWrg

I'll commit this same commit to main, but I wanted to get this into the release before tomorrow's stakeholder meeting.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Created the instructions -  https://scribehow.com/shared/Workflow__frxtD0mKTaOCYqeXDQtWrg

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
