### PR TITLE
3508 confirmation email requested items quantities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -703,4 +703,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.8
+   2.4.10

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -12,10 +12,17 @@ class RequestsConfirmationMailer < ApplicationMailer
 
   def fetch_items(request)
     combined = combined_items(request)
-    item_ids = combined&.map { |item| item['item_id'] }
-    items_names = Item.where(id: item_ids).order(:id).pluck(:name)
-    names_hash = items_names.map { |name| { 'name' => name } }
-    combined.zip(names_hash).map { |items, names| items.merge(names) }
+
+
+
+
+
+
+
+    # item_ids = combined&.map { |item| item['item_id'] }
+    #items_names = Item.where(id: item_ids).order(:id).pluck(:name)
+    #names_hash = items_names.map { |name| { 'name' => name } }
+    #combined.zip(names_hash).map { |items, names| items.merge(names) }
   end
 
   def combined_items(request)
@@ -24,7 +31,7 @@ class RequestsConfirmationMailer < ApplicationMailer
     grouped = request.request_items.group_by { |i| i['item_id'] }
     # convert hash into an array of items with combined quantities
     grouped.map do |id, items|
-      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum }
+      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum, 'name'=> Item.find(id).name }
     end
   end
 end

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -14,8 +14,8 @@ class RequestsConfirmationMailer < ApplicationMailer
     combined = combined_items(request)
     item_ids = combined&.map { |item| item['item_id'] }
     db_items = Item.where(id: item_ids).select(:id, :name)
-    combined.each { |i| i['name'] = db_items.find { |db_item| i["item_id"] == db_item.id}.name }
-    combined.sort_by{|i| i['name']}
+    combined.each { |i| i['name'] = db_items.find { |db_item| i["item_id"] == db_item.id }.name }
+    combined.sort_by { |i| i['name'] }
   end
 
   def combined_items(request)
@@ -25,7 +25,6 @@ class RequestsConfirmationMailer < ApplicationMailer
     # convert hash into an array of items with combined quantities
     grouped.map do |id, items|
       { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum }
-      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum, 'name'=> Item.find(id).name }
     end
   end
 end

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -24,7 +24,8 @@ class RequestsConfirmationMailer < ApplicationMailer
     grouped = request.request_items.group_by { |i| i['item_id'] }
     # convert hash into an array of items with combined quantities
     grouped.map do |id, items|
-      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum, name: Item.find(id).name }
+      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum }
+      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum, 'name'=> Item.find(id).name }
     end
   end
 end

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -24,8 +24,7 @@ class RequestsConfirmationMailer < ApplicationMailer
     grouped = request.request_items.group_by { |i| i['item_id'] }
     # convert hash into an array of items with combined quantities
     grouped.map do |id, items|
-      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum }
-      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum, 'name'=> Item.find(id).name }
+      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum, name: Item.find(id).name }
     end
   end
 end

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -11,27 +11,14 @@ class RequestsConfirmationMailer < ApplicationMailer
   private
 
   def fetch_items(request)
-    combined = combined_items(request)
-
-
-
-
-
-
-
-    # item_ids = combined&.map { |item| item['item_id'] }
-    #items_names = Item.where(id: item_ids).order(:id).pluck(:name)
-    #names_hash = items_names.map { |name| { 'name' => name } }
-    #combined.zip(names_hash).map { |items, names| items.merge(names) }
-  end
-
-  def combined_items(request)
     return [] if request.request_items.size == 0
-    # convert items into a hash of (id => list of items with that ID)
+    # convert items into a hash of (id => list of items with that ID
+
     grouped = request.request_items.group_by { |i| i['item_id'] }
     # convert hash into an array of items with combined quantities
-    grouped.map do |id, items|
-      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum, 'name'=> Item.find(id).name }
+    compacted = grouped.map do |id, items|
+      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum, 'name' => Item.find(id).name }
     end
