### PR TITLE
[3311] Consider only distributions issued during current year when calculating year to date quantity

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -204,7 +204,7 @@ class Partner < ApplicationRecord
   def quantity_year_to_date
     distributions
       .includes(:line_items)
-      .where("line_items.created_at > ?", Time.zone.today.beginning_of_year)
+      .where('distributions.issued_at >= ?', Time.zone.today.beginning_of_year)
       .references(:line_items).map(&:line_items).flatten.sum(&:quantity)
   end
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -273,12 +273,12 @@ RSpec.describe Partner, type: :model do
       create(:distribution, :with_items, partner: partner)
     end
 
-    it "includes all item quantities for the given year" do
+    it "includes all item quantities from distributions issued during the current year" do
       expect(partner.quantity_year_to_date).to eq(300)
     end
 
-    it "does not include quantities from last year" do
-      LineItem.last.update(created_at: Time.zone.today.beginning_of_year - 20)
+    it "does not include quantities from distributions issued during the previous year" do
+      partner.distributions.last.update(issued_at: Time.zone.today.beginning_of_year - 20)
       expect(partner.quantity_year_to_date).to eq(200)
     end
   end


### PR DESCRIPTION

Resolves [#3311  <!--fill issue number-->](https://github.com/rubyforgood/human-essentials/issues/3311)

### Description
Method `quantity_year_to_date` in `Partner` model changed so it only considers distributions issued during the current year when calculating total quantity.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested generating PDF for a distribution locally, verified the change through spec.

