### PR TITLE
WIP disallow entering numbers with commas

### DIFF
--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -11,7 +11,7 @@
           <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false, input_html: { class: "my-0", "data-controller": "select2" } %>
         </span>
         <div class="li-quantity mx-2">
-          <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity my-0"} %>
+          <%= f.input :quantity, as: :string, placeholder: "Quantity", label: false, input_html: { class: "quantity my-0"} %>
         </div>
       </div>
     </div>

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -332,7 +332,7 @@ RSpec.feature "Distributions", type: :system do
 
       it "User creates a distribution from a donation then edits it" do
         within ".distribution_line_items_quantity" do
-          first(".numeric").set 13
+          first(".string").set 13
         end
         click_on "Save"
         expect(page).to have_content "Distribution updated!"
@@ -341,7 +341,7 @@ RSpec.feature "Distributions", type: :system do
 
       it "User creates a distribution from a donation then tries to make the quantity too big", js: true do
         within ".distribution_line_items_quantity" do
-          first(".numeric").set 999_999
+          first(".string").set 999_999
         end
         click_on "Save"
         expect(page).to have_no_content "Distribution updated!"
@@ -357,10 +357,11 @@ RSpec.feature "Distributions", type: :system do
         item_type = @distribution.line_items.first.item.name
         first_item_name_field = 'distribution_line_items_attributes_0_item_id'
         select(item_type, from: first_item_name_field)
-        find_all(".numeric")[0].set 1
+        fill_in "distribution_line_items_attributes_0_quantity", with: 1
 
         click_on "Add another item"
-        find_all(".numeric")[1].set 3
+        text_id = page.find_all('.distribution_line_items_quantity > input').last[:id]
+        fill_in text_id, with: 3
 
         first("button", text: "Save").click
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3373 

### Description
Change the input type of the line item quantity from number to string

Before this change, if the user added a comma to the number, it was considered invalid. The value was not sent to the backend, the save failed silently.

Now, with the string input type, the value is sent to the backend, and there is always an explicit error.

Note that this affects multiple places where the issue also occurred, for example when creating a distribution.

WIP because some barcode tests are still failing. 

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Added automatic tests.
Verified that this was working
Manually tested on firefox and chrome

### Screenshots

![image](https://user-images.githubusercontent.com/9966978/221177955-0282443b-0e33-4839-b479-cc409667b564.png)

