### PR TITLE
[3264] Change logic for enabling/disabling request flags on organisations and their partners

### DIFF
--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -22,6 +22,10 @@ class OrganizationUpdateService
     # @param organization [Organization]
     def update_partner_flags(organization)
       FIELDS.each do |field|
+        # We don't want to automatically enable request types
+        # on a partner. This should be left up to 
+        # individual partners to decide themselves
+        # github.com/rubyforgood/human-essentials/issues/3264
         next if organization.send(field)
         organization.partners.map(&:profile).each do |profile|
           profile.update!(field => organization.send(field))
@@ -34,19 +38,19 @@ class OrganizationUpdateService
     def valid?(organization, params)
       return true unless organization.partners.any?
 
-      disable_params = FIELDS.select { |field| params[field] == false }
+      disable_fields = FIELDS.select { |field| params[field] == false }
 
       organization.partners.each do |partner|
-        return false if disables_all_partner_fields?(partner, disable_params)
+        return false if disables_all_partner_fields?(partner, disable_fields)
       end
 
       true
     end
 
-    def disables_all_partner_fields?(partner, disable_params)
+    def disables_all_partner_fields?(partner, disable_fields)
       enabled_fields = FIELDS.select { |field| partner.profile.send(field) == true }
 
-      enabled_fields.all? { |field| disable_params.include?(field) }
+      enabled_fields.all? { |field| disable_fields.include?(field) }
     end
   end
 end

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -1,52 +1,52 @@
 class OrganizationUpdateService
-  FIELDS = %i[
+  class << self
+    FIELDS = %i[
       enable_child_based_requests
       enable_individual_requests
       enable_quantity_based_requests
     ]
 
-  # @param organization [Organization]
-  # @param params [ActionDispatch::Http::Parameters]
-  # @return [Boolean]
-  def self.update(organization, params)
-    return false unless self.valid?(organization, params)
+    # @param organization [Organization]
+    # @param params [ActionDispatch::Http::Parameters]
+    # @return [Boolean]
+    def update(organization, params)
+      return false unless valid?(organization, params)
 
-    result = organization.update(params)
-    return false unless result
+      result = organization.update(params)
+      return false unless result
 
-    update_partner_flags(organization)
-    true
-  end
+      update_partner_flags(organization)
+      true
+    end
 
-  # @param organization [Organization]
-  def self.update_partner_flags(organization)
-    FIELDS.each do |field|
-      next if organization.send(field) 
-      organization.partners.map(&:profile).each do |profile|
-        profile.update!(field => organization.send(field))
+    # @param organization [Organization]
+    def update_partner_flags(organization)
+      FIELDS.each do |field|
+        next if organization.send(field)
+        organization.partners.map(&:profile).each do |profile|
+          profile.update!(field => organization.send(field))
+        end
       end
     end
-  end
 
-  private
+    private
 
-  def self.valid?(organization, params)
-    return true unless organization.partners.any?
-    
-    disable_params = FIELDS.map do |field|
-      field if params[field] == false
+    def valid?(organization, params)
+      return true unless organization.partners.any?
+
+      disable_params = FIELDS.select { |field| params[field] == false }
+
+      organization.partners.each do |partner|
+        return false if disables_all_partner_fields?(partner, disable_params)
+      end
+
+      true
     end
 
-    organization.partners.each do |partner|
-      return false if self.disables_all_partner_fields?(partner, disable_params)
+    def disables_all_partner_fields?(partner, disable_params)
+      enabled_fields = FIELDS.select { |field| partner.profile.send(field) == true }
+
+      enabled_fields.all? { |field| disable_params.include?(field) }
     end
-
-    true
-  end
-
-  def self.disables_all_partner_fields?(partner, disable_params)
-    enabled_fields = FIELDS.select { |field| partner.profile.send(field) == true }
-
-    enabled_fields.all? { |field| disable_params.include?(field) }
   end
 end

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -36,21 +36,19 @@ class OrganizationUpdateService
     private
 
     def valid?(organization, params)
-      return true unless organization.partners.any?
+      return true if organization.partners.none?
 
-      disable_fields = FIELDS.select { |field| params[field] == false }
+      fields_marked_for_disabling = FIELDS.select { |field| params[field] == false }
 
-      organization.partners.each do |partner|
-        return false if disables_all_partner_fields?(partner, disable_fields)
+      organization.partners.none? do |partner|
+        all_fields_will_be_disabled?(partner, fields_marked_for_disabling)
       end
-
-      true
     end
 
-    def disables_all_partner_fields?(partner, disable_fields)
+    def all_fields_will_be_disabled?(partner, fields_marked_for_disabling)
       enabled_fields = FIELDS.select { |field| partner.profile.send(field) == true }
 
-      enabled_fields.all? { |field| disable_fields.include?(field) }
+      (enabled_fields - fields_marked_for_disabling).empty?
     end
   end
 end

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -1,8 +1,16 @@
 class OrganizationUpdateService
+  FIELDS = %i[
+      enable_child_based_requests
+      enable_individual_requests
+      enable_quantity_based_requests
+    ]
+
   # @param organization [Organization]
   # @param params [ActionDispatch::Http::Parameters]
   # @return [Boolean]
   def self.update(organization, params)
+    return false unless self.valid?(organization, params)
+
     result = organization.update(params)
     return false unless result
 
@@ -12,16 +20,33 @@ class OrganizationUpdateService
 
   # @param organization [Organization]
   def self.update_partner_flags(organization)
-    fields = %i[
-      enable_child_based_requests
-      enable_individual_requests
-      enable_quantity_based_requests
-    ]
-    fields.each do |field|
+    FIELDS.each do |field|
       next if organization.send(field) 
       organization.partners.map(&:profile).each do |profile|
         profile.update!(field => organization.send(field))
       end
     end
+  end
+
+  private
+
+  def self.valid?(organization, params)
+    return true unless organization.partners.any?
+    
+    disable_params = FIELDS.map do |field|
+      field if params[field] == false
+    end
+
+    organization.partners.each do |partner|
+      return false if self.disables_all_partner_fields?(partner, disable_params)
+    end
+
+    true
+  end
+
+  def self.disables_all_partner_fields?(partner, disable_params)
+    enabled_fields = FIELDS.select { |field| partner.profile.send(field) == true }
+
+    enabled_fields.all? { |field| disable_params.include?(field) }
   end
 end

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -23,8 +23,8 @@ class OrganizationUpdateService
     def update_partner_flags(organization)
       FIELDS.each do |field|
         # We don't want to automatically enable request types
-        # on a partner. This should be left up to 
-        # individual partners to decide themselves
+        # on a partner. This should be left up to
+        # individual partners to decide themselves as per
         # github.com/rubyforgood/human-essentials/issues/3264
         next if organization.send(field)
         organization.partners.map(&:profile).each do |profile|

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -18,7 +18,7 @@ class OrganizationUpdateService
       enable_quantity_based_requests
     ]
     fields.each do |field|
