### PR TITLE
fixed issued_at bug on certain browsers for issue #3466

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -36,7 +36,7 @@ class Distribution < ApplicationRecord
   has_one :request, dependent: :nullify
   accepts_nested_attributes_for :request
 
-  validates :storage_location, :partner, :organization, :delivery_method, presence: true
+  validates :storage_location, :partner, :organization, :delivery_method, :issued_at, presence: true
   validate :line_item_items_exist_in_inventory
   validate :line_item_items_quantity_is_positive
 

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -11,7 +11,7 @@
       error: "Which partner is this distribution going to?" %>
 
     <div class='w-72'>
-      <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date", html5: true %>
+      <%= f.input :issued_at, as: :date, label: "Distribution date", html5: true %>
     </div>
     <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
     <%= f.input :agency_rep, label: "Agency representative" %>

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -11,7 +11,7 @@
       error: "Which partner is this distribution going to?" %>
 
     <div class='w-72'>
-      <%= f.input :issued_at, as: :date, label: "Distribution date", html5: true %>
+      <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date and time", html5: true %>
     </div>
     <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
     <%= f.input :agency_rep, label: "Agency representative" %>

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -179,11 +179,11 @@ RSpec.feature "Distributions", type: :system do
     it "allows the user can change the issued_at date" do
       click_on "Edit", match: :first
       expect do
-        fill_in "Distribution date", with: Time.zone.parse("2001-10-01")
+        fill_in "Distribution date", with: Time.zone.parse("2001-10-01 10:00")
 
         click_on "Save", match: :first
         distribution.reload
-      end.to change { distribution.issued_at }.to(Time.zone.parse("2001-10-01"))
+      end.to change { distribution.issued_at }.to(Time.zone.parse("2001-10-01 10:00"))
     end
 
     it "disallows the user from changing the quantity above the inventory quantity" do

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -179,11 +179,11 @@ RSpec.feature "Distributions", type: :system do
     it "allows the user can change the issued_at date" do
       click_on "Edit", match: :first
       expect do
-        fill_in "Distribution date", with: Time.zone.parse("2001-10-01 10:00")
+        fill_in "Distribution date", with: Time.zone.parse("2001-10-01")
 
         click_on "Save", match: :first
         distribution.reload
-      end.to change { distribution.issued_at }.to(Time.zone.parse("2001-10-01 10:00"))
+      end.to change { distribution.issued_at }.to(Time.zone.parse("2001-10-01"))
     end
 
     it "disallows the user from changing the quantity above the inventory quantity" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3466  <!--fill issue number-->

### Description

I can recreate this issue on Firefox, but not on Edge.
The form input for issued_at was an ```as: datetime```
This showed up in Edge with a date and time interface but on Firefox it shows only a date interface. 
Firefox sends nothing for issued_at and for some reason it gets filled in as the created_at time before getting inserted in the table
I've changed the form input to be ```as: date``` which fixes this issue but removes the ability to select a time.

This may not be a good solution if the time is required, the label just says "Distribution date" so I think it's fine?

_I'm assuming this will also fix Safari but I haven't tested it_

### Type of change


* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

There are already tests for this in the distribution_requests spec. 
A test for this bug would need to be browser specific
I'm assuming the tests passed in the first place because rspec uses chrome

