### PR TITLE
Partial for issue 3256.  Updating sender name on no-reply emails to include "Please do not reply..." messaging…

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 # Default Mailer Info
 class ApplicationMailer < ActionMailer::Base
-  default from: "no-reply@humanessentials.app"
+  default from: "Please do not reply to this email as this mail box is not monitored — Human Essentials <no-reply@humanessentials.app>"
   layout "mailer"
 end

--- a/app/mailers/organization_mailer.rb
+++ b/app/mailers/organization_mailer.rb
@@ -1,5 +1,5 @@
 class OrganizationMailer < ApplicationMailer
-  default from: "no-reply@humanessentials.app"
+  default from: "Please do not reply to this email as this mail box is not monitored — Human Essentials <no-reply@humanessentials.app>"
 
   def partner_approval_request(organization:, partner:)
     @partner = partner

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -1,5 +1,5 @@
 class PartnerMailer < ApplicationMailer
-  default from: "no-reply@humanessentials.app"
+  default from: "Please do not reply to this email as this mail box is not monitored — Human Essentials <no-reply@humanessentials.app>"
 
   def recertification_request(partner:)
     @partner = partner


### PR DESCRIPTION

# Checklist:

Partial resolution of  #3256 <!--fill issue number-->

### Description

Added sender name as "Please do not reply to this email as this mail box is not monitored — Human Essentials" to emails coming from no-reply@human-essentials .com

### Reason

Hammering home that we don't want replies to those emails.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- Current tests all pass
- Had our "invited" partner request approval -- visual confirmation that display name is included.

<!-- Please describe the tests that you ran to verify your work
