### PR TITLE
Reminder email correction -- substitute "an essentials request" for "… "a diaper request"

### DIFF
--- a/app/views/reminder_deadline_mailer/notify_deadline.html.erb
+++ b/app/views/reminder_deadline_mailer/notify_deadline.html.erb
@@ -3,7 +3,7 @@
     This is a friendly reminder that <%= @organization.name %> requires your human essentials requests to be submitted by <%= @deadline.strftime('%a, %d %b %Y') %>
 if you would like to receive a distribution next month.</p>
     <p>Please log into <a href="https://humanessentials.app">partnerbase</a>
-before this date and submit your request if you are intending to submit a diaper request.</p>
+before this date and submit your request if you are intending to submit an essentials request.</p>
     <p>Please contact <%= @organization.name %> at <%= @organization.email %>
 if you have any questions about this!</p>
 

--- a/app/views/reminder_deadline_mailer/notify_deadline.text.erb
+++ b/app/views/reminder_deadline_mailer/notify_deadline.text.erb
@@ -3,7 +3,7 @@ Hello <%= @partner.name %>,
 This is a friendly reminder that <%= @organization.name %> requires your human essentials requests to be submitted by <%= @deadline.strftime('%a, %d %b %Y') %>
 if you would like to receive a distribution next month.
 
-Please log into PartnerBase at https://humanessentials.app before this date and submit your request if you are intending to submit a diaper request.
+Please log into PartnerBase at https://humanessentials.app before this date and submit your request if you are intending to submit an essentials request.
 
 Please contact <%= @organization.name %> at <%= @organization.email %>
 if you have any questions about this!


### PR DESCRIPTION
### Description
This resolves a concern raised by a period supply bank that the deadline reminder email sent to the partners still refers to diapers.  (somehow this was missed in the earlier effort.  Mea culpa.)

It is a text change only.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I have run all the existing tests, and they still pass 
I have not tested it manually

