### PR TITLE
Fix purchase vendor modal

### DIFF
--- a/app/views/purchases/new.html.erb
+++ b/app/views/purchases/new.html.erb
@@ -34,7 +34,7 @@
           <!-- form start -->
           <div class="card-body">
             <%= render partial: "purchase_form", object: @purchase %>
-            <%= link_to "Add vendor", new_vendor_path, {:remote => true, "data-toggle" => "modal", "data-target" => "#modal_new", id: "new_vendor", "style" => "display: none;"} %>
+            <%= link_to "Add vendor", new_vendor_path, {:remote => true, "data-toggle" => "modal", "data-target" => "#modal-window", id: "new_vendor", "style" => "display: none;"} %>
           </div><!-- /.box -->
         </div>
       </div>

--- a/app/views/vendors/new_modal.js.erb
+++ b/app/views/vendors/new_modal.js.erb
@@ -1,11 +1,2 @@
 $("#modal_new").html("<%= j (render "vendors/new_modal") %>");
 $("#modal_new").modal("show");
-
-// There seems to be an odd bug where *only on this page* the close button for the modal
-// doesn't work if the "fade" class is added to the modal.
-// To keep the fade functionality, we remove it once the modal is shown so the close button
-// works, then re-add it in case the modal has to be popped up again.
-$("#modal_new").on('hidden.bs.modal', function(e) {
-  $("#modal_new").addClass("fade");
-})
-$("#modal_new").removeClass("fade");

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe "Purchases", type: :system, js: true do
           fill_in "vendor_email", with: "123@mail.ru"
           click_on "vendor-submit"
           select "businesstest", from: "purchase_vendor_id"
+          expect(page).to have_no_content("New Vendor")
         end
 
         it "User can create a purchase using dollars decimal amount" do


### PR DESCRIPTION
Now it matches all the other modal instances. I think the fade css class was a red herring.

Tested locally, creating new purchase and making sure the dialog closes. Updated the system test as well.