### PR TITLE
3285 Distribution pdf package count correction

### DIFF
--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -163,7 +163,7 @@ class DistributionPdf
 
     data + [["", "", "", "", ""],
       ["Total Items Received",
-        @distribution.line_items.total + requested_not_received.map(&:quantity).sum,
+        request_items.map(&:quantity).sum,
         @distribution.line_items.total,
         "",
         dollar_value(@distribution.value_per_itemizable),

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -158,7 +158,7 @@ class DistributionPdf
         "",
         dollar_value(c.item.value_in_cents),
         dollar_value(c.value_per_line_item),
-        c.package_count]
+        nil]
     end
 
     data + [["", "", "", "", ""],

--- a/spec/pdfs/distribution_pdf_spec.rb
+++ b/spec/pdfs/distribution_pdf_spec.rb
@@ -21,7 +21,7 @@ describe DistributionPdf do
       ["Item 2", 30, 100, "$2.00", "$200.00", nil],
       ["Item 3", 50, "", "$3.00", "$150.00", nil],
       ["", "", "", "", ""],
-      ["Total Items Received", 200, 150, "", "$250.00", ""]
+      ["Total Items Received", 80, 150, "", "$250.00", ""]
                           ])
   end
 

--- a/spec/pdfs/distribution_pdf_spec.rb
+++ b/spec/pdfs/distribution_pdf_spec.rb
@@ -5,12 +5,13 @@ describe DistributionPdf do
   let(:item1) { FactoryBot.create(:item, name: "Item 1", package_size: 50, value_in_cents: 100) }
   let(:item2) { FactoryBot.create(:item, name: "Item 2", value_in_cents: 200) }
   let(:item3) { FactoryBot.create(:item, name: "Item 3", value_in_cents: 300) }
+  let(:item4) { FactoryBot.create(:item, name: "Item 4", package_size: 25, value_in_cents: 400) }
   before(:each) do
     FactoryBot.create(:line_item, itemizable: distribution, item: item1, quantity: 50)
     FactoryBot.create(:line_item, itemizable: distribution, item: item2, quantity: 100)
     FactoryBot.create(:request, distribution: distribution,
       request_items: [{"item_id" => item2.id, "quantity" => 30},
-        {"item_id" => item3.id, "quantity" => 50}])
+        {"item_id" => item3.id, "quantity" => 50}, {"item_id" => item4.id, "quantity" => 120}])
   end
 
   specify "#request_data" do
@@ -20,8 +21,9 @@ describe DistributionPdf do
       ["Item 1", "", 50, "$1.00", "$50.00", "1"],
       ["Item 2", 30, 100, "$2.00", "$200.00", nil],
       ["Item 3", 50, "", "$3.00", "$150.00", nil],
+      ["Item 4", 120, "", "$4.00", "$480.00", nil],
       ["", "", "", "", ""],
-      ["Total Items Received", 80, 150, "", "$250.00", ""]
+      ["Total Items Received", 200, 150, "", "$250.00", ""]
                           ])
   end
 


### PR DESCRIPTION
Resolves #3285 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 

Suppressed package count on distribution pdf if item not distributed 
   
This is on a branch from  PR #3439, dealing with the same pdf.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- adjusted automated test,  ran them all.
- manual confirmation.  See screenshot below - the final item does have a package size, but it does not show.

### Screenshots
<img width="806" alt="Screenshot 2023-03-08 at 1 29 01 PM" src="https://user-images.githubusercontent.com/10157589/223804287-b802cc0e-783d-42a7-9746-fd52b7371340.png">
