### PR TITLE
[3284] Send params as permitted when displaying or filtering product drives

### DIFF
--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -95,6 +95,6 @@ class ProductDrivesController < ApplicationController
     def filter_params
     return {} unless params.key?(:filters)
 
-    params.require(:filters).slice(:by_name)
+    params.require(:filters).permit(:by_name)
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3284 

### Description
Bug from user POV described in linked issue.
Bug description from a dev POV: we render a button on the product drives page to download displayed product drives as a csv. [The code for rendering this button](https://github.com/rubyforgood/human-essentials/blob/58814c53241a34c1d06f668c558752f7c266602f/app/views/product_drives/index.html.erb#L56) was throwing an error because we were passing through unpermitted params and at [somepoimt in the stack](https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/actionpack/lib/action_dispatch/routing/route_set.rb#L325) we would try and convert these params to a hash - [which is not allowed](https://api.rubyonrails.org/classes/ActionController/UnfilteredParameters.html)
The fix? Send through the params as permitted :)

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Added a new test which tests the filter function on the product drives page (and therefore tests the rendering of the aforementioned button).