### PR TITLE
fix deprecation warnings

### DIFF
--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -261,12 +261,12 @@ RSpec.describe Donation, type: :model do
     end
 
     specify 'the hash is immutable' do
-      expect(-> { Donation::SOURCES[:foo] = 'bar' }).to raise_error(FrozenError)
+      expect { Donation::SOURCES[:foo] = 'bar' }.to raise_error(FrozenError)
     end
 
     specify 'the hash values are immutable' do
       Donation::SOURCES.values.each do |frozen_string|
-        expect(-> { frozen_string << 'bar' }).to raise_error(FrozenError)
+        expect { frozen_string << 'bar' }.to raise_error(FrozenError)
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -239,11 +239,11 @@ RSpec.describe Item, type: :model do
     context "when item does not have kit" do
       let(:kit) { nil }
 
-      it "does not raise NoMethodError" do
+      it "does not raise any errors" do
         allow_any_instance_of(Kit).to receive(:update).and_return(true)
         expect {
           item.update(name: "my new name")
-        }.not_to raise_error(NoMethodError)
+        }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3342  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

This PR addresses Rspec deprecation warnings around error expectations in `item_spec.rb` and `donation_spec.rb`. 

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Spec