-      next unless organization.saved_change_to_attribute?(field)
+      next if organization.send(field) 
       organization.partners.map(&:profile).each do |profile|
         profile.update!(field => organization.send(field))
       end

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -22,9 +22,11 @@ class OrganizationUpdateService
     # @param organization [Organization]
     def update_partner_flags(organization)
       FIELDS.each do |field|
-        # We don't want to automatically enable request types
+        # If organization.send(field) is true then that means a
+        # request type on the organization has been enabled. 
+        # We don't want to automatically enable the request type
         # on a partner. This should be left up to
-        # individual partners to decide themselves as per
+        # individual partners to decide themselves as per:
         # github.com/rubyforgood/human-essentials/issues/3264
         next if organization.send(field)
         organization.partners.map(&:profile).each do |profile|
@@ -40,6 +42,10 @@ class OrganizationUpdateService
 
       fields_marked_for_disabling = FIELDS.select { |field| params[field] == false }
 
+      # Here we do a check: if applying the params for disabling request types to all 
+      # partners would mean any one partner would have all its request types disabled, 
+      # then we should not apply the params. As per:
+      # github.com/rubyforgood/human-essentials/issues/3264
       organization.partners.none? do |partner|
         all_fields_will_be_disabled?(partner, fields_marked_for_disabling)
       end

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -23,14 +23,14 @@ class OrganizationUpdateService
     def update_partner_flags(organization)
       FIELDS.each do |field|
         # If organization.send(field) is true then that means a
-        # request type on the organization has been enabled. 
+        # request type on the organization has been enabled.
         # We don't want to automatically enable the request type
         # on a partner. This should be left up to
         # individual partners to decide themselves as per:
         # github.com/rubyforgood/human-essentials/issues/3264
         next if organization.send(field)
