### PR TITLE
#3230 This fix prevents layout from breaking borders and to work as intended

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -2,14 +2,14 @@
 @import 'AdminLTE';
 
 @mixin for-desktop {
-    @media (min-width: 992px) and (min-height: 769px) { 
+    @media (min-width: 992px) and (min-height: 769px) {
         @content;
     }
 }
 
 .full-height {
     height: 'auto';
-    @include for-desktop { 
+    @include for-desktop {
         height: calc(100vh - #{$diaper-navbar-height}px - #{$diaper-footer-height}px);
     }
 }
@@ -21,15 +21,15 @@
 
 #pick-ups-header {
     height: 'auto';
-    @include for-desktop { 
-        height: 10%;        
+    @include for-desktop {
+        height: 10%;
     }
 }
 
 #pick-ups-calendar {
     height: 'auto';
-    @include for-desktop { 
-        height: 90%;        
+    @include for-desktop {
+        height: 90%;
     }
 }
 
@@ -43,7 +43,9 @@
 }
 
 .login-page--user {
-  background: linear-gradient(135deg, #3023AE, #C86DD7)
+  background: linear-gradient(135deg, #3023AE, #C86DD7);
+  background-attachment: fixed;
+  flex-flow: wrap;
 }
 
 .login-page--consolidated {


### PR DESCRIPTION
Resolves [#3230](https://github.com/rubyforgood/human-essentials/issues/3230)

### Description
 Added `background-attachment: fixed` and `flex-flow: wrap` to `.login-page--user` under custom.scss. No other changes were made. This change is intended to retain the styling of the log-in view while correcting the breaking border caused by the simple form fields under `account_requests/new`.
   
### Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

As this is a styling change, reviewing the two views affected by this PR will be needed:
- `/account_requests/new`
- `/users/sign_in`

### Screenshots

Current:

<img width="1512" alt="Screen Shot 2022-11-03 at 20 53 44" src="https://user-images.githubusercontent.com/48500289/199714072-0d34cb8f-af8a-47c7-9cd7-634909aa3788.png">

When selecting first radio button:
<img width="1512" alt="Screen Shot 2022-11-03 at 20 54 45" src="https://user-images.githubusercontent.com/48500289/199714254-ff5f51d8-945d-480c-804c-676ea32a0488.png">

With change:

When selecting first radio button (zoomed out to 67%):

<img width="1512" alt="Screen Shot 2022-11-03 at 20 56 09" src="https://user-images.githubusercontent.com/48500289/199714524-feb7193d-bb33-4bab-997c-82292cb1bab9.png">

Note: scroll is needed at 100% and the /users/sign_in is unaffected by this change.

Look forward to any notes, reviews, or questions - thanks!