### PR TITLE
[WIP?] 3470 display all editable partner information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -704,4 +704,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.9
+   2.4.10

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -24,7 +24,7 @@
             <%= form.input :program_name, label: "Program Name(s)", class: "form-control", wrapper: :input_group %>
             <%= form.input :program_description, label: "Program Description(s)", class: "form-control", wrapper: :input_group %>
             <%= form.input :program_age, label: "Agency Age", class: "form-control", wrapper: :input_group %>
-            <%= form.input :evidence_based, label: "Do You Track Program Results", as: :boolean,
+            <%= form.input :evidence_based, label: "Evidence Based?", as: :boolean,
                            class: "form-control", wrapper: :input_group %>
             <%= form.input :case_management, label: "Case Management", class: "form-control", wrapper: :input_group %>
             <%= form.input :essentials_use, label: "How Are Essentials (e.g. diapers, period supplies) Used In Your Program?", as: :text,

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -2,12 +2,11 @@
   <div class="col-md-6">
     <!-- /.box-header -->
     <h2 class='text-2xl underline'>Agency Information</h2>
-    <! -- The field for inputting the name registers it as partner.name, 
-    not partner_profile.name, so this pulls from partner.name -->
+    <! -- #The field for inputting the name registers it as partner.name, 
+    #not partner_profile.name, so this pulls from partner.name -->
     <p>Name: <%= @partner.name %></p>
-    <p>Distributor Type: <%= partner_profile.distributor_type %></p>
     <p>Agency Type: <%= partner_profile.agency_type %>
-    <% if partner_profile.agency_type == "Other" %>
+    <% if partner_profile.agency_type == "Other" && partner_profile.other_agency_type %>
       (<%=partner_profile.other_agency_type%>)
     <% end %>
     </p>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -2,9 +2,15 @@
   <div class="col-md-6">
     <!-- /.box-header -->
     <h2 class='text-2xl underline'>Agency Information</h2>
-    <p>Name: <%= partner_profile.name %></p>
-    <p>Distributor Type <%= partner_profile.distributor_type %></p>
-    <p>Agency Type: <%= partner_profile.agency_type %></p>
+    <! -- The field for inputting the name registers it as partner.name, 
+    not partner_profile.name, so this pulls from partner.name -->
+    <p>Name: <%= @partner.name %></p>
+    <p>Distributor Type: <%= partner_profile.distributor_type %></p>
+    <p>Agency Type: <%= partner_profile.agency_type %>
+    <% if partner_profile.agency_type == "Other" %>
+      (<%=partner_profile.other_agency_type%>)
+    <% end %>
+    </p>
     <p>Proof of Agency Status
     <% if partner_profile.proof_of_partner_status.attached? %>
       <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
@@ -30,30 +36,21 @@
     <% if partner_profile_fields.include?('agency_stability') || partner_profile_fields.empty? %>
       <h2 class='text-2xl underline'>Agency Stability</h2>
       <p>Founded <%= partner_profile.founded %></p>
-      <p>Form 990: <%= partner_profile.proof_of_form_990.attached? ? 'Yes' : 'No' %></p>
+      <p>Form 990: <%= humanize_boolean(partner_profile.proof_of_form_990.attached?) %></p>
       <p>Form 990
       <% if partner_profile.proof_of_form_990.attached? %>
         <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
         (Link): <%= link_to partner_profile.proof_of_form_990.filename, rails_blob_path(partner_profile.proof_of_form_990, disposition: 'attachment') %>
     <% end %>
       </p>
-      <p>Program Name(s) <%= partner_profile.program_name %></p>
-      <p>Program Description(s) <%= partner_profile.program_description %></p>
-      <p>Program Age <%= partner_profile.program_age %></p>
-      <p>Case Management: <%= partner_profile.case_management %></p>
-      <p>Evidence Based: <%= partner_profile.evidence_based %></p>
+      <p>Program Name(s): <%= partner_profile.program_name %></p>
+      <p>Program Description(s): <%= partner_profile.program_description %></p>
+      <p>Program Age: <%= partner_profile.program_age %></p>
+      <p>Case Management: <%= humanize_boolean(partner_profile.case_management) %></p>
+      <p>Evidence Based: <%= humanize_boolean(partner_profile.evidence_based) %></p>
       <p>How Are Essentials (e.g. diapers, period supplies) Used In Your Program? <%= partner_profile.essentials_use %></p>
       <p>Do You Receive Essentials from Other Sources? <%= partner_profile.receives_essentials_from_other %></p>
-      <p>Currently Provide Diapers: <%= partner_profile.currently_provide_diapers %></p>
-      <% if partner_profile.organization.enable_child_based_requests? %>
-        <p>Enable Child-based Requests: <%= partner_profile.enable_child_based_requests? %></p>
-      <% end %>
-      <% if partner_profile.organization.enable_individual_requests? %>
-        <p>Enable Requests for Individuals: <%= partner_profile.enable_individual_requests? %></p>
-      <% end %>
-      <% if partner_profile.organization.enable_quantity_based_requests? %>
-        <p>Enable Quantity-based Requests: <%= partner_profile.enable_quantity_based_requests? %></p>
-      <% end %>
+      <p>Currently Providing Diapers: <%= humanize_boolean(partner_profile.currently_provide_diapers) %></p>
       <br>
       <h3>Program Address (if different)</h3>
       <p>Program Address: <%= partner_profile.program_address1 %></p>
@@ -66,15 +63,14 @@
     <% if partner_profile_fields.include?('organizational_capacity') || partner_profile_fields.empty? %>
       <h2 class='text-2xl underline'>Organizational Capacity</h2>
       <p>Client Capacity: <%= partner_profile.client_capacity %></p>
