### PR TITLE
3387 type error in request confirmation mailer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -708,4 +708,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.25
+   2.4.7

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -10,11 +10,25 @@ class RequestsConfirmationMailer < ApplicationMailer
   private
 
   def fetch_items(request)
-    items_sorted = request.request_items.sort_by { |k| k['item_id'] }
-    item_ids = items_sorted&.map { |item| item['item_id'] }
+    combined = combined_items(request)
+    item_ids = combined&.map { |item| item['item_id'] }
     items_names = Item.where(id: item_ids).order(:id).pluck(:name)
     names_hash = items_names.map { |name| { 'name' => name } }
+    combined.zip(names_hash).map { |items, names| items.merge(names) }
+  end
 
-    items_sorted.zip(names_hash).map { |items, names| items.merge(names) }
+  def combined_items(request)
+    return [] if request.request_items.size == 0
+    sorted = request.request_items.sort_by { |k| k['item_id'] }
+    combined = [sorted[0]]
+    (1..sorted.size - 1).each do |i|
+      request_item = sorted[i]
+      if request_item["item_id"] == combined.last["item_id"]
+        combined.last["quantity"] = combined.last["quantity"] + request_item["quantity"]
+      else
+        combined.push request_item
+      end
+    end
+    combined
   end
 end

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -21,8 +21,7 @@ class RequestsConfirmationMailer < ApplicationMailer
     return [] if request.request_items.size == 0
     sorted = request.request_items.sort_by { |k| k['item_id'] }
     combined = [sorted[0]]
-    (1..sorted.size - 1).each do |i|
-      request_item = sorted[i]
+    sorted[1..].each do |request_item|
       if request_item["item_id"] == combined.last["item_id"]
         combined.last["quantity"] = combined.last["quantity"] + request_item["quantity"]
       else

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -19,15 +19,11 @@ class RequestsConfirmationMailer < ApplicationMailer
 
   def combined_items(request)
     return [] if request.request_items.size == 0
-    sorted = request.request_items.sort_by { |k| k['item_id'] }
-    combined = [sorted[0]]
-    sorted[1..].each do |request_item|
-      if request_item["item_id"] == combined.last["item_id"]
-        combined.last["quantity"] = combined.last["quantity"] + request_item["quantity"]
-      else
-        combined.push request_item
-      end
+    # convert items into a hash of (id => list of items with that ID)
+    grouped = request.request_items.group_by { |i| i['item_id'] }
+    # convert hash into an array of items with combined quantities
+    grouped.map do |id, items|
+      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum }
     end
-    combined
   end
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -21,12 +21,6 @@ def random_request_items
   keys.map { |k| { "item_id" => k, "quantity" => rand(3..10) } }
 end
 
-def request_items_w_duplicates
-  keys = Item.active.pluck(:id).sample(3)
-  keys.push(keys[0])
-  keys.map { |k| { "item_id" => k, "quantity" => 50 } }
-end
-
 FactoryBot.define do
   factory :request do
     partner { Partner.try(:first) || create(:partner) }
@@ -49,6 +43,13 @@ FactoryBot.define do
   end
 
   trait :with_duplicates do
-    request_items { request_items_w_duplicates }
+    request_items {
+      # get 3 unique item ids
+      keys = Item.active.pluck(:id).sample(3)
+      # add an extra of the first key, so we have one duplicated item
+      keys.push(keys[0])
+      # give each item a quantity of 50
+      keys.map { |k| { "item_id" => k, "quantity" => 50 } }
+    }
   end
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -21,6 +21,12 @@ def random_request_items
   keys.map { |k| { "item_id" => k, "quantity" => rand(3..10) } }
 end
 
+def request_items_w_duplicates
+  keys = Item.active.pluck(:id).sample(3)
+  keys.push(keys[0])
+  keys.map { |k| { "item_id" => k, "quantity" => 50 } }
+end
+
 FactoryBot.define do
   factory :request do
     partner { Partner.try(:first) || create(:partner) }
@@ -40,5 +46,9 @@ FactoryBot.define do
 
   trait :pending do
     status { 'pending' }
+  end
+
+  trait :with_duplicates do
+    request_items { request_items_w_duplicates }
   end
 end

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -1,9 +1,11 @@
 RSpec.describe RequestsConfirmationMailer, type: :mailer do
   let(:request) { create(:request) }
+  let(:mail) { RequestsConfirmationMailer.confirmation_email(request) }
+
+  let(:request_w_duplicates) { create(:request, :with_duplicates) }
+  let(:mail_w_duplicates) { RequestsConfirmationMailer.confirmation_email(request_w_duplicates) }
 
   describe "#confirmation_email" do
-    let(:mail) { RequestsConfirmationMailer.confirmation_email(request) }
-
     it 'renders the headers' do
       expect(mail.subject).to eq("#{request.organization.name} - Requests Confirmation")
       expect(mail.to).to include(request.partner.email)
@@ -15,5 +17,11 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
       expect(mail.body.encoded).to match('This is an email confirmation')
       expect(mail.body.encoded).to match('For more info, please e-mail me@org.com')
     end
+  end
+
+  it 'handles duplicates' do
+    @organization.update!(email: "me@org.com")
+    expect(mail_w_duplicates.body.encoded).to match('This is an email confirmation')
+    expect(mail_w_duplicates.body.encoded).to match(' - 100')
   end
 end


### PR DESCRIPTION
Resolves #3387  

### Description
Confirmation emails have been failing - and it appears that it is when the requester requests the same item more than once.
Solved by combining the duplicate request items in the request confirmation email
I considered combining  them when saved, but  I'd prefer to run whether there is a good reason to have them separate by the stakeholders before making that change.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Added an automatic test 
Manual confirmation
