### PR TITLE
re #3465 [BUG] Another Safari bug! Date Range Picker does not work

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -53,7 +53,7 @@ function isShortHeightScreen() {
   return $(window).height() < 768 && !isMobileResolution();
 }
 
-function runOnStart(){
+$(document).ready(function(){
     const hash = window.location.hash;
     if (hash) {
       $('ul.nav a[href="' + hash + '"]').tab('show');
@@ -104,18 +104,5 @@ function runOnStart(){
       }
     });
     picker.setDateRange(startDate, endDate);
-}
-
-
-// This logic is a workaround for a problem with the date range picker in Safari
-// See https://developer.apple.com/forums/thread/651215
-
-if(document.readyState != 'loading'){
-  runOnStart();
-} else{
-// es-module-shims calls DOMContentLoaded twice for some reason
-  document.addEventListener("DOMContentLoaded", function() {
-    runOnStart();
-  }, false);
-}
+});
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -36,7 +36,6 @@ import 'utils/purchases'
 
 import Rails from "@rails/ujs"
 Rails.start()
-
 // Disable turbo by default to avoid issues with turbolinks
 Turbo.session.drive = false
 
@@ -54,60 +53,69 @@ function isShortHeightScreen() {
   return $(window).height() < 768 && !isMobileResolution();
 }
 
-
-// es-module-shims calls DOMContentLoaded twice for some reason
-document.addEventListener("DOMContentLoaded", function() {
-  const hash = window.location.hash;
-  if (hash) {
-    $('ul.nav a[href="' + hash + '"]').tab('show');
-  }
-  const isMobile = isMobileResolution();
-  const isShortHeight = isShortHeightScreen();
-
-  const calendarElement = document.getElementById('calendar');
-  if (calendarElement) {
-    new Calendar(calendarElement, {
-      timeZone: 'UTC',
-      firstDay: 1,
-      plugins: [luxonPlugin, dayGridPlugin, listPlugin],
-      displayEventTime: true,
-      eventLimit: true,
-      events: 'schedule.json',
-      height: isMobile || isShortHeight ? 'auto' : 'parent',
-      defaultView: isMobile ? 'listWeek' : 'month'
-    }).render();
-  }
-
-  const rangeElement = document.getElementById("filters_date_range");
-  if (!rangeElement) {
-    return;
-  }
-
-  const today = DateTime.now();
-  const startDate = new Date(rangeElement.dataset["initialStartDate"]);
-  const endDate = new Date(rangeElement.dataset["initialEndDate"]);
-
-  const picker = new Litepicker({
-    element: rangeElement,
-    plugins: ['ranges'],
-    startDate: startDate,
-    endDate: endDate,
-    format: "MMMM D, YYYY",
-    ranges: {
-      customRanges: {
-        'All Time': [today.minus({ 'years': 100}).toJSDate(), today.toJSDate()],
-        'Today': [today.toJSDate(), today.toJSDate()],
-        'Yesterday': [today.minus({'days': 1}).toJSDate(), today.minus({'days': 1}).toJSDate()],
-        'Last 7 Days': [today.minus({'days': 6}).toJSDate(), today.toJSDate()],
-        'Last 30 Days': [today.minus({'days': 29}).toJSDate(), today.toJSDate()],
-        'This Month': [today.startOf('month').toJSDate(), today.endOf('month').toJSDate()],
-        'Last Month': [today.minus({'months': 1}).startOf('month').toJSDate(),
-          today.minus({'month': 1}).endOf('month').toJSDate()],
-        'This Year': [today.startOf('year').toJSDate(), today.endOf('year').toJSDate()]
-      }
+function runOnStart(){
+    const hash = window.location.hash;
+    if (hash) {
+      $('ul.nav a[href="' + hash + '"]').tab('show');
     }
-  });
-  picker.setDateRange(startDate, endDate);
-}, false);
+    const isMobile = isMobileResolution();
+    const isShortHeight = isShortHeightScreen();
 
+    const calendarElement = document.getElementById('calendar');
+    if (calendarElement) {
+      new Calendar(calendarElement, {
+        timeZone: 'UTC',
+        firstDay: 1,
+        plugins: [luxonPlugin, dayGridPlugin, listPlugin],
+        displayEventTime: true,
+        eventLimit: true,
+        events: 'schedule.json',
+        height: isMobile || isShortHeight ? 'auto' : 'parent',
+        defaultView: isMobile ? 'listWeek' : 'month'
+      }).render();
+    }
+
+    const rangeElement = document.getElementById("filters_date_range");
+    if (!rangeElement) {
+      return;
+    }
+    const today = DateTime.now();
+    const startDate = new Date(rangeElement.dataset["initialStartDate"]);
+    const endDate = new Date(rangeElement.dataset["initialEndDate"]);
+
+    const picker = new Litepicker({
+      element: rangeElement,
+      plugins: ['ranges'],
+      startDate: startDate,
+      endDate: endDate,
+      format: "MMMM D, YYYY",
+      ranges: {
+        customRanges: {
+          'All Time': [today.minus({ 'years': 100}).toJSDate(), today.toJSDate()],
+          'Today': [today.toJSDate(), today.toJSDate()],
+          'Yesterday': [today.minus({'days': 1}).toJSDate(), today.minus({'days': 1}).toJSDate()],
+          'Last 7 Days': [today.minus({'days': 6}).toJSDate(), today.toJSDate()],
+          'Last 30 Days': [today.minus({'days': 29}).toJSDate(), today.toJSDate()],
+          'This Month': [today.startOf('month').toJSDate(), today.endOf('month').toJSDate()],
+          'Last Month': [today.minus({'months': 1}).startOf('month').toJSDate(),
+            today.minus({'month': 1}).endOf('month').toJSDate()],
+          'This Year': [today.startOf('year').toJSDate(), today.endOf('year').toJSDate()]
+        }
+      }
+    });
+    picker.setDateRange(startDate, endDate);
+}
+
+
+// This logic is a workaround for a problem with the date range picker in Safari
+// See https://developer.apple.com/forums/thread/651215
+
+if(document.readyState != 'loading'){
+  runOnStart();
+} else{
+// es-module-shims calls DOMContentLoaded twice for some reason
+  document.addEventListener("DOMContentLoaded", function() {
+    runOnStart();
+  }, false);
+}
 


### PR DESCRIPTION
Resolves #3465  

### Description

Workaround for DOMContentLoaded event listener not being invoked on Safari

When I poked around for some clues as to why the date range picker wasn't working, I discovered that the EventListener for DOMContentLoaded that we add in application.js  wasn't being invoked in Safari, though it was in Chrome.   Googling yielded as workaround.  See https://developer.apple.com/forums/thread/651215 -- it appears that the DOMContentLoaded event sometimes happens before we add the listener.

The fix doesn't seem particularly elegant, but it seems to work.  

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- verified that the date picker comes up and works on the dashboard in Safari  We should check it throughout before release, but the workaround *should* apply throughout.
- automated tests pass 