### PR TITLE
3420: Fix for missing bootstrap select

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -160,3 +160,6 @@ body:not(.sidebar-mini-md) .content-wrapper, body:not(.sidebar-mini-md) .main-fo
   margin-left: 280px;
 }
 
+select.selectpicker + .dropdown-toggle::after {
+  display: none;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -10,6 +10,7 @@ import 'filterrific'
 import { Turbo } from "@hotwired/turbo-rails"
 import "trix"
 import "@rails/actiontext"
+import "bootstrap-select"
 
 import {DateTime} from "luxon";
 import 'litepicker';

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -31,3 +31,4 @@ pin "@rails/ujs", to: "https://ga.jspm.io/npm:@rails/ujs@7.0.4/lib/assets/compil
 pin "cocoon-js-vanilla", to: "https://ga.jspm.io/npm:cocoon-js-vanilla@1.3.0/index.js"
 # NOTE: This has been vendored into vendor/javascript because there isn't a JS module exported by this package
 pin "filterrific", to: "filterrific.js"
+pin "bootstrap-select", to: "https://ga.jspm.io/npm:bootstrap-select@1.13.18/dist/js/bootstrap-select.js"


### PR DESCRIPTION
Resolves #3520

### Description

Looks like we somehow missed bootstrap-select as a dependency. Added this back and the missing field is there again:

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/1986893/222823371-0ea8d286-7c8a-4ee7-9283-a6f2be4ae657.png">

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Local testing.