### PR TITLE
adding function to allow super admins to broadcast announcements to b…

### DIFF
--- a/app/controllers/admin/broadcast_announcements_controller.rb
+++ b/app/controllers/admin/broadcast_announcements_controller.rb
@@ -1,0 +1,59 @@
+class Admin::BroadcastAnnouncementsController < ApplicationController
+  before_action :set_broadcast_announcement, only: %i[edit update destroy]
+  before_action :require_admin
+
+  def require_admin
+    verboten! unless current_user.has_role?(Role::SUPER_ADMIN)
+  end
+
+  def index
+    @broadcast_announcements = BroadcastAnnouncement.where(organization_id: nil)
+  end
+
+  def new
+    @broadcast_announcement = BroadcastAnnouncement.new
+  end
+
+  def edit
+  end
+
+  def create
+    @broadcast_announcement = BroadcastAnnouncement.new(broadcast_announcement_params)
+
+    respond_to do |format|
+      if @broadcast_announcement.save
+        format.html { redirect_to admin_broadcast_announcements_url, notice: "Broadcast announcement was successfully created." }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @broadcast_announcement.update(broadcast_announcement_params)
+        format.html { redirect_to admin_broadcast_announcements_url, notice: "Broadcast announcement was successfully updated." }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @broadcast_announcement.destroy
+
+    respond_to do |format|
+      format.html { redirect_to admin_broadcast_announcements_url, notice: "Broadcast announcement was successfully destroyed." }
+    end
+  end
+
+  private
+
+  def set_broadcast_announcement
+    @broadcast_announcement = BroadcastAnnouncement.find(params[:id])
+  end
+
+  def broadcast_announcement_params
+    params.require(:broadcast_announcement).permit(:user_id, :organization_id, :message, :link, :expiry)
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -26,5 +26,8 @@ class DashboardController < ApplicationController
     @top_manufacturers = current_organization.manufacturers.by_donation_count
 
     @distribution_data = helpers.received_distributed_data(helpers.selected_range)
+
+    # passing nil here filters the announcements that didn't come from an organization
+    @broadcast_announcements = BroadcastAnnouncement.filter_announcements(nil)
   end
 end

--- a/app/models/broadcast_announcement.rb
+++ b/app/models/broadcast_announcement.rb
@@ -23,7 +23,7 @@ class BroadcastAnnouncement < ApplicationRecord
   end
 
   def self.filter_announcements(parent_org)
-    BroadcastAnnouncement.where(organization_id: [parent_org, nil].uniq)
+    BroadcastAnnouncement.where(organization_id: parent_org)
       .where("expiry IS ? or expiry >= ?", nil, Time.zone.today)
       .reverse
   end

--- a/app/views/admin/broadcast_announcements/_broadcast_announcement.html.erb
+++ b/app/views/admin/broadcast_announcements/_broadcast_announcement.html.erb
@@ -1,0 +1,14 @@
+<tr id="<%= dom_id broadcast_announcement %>">
+  <td><%= broadcast_announcement.message %></td>
+  <td><%= link_to  broadcast_announcement.link, broadcast_announcement.link %></td>
+  <td><%= broadcast_announcement.user&.name || "N/A" %></td>
+  <td><%= broadcast_announcement.expiry %>
+    <% if broadcast_announcement.expired? %> 
+      <span class="badge badge-danger">Expired</span>
+    <% end %>
+  </td>
+  <td class="text-right">
+    <%= edit_button_to edit_admin_broadcast_announcement_path(broadcast_announcement) %>
+    <%= delete_button_to admin_broadcast_announcement_path(broadcast_announcement), method: :delete %>
+  </td>
+</tr>

--- a/app/views/admin/broadcast_announcements/_form.html.erb
+++ b/app/views/admin/broadcast_announcements/_form.html.erb
@@ -1,0 +1,34 @@
+  <%= simple_form_for @broadcast_announcement, url: admin_form_url, html: { class: 'form-horizontal' } do |f| %>
+    <%= f.error_notification %>
+    <section class="content">
+      <div class="container-fluid">
+        <div class="row">
+          <!-- left column -->
+          <div class="col-md-12">
+            <!-- jquery validation -->
+            <div class="card card-primary">
+              <!-- /.card-header -->
+              <!-- form start -->
+              <div class="card-body w-50">
+                <%= f.hidden_field :user_id, value: current_user.id %>
+                <%= f.label :message, "Announcement " %> <i>(500 character max)</i>
+                <%= f.input :message, label: false, maxlength: 500, autofocus: true %>
+                <%= f.label :link, "URL for more information" %>
+                <%= f.input :link, label: false %>
+                <%= f.input :expiry,
+                  label: "Expiration date",
+                  as: :date,
+                  html5: true %>
+                <!-- /.card-body -->
+                <div class="card-footer">
+                  <%= submit_button({ text: "Broadcast Announcement", icon: "envelope" }) %>
+                </div>
+              </div>
+            </div>
+            <!-- /.card -->
+          </div>
+        </div>
+        <!-- /.row -->
+      </div><!-- /.container-fluid -->
+    </section>
+  <% end %>