-        organization.partners.map(&:profile).each do |profile|
-          profile.update!(field => organization.send(field))
+        organization.partners.each do |partner|
+          partner.profile.update!(field => organization.send(field))
         end
       end
     end
@@ -42,8 +42,8 @@ class OrganizationUpdateService
 
       fields_marked_for_disabling = FIELDS.select { |field| params[field] == false }
 
-      # Here we do a check: if applying the params for disabling request types to all 
-      # partners would mean any one partner would have all its request types disabled, 
+      # Here we do a check: if applying the params for disabling request types to all
+      # partners would mean any one partner would have all its request types disabled,
       # then we should not apply the params. As per:
       # github.com/rubyforgood/human-essentials/issues/3264
       organization.partners.none? do |partner|

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Organizations", type: :request do
 
         it "redirects to #edit with an error message" do
           subject
-          
+
           expect(subject).to render_template("edit")
           expect(flash[:error]).to be_present
         end

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -77,6 +77,17 @@ RSpec.describe "Organizations", type: :request do
       it "can update name" do
         expect { subject }.to change { @organization.reload.name }.to "Thunder Pants"
       end
+
+      context "when organization can not be updated" do
+        before { allow(OrganizationUpdateService).to receive(:update).and_return(false) }
+
+        it "redirects to #edit with an error message" do
+          subject
+          
+          expect(subject).to render_template("edit")
+          expect(flash[:error]).to be_present
+        end
+      end
     end
 
     describe "POST #promote_to_org_admin" do

--- a/spec/services/organization_update_service_spec.rb
+++ b/spec/services/organization_update_service_spec.rb
@@ -117,9 +117,6 @@ describe OrganizationUpdateService, skip_seed: true do
       end
 
       it "should NOT update partners' request flags when enabling request flags on the organization" do
