### PR TITLE
Issue 3448 - inkind value fix

### DIFF
--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -157,7 +157,7 @@ class DistributionPdf
         c.quantity,
         "",
         dollar_value(c.item.value_in_cents),
-        dollar_value(c.value_per_line_item),
+        nil,
         nil]
     end
 

--- a/spec/pdfs/distribution_pdf_spec.rb
+++ b/spec/pdfs/distribution_pdf_spec.rb
@@ -20,8 +20,8 @@ describe DistributionPdf do
                             ["Items Received", "Requested", "Received", "Value/item", "In-Kind Value Received", "Packages"],
       ["Item 1", "", 50, "$1.00", "$50.00", "1"],
       ["Item 2", 30, 100, "$2.00", "$200.00", nil],
-      ["Item 3", 50, "", "$3.00", "$150.00", nil],
-      ["Item 4", 120, "", "$4.00", "$480.00", nil],
+      ["Item 3", 50, "", "$3.00", nil, nil],
+      ["Item 4", 120, "", "$4.00", nil, nil],
       ["", "", "", "", ""],
       ["Total Items Received", 200, 150, "", "$250.00", ""]
                           ])


### PR DESCRIPTION
### Resolves #3448.

This change fixes the issue where an item was deleted from a distribution request but was still showing an in-kind value when it shouldn't have.

Changed line 160 from calculating value per line item to nil, since there shouldn't be a value if it's not received.

### Relevant file(s):
App > pdfs > distribution_pdf.rb, distribution_pdf_spec.rb

Relevant account types: admin level 
Bug issue this fixes: when items are deleted from an existing request, this issue would previously keep the in-kind value of whatever the received quantity was supposed to be. (IE expected 10 of an item valued at $1 would still show an in-kind value of $10 as was expected, but the items were deleted from the request.) After the fix, it no longer shows an in-kind value if the item was deleted from the request.

I would also love to do a little refactoring of this particular test in a separate ticket to account for different situations like this. Let me know if that’s ok with you all! If not, I’ll leave it as-is. 

### Screenshots
Screenshots with the previous issue and after the fix.
[finalafterfix.pdf](https://github.com/rubyforgood/human-essentials/files/11033252/finalafterfix.pdf)
[inkindbefore.pdf](https://github.com/rubyforgood/human-essentials/files/11033253/inkindbefore.pdf)
   

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This has been tested with an update to the distribution_pdf_spec.rb file. Lines 23 and 24 previously had expected values of $150 and $480. We are now asserting that, if they are not expected, they should be nil. The tests now pass with the updates. Spec tests have been updated to expect nil for in-kind value if the item was requested but not received. 

