### PR TITLE
Fix discarded users

### DIFF
--- a/db/migrate/20230126184524_fix_discarded_users.rb
+++ b/db/migrate/20230126184524_fix_discarded_users.rb
@@ -1,0 +1,23 @@
+class FixDiscardedUsers < ActiveRecord::Migration[7.0]
+  def up
+    User.unscoped.discarded.find_each do |user|
+      if user.organization_id.present?
+        org = Organization.find_by_id(user.organization_id)
+        user.add_role(:org_user, org) if org
+      end
+      if user.partner_id.present?
+        partner = Partner.find_by_id(user.partner_id)
+        user.add_role(:partner, partner)
+      end
+      if user.read_attribute(:super_admin)
+        user.add_role(:super_admin)
+      elsif user.read_attribute(:organization_admin)
+        org = Organization.find_by_id(user.organization_id)
+        user.add_role(:org_admin, org) if org
+      end
+    end  end
+
+  def down
+
+  end
+end

--- a/db/migrate/20230126184524_fix_discarded_users.rb
+++ b/db/migrate/20230126184524_fix_discarded_users.rb
@@ -7,7 +7,7 @@ class FixDiscardedUsers < ActiveRecord::Migration[7.0]
       end
       if user.partner_id.present?
         partner = Partner.find_by_id(user.partner_id)
-        user.add_role(:partner, partner)
+        user.add_role(:partner, partner) if partner
       end
       if user.read_attribute(:super_admin)
         user.add_role(:super_admin)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_04_191611) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_184524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
As per Slack - discarded users were not included in the original role migration due to a default scope. This creates roles for them as well.

cc: @cielf 