+    compacted.sort_by{|i| i['name']}
   end
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -64,9 +64,4 @@ FactoryBot.define do
       keys.map.with_index { |k, i| { "item_id" => k, "quantity" => item_quantities[i]} }
     }
   end
-
-
-
-
-
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -52,4 +52,21 @@ FactoryBot.define do
       keys.map { |k| { "item_id" => k, "quantity" => 50 } }
     }
   end
+
+  trait :with_varied_quantities do
+    request_items {
+      # get 10 unique item ids
+      keys = Item.active.pluck(:id).sample(10)
+
+      # This *could* pass in error -- if the plucking order happens to match the end order.
+
+      item_quantities = [50, 150, 75, 125, 200, 3, 15, 88, 46, 22]
+      keys.map.with_index { |k, i| { "item_id" => k, "quantity" => item_quantities[i]} }
+    }
+  end
+
+
+
+
+
 end

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
   let(:mail) { RequestsConfirmationMailer.confirmation_email(request) }
 
   let(:request_w_duplicates) { create(:request, :with_duplicates) }
-  let(:request_w_varied_quantities) { create(:request, :with_varied_quantities)}
+  let(:request_w_varied_quantities) { create(:request, :with_varied_quantities) }
   let(:mail_w_duplicates) { RequestsConfirmationMailer.confirmation_email(request_w_duplicates) }
   let(:mail_w_varied_quantities) { RequestsConfirmationMailer.confirmation_email(request_w_varied_quantities) }
 
@@ -32,11 +32,8 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
     @organization.update!(email: "me@org.com")
     expect(mail_w_varied_quantities.body.encoded).to match('This is an email confirmation')
     request_w_varied_quantities.request_items.each { |ri|
-      item = Item.find(ri["item_id"])
-      puts "item name is: #{item.name}"
-      expected_string = "#{item.name} - #{ri['quantity']}"
+      expected_string = "#{Item.find(ri["item_id"]).name} - #{ri["quantity"]}"
       expect(mail_w_varied_quantities.body.encoded).to include(expected_string)
     }
   end
-
 end

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -3,7 +3,9 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
   let(:mail) { RequestsConfirmationMailer.confirmation_email(request) }
 
   let(:request_w_duplicates) { create(:request, :with_duplicates) }
+  let(:request_w_varied_quantities) { create(:request, :with_varied_quantities)}
   let(:mail_w_duplicates) { RequestsConfirmationMailer.confirmation_email(request_w_duplicates) }
+  let(:mail_w_varied_quantities) { RequestsConfirmationMailer.confirmation_email(request_w_varied_quantities) }
 
   describe "#confirmation_email" do
     it 'renders the headers' do
@@ -25,4 +27,16 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
     expect(mail_w_duplicates.body.encoded).to match('This is an email confirmation')
     expect(mail_w_duplicates.body.encoded).to match(' - 100')
   end
+
+  it 'pairs the right quantities with the right item names' do
+    @organization.update!(email: "me@org.com")
+    expect(mail_w_varied_quantities.body.encoded).to match('This is an email confirmation')
+    request_w_varied_quantities.request_items.each { |ri|
+      item = Item.find(ri["item_id"])
+      puts "item name is: #{item.name}"
+      expected_string = "#{item.name} - #{ri['quantity']}"
+      expect(mail_w_varied_quantities.body.encoded).to include(expected_string)
+    }
+  end
+
 end


### PR DESCRIPTION
Resolves #3508 

### Description

The quantities and item names were mismatched on confirmation emails.  This fixes that.

All the tests pass on this, but I'm a bit concerned that I've missed something - because what I have here is much simpler than what was there before.   

To be granted,  it will hit the database more times.   That's where our tradeoff is.   But I don't think we've such high volume that it's going to be a big issue.  And, fwiw,  in the isolated environment of my local,  the relevant test runs faster.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Automated test suite has been run.  Additional test in place.
It should be visually tested as well, and has not yet been.
