### PR TITLE
[3431] Include All Organization items in Product Drive Export 

### DIFF
--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -14,7 +14,7 @@ class ProductDrivesController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportProductDrivesCSVService.generate_csv(@product_drives), filename: "Product-Drives-#{Time.zone.today}.csv"
+        send_data Exports::ExportProductDrivesCSVService.generate_csv(@product_drives, current_organization), filename: "Product-Drives-#{Time.zone.today}.csv"
       end
     end
   end

--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -14,7 +14,7 @@ class ProductDrivesController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportProductDrivesCSVService.generate_csv(@product_drives, current_organization), filename: "Product-Drives-#{Time.zone.today}.csv"
+        send_data Exports::ExportProductDrivesCSVService.new(@product_drives, current_organization).generate_csv, filename: "Product-Drives-#{Time.zone.today}.csv"
       end
     end
   end

--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -14,7 +14,11 @@ class ProductDrivesController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportProductDrivesCSVService.new(@product_drives, current_organization).generate_csv, filename: "Product-Drives-#{Time.zone.today}.csv"
+        send_data Exports::ExportProductDrivesCSVService.new(
+          @product_drives,
+          current_organization,
+          helpers.selected_range
+        ).generate_csv, filename: "Product-Drives-#{Time.zone.today}.csv"
       end
     end
   end

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -63,13 +63,26 @@ class ProductDrive < ApplicationRecord
     @search_date_range = { start_date: dates[0], end_date: dates[1] }
   end
 
-  def item_quantities_by_name
+  def item_quantities_by_name_and_date(date_range)
     quantities = donations.joins(:line_items)
+      .during(date_range)
       .group('line_items.item_id')
       .sum('line_items.quantity')
 
     organization.items.order(:name).map do |item|
       quantities[item.id] || 0
     end
+  end
+
+  def donation_quantity_by_date(date_range)
+    donations.joins(:line_items)
+      .during(date_range)
+      .sum('line_items.quantity')
+  end
+
+  def distinct_items_count_by_date(date_range)
+    donations.joins(:line_items)
+      .during(date_range)
+      .select('line_items.item_id').distinct.count
   end
 end

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -63,7 +63,7 @@ class ProductDrive < ApplicationRecord
     @search_date_range = { start_date: dates[0], end_date: dates[1] }
   end
 
-  def items_quantity_by_name
+  def item_quantities_by_name
     quantities = donations.joins(:line_items)
       .group('line_items.item_id')
       .sum('line_items.quantity')

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -62,4 +62,14 @@ class ProductDrive < ApplicationRecord
     dates = dates.split(" - ")
     @search_date_range = { start_date: dates[0], end_date: dates[1] }
   end
+
+  def items_quantity_by_name
+    quantities = donations.joins(:line_items)
+      .group('line_items.item_id')
+      .sum('line_items.quantity')
+
+    organization.items.order(:name).map do |item|
+      quantities[item.id] || 0
+    end
+  end
 end

--- a/app/services/exports/export_product_drives_csv_service.rb
+++ b/app/services/exports/export_product_drives_csv_service.rb
@@ -11,7 +11,7 @@ module Exports
 
     def generate_csv
       CSV.generate do |csv|
-        csv << generate_headers(organization)
+        csv << generate_headers
 
         product_drives.each do |drive|
           csv << generate_row(drive)
@@ -32,11 +32,11 @@ module Exports
         drive.donation_quantity.to_s,
         drive.distinct_items_count.to_s,
         dollar_value(drive.in_kind_value).to_s,
-        *drive.items_quantity_by_name
+        *drive.item_quantities_by_name
       ]
     end
 
-    def generate_headers(organization)
+    def generate_headers
       HEADERS + item_headers
     end
 

--- a/app/services/exports/export_product_drives_csv_service.rb
+++ b/app/services/exports/export_product_drives_csv_service.rb
@@ -4,9 +4,10 @@ module Exports
     HEADERS = ["Product Drive Name", "Start Date", "End Date", "Held Virtually?", "Quantity of Items",
       "Variety of Items", "In Kind Value"].freeze
 
-    def initialize(product_drives, organization)
+    def initialize(product_drives, organization, date_range)
       @product_drives = product_drives
       @organization = organization
+      @date_range = date_range
     end
 
     def generate_csv
@@ -21,7 +22,7 @@ module Exports
 
     private
 
-    attr_reader :product_drives, :organization
+    attr_reader :product_drives, :organization, :date_range
 
     def generate_row(drive)
       [
@@ -29,10 +30,10 @@ module Exports
         drive.start_date.strftime("%m-%d-%Y").to_s,
         drive.end_date&.strftime("%m-%d-%Y").to_s,
         (drive.virtual ? "Yes" : "No").to_s,
-        drive.donation_quantity.to_s,
-        drive.distinct_items_count.to_s,
+        drive.donation_quantity_by_date(date_range).to_s,
+        drive.distinct_items_count_by_date(date_range).to_s,
         dollar_value(drive.in_kind_value).to_s,
-        *drive.item_quantities_by_name
+        *drive.item_quantities_by_name_and_date(date_range)
       ]
     end
 

