### PR TITLE
Issue 3472: Bring request info to distribution

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -105,6 +105,7 @@ class Distribution < ApplicationRecord
     self.request = request
     self.organization_id = request.organization_id
     self.partner_id = request.partner_id
+    self.agency_rep = request.partner_user&.formatted_email
     self.comment = request.comments
     self.issued_at = Time.zone.today + 1.day
     request.request_items.each do |item|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,6 +78,10 @@ class User < ApplicationRecord
   has_many :requests, class_name: "::Request", foreign_key: :partner_id, dependent: :destroy, inverse_of: :partner_user
   has_many :submitted_requests, class_name: "Request", foreign_key: :partner_user_id, dependent: :destroy, inverse_of: :partner_user
 
+  def formatted_email
+    email.present? ? "#{name} <#{email}>" : ""
+  end
+
   def password_complexity
     return if password.blank? || password =~ /(?=.*?[#?!@$%^&*-])/
 

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -3,7 +3,7 @@
   <td><%= request_row.partner.name %> </td>
   <td>
     <% partner_user = @partner_users.find { |pu| pu.id == request_row.partner_user_id } %>
-    <%= partner_user && "#{partner_user.name} <#{partner_user.email}>" %>
+    <%= "#{partner_user&.formatted_email}" %>
   </td>
   <td class="<%= quota_column_class(request_row.total_items, request_row.partner) %>">
     <%= request_row.total_items %>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -44,7 +44,7 @@
               <tbody>
               <tr>
                 <td><%= @request.partner.name %></td>
-                <td><%= @request.partner_user.present? ? "#{@request.partner_user.name} <#{@request.partner_user.email}>" : "" %></td>
+                <td><%= @request.partner_user&.formatted_email %></td>
                 <td><%= render partial: "status", locals: {status: @request.status} %></td>
                 <td><%= @request.comments || 'None' %></td>
               </tr>

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -187,6 +187,30 @@ RSpec.describe Distribution, type: :model do
       end
     end
 
+    describe "#copy_from_request" do
+      it "copy over relevant request information into the distrubution" do
+        item1 = create(:item, name: "Item1")
+        item2 = create(:item, name: "Item2")
+        request = create(:request,
+          organization: @organization,
+          partner_user: ::User.partner_users.first,
+          request_items: [
+            { item_id: item1.id, quantity: 15 },
+            { item_id: item2.id, quantity: 18 }
+          ])
+        distribution = Distribution.new
+        distribution.copy_from_request(request.id)
+        expect(distribution.line_items.size).to eq 2
+        expect(distribution.line_items.first.quantity).to eq 15
+        expect(distribution.line_items.second.quantity).to eq 18
+        expect(distribution.organization_id).to eq @organization.id
+        expect(distribution.partner_id).to eq request.partner_id
+        expect(distribution.agency_rep).to eq "#{request.partner_user.name} <#{request.partner_user.email}>"
+        expect(distribution.comment).to eq request.comments
+        expect(distribution.issued_at.to_date).to eq(Time.zone.today + 1.day)
+      end
+    end
+
     describe "#future?" do
       let(:dist1)    { create(:distribution, issued_at: Time.zone.tomorrow) }
       let(:dist2)    { create(:distribution, issued_at: Time.zone.yesterday) }


### PR DESCRIPTION
 Resolves #3472

### Description

Added automatic population of the agency representatives name and email address in the distribution form based around the `copy_from_request` method in the distribution model. I also added a function to user model to return a formatted version of the partenr_users name and email for the front end table in request as well as the filling in of agency representatives. I did this through a function to keep things DRY.

 Added a test to ensure that the partner, agency representatives and
 comments are all properly being passed from the request to the distribution
  using the #copy_from_request function


### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I have added a test and I have also tested manually, manual testing steps would be

1. Go to the request page and find a request you would like to transfer
2. Take note of the request sender field
3. Click on the "view" icon on the list item
4. Click the "Fulfill request" button
5. Confirm you see the request sender's information in "Agency representative" field

Test to verify changes : bundle exec rspec spec/system/distribution_system_spec.rb:398

### Screenshots

<img width="1352" alt="Screenshot 2023-03-26 at 9 33 28 PM" src="https://user-images.githubusercontent.com/12036882/227826714-2f11a0c5-85a4-4290-9df9-dc536319148b.png">
