### PR TITLE
3350 change partnerbase text to essentials

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -10,7 +10,7 @@ class CustomDeviseMailer < Devise::Mailer
     if resource.has_role?(Role::PARTNER, :any) && resource.id == resource.partner.primary_user&.id
       "You've been invited to be a partner with #{resource.partner.organization.name}"
     elsif resource.has_role?(Role::PARTNER, :any) && resource.id != resource.partner.primary_user&.id
-      "You've been invited to #{resource.partner.name}'s partnerbase account"
+      "You've been invited to #{resource.partner.name}'s Human Essentials account"
     else
       super
     end

--- a/app/views/account_request_mailer/confirmation.html.erb
+++ b/app/views/account_request_mailer/confirmation.html.erb
@@ -21,7 +21,10 @@
 </p>
 
 <p>
-      <a href='https://staging.humanessentials.app/users/sign_in'>Human Essentials</a>
+  <a href='https://staging.humanessentials.app/users/sign_in'>Human Essentials</a>
+</p>
+<p>
+  <strong> Bank user login: </strong>
   <br>
   <span>Username: org_admin1@example.com</span>
   <br>
@@ -29,7 +32,7 @@
 </p>
 
 <p>
-  <a href='https://staging.humanessentials.app/partner_users/sign_in'>PartnerBase</a>
+  <strong>Partner user login:</strong>
   <br>
   <span>Username: verified@example.com</span>
   <br>

--- a/app/views/account_request_mailer/confirmation.text.erb
+++ b/app/views/account_request_mailer/confirmation.text.erb
@@ -12,11 +12,12 @@ If you'd like to experience the app, please log in to the sandbox/demo sites and
 
 Human Essentials:
 Link: https://staging.humanessentials.app/users/sign_in
+
+Bank user login:
 Username: org_admin1@example.com
 Password: password!
 
-PartnerBase:
-Link: https://staging.humanessentials.app/partner_users/sign_in
+Partner user login:
 Username: verified@example.com
 Password: password!
 

--- a/app/views/layouts/partners/application.html.erb
+++ b/app/views/layouts/partners/application.html.erb
@@ -33,7 +33,7 @@
   <aside class="main-sidebar sidebar-dark-primary elevation-4">
     <!-- Brand Logo -->
     <%= link_to "", class: "brand-link" do %>
-      Human Essentials 
+      <img src="/img/essentials.svg" alt="Essentials Logo (icon)" title="HumanEssentials" class="main_logo">
     <% end %>
 
     <!-- Sidebar -->

--- a/app/views/layouts/partners/application.html.erb
+++ b/app/views/layouts/partners/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>PartnerBase</title>
+  <title>Human Essentials</title>
   <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
   <%= csrf_meta_tags %>
   <%= javascript_include_tag 'application' %>
@@ -33,7 +33,7 @@
   <aside class="main-sidebar sidebar-dark-primary elevation-4">
     <!-- Brand Logo -->
     <%= link_to "", class: "brand-link" do %>
-      PartnerBase
+      Human Essentials 
     <% end %>
 
     <!-- Sidebar -->
@@ -61,7 +61,7 @@
   <footer class="main-footer">
     <div class="pull-right hidden-xs">
     </div>
-    <strong>PartnerBase was built with <i class="fa fa-heart fa-beat" style="color:red;"></i> by <a href="http://rubyforgood.org">Ruby for Good</a>.</strong>
+    <strong>Human Essentials was built with <i class="fa fa-heart fa-beat" style="color:red;"></i> by <a href="http://rubyforgood.org">Ruby for Good</a>.</strong>
   </footer>
 
   </aside>

--- a/app/views/reminder_deadline_mailer/notify_deadline.html.erb
+++ b/app/views/reminder_deadline_mailer/notify_deadline.html.erb
@@ -2,7 +2,7 @@
     <p>
     This is a friendly reminder that <%= @organization.name %> requires your human essentials requests to be submitted by <%= @deadline.strftime('%a, %d %b %Y') %>
 if you would like to receive a distribution next month.</p>
-    <p>Please log into <a href="https://humanessentials.app">partnerbase</a>
+    <p>Please log into <a href="https://humanessentials.app">Human Essentials</a>
 before this date and submit your request if you are intending to submit an essentials request.</p>
     <p>Please contact <%= @organization.name %> at <%= @organization.email %>
 if you have any questions about this!</p>

--- a/app/views/reminder_deadline_mailer/notify_deadline.text.erb
+++ b/app/views/reminder_deadline_mailer/notify_deadline.text.erb
@@ -3,7 +3,7 @@ Hello <%= @partner.name %>,
 This is a friendly reminder that <%= @organization.name %> requires your human essentials requests to be submitted by <%= @deadline.strftime('%a, %d %b %Y') %>
 if you would like to receive a distribution next month.
 
-Please log into Essentials at https://humanessentials.app before this date and submit your request if you are intending to submit an essentials request.
+Please log into Human Essentials at https://humanessentials.app before this date and submit your request if you are intending to submit an essentials request.
 
 Please contact <%= @organization.name %> at <%= @organization.email %>
 if you have any questions about this!

--- a/app/views/reminder_deadline_mailer/notify_deadline.text.erb
+++ b/app/views/reminder_deadline_mailer/notify_deadline.text.erb
@@ -3,7 +3,7 @@ Hello <%= @partner.name %>,
 This is a friendly reminder that <%= @organization.name %> requires your human essentials requests to be submitted by <%= @deadline.strftime('%a, %d %b %Y') %>
 if you would like to receive a distribution next month.
 
-Please log into PartnerBase at https://humanessentials.app before this date and submit your request if you are intending to submit an essentials request.
+Please log into Essentials at https://humanessentials.app before this date and submit your request if you are intending to submit an essentials request.
 
 Please contact <%= @organization.name %> at <%= @organization.email %>
 if you have any questions about this!

--- a/spec/mailers/account_request_mailer_spec.rb
+++ b/spec/mailers/account_request_mailer_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe AccountRequestMailer, type: :mailer do
         expect(html).to match('Username: org_admin1@example.com')
         expect(html).to match('Password: password!')
 
-        expect(html).to match(%r{<a href='https://staging.humanessentials.app/partner_users/sign_in'>PartnerBase</a>})
         expect(html).to match('Username: verified@example.com')
         expect(html).to match('Password: password!')
       end
@@ -54,7 +53,6 @@ RSpec.describe AccountRequestMailer, type: :mailer do
         expect(text).to match('Username: org_admin1@example.com')
         expect(text).to match('Password: password!')
 
-        expect(text).to match(%r{https://staging.humanessentials.app/partner_users/sign_in})
         expect(text).to match('Username: verified@example.com')
         expect(text).to match('Password: password!')
       end

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CustomDeviseMailer, type: :mailer do
       let(:user) { create(:partner_user, partner: partner) }
 
       it "invites to partner user" do
-        expect(mail.subject).to eq("You've been invited to #{user.partner.name}'s partnerbase account")
+        expect(mail.subject).to eq("You've been invited to #{user.partner.name}'s Human Essentials account")
         expect(mail.html_part.body).to include("You've been invited to <strong>#{user.partner.name}'s</strong> account for requesting items from <strong>#{user.partner.organization.name}!")
       end
     end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3350  <!--fill issue number-->

### Description

Changed the remaining user facing instances of "Partnerbase" to "Human Essentials"
Labeled the two different logins in the account request confirmation mailer and removed the link to /partner_users/sign_in
Changed the "Partnerbase" text at the top of the partner user sidebar to the Essentials logo svg

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

2 mailer tests were changed to reflect the new wording

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
