### PR TITLE
3441 - Changing request items in seeds to be sampled from just the organization's items

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -337,7 +337,7 @@ note = [
 
     item_requests = [] 
     Array.new(Faker::Number.within(range: 5..15)) do
-      item = Item.all.sample
+      item = p.organization.items.sample
       new_item_request = Partners::ItemRequest.new(
         item_id: item.id,
         quantity: Faker::Number.within(range: 10..30),


### PR DESCRIPTION
Resolves #3441 

### Description

Changing seeds so request items are sampled from the organization's items rather than all items.


### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

Visually confirmed dropdowns no longer say "Choose an item" and are instead pre-populated with an item.


### Screenshots

![screencapture-localhost-3000-diaper-bank-distributions-new-2023-03-09-12_40_27](https://user-images.githubusercontent.com/32309015/224110695-6e14ecbd-68a1-47a2-aebd-ab5868eed565.png)