--- a/app/services/exports/export_product_drives_csv_service.rb
+++ b/app/services/exports/export_product_drives_csv_service.rb
@@ -3,9 +3,9 @@ module Exports
     extend ItemsHelper
     HEADERS = ["Product Drive Name", "Start Date", "End Date", "Held Virtually?", "Quantity of Items", "Variety of Items", "In Kind Value"]
 
-    def self.generate_csv(product_drives)
+    def self.generate_csv(product_drives, organization)
       CSV.generate do |csv|
-        csv << HEADERS
+        csv << generate_headers(organization)
 
         product_drives.each do |drive|
           csv << generate_row(drive)
@@ -13,19 +13,25 @@ module Exports
       end
     end
 
-    private_class_method(
-      # The following indentation is idiotic, but it's what rubocop wants
-      def self.generate_row(drive)
-      [
-        drive.name.to_s,
-        drive.start_date.strftime("%m-%d-%Y").to_s,
-        drive.end_date&.strftime("%m-%d-%Y").to_s,
-        (drive.virtual ? "Yes" : "No").to_s,
-        drive.donation_quantity.to_s,
-        drive.distinct_items_count.to_s,
-        dollar_value(drive.in_kind_value).to_s
-      ]
+    class << self
+      private
+
+      def generate_row(drive)
+        [
+          drive.name.to_s,
+          drive.start_date.strftime("%m-%d-%Y").to_s,
+          drive.end_date&.strftime("%m-%d-%Y").to_s,
+          (drive.virtual ? "Yes" : "No").to_s,
+          drive.donation_quantity.to_s,
+          drive.distinct_items_count.to_s,
+          dollar_value(drive.in_kind_value).to_s,
+          *drive.items_quantity_by_name
+        ]
+      end
+
+      def generate_headers(organization)
+        HEADERS + organization.items.order(:name).pluck(:name)
+      end
     end
-    )
   end
 end

--- a/app/services/exports/export_product_drives_csv_service.rb
+++ b/app/services/exports/export_product_drives_csv_service.rb
@@ -1,9 +1,15 @@
 module Exports
   class ExportProductDrivesCSVService
-    extend ItemsHelper
-    HEADERS = ["Product Drive Name", "Start Date", "End Date", "Held Virtually?", "Quantity of Items", "Variety of Items", "In Kind Value"]
+    include ItemsHelper
+    HEADERS = ["Product Drive Name", "Start Date", "End Date", "Held Virtually?", "Quantity of Items",
+      "Variety of Items", "In Kind Value"].freeze
 
-    def self.generate_csv(product_drives, organization)
+    def initialize(product_drives, organization)
+      @product_drives = product_drives
+      @organization = organization
+    end
+
+    def generate_csv
       CSV.generate do |csv|
         csv << generate_headers(organization)
 
@@ -13,25 +19,29 @@ module Exports
       end
     end
 
-    class << self
-      private
+    private
 
-      def generate_row(drive)
-        [
-          drive.name.to_s,
-          drive.start_date.strftime("%m-%d-%Y").to_s,
-          drive.end_date&.strftime("%m-%d-%Y").to_s,
-          (drive.virtual ? "Yes" : "No").to_s,
-          drive.donation_quantity.to_s,
-          drive.distinct_items_count.to_s,
-          dollar_value(drive.in_kind_value).to_s,
-          *drive.items_quantity_by_name
-        ]
-      end
+    attr_reader :product_drives, :organization
 
-      def generate_headers(organization)
-        HEADERS + organization.items.order(:name).pluck(:name)
-      end
+    def generate_row(drive)
+      [
+        drive.name.to_s,
+        drive.start_date.strftime("%m-%d-%Y").to_s,
+        drive.end_date&.strftime("%m-%d-%Y").to_s,
+        (drive.virtual ? "Yes" : "No").to_s,
+        drive.donation_quantity.to_s,
+        drive.distinct_items_count.to_s,
+        dollar_value(drive.in_kind_value).to_s,
+        *drive.items_quantity_by_name
+      ]
+    end
+
+    def generate_headers(organization)
+      HEADERS + item_headers
+    end
+
+    def item_headers
+      organization.items.order(:name).pluck(:name)
     end
   end
 end

--- a/app/views/product_drives/index.html.erb
+++ b/app/views/product_drives/index.html.erb
@@ -101,8 +101,8 @@
                   <td><%= product_drive.start_date.strftime("%m-%d-%Y") %></td>
                   <td><%= product_drive.end_date&.strftime("%m-%d-%Y") %></td>
                   <td><%= is_virtual(product_drive: product_drive) %></td>
-                  <td class="text-right"><%= product_drive.donation_quantity %></td>
-                  <td class="text-right"><%= product_drive.distinct_items_count %></td>
+                  <td class="text-right"><%= product_drive.donation_quantity_by_date(selected_range) %></td>
+                  <td class="text-right"><%= product_drive.distinct_items_count_by_date(selected_range) %></td>
                   <td class="text-right"><strong><%= dollar_value(product_drive.in_kind_value) %></strong></td>
                   <td class="text-right"><%= view_button_to product_drive_path(product_drive.id) %></td>
                 </tr>


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

Resolves #3431

### Description
Add all organization items in the product drive export to make it more useful to banks. They can see the quantity of each item it the drive. 

### Type of change

<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- login as an organization admin
- go to product drives
- export -> view csv (it should have quantities for all organization items) 