-      <p>Storage Space: <%= partner_profile.storage_space %></p>
+      <p>Storage Space: <%= humanize_boolean(partner_profile.storage_space) %></p>
       <p>Storage Space Description: <%= partner_profile.describe_storage_space %></p>
       <br>
     <% end %>
     <% if partner_profile_fields.include?('population_served') || partner_profile_fields.empty? %>
       <h2 class='text-2xl underline'>Population Served</h2>
-      <p>Income Requirement
-      Description: <%= partner_profile.income_requirement_desc %></p>
-      <p>Income Verification: <%= partner_profile.income_verification %></p>
+      <p>Income Requirement: <%= humanize_boolean(partner_profile.income_requirement_desc) %></p>
+      <p>Income Verification: <%= humanize_boolean(partner_profile.income_verification) %></p>
       <br>
     <% end %>
   </div>
@@ -135,27 +131,25 @@
       <p>Sources of Diapers: <%= partner_profile.sources_of_diapers %> </p>
       <p>Essentials Budget:<%= partner_profile.essentials_budget %></p>
       <p>Essentials Funding Source: <%= partner_profile.essentials_funding_source %></p>
+      <br/>
     <% end %>
     <% if partner_profile_fields.include?('attached_documents') || partner_profile_fields.empty? %>
-      <h2 class='text-2xl underline'>Other Documents</h2><br/>
-      <ul>
+      <h2 class='text-2xl underline'>Other Documents</h2>
         <% partner_profile.documents.each do |document| %>
-          <li><%= link_to document.filename, rails_blob_path(document, disposition: 'inline') %></li>
+          <p><%= link_to document.filename, rails_blob_path(document, disposition: 'inline') %></p>
+        <br/>
         <% end %>
-      </ul>
     <h2 class='text-2xl underline'>Settings</h2>
-      <ul>
         <% if partner_profile.organization.enable_child_based_requests? %>
-          <li>Uses Child Based Requests: <%= humanize_boolean(partner_profile.enable_child_based_requests) %></li>
+          <p>Uses Child Based Requests: <%= humanize_boolean(partner_profile.enable_child_based_requests) %></p>
         <% end %>
         <% if partner_profile.organization.enable_individual_requests? %>
-          <li>Uses Individual Requests: <%= humanize_boolean(partner_profile.enable_individual_requests) %></li>
+          <p>Uses Individual Requests: <%= humanize_boolean(partner_profile.enable_individual_requests) %></p>
         <% end %>
         <% if partner_profile.organization.enable_quantity_based_requests? %>
-          <li>Uses Quantity Based Requests: <%= humanize_boolean(partner_profile.enable_quantity_based_requests) %></li>
+          <p>Uses Quantity Based Requests: <%= humanize_boolean(partner_profile.enable_quantity_based_requests) %></p>
         <% end %>
-      </ul>
-  </div>
+      <br/>
 <% end %>
 <!-- /.box -->
 </div>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -137,8 +137,8 @@
       <h2 class='text-2xl underline'>Other Documents</h2>
         <% partner_profile.documents.each do |document| %>
           <p><%= link_to document.filename, rails_blob_path(document, disposition: 'inline') %></p>
-        <br/>
         <% end %>
+        <br/>
     <h2 class='text-2xl underline'>Settings</h2>
         <% if partner_profile.organization.enable_child_based_requests? %>
           <p>Uses Child Based Requests: <%= humanize_boolean(partner_profile.enable_child_based_requests) %></p>


### PR DESCRIPTION
# Checklist:

Resolves #3470

### Description


[Fixed] Name does not show up

[Fixed] The field for other agency type doesn't show up

[Fixed] Currently Providing diapers, Case Management, Evidence Based, Storage Space, Income Requirement and Income Verification show up as true/false instead of Yes/No

[Fixed] Program Name(s), Descriptions(s) and Age are missing a colon

[Changed] Currently Provide diapers -> Currently Providing Diapers

[Fixed] Child-based requests, Requests for individuals, and Quantity-based requests all show up in the Agency Stability section when they are already in the Settings section

[Changed] Additional documents and Settings pieces are now arranged in the same format as the rest of the page (no longer bullet points)


-- Additional Considerations --

Additional documents field becomes blank if a document is not added every edit step, not sure why.

"How Are Essentials (e.g. diapers, period supplies) Used In Your Program?" And "Do You Receive Essentials from Other Sources?" Could be re-worded to be consistent.

"More Docs Required" is a text box, should it be a check box?

Income Requirement was labeled as "Income Requirement Description" but it is a check box. Should the income requirement be a number instead of a boolean?

Percentages are all integers, should they be changed to floats?

Do You Track Program Results (in editing) -> Evidence Based?

Distributor type appears to be an unused field.

### Type of change

* Bug fix
* New feature (ish?)


### How Has This Been Tested?

Login as org_admin1@example.com
Go to Partner Agencies -> All Partners
Click on a partner account and scroll to "Application & Information"
Edit the partner and fill in any fields
Press "Update Information" and verify that all information entered shows up in the "Application & Information" section


### Screenshots
<img width="208" alt="Screen Shot 2023-04-03 at 2 10 00 PM" src="https://user-images.githubusercontent.com/84088137/229591858-d3e7a2a7-094d-48e5-af1f-bf964492aa8c.png">
<img width="418" alt="Screen Shot 2023-04-03 at 2 08 19 PM" src="https://user-images.githubusercontent.com/84088137/229591628-1570f478-17cc-476a-99b4-8e31cbc4ee3b.png">


