### PR TITLE
Distribution pdf requested total = total of requested item quantities

### DIFF
--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -163,7 +163,7 @@ class DistributionPdf
 
     data + [["", "", "", "", ""],
       ["Total Items Received",
-        @distribution.line_items.total + requested_not_received.map(&:quantity).sum,
+        request_items.map(&:quantity).sum,
         @distribution.line_items.total,
         "",
         dollar_value(@distribution.value_per_itemizable),

--- a/spec/pdfs/distribution_pdf_spec.rb
+++ b/spec/pdfs/distribution_pdf_spec.rb
@@ -21,7 +21,7 @@ describe DistributionPdf do
       ["Item 2", 30, 100, "$2.00", "$200.00", nil],
       ["Item 3", 50, "", "$3.00", "$150.00", nil],
       ["", "", "", "", ""],
-      ["Total Items Received", 200, 150, "", "$250.00", ""]
+      ["Total Items Received", 80, 150, "", "$250.00", ""]
                           ])
   end
 


### PR DESCRIPTION


Resolves #3427 <!--fill issue number-->

### Description
Total requested items on distribution printout should equal the total of the request item quantities.  It didn't.  It now does.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
### How Has This Been Tested?
Updated the automated tests to be correct
Manual confirmation  
### Screenshot
![Screenshot 2023-03-08 at 1 01 58 PM](https://user-images.githubusercontent.com/10157589/223793440-973f5986-e873-4221-8e10-437946268b86.png)

