### PR TITLE
[3425] Add Organization Logo File Size Limit and Warning 

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -43,6 +43,7 @@ class Organization < ApplicationRecord
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   validate :correct_logo_mime_type
   validate :some_request_type_enabled
+  validate :logo_size_check, if: proc { |org| org.logo.attached? }
 
   belongs_to :account_request, optional: true
   belongs_to :ndbn_member, class_name: 'NDBNMember', optional: true
@@ -265,5 +266,9 @@ class Organization < ApplicationRecord
 
   def get_admin_email
     User.with_role(Role::ORG_ADMIN, self).sample.email
+  end
+
+  def logo_size_check
+    errors.add(:logo, 'File size is greater than 1 MB') if logo.byte_size > 1.megabytes
   end
 end

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -116,7 +116,7 @@
                   <%= f.input_field :logo, as: :file %>
                   <p class="help-block">
                     Logo should be a 4:1 ratio of width / height (default image is 763 x 188 pixels).
-                    Only jpeg/png format is supported.
+                    Only jpeg/png format is supported. Images should be under 1 MB in size.
                   </p>
 
                 <% end %>

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe Organization, type: :model do
         enable_quantity_based_requests: false
       )).to_not be_valid
     end
+
+    it "validates that attachment file size is not higher than 1 MB" do
+      fixture_path = File.join(Rails.root, 'spec', 'fixtures', 'files', 'logo.jpg')
+      fixture_file = File.open(fixture_path)
+      organization = build(:organization)
+
+      allow(fixture_file).to receive(:size) { 2.megabytes }
+      organization.logo.attach(io: fixture_file, filename: 'logo.jpg')
+
+      expect(organization).to_not be_valid
+
+      allow(fixture_file).to receive(:size) { 10.kilobytes }
+      organization.logo.attach(io: fixture_file, filename: 'logo.jpg')
+
+      expect(organization).to be_valid
+    end
   end
 
   context "Associations >" do


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

Resolves #3425 

### Description
Large image files for the logos impact the speed of the items that use them.
This fix adds a warning as well as limit on logo file input to tackle the speed issues

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Login as [org_admin1@example.com](mailto:org_admin1@example.com) --> My Organization | Edit. Scroll down to the bottom
upload logo image greater than 1MB, it will show error.
