### PR TITLE
3446: Fix file uploads for partner form

### DIFF
--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -20,7 +20,7 @@ module Partners
     end
 
     def profile_params
-      params.require(:profile).permit(
+      params.require(:partner).require(:profile).permit(
         :agency_type,
         :other_agency_type,
         :proof_of_partner_status,

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -20,7 +20,7 @@ class ProfilesController < ApplicationController
   end
 
   def edit_profile_params
-    params.require(:profile).permit(
+    params.require(:partner).require(:profile).permit(
       :agency_type,
       :other_agency_type,
       :proof_of_partner_status,

--- a/app/views/partners/profiles/edit.html.erb
+++ b/app/views/partners/profiles/edit.html.erb
@@ -28,7 +28,7 @@
         <!-- jquery validation -->
         <div class="card-transparent">
           <%= simple_form_for current_partner, url: partners_profile_path, html: {role: 'form', class: 'form-horizontal'} do |form| %>
-            <%= simple_fields_for :profile, current_partner.profile do |profile_form| %>
+            <%= form.simple_fields_for :profile, current_partner.profile do |profile_form| %>
               <div class="row">
                 <div class="col-6">
                   <%= render partial: "partners/profiles/edit/agency_information", locals: {form: form, profile: current_partner.profile, profile_form: profile_form} %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -16,7 +16,7 @@
       <div class="col-md-12">
         <div class="card-transparent">
           <%= simple_form_for @partner, url: profile_path, html: {role: 'form', class: 'form-horizontal'} do |form| %>
-            <%= simple_fields_for :profile, @partner.profile do |profile_form| %>
+            <%= form.simple_fields_for :profile, @partner.profile do |profile_form| %>
               <div class="row">
                 <div class="col-6">
                   <%= render partial: "partners/profiles/edit/agency_information",

--- a/spec/requests/partners/profiles_requests_spec.rb
+++ b/spec/requests/partners/profiles_requests_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe "/partners/profiles", type: :request do
     it "updates the partner and profile" do
       partner.profile.update!(address1: "123 Main St.", address2: "New York, New York")
       put partners_profile_path(partner,
-        partner: {name: "Partnerdude"},
-        profile: {address1: "456 Main St.", address2: "Washington, DC"})
+        partner: {name: "Partnerdude", profile: {address1: "456 Main St.", address2: "Washington, DC"}})
       expect(partner.reload.name).to eq("Partnerdude")
       expect(partner.profile.reload.address1).to eq("456 Main St.")
       expect(partner.profile.address2).to eq("Washington, DC")

--- a/spec/requests/profiles_requests_spec.rb
+++ b/spec/requests/profiles_requests_spec.rb
@@ -18,11 +18,13 @@ RSpec.describe "Profiles", type: :request do
 
   describe "POST #update" do
     context "successful save" do
-      partner_params = { name: "Awesome Partner" }
-      profiles_params = { executive_director_email: "awesomepartner@example.com", facebook: "facebooksucks" }
+      let(:partner_params) do
+        { name: "Awesome Partner", profile:
+                               { executive_director_email: "awesomepartner@example.com", facebook: "facebooksucks" } }
+      end
 
       it "update partner" do
-        put profile_path(default_params.merge(id: partner, partner: partner_params, profile: profiles_params))
+        put profile_path(default_params.merge(id: partner, partner: partner_params))
         expect(response).to have_http_status(:redirect)
         expect(partner.reload.name).to eq("Awesome Partner")
         expect(partner.profile.reload.executive_director_email).to eq("awesomepartner@example.com")
@@ -30,7 +32,7 @@ RSpec.describe "Profiles", type: :request do
       end
 
       it "redirects to #show" do
-        put profile_path(default_params.merge(id: partner, partner: partner_params, profile: profiles_params))
+        put profile_path(default_params.merge(id: partner, partner: partner_params))
         expect(response).to redirect_to(partner_path(partner) + "#partner-information")
       end
     end


### PR DESCRIPTION
Resolves #3446 .

### Description
When we merged partners, we used the `simple_fields_for` method to update what was now the partner profile. However, there are **two** versions of this method - one meant for use inside a bare form tag, and one for use inside a form *builder* (i.e. using the `form_for` or `form_with` method). We were using the wrong one, meaning that the form builder was not updated as "multipart", which happens when a file field is included in the form. This skipped the necessary attributes allowing file uploads, which caused all file uploads to fail.

This PR fixes it!

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Local testing