### PR TITLE
3261 prevent invalid distribution creation

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -217,7 +217,7 @@ class DistributionsController < ApplicationController
   private
 
   def insufficient_error_message(details)
-    "Sorry, we weren't able to save the distribution. \n #{@distribution.errors.full_messages.join(', ')} #{details}"
+    "Sorry, we weren't able to save the distribution. \n #{details}"
   end
 
   def send_notification(org, dist, subject: 'Your Distribution', distribution_changes: {})

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -122,8 +122,7 @@ module Itemizable
 
     line_items.each do |line_item|
       next unless line_item.item
-
-      next unless line_item.quantity <= 0
+      next unless line_item.quantity != nil && line_item.quantity <= 0
 
       errors.add(:inventory,
                  "#{line_item.item.name}'s quantity " \

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -122,7 +122,7 @@ module Itemizable
 
     line_items.each do |line_item|
       next unless line_item.item
-      next unless line_item.quantity != nil && line_item.quantity <= 0
+      next unless !line_item.quantity.nil? && line_item.quantity <= 0
 
       errors.add(:inventory,
                  "#{line_item.item.name}'s quantity " \

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -38,6 +38,7 @@ class Distribution < ApplicationRecord
 
   validates :storage_location, :partner, :organization, :delivery_method, presence: true
   validate :line_item_items_exist_in_inventory
+  validate :line_item_items_quantity_is_positive
 
   before_save :combine_distribution
 

--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -36,10 +36,10 @@ module Errors
     #   that are insufficient.
     ###
     def message
-      super.to_s + ("<ul><li>" + insufficient_items.map do |i|
+      super.to_s + (" " + insufficient_items.map do |i|
         "#{i[:quantity_requested]} #{i[:item_name]} requested, only #{i[:quantity_on_hand]} available." \
         "(Reduce by #{i[:quantity_requested].to_i - i[:quantity_on_hand].to_i})"
-      end.join("</li><li>") + "</li></ul>")
+      end.join(""))
     end
   end
 

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -176,7 +176,7 @@ class StorageLocation < ApplicationRecord
       # Raise this custom error with information about each of the items that showed insufficient
       # This bails out of the method!
       raise Errors::InsufficientAllotment.new(
-        "Requested items exceed the available inventory",
+        "Requested items exceed the available inventory.",
         insufficient_items
       )
     end

--- a/app/services/distribution_service.rb
+++ b/app/services/distribution_service.rb
@@ -8,6 +8,9 @@ class DistributionService
   rescue ActiveRecord::RecordNotFound => e
     Rails.logger.error "[!] #{self.class.name} failed to destroy distribution #{distribution_id} because it does not exist"
     set_error(e)
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error  "[!] #{self.class.name} #{e} "
+    set_error(e)
   rescue Errors::InsufficientAllotment => e
     distribution.line_items.assign_insufficiency_errors(e.insufficient_items)
     Rails.logger.error "[!] #{self.class.name} failed because of Insufficient Allotment #{distribution_organization.short_name}: #{distribution.errors.full_messages} [#{e.message}]"

--- a/app/services/distribution_service.rb
+++ b/app/services/distribution_service.rb
@@ -8,15 +8,12 @@ class DistributionService
   rescue ActiveRecord::RecordNotFound => e
     Rails.logger.error "[!] #{self.class.name} failed to destroy distribution #{distribution_id} because it does not exist"
     set_error(e)
-  rescue ActiveRecord::RecordInvalid => e
-    Rails.logger.error  "[!] #{self.class.name} #{e} "
-    set_error(e)
   rescue Errors::InsufficientAllotment => e
     distribution.line_items.assign_insufficiency_errors(e.insufficient_items)
     Rails.logger.error "[!] #{self.class.name} failed because of Insufficient Allotment #{distribution_organization.short_name}: #{distribution.errors.full_messages} [#{e.message}]"
     set_error(e)
   rescue StandardError => e
-    Rails.logger.error "[!] #{self.class.name} failed to destroy distribution for #{distribution_organization.short_name}: #{distribution.errors.full_messages} [#{e.inspect}]"
+    Rails.logger.error "[!] #{self.class.name} failed for #{distribution_organization.short_name}: #{distribution.errors.full_messages} [#{e.inspect}]"
     set_error(e)
   ensure
     return self

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -124,7 +124,6 @@ RSpec.describe DistributionsController, type: :controller do
         end
         subject { post :create, params: params.merge(format: :turbo_stream) }
 
-
         it "flashes an error" do
           expect(subject).to have_http_status(:bad_request)
           expect(flash[:error]).to include("Sorry, we weren't able to save the distribution. \n Validation failed: Inventory Item 1's quantity needs to be positive")

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -105,6 +105,31 @@ RSpec.describe DistributionsController, type: :controller do
           expect(flash[:alert]).to eq("The following items have fallen below the recommended on hand quantity: Item 1, Item 2")
         end
       end
+
+      context "when line item quantity is not positive" do
+        let(:item) { create(:item, name: "Item 1", organization: @organization, on_hand_minimum_quantity: 5) }
+        let(:storage_location) { create(:storage_location, :with_items, item: item, item_quantity: 2) }
+        let(:params) do
+          {
+            organization_id: @organization.id,
+            distribution: {
+              partner_id: @partner.id,
+              storage_location_id: storage_location.id,
+              line_items_attributes:
+                {
+                  "0": { item_id: storage_location.items.first.id, quantity: 0 }
+                }
+            }
+          }
+        end
+        subject { post :create, params: params.merge(format: :turbo_stream) }
+
+
+        it "flashes an error" do
+          expect(subject).to have_http_status(:bad_request)
+          expect(flash[:error]).to include("Sorry, we weren't able to save the distribution. \n Validation failed: Inventory Item 1's quantity needs to be positive")
+        end
+      end
     end
 
     describe "PUT #update" do

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Distributions", type: :request do
       end
 
       it "sums distribution totals accurately" do
-        distribution = create(:distribution, :with_items, item_quantity: 0)
+        distribution = create(:distribution, :with_items, item_quantity: 1)
 
         item_quantity = 6
         package_size = 2
@@ -158,7 +158,7 @@ RSpec.describe "Distributions", type: :request do
         )
         get distribution_path(default_params.merge(id: distribution.id))
 
-        expect(assigns(:total_quantity)).to eq(item_quantity)
+        expect(assigns(:total_quantity)).to eq(item_quantity + 1)
         expect(assigns(:total_package_count)).to eq(item_quantity / package_size)
       end
     end

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -119,13 +119,15 @@ RSpec.describe DistributionCreateService, type: :service do
     end
 
     context "when the line item quantity is not positive" do
-      let(:params) { {
-        organization_id: @organization.id,
-        partner_id: @partner.id,
-        storage_location_id: storage_location.id,
-        delivery_method: :delivery,
-        line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 0 } }
-      } }
+      let(:params) {
+        {
+          organization_id: @organization.id,
+          partner_id: @partner.id,
+          storage_location_id: storage_location.id,
+          delivery_method: :delivery,
+          line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 0 } }
+        }
+      }
 
       it "preserves the RecordInvalid error and is unsuccessful" do
         result = subject.new(params).call

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -117,5 +117,21 @@ RSpec.describe DistributionCreateService, type: :service do
         expect(result).not_to be_success
       end
     end
+
+    context "when the line item quantity is not positive" do
+      let(:params) { {
+        organization_id: @organization.id,
+        partner_id: @partner.id,
+        storage_location_id: storage_location.id,
+        delivery_method: :delivery,
+        line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 0 } }
+      } }
+
+      it "preserves the RecordInvalid error and is unsuccessful" do
+        result = subject.new(params).call
+        expect(result.error).to be_instance_of(ActiveRecord::RecordInvalid)
+        expect(result).not_to be_success
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3261 <!--fill issue number-->

### Description
Use itemizable helper method `line_item_items_quantity_is_positive` to ensure that when a distribution is created, it must have a positive line item number.

This change does not prevent users from making inventory adjustments with negative numbers.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/13841769/213937745-15035857-1268-4894-b96d-cd3ca5ee14a2.png">