### PR TITLE
3505 Fix text overwriting logo on distribution printout

### DIFF
--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -21,7 +21,7 @@ class DistributionPdf
 
     image logo_image, fit: [250, 85]
 
-    bounding_box [bounds.right - 225, bounds.top], width: 225, height: 50 do
+    bounding_box [bounds.right - 225, bounds.top], width: 225, height: 85 do
       text @organization.name, align: :right
       text @organization.address, align: :right
       text @organization.email, align: :right


### PR DESCRIPTION

Resolves #3505  <!--fill issue number-->

### Description
Increased the bounding box size on the bank's address to match the logo size,  making the following text appear below the logo

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Visual inspection on local.
I'm not sure how to automatically test this 

### Screenshots
Before:

<img width="771" alt="Screenshot 2023-03-27 at 11 57 25 AM" src="https://user-images.githubusercontent.com/10157589/227996749-841f9138-c7e4-4c95-92a2-d3eb2f3f4546.png">

After:  
<img width="768" alt="Screenshot 2023-03-27 at 11 56 18 AM" src="https://user-images.githubusercontent.com/10157589/227996831-59b11710-aa54-45eb-a7b0-84827f22420f.png">