--- a/app/views/admin/broadcast_announcements/edit.html.erb
+++ b/app/views/admin/broadcast_announcements/edit.html.erb
@@ -1,0 +1,25 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Send broadcast announcement" %>
+        <h1>
+          Edit Broadcast Announcement
+        </h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><%= link_to(dashboard_path) do %>
+              <i class="fa fa-dashboard"></i> Home
+            <% end %>
+          </li>
+          <li class="breadcrumb-item"><%= link_to "All Organizations", (admin_organizations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Broadcast Announcements", admin_broadcast_announcements_url %></li>
+          <li class="breadcrumb-item"><%= link_to "Edit Announcements", edit_admin_broadcast_announcement_path(@broadcast_announcement) %></li>
+        </ol>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<%= render "form", broadcast_announcement: @broadcast_announcement, admin_form_url: admin_broadcast_announcement_url %>

--- a/app/views/admin/broadcast_announcements/index.html.erb
+++ b/app/views/admin/broadcast_announcements/index.html.erb
@@ -1,0 +1,59 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Send broadcast announcement" %>
+        <h1>
+          Broadcast Announcement to Banks 
+        </h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><%= link_to(dashboard_path) do %>
+              <i class="fa fa-dashboard"></i> Home
+            <% end %>
+          </li>
+          <li class="breadcrumb-item"><%= link_to "All Organizations", (admin_organizations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Broadcast Announcements", admin_broadcast_announcements_path %></li>
+        </ol>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <!-- left column -->
+      <div class="col-md-12">
+        <!-- jquery validation -->
+        <div class="card card-primary">
+          <!-- /.card-header -->
+          <div class="card-body">
+            <div class='flex justify-end mb-4'>
+              <%= new_button_to new_admin_broadcast_announcement_path, {text: "New Announcement"} %>
+            </div>
+            <table class="table table-responsive-md">
+              <thead>
+                <tr>
+                  <th class="w-50">Announcement</th>
+                  <th>More info</th>
+                  <th>Sent by</th>
+                  <th>Expiration</th>
+                  <th class="text-center">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @broadcast_announcements.reverse.each do |broadcast_announcement| %>
+                  <%= render broadcast_announcement %>
+                <% end %>
+              </tbody>
+            </table>
+            <!-- /.card-body -->
+          </div>
+        </div>
+        <!-- /.card -->
+      </div>
+    </div>
+    <!-- /.row -->
+  </div><!-- /.container-fluid -->
+</section>

--- a/app/views/admin/broadcast_announcements/new.html.erb
+++ b/app/views/admin/broadcast_announcements/new.html.erb
@@ -1,0 +1,25 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Send broadcast announcement" %>
+        <h1>
+          Send Broadcast Announcement to Banks
+        </h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><%= link_to(dashboard_path) do %>
+              <i class="fa fa-dashboard"></i> Home
+            <% end %>
+          </li>
+          <li class="breadcrumb-item"><%= link_to "All Organizations", (admin_organizations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Broadcast Announcements", admin_broadcast_announcements_url %></li>
+          <li class="breadcrumb-item"><%= link_to "Send Announcement", new_admin_broadcast_announcement_url %></li>
+        </ol>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<%= render "form", broadcast_announcement: @broadcast_announcement, admin_form_url: admin_broadcast_announcements_url %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -91,6 +91,38 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-lg-6">
+        <% if @broadcast_announcements.any? %>
+          <div class="card" id="distributions">
+            <div class="card-header border-0 bg-gradient-warning">
+              <h3 class="card-title">Announcements
+                <small>from Super Admins</small></h3>
+              <div class="card-tools">
+                <button type="button" class="btn btn-tool" data-card-widget="collapse">
+                  <i class="fas fa-minus"></i>
+                </button>
+              </div>
+            </div>
+            <div class="card-body">
+              <ul class="list-group list-group-flush">
+                <% @broadcast_announcements.each do |announcement| %>
+                  <li class="list-group-item">
+                    <strong><%= if announcement.created_at.strftime("%Y") == DateTime.now.strftime("%Y")
+                                  announcement.created_at.strftime("%B %d")
+                                else
+                                  announcement.created_at.strftime("%B %d %Y") 
+                                end %></strong>
+                    <br />
+                    <%= announcement.message %>
+                    <% unless announcement.link == '' %>
+                      <br />
+                      <a href="<%= announcement.link %>" class="btn btn-primary">more info</a>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
+        <% end %>
 
         <div class="card" id="distributions">
           <div class="card-header border-0 bg-gradient-info">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -95,7 +95,7 @@
           <div class="card" id="distributions">
             <div class="card-header border-0 bg-gradient-warning">
               <h3 class="card-title">Announcements
-                <small>from Super Admins</small></h3>
+                <small>from Human Essentials</small></h3>
               <div class="card-tools">
                 <button type="button" class="btn btn-tool" data-card-widget="collapse">
                   <i class="fas fa-minus"></i>

--- a/app/views/layouts/_lte_admin_sidebar.html.erb
+++ b/app/views/layouts/_lte_admin_sidebar.html.erb
@@ -64,6 +64,11 @@
           <i class="nav-icon fa fa-plus-circle"></i> New Organization
         <% end %>
       </li>
+      <li class="nav-item <%= 'active' if current_page?(admin_broadcast_announcements_path) %>">
+        <%= link_to(admin_broadcast_announcements_path, class: "nav-link #{"active" if current_page?(admin_broadcast_announcements_path)}") do %>
+          <i class="nav-icon fa fa-circle-o"></i> Bank Announcement
+        <% end %>
+      </li>
     </ul>
   </li>
 

--- a/app/views/layouts/_lte_admin_sidebar.html.erb
+++ b/app/views/layouts/_lte_admin_sidebar.html.erb
@@ -64,11 +64,6 @@
           <i class="nav-icon fa fa-plus-circle"></i> New Organization
         <% end %>
       </li>
-      <li class="nav-item <%= 'active' if current_page?(admin_broadcast_announcements_path) %>">
-        <%= link_to(admin_broadcast_announcements_path, class: "nav-link #{"active" if current_page?(admin_broadcast_announcements_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Bank Announcement
-        <% end %>
-      </li>
     </ul>
   </li>
 
@@ -106,6 +101,13 @@
         <% end %>
       </li>
     </ul>
+  </li>
+
+  <li class="nav-item <%= 'active' if current_page?(admin_broadcast_announcements_path) %>">
+        <%= link_to(admin_broadcast_announcements_path, class: "nav-link #{"active" if current_page?(admin_broadcast_announcements_path)}") do %>
+      <i class="nav-icon fa fa-envelope"></i>
+      <p>Announcements</p>
+    <% end %>
   </li>
 
   <li class="nav-item <%= active_class(['account_requests']) %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
       get :for_rejection, on: :collection
     end
     resources :questions
+    resources :broadcast_announcements
   end
 
   match "/404", to: "errors#not_found", via: :all

--- a/spec/models/broadcast_announcement_spec.rb
+++ b/spec/models/broadcast_announcement_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe BroadcastAnnouncement, type: :model do
   end
 
   context "filter_announcements" do
-    it "should include only announcements from the passed organization and from admins" do
+    it "should include only announcements from the passed organization" do
       BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1)
       BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1)
       BroadcastAnnouncement.create!(message: "test", user_id: 1)
       BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 2)
-      expect(BroadcastAnnouncement.filter_announcements(1).count).to eq(3)
+      expect(BroadcastAnnouncement.filter_announcements(1).count).to eq(2)
     end
 
     it "shouldn't include expired announcements" do

--- a/spec/requests/admin/broadcast_announcements_spec.rb
+++ b/spec/requests/admin/broadcast_announcements_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe "BroadcastAnnouncements", type: :request do
+  before do
+    sign_in(@super_admin)
+  end
+  let(:valid_attributes) {
+    {
+      expiry: Time.zone.today,
+      link: "http://google.com",
+      message: "test",
+      user_id: 1,
+      organization_id: nil
+    }
+  }
+
+  let(:invalid_attributes) {
+    {
+      link: "badlink.com"
+    }
+  }
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      BroadcastAnnouncement.create! valid_attributes
+      get admin_broadcast_announcements_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      get new_admin_broadcast_announcement_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /edit" do
+    it "render a successful response" do
+      announcement = BroadcastAnnouncement.create! valid_attributes
+      get edit_admin_broadcast_announcement_url(announcement)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      it "creates a new BroadcastAnnouncement then redirects" do
+        expect {
+          post admin_broadcast_announcements_url, params: {broadcast_announcement: valid_attributes}
+        }.to change(BroadcastAnnouncement, :count).by(1)
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not create a new BroadcastAnnouncement" do
+        expect {
+          post admin_broadcast_announcements_url, params: {broadcast_announcement: invalid_attributes}
+        }.to change(BroadcastAnnouncement, :count).by(0)
+      end
+
+      it "does not render a successful response" do
+        post admin_broadcast_announcements_url, params: {broadcast_announcement: invalid_attributes}
+        expect(response).not_to be_successful
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      let(:new_attributes) {
+        {
+          expiry: Time.zone.yesterday,
+          link: "http://google.com",
+          message: "new_test",
+          user_id: 1,
+          organization_id: 1
+        }
+      }
+
+      it "updates the requested announcement and redirects" do
+        announcement = BroadcastAnnouncement.create! valid_attributes
+        patch admin_broadcast_announcement_url(announcement), params: {broadcast_announcement: new_attributes}
+        announcement.reload
+        expect(announcement.message).to eq("new_test")
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not render a successful response" do
+        announcement = BroadcastAnnouncement.create! valid_attributes
+        patch admin_broadcast_announcement_url(announcement), params: {broadcast_announcement: invalid_attributes}
+        expect(response).not_to be_successful
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "destroys the requested announcement then redirects" do
+      announcement = BroadcastAnnouncement.create! valid_attributes
+      expect {
+        delete admin_broadcast_announcement_url(announcement)
+      }.to change(BroadcastAnnouncement, :count).by(-1)
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  context "When logged in as an organization_admin" do
+    before do
+      sign_in @organization_admin
+    end
+
+    describe "GET /new" do
+      it "redirects" do
+        get new_admin_broadcast_announcement_url
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+
+    describe "POST /create" do
+      it "redirects" do
+        post admin_broadcast_announcements_url, params: {user: 1, message: "test"}
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+  end
+end

--- a/spec/requests/dashboard_requests_spec.rb
+++ b/spec/requests/dashboard_requests_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe "Dashboard", type: :request do
         end
       end
     end
+
+    context "BroadcastAnnouncement card" do
+      it "displays announcements if there are valid ones" do
+        BroadcastAnnouncement.create(message: "test announcement", user_id: 1, organization_id: nil)
+        get dashboard_path(default_params)
+        expect(response.body).to include("test announcement")
+      end
+
+      it "doesn't display announcements if they are not from super admins" do
+        BroadcastAnnouncement.create(message: "test announcement", user_id: 1, organization_id: 1)
+        get dashboard_path(default_params)
+        expect(response.body).not_to include("test announcement")
+      end
+    end
   end
 
   context "While not signed in" do

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -68,5 +68,11 @@ RSpec.describe "/partners/dashboard", type: :request do
       get partners_dashboard_path
       expect(response.body).not_to include("test announcement")
     end
+
+    it "doesn't display announcements from super admins" do
+      BroadcastAnnouncement.create(message: "test announcement", user_id: 1, organization_id: nil)
+      get partners_dashboard_path
+      expect(response.body).not_to include("test announcement")
+    end
   end
 end

--- a/spec/system/navigation_system_spec.rb
+++ b/spec/system/navigation_system_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Navigation", type: :system, js: true do
 
     context "with superadmin user" do
       let(:user) { create(:super_admin) }
-      let(:links) { ["Admin Dashboard", "Barcode Items", "Base Items", "Organizations", "Partners", "Users", "Account Requests", "FAQ", "My Organization"] }
+      let(:links) { ["Admin Dashboard", "Barcode Items", "Base Items", "Organizations", "Partners", "Users", "Announcements", "Account Requests", "FAQ", "My Organization"] }
 
       it "shows navigation options" do
         sidebar = page.find(".sidebar")


### PR DESCRIPTION

Resolves #3391  <!--fill issue number-->

### Description
Added the ability for super admins to send announcements to banks and an announcement card on the bank dashboard to show the admin announcements. The card is collapsible like the other cards on the dashboard and does not show up if there are not active announcements to display

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

There is a request spec for the controller that checks the CRUD methods and admin authentication. I added tests to the bank dashboard spec for checking if the announcements show up when they should


### Screenshots
![image](https://user-images.githubusercontent.com/94578504/226086038-2ce80e93-6805-4805-ae68-caf8440aaf34.png)

I highlighted the menu change
![Screenshot from 2023-03-17 22-07-59](https://user-images.githubusercontent.com/94578504/226086194-2cd2bc30-9fdf-4955-b6a5-48d260e9e438.png)

