### PR TITLE
Allow for more local docker dev env without bothering others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dump.rdb
 /log/*.log
 /tmp
 .env
+.env.production
 .byebug_history
 
 # Ignore locally installed bundled gems
@@ -53,6 +54,8 @@ dump.rdb
 # Ignore Docker stuff (see issues #503, #603)
 Dockerfile
 docker-compose.yml
+.dockerignore
+
 /public/packs
 /public/packs-test
 /node_modules

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: localhost
+  host: <%= ENV.fetch("PG_HOST", 'localhost') %>
   database: diaper_dev
   username: <%= ENV.fetch("PG_USERNAME", 'postgres') %>
   password: <%= ENV.fetch("PG_PASSWORD", nil) %>

--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -15,7 +15,10 @@ task :fetch_latest_db => :environment do
 
   puts "Restoring the database with #{backup.name}"
   backup_filepath = fetch_file_path(backup)
-  system("pg_restore --clean --no-acl --no-owner -h localhost -d diaper_dev -U postgres #{backup_filepath}")
+  db_username = ENV.fetch("PG_USERNAME", 'postgres')
+  db_host = ENV.fetch("PG_HOST", 'localhost')
+  system("pg_restore --clean --no-acl --no-owner -h #{db_host} -d diaper_dev -U #{db_username} #{backup_filepath}")
+
   puts "Done!"
 
   # Update the ar_internal_metadata table to have the correct environment

--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -15,7 +15,7 @@ task :fetch_latest_db => :environment do
 
   puts "Restoring the database with #{backup.name}"
   backup_filepath = fetch_file_path(backup)
-  system("pg_restore --clean --no-acl --no-owner -h localhost -d diaper_dev #{backup_filepath}")
+  system("pg_restore --clean --no-acl --no-owner -h localhost -d diaper_dev -U postgres #{backup_filepath}")
   puts "Done!"
 
   # Update the ar_internal_metadata table to have the correct environment


### PR DESCRIPTION
These are some local-dev related changes so that I can use docker-compose but keep it as a non-supported dev env. Also ignores `env.production` since that shouldn't ever get committed accidentally.