### PR TITLE
3339: allow partners to be approved when invited or awaiting_review

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -134,6 +134,10 @@ class Partner < ApplicationRecord
       users&.none?
   end
 
+  def approvable?
+    invited? || awaiting_review?
+  end
+
   # better to extract this outside of the model
   def self.import_csv(csv, organization_id)
     organization = Organization.find(organization_id)

--- a/app/services/partner_approval_service.rb
+++ b/app/services/partner_approval_service.rb
@@ -25,7 +25,7 @@ class PartnerApprovalService
   attr_reader :partner
 
   def valid?
-    unless partner.awaiting_review?
+    unless partner.approvable?
       errors.add(:partner, 'is not waiting for approval')
     end
 

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -224,7 +224,7 @@
             <div class='pull-right'>
               <% tooltip_message = "Partner has not requested approval yet. Partners are able to request approval by going into 'My Organization' and clicking 'Request Approval' button." %>
               <span id="pending-approval-request-tooltip" title="<%= tooltip_message unless @partner.awaiting_review? %>">
-                <%= print_button_to approve_application_partner_path(@partner), { text: "Approve Partner", icon: "thumbs-o-up", type: "success", size: "md", enabled: @partner.awaiting_review? } %>
+                <%= print_button_to approve_application_partner_path(@partner), { text: "Approve Partner", icon: "thumbs-o-up", type: "success", size: "md", enabled: @partner.approvable? } %>
               </span>
               <%= edit_button_to edit_profile_path(@partner), { text: "Edit Information", size: "md" } %>
             </div>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -64,7 +64,9 @@
                 <% end %>
                 <br>
                 <br>
-                <%= print_button_to approve_application_partner_path(@partner), { text: "Activate Partner Now", icon: "thumbs-o-up", type: "success", size: "m" } if can_administrate? %>
+                <% unless @partner.approved? %>
+                  <%= print_button_to approve_application_partner_path(@partner), { text: "Activate Partner Now", icon: "thumbs-o-up", type: "success", size: "m" } if can_administrate? %>
+                <% end %>
               </div>
             </div>
           </div>
@@ -222,10 +224,9 @@
               <h2 class="card-title">Application & Information</h2>
             </div>
             <div class='pull-right'>
-              <% tooltip_message = "Partner has not requested approval yet. Partners are able to request approval by going into 'My Organization' and clicking 'Request Approval' button." %>
-              <span id="pending-approval-request-tooltip" title="<%= tooltip_message unless @partner.awaiting_review? %>">
+              <% unless @partner.approved? %>
                 <%= print_button_to approve_application_partner_path(@partner), { text: "Approve Partner", icon: "thumbs-o-up", type: "success", size: "md", enabled: @partner.approvable? } %>
-              </span>
+              <% end %>
               <%= edit_button_to edit_profile_path(@partner), { text: "Edit Information", size: "md" } %>
             </div>
           </div>
@@ -342,9 +343,3 @@
     </div><!-- modal-dialog -->
   </div><!-- addUserModal -->
 </section>
-
-<script type="module">
-  $(function () {
-    $('#pending-approval-request-tooltip').tooltip()
-  })
-</script>

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -175,6 +175,30 @@ RSpec.describe Partner, type: :model do
     end
   end
 
+  describe '#approvable?' do
+    context 'when status is invited' do
+      it 'should return true' do
+        expect(build(:partner, status: :invited)).to be_approvable
+      end
+    end
+
+    context 'when status is awaiting_review' do
+      it 'should return true' do
+        expect(build(:partner, status: :awaiting_review)).to be_approvable
+      end
+    end
+
+    context 'when status is not invited or awaiting_review' do
+      it 'should return false', :aggregate_failures do
+        expect(build(:partner, status: :uninvited)).not_to be_approvable
+        expect(build(:partner, status: :approved)).not_to be_approvable
+        expect(build(:partner, status: :error)).not_to be_approvable
+        expect(build(:partner, status: :recertification_required)).not_to be_approvable
+        expect(build(:partner, status: :deactivated)).not_to be_approvable
+      end
+    end
+  end
+
   describe 'changing emails' do
     let(:partner) { create(:partner, status: :invited) }
     before do

