### PR TITLE
Issue: 3519 Edit text in Inventory transfer screen to Items in this transfer

### DIFF
--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -51,7 +51,7 @@
                     <%= f.input :comment %>
 
                     <fieldset style="margin-bottom: 2rem;" class='w-70'>
-                      <legend>Items in this donation</legend>
+                      <legend>Items in this transfer</legend>
                       <div id="transfer_line_items" class="line-item-fields" data-capture-barcode="true">
                         <%= f.simple_fields_for :line_items do |item| %>
                           <%= render 'line_items/line_item_fields', f: item %>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #001 <!--3519-->

### Description
Completed text edit in the Inventory transfer page. Edited text to display "Items in this transfer"
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change
Text edit

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
I did not find any tests that would fail with this change. If I missed any please let me know and I will fix ASAP.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