-        organization.update!(enable_quantity_based_requests: false)
-        organization.update!(enable_quantity_based_requests: true)
-
         organization.partners.each { |p|
           p.profile.update!(
             enable_individual_requests: false,

--- a/spec/services/organization_update_service_spec.rb
+++ b/spec/services/organization_update_service_spec.rb
@@ -116,7 +116,7 @@ describe OrganizationUpdateService, skip_seed: true do
           .to eq([false, false])
       end
 
-      it "should not update partners' request types when enabling request types on the organization" do
+      it "should NOT update partners' request types when enabling request types on the organization" do
         organization.update!(enable_quantity_based_requests: false)
         organization.update!(enable_quantity_based_requests: true)
 

--- a/spec/services/organization_update_service_spec.rb
+++ b/spec/services/organization_update_service_spec.rb
@@ -26,14 +26,16 @@ describe OrganizationUpdateService, skip_seed: true do
         create(:organization, enable_individual_requests: true, enable_child_based_requests: true, enable_quantity_based_requests: true)
       end
       let(:partners) { create_list(:partner, 2, organization: organization) }
+      let(:partner_one) { partners.first }
+      let(:partner_two) { partners.last }
 
       before do
-        partners.first.profile.update!(
+        partner_one.profile.update!(
           enable_individual_requests: true,
           enable_child_based_requests: true,
           enable_quantity_based_requests: false
         )
-        partners.last.profile.update!(
+        partner_two.profile.update!(
           enable_individual_requests: true,
           enable_child_based_requests: true,
           enable_quantity_based_requests: true
@@ -44,13 +46,17 @@ describe OrganizationUpdateService, skip_seed: true do
         before { described_class.update(organization, {enable_individual_requests: false, enable_child_based_requests: false}) }
 
         it "should NOT change request flags in organization or its partners" do
+          organization.reload
+          partner_one.profile.reload
+          partner_two.profile.reload
+
           aggregate_failures "request type in organization and partners" do
-            expect(organization.reload.enable_individual_requests).to eq(true)
-            expect(partners.first.profile.reload.enable_individual_requests).to eq(true)
-            expect(partners.last.profile.reload.enable_individual_requests).to eq(true)
-            expect(organization.reload.enable_child_based_requests).to eq(true)
-            expect(partners.first.profile.reload.enable_child_based_requests).to eq(true)
-            expect(partners.last.profile.reload.enable_child_based_requests).to eq(true)
+            expect(organization.enable_individual_requests).to eq(true)
+            expect(partner_one.profile.enable_individual_requests).to eq(true)
+            expect(partner_two.profile.enable_individual_requests).to eq(true)
+            expect(organization.enable_child_based_requests).to eq(true)
+            expect(partner_one.profile.enable_child_based_requests).to eq(true)
+            expect(partner_two.profile.enable_child_based_requests).to eq(true)
           end
         end
       end
@@ -59,10 +65,14 @@ describe OrganizationUpdateService, skip_seed: true do
         before { described_class.update(organization, enable_individual_requests: false) }
 
         it "should allow the disabling of request flags in organization and its partners" do
+          organization.reload
+          partner_one.profile.reload
+          partner_two.profile.reload
+
           aggregate_failures "request type in organization and partners" do
-            expect(organization.reload.enable_individual_requests).to eq(false)
-            expect(partners.first.profile.reload.enable_individual_requests).to eq(false)
-            expect(partners.last.profile.reload.enable_individual_requests).to eq(false)
+            expect(organization.enable_individual_requests).to eq(false)
+            expect(partner_one.profile.enable_individual_requests).to eq(false)
+            expect(partner_two.profile.enable_individual_requests).to eq(false)
           end
         end
       end

--- a/spec/services/organization_update_service_spec.rb
+++ b/spec/services/organization_update_service_spec.rb
@@ -68,6 +68,28 @@ describe OrganizationUpdateService, skip_seed: true do
         expect(organization.partners.map { |p| p.profile.enable_quantity_based_requests })
           .to eq([false, false])
       end
+
+      it "should not update partners' request types when enabling request types on the organization" do
+        organization.update!(enable_quantity_based_requests: false)
+        organization.update!(enable_quantity_based_requests: true)
+
+        organization.partners.each { |p|
+          p.profile.update!(
+            enable_individual_requests: false,
+            enable_child_based_requests: false,
+            enable_quantity_based_requests: false
+          )
+        }
+
+        described_class.update_partner_flags(organization)
+
+        expect(organization.partners.map { |p| p.profile.enable_child_based_requests })
+          .to eq([false, false])
+        expect(organization.partners.map { |p| p.profile.enable_individual_requests })
+          .to eq([false, false])
+        expect(organization.partners.map { |p| p.profile.enable_quantity_based_requests })
+          .to eq([false, false])
+      end
     end
   end
 end

--- a/spec/services/organization_update_service_spec.rb
+++ b/spec/services/organization_update_service_spec.rb
@@ -21,48 +21,48 @@ describe OrganizationUpdateService, skip_seed: true do
       end
     end
 
-    context 'when an organization has a partner' do
-      let(:organization) { create(:organization, enable_individual_requests: true, enable_child_based_requests: true, enable_quantity_based_requests: true) }
+    context "when organization has partners" do
+      let(:organization) do
+        create(:organization, enable_individual_requests: true, enable_child_based_requests: true, enable_quantity_based_requests: true)
+      end
       let(:partners) { create_list(:partner, 2, organization: organization) }
 
-      context "when all of a partners' request types will be disabled" do
-        before do
-          partners.first.profile.update!(
-              enable_individual_requests: true,
-              enable_child_based_requests: true,
-              enable_quantity_based_requests: false
-          )
-          partners.last.profile.update!(
-              enable_individual_requests: true,
-              enable_child_based_requests: true,
-              enable_quantity_based_requests: true
-          )
-        end
+      before do
+        partners.first.profile.update!(
+          enable_individual_requests: true,
+          enable_child_based_requests: true,
+          enable_quantity_based_requests: false
+        )
+        partners.last.profile.update!(
+          enable_individual_requests: true,
+          enable_child_based_requests: true,
+          enable_quantity_based_requests: true
+        )
+      end
 
-        context "when all of a single partner's request types will be disabled" do
-          before { described_class.update(organization, { enable_individual_requests: false, enable_child_based_requests: false }) }
+      context "when all of a single partner's request flags will be disabled" do
+        before { described_class.update(organization, {enable_individual_requests: false, enable_child_based_requests: false}) }
 
-          it 'should NOT allow the enabled request type to be disabled in organization or its partners' do
-            aggregate_failures 'request type in organization and partners' do
-              expect(organization.reload.enable_individual_requests).to eq(true)
-              expect(partners.first.profile.reload.enable_individual_requests).to eq(true)
-              expect(partners.last.profile.reload.enable_individual_requests).to eq(true)
-              expect(organization.reload.enable_child_based_requests).to eq(true)
-              expect(partners.first.profile.reload.enable_child_based_requests).to eq(true)
-              expect(partners.last.profile.reload.enable_child_based_requests).to eq(true)
-            end
+        it "should NOT change request flags in organization or its partners" do
+          aggregate_failures "request type in organization and partners" do
+            expect(organization.reload.enable_individual_requests).to eq(true)
+            expect(partners.first.profile.reload.enable_individual_requests).to eq(true)
+            expect(partners.last.profile.reload.enable_individual_requests).to eq(true)
+            expect(organization.reload.enable_child_based_requests).to eq(true)
+            expect(partners.first.profile.reload.enable_child_based_requests).to eq(true)
+            expect(partners.last.profile.reload.enable_child_based_requests).to eq(true)
           end
         end
+      end
 
-        context "when all of a single partner's request types WILL NOT be disabled" do
-          before { described_class.update(organization, enable_individual_requests: false ) }
+      context "when all of a single partner's request flags WILL NOT be disabled" do
+        before { described_class.update(organization, enable_individual_requests: false) }
 
-          it 'should allow the enabled request type to be disabled in organization and its partners' do
-            aggregate_failures 'request type in organization and partners' do
-              expect(organization.reload.enable_individual_requests).to eq(false)
-              expect(partners.first.profile.reload.enable_individual_requests).to eq(false)
-              expect(partners.last.profile.reload.enable_individual_requests).to eq(false)
-            end
+        it "should allow the disabling of request flags in organization and its partners" do
+          aggregate_failures "request type in organization and partners" do
+            expect(organization.reload.enable_individual_requests).to eq(false)
+            expect(partners.first.profile.reload.enable_individual_requests).to eq(false)
+            expect(partners.last.profile.reload.enable_individual_requests).to eq(false)
           end
         end
       end
@@ -81,7 +81,7 @@ describe OrganizationUpdateService, skip_seed: true do
       }
     end
 
-    context "when field hasn't changed" do
+    context "when request flags haven't changed" do
       it "should not update partners" do
         described_class.update_partner_flags(organization)
         expect(organization.partners.map { |p| p.profile.enable_child_based_requests })
@@ -93,8 +93,8 @@ describe OrganizationUpdateService, skip_seed: true do
       end
     end
 
-    context "when field has changed" do
-      it "should update partners when disabling child and individual requests" do
+    context "when request flags have changed" do
+      it "should update partners when disabling child and individual request flags" do
         organization.update!(enable_child_based_requests: false, enable_individual_requests: false, enable_quantity_based_requests: true)
         described_class.update_partner_flags(organization)
         expect(organization.partners.map { |p| p.profile.enable_child_based_requests })
@@ -105,7 +105,7 @@ describe OrganizationUpdateService, skip_seed: true do
           .to eq([true, true])
       end
 
-      it "should update partners when disabling quantity based requests" do
+      it "should update partners when disabling quantity-based request flags" do
         organization.update!(enable_quantity_based_requests: false)
         described_class.update_partner_flags(organization)
         expect(organization.partners.map { |p| p.profile.enable_child_based_requests })
@@ -116,7 +116,7 @@ describe OrganizationUpdateService, skip_seed: true do
           .to eq([false, false])
       end
 
-      it "should NOT update partners' request types when enabling request types on the organization" do
+      it "should NOT update partners' request flags when enabling request flags on the organization" do
         organization.update!(enable_quantity_based_requests: false)
         organization.update!(enable_quantity_based_requests: true)
 


### PR DESCRIPTION
Resolves #3264 

### Description
Feature request:
AC1:
Given an organization with partners
And given a request flag (eg `enable_child_based_requests`) is set to false on organisation AND partners
When the organisation enables said flag
The flag is NOT automatically enabled on partners

AC2:
Given an organization with partners
And given one of the partners has only one request flag set to true (eg `enable_child_based_requests`) 
When the organisation disables said flag
The flag is NOT disabled on organisation
And the flag is NOT changed for any partners

AC3:
_(Maintain current behaviour)_
Given an organization with partners
And each partner has more than one flag set to true
When the organisation disables one of the flags
The flag IS disabled on organisation
And the flag IS disabled on all partners
  

### Type of change
* Changes existing functionality

### How Has This Been Tested?
Tests have been written to cover above ACs. Also, a test has been added to one of the request specs for this feature (to cover a previously uncovered unhappy path).