### PR TITLE
Fixing banks re-send invite of partner

### DIFF
--- a/app/services/user_invite_service.rb
+++ b/app/services/user_invite_service.rb
@@ -7,11 +7,22 @@ module UserInviteService
   def self.invite(email:, resource:, name: nil, roles: [])
     raise "Resource not found!" if resource.nil?
 
-    User.invite!(email: email) do |user|
-      user.name = name if name
-      roles.each do |role|
-        user.add_role(role, resource)
-      end
+    user = User.find_by(email: email)
+    if user
+      user.invite!
+      add_roles(user, resource: resource, roles: roles)
+      return user
+    end
+
+    User.invite!(email: email) do |user1|
+      user1.name = name if name # Does this get persisted somewhere up the line? - CLF 20230203
+      add_roles(user1, resource: resource, roles: roles)
+    end
+  end
+
+  def self.add_roles(user, resource:, roles: [])
+    roles.each do |role|
+      user.add_role(role, resource)
     end
   end
 end

--- a/spec/services/user_invite_service_spec.rb
+++ b/spec/services/user_invite_service_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe UserInviteService, type: :service, skip_seed: true do
       User.create!(name: "Some Name", email: "email@email.com", password: "blahblah!")
     end
     it "should invite the existing user" do
-      allow(User).to receive(:invite!).and_call_original
-      result = described_class.invite(email: "email@email.com", resource: @organization)
-      expect(result.id).to eq(user.id)
-      expect(User).to have_received(:invite!)
+      expect { described_class.invite(email: "email@email.com", resource: @organization) }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
 
     it "should add roles to existing user" do


### PR DESCRIPTION
Resolves #3368 

### Description
Re-sending invites to partners is showing that the invitation has been sent, when it does not

It seems that using User.invite!(:email) with an already existing user does nothing.  
Per devise documentation,  used user.invite!  instead for existing user.
Adapted tests so they would catch whether the email would actually go out for existing user
   
### Type of change

* Bug fix (non-breaking change which fixes an issue)
### How Has This Been Tested?

Manual test on local -- try to reinvite Pawnee Homeless Shelter as org_admin1@example.com.  Tested that accepting the password also works.
-- checked that sending out an invitation to a bank user still sends out an invite
automated tests -- one of which was adapted to just check if the email went out

