### PR TITLE
Distribution pdf spec corrected

### DIFF
--- a/spec/pdfs/distribution_pdf_spec.rb
+++ b/spec/pdfs/distribution_pdf_spec.rb
@@ -23,7 +23,7 @@ describe DistributionPdf do
       ["Item 3", 50, "", "$3.00", "$150.00", nil],
       ["Item 4", 120, "", "$4.00", "$480.00", nil],
       ["", "", "", "", ""],
-      ["Total Items Received", 80, 150, "", "$250.00", ""]
+      ["Total Items Received", 200, 150, "", "$250.00", ""]
                           ])
   end
 


### PR DESCRIPTION
### Description

Somehow, the distribution spec on main is wrong (one line is from 3427-distribution-requested-total-correction , but should be the one from  3285-package-count-correction) .  This corrects that.
   

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)  (with the spec)
### How Has This Been Tested?
Ran the corrected test suite.  All passed. 

