### PR TITLE
Use the local user by default for postgres admin data load

### DIFF
--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -15,7 +15,7 @@ task :fetch_latest_db => :environment do
 
   puts "Restoring the database with #{backup.name}"
   backup_filepath = fetch_file_path(backup)
-  db_username = ENV.fetch("PG_USERNAME", 'postgres')
+  db_username = ENV.fetch("PG_USERNAME", ENV["USER"])
   db_host = ENV.fetch("PG_HOST", 'localhost')
   system("pg_restore --clean --no-acl --no-owner -h #{db_host} -d diaper_dev -U #{db_username} #{backup_filepath}")
 

--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -15,8 +15,8 @@ task :fetch_latest_db => :environment do
 
   puts "Restoring the database with #{backup.name}"
   backup_filepath = fetch_file_path(backup)
-  db_username = ENV.fetch("PG_USERNAME", ENV["USER"])
-  db_host = ENV.fetch("PG_HOST", 'localhost')
+  db_username = ENV["PG_USERNAME"].presence || ENV["USER"].presence || "postgres"
+  db_host = ENV["PG_HOST"].presence || "localhost"
   system("pg_restore --clean --no-acl --no-owner -h #{db_host} -d diaper_dev -U #{db_username} #{backup_filepath}")
 
   puts "Done!"


### PR DESCRIPTION
On OSX, which is the most-supported platform for us, postgres is running as the logged in $USER by default, so we should use that when running `bin/rake fetch_latest_db` (instead of an explicit/env parameter).