--- a/spec/services/partner_approval_service_spec.rb
+++ b/spec/services/partner_approval_service_spec.rb
@@ -11,9 +11,9 @@ describe PartnerApprovalService do
     end
 
     context 'when the arguments are incorrect' do
-      context 'because the partner is not awaiting_review' do
+      context 'because the partner is not approvable' do
         before do
-          partner.invited!
+          allow(partner).to receive(:approvable?).and_return(false)
         end
 
         it 'should return the PartnerApprovalService object with an error' do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -345,12 +345,6 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         before { visit_approval_page(partner_name: invited_partner.name) }
 
         it { expect(page).to have_selector(:link_or_button, 'Approve Partner') }
-        it { expect(page).to have_selector('span#pending-approval-request-tooltip') }
-
-        it 'shows correct tooltip' do
-          page.execute_script('$("#pending-approval-request-tooltip").mouseover()')
-          expect(page).to have_content tooltip_message, wait: page_content_wait
-        end
       end
 
       context "when viewing a partner's users" do
@@ -377,13 +371,6 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         before { visit_approval_page(partner_name: awaiting_review_partner.name) }
 
         it { expect(page).to have_selector(:link_or_button, 'Approve Partner') }
-        it { expect(page).not_to have_selector('span#pending-approval-request-tooltip > a.btn.btn-success.btn-md.disabled') }
-
-        it 'shows no tooltip' do
-          expect(page).to have_selector('#pending-approval-request-tooltip', wait: page_content_wait)
-          page.execute_script('$("#pending-approval-request-tooltip").mouseover()')
-          expect(page).not_to have_content tooltip_message
-        end
       end
     end
 

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -345,7 +345,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         before { visit_approval_page(partner_name: invited_partner.name) }
 
         it { expect(page).to have_selector(:link_or_button, 'Approve Partner') }
-        it { expect(page).to have_selector('span#pending-approval-request-tooltip > a.btn.btn-success.btn-md.disabled') }
+        it { expect(page).to have_selector('span#pending-approval-request-tooltip') }
 
         it 'shows correct tooltip' do
           page.execute_script('$("#pending-approval-request-tooltip").mouseover()')


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3339 (could not assign myself)

### Description
Allow partners to be approved when their status is "invited" or "awaiting review". This involved:
- Adding an `approvable?` method to partners.
- Changing the `enabled` condition on the second approval button on the page to use this new method.
- Updating the partner approval service to use this new method.

#### Notes
 1. There is another button further up on this page that is always enabled for users that `can_administrate?` - it might make sense for this button to be disabled for partners that are not approvable as well, so that it matches the other button on this page.
 2. ~~There is some tooltip text that I left that may need to changed or be removed, see the first screenshot below for more information.~~ Tooltip has been removed.
 3. ~~The approval buttons are still visible for approved partners, is this by design, or should they be hidden? See second screenshot below for more information.~~ Approval buttons removed for "approved" partners.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested locally and with unit tests - approved a partner that was invited, and a partner that was awaiting review. Confirmed that partners of other statuses could not be approved.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshot 1

This partner is "invited". ~~I left the tooltip text because it is still technically true, but this button is now enabled. If the tooltip is no longer useful it can easily be removed though.~~ Tooltip has been removed.

<img width="361" alt="Screen Shot 2023-03-03 at 9 26 30 PM" src="https://user-images.githubusercontent.com/7715500/222873537-300e75c3-6289-487a-9888-bb7d7029642e.png">

### Screenshot 2

The following screenshot is of an "approved" partner. ~~Notice that the two approval buttons on this page ("Activate Partner Now" and "Approve Partner") are still visible. Is this intentional, or should they be hidden if the partner is approved?~~ Approval buttons removed for "approved" partners.

![ApprovedPartner](https://user-images.githubusercontent.com/7715500/222873633-5f9a53fa-9152-42cc-ba9c-871a8434afd1.png)

