### PR TITLE
Changing the menu-sidebar width to be auto rather than a set pixel value

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -153,10 +153,6 @@ body a {
   margin-left: 10px;
 }
 
-.main-sidebar, .main-sidebar::before {
-  width: 280px;
+.main-sidebar {
+  width: auto;
 }
-body:not(.sidebar-mini-md) .content-wrapper, body:not(.sidebar-mini-md) .main-footer, body:not(.sidebar-mini-md) .main-header {
-  margin-left: 280px;
-}
-


### PR DESCRIPTION
Resolves #3389

### Description

Changing the left menu bar styling to auto width rather than a set pixel value. I saw it was being set manually to fix #2840 . Setting the width of the menu bar to auto fixes this issue and keeps the drop down arrows visible in Firefox when the menu  drop downs are expanded on mobile.

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

Visually confirmed this issue and #2840 is fixed in Chrome and Firefox, rspec passes 

### Screenshots

![Screen Shot 2023-03-07 at 10 18 29 AM](https://user-images.githubusercontent.com/32309015/223467569-76f49b4d-aae5-471e-b826-56d3b9ad122d.png)
![Screen Shot 2023-03-07 at 10 18 50 AM](https://user-images.githubusercontent.com/32309015/223467598-223a2a59-78f4-4122-b4ad-4ea5cbea248c.png)
