### PR TITLE
Fix dashboard recently added useers (#3473)

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -8,7 +8,7 @@ class AdminController < ApplicationController
 
   def dashboard
     @recent_organizations = Organization.where('created_at > ?', 1.week.ago)
-    @recent_users = User.where('created_at > ?', 1.week.ago)
+    @recent_users = User.where('created_at > ?', 1.week.ago).limit(20)
     @active_users = User.where('last_request_at > ?', 1.week.ago.utc).includes(:organization).order('organizations.name')
     @top_10_other = Item.by_partner_key('other').where.not(name: "Other").group(:name).limit(10).order('count_name DESC').count(:name)
     @donation_count = Donation.where('created_at > ?', 1.week.ago).count

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -8,7 +8,7 @@ class AdminController < ApplicationController
 
   def dashboard
     @recent_organizations = Organization.where('created_at > ?', 1.week.ago)
-    @recent_users = User.where('created_at > ?', 1.week.ago).limit(20)
+    @recent_users = User.where('created_at > ?', 1.week.ago).order(created_at: :desc).limit(20)
     @active_users = User.where('last_request_at > ?', 1.week.ago.utc).includes(:organization).order('organizations.name')
     @top_10_other = Item.by_partner_key('other').where.not(name: "Other").group(:name).limit(10).order('count_name DESC').count(:name)
     @donation_count = Donation.where('created_at > ?', 1.week.ago).count

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -41,7 +41,7 @@ module DashboardHelper
   end
 
   def recently_added_user_display_text(user)
-    (user.name.presence == "Name Not Provided") ? user.email : user.name
+    (user.name == "Name Not Provided") ? user.email : user.name
   end
 
   private

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -40,6 +40,10 @@ module DashboardHelper
     number_with_delimiter future_distributed_unformatted
   end
 
+  def recently_added_user_display_text(user)
+    (user.name.presence == "Name Not Provided") ? user.email : user.name
+  end
+
   private
 
   def total_received_donations_unformatted(range = selected_range)

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -16,64 +16,68 @@
         </ol>
       </div>
     </div>
-  </div><!-- /.container-fluid -->
+  </div>
+  <!-- /.container-fluid -->
 </section>
-
 <section class="content">
   <div class="row">
     <div class="col-md-3 col-sm-6 col-xs-12">
       <div class="info-box">
         <span class="info-box-icon bg-blue"><i class="fa fa-gratipay"></i></span>
-
         <div class="info-box-content">
           <span class="info-box-text">Donations</span>
           <span class="info-box-number"><%= @donation_count %></span>
-        </div><!-- /.info-box-content -->
-      </div><!-- /.info-box -->
-    </div><!-- /.col -->
+        </div>
+        <!-- /.info-box-content -->
+      </div>
+      <!-- /.info-box -->
+    </div>
+    <!-- /.col -->
     <div class="col-md-3 col-sm-6 col-xs-12">
       <div class="info-box">
         <span class="info-box-icon bg-red"><i class="fa fa-money"></i></span>
-
         <div class="info-box-content">
           <span class="info-box-text">Distributions</span>
           <span class="info-box-number"><%= @distribution_count %></span>
-        </div><!-- /.info-box-content -->
-      </div><!-- /.info-box -->
-    </div><!-- /.col -->
-
+        </div>
+        <!-- /.info-box-content -->
+      </div>
+      <!-- /.info-box -->
+    </div>
+    <!-- /.col -->
     <!-- fix for small devices only -->
     <div class="clearfix visible-sm-block"></div>
-
     <div class="col-md-3 col-sm-6 col-xs-12">
       <div class="info-box">
         <span class="info-box-icon bg-green"><i class="fa fa-file-text"></i></span>
-
         <div class="info-box-content">
           <span class="info-box-text">Requests</span>
           <span class="info-box-number"><%= @request_count %></span>
-        </div><!-- /.info-box-content -->
-      </div><!-- /.info-box -->
-    </div><!-- /.col -->
+        </div>
+        <!-- /.info-box-content -->
+      </div>
+      <!-- /.info-box -->
+    </div>
+    <!-- /.col -->
     <div class="col-md-3 col-sm-6 col-xs-12">
       <div class="info-box">
         <span class="info-box-icon bg-yellow"><i class="ion ion-ios-people-outline"></i></span>
-
         <div class="info-box-content">
           <span class="info-box-text">Total Organizations</span>
           <span class="info-box-number"><%= @organization_count %></span>
-        </div><!-- /.info-box-content -->
-      </div><!-- /.info-box -->
-    </div><!-- /.col -->
+        </div>
+        <!-- /.info-box-content -->
+      </div>
+      <!-- /.info-box -->
+    </div>
+    <!-- /.col -->
   </div>
-
   <div class="row">
     <div class="col-md-6">
       <!-- USERS LIST -->
       <div class="card">
         <div class="card-header border-transparent">
           <h3 class="card-title"><strong>Recently Added Users</strong></h3>
-
           <div class="card-tools">
             <span class="badge badge-danger"><%= pluralize(@recent_users.count, "New User") %></span>
             <button type="button" class="btn btn-tool" data-card-widget="collapse">
@@ -88,14 +92,17 @@
         <div class="card-body users-list p-0">
           <!-- /.table-responsive -->
           <ul class="users-list clearfix">
-
-          <% @recent_users.each do |user| %>
-            <li>
-              <%= image_tag gravatar_url(user.email, 32) %>
-              <%= link_to user.name, admin_user_path(user), class: "users-list-name" %>
-              <span class="users-list-date"><%= time_ago_in_words(user.created_at) %></span>
-            </li>
-          <% end %>
+            <% @recent_users.each do |user| %>
+              <li>
+                <%= image_tag gravatar_url(user.email, 32) %>
+                <% if !user.name.nil? %>
+                  <%= link_to user.email, edit_admin_user_path(user), class: "users-list-name" %>
+                <% else %>
+                  <%= link_to user.name, edit_admin_user_path(user), class: "users-list-name" %>
+                <% end %>
+                <span class="users-list-date"><%= time_ago_in_words(user.created_at) %></span>
+              </li>
+            <% end %>
           </ul>
           <br>
           <div class="text-center">
@@ -108,15 +115,12 @@
         </div>
         <!-- /.card-footer -->
       </div>
-
     </div>
-
     <div class="col-md-6">
       <!-- USERS LIST -->
       <div class="card">
         <div class="card-header border-transparent">
           <h3 class="card-title"><strong>Recently Added Organizations</strong></h3>
-
           <div class="card-tools">
             <span class="badge badge-danger"><%= pluralize(@recent_organizations.count, "New Organization") %></span>
             <button type="button" class="btn btn-tool" data-card-widget="collapse">
@@ -147,20 +151,15 @@
         <!-- /.card-body -->
         <div class="card-footer clearfix">
           <%= link_to "View All Organizations", admin_organizations_path, class:"btn btn-sm btn-info float-left" %>
-
           <a href="#" class="btn btn-sm btn-secondary float-right">View All Orders</a>
         </div>
       </div>
     </div>
   </div>
-
-
-
   <div class="col-md-14">
     <div class="card">
       <div class="card-header border-transparent">
         <h3 class="card-title"><strong>Top 10 Uses of Other</strong></h3>
-
         <div class="card-tools">
           <button type="button" class="btn btn-tool" data-card-widget="collapse">
             <i class="fas fa-minus"></i>
@@ -175,18 +174,18 @@
         <!-- /.table-responsive -->
         <table class="table">
           <thead>
-          <tr>
-            <th>Name</th>
-            <th>Occurrence</th>
-          </tr>
+            <tr>
+              <th>Name</th>
+              <th>Occurrence</th>
+            </tr>
           </thead>
           <tbody>
-          <% @top_10_other.each do |other| %>
-            <tr>
-              <td><%= other[0] %></td>
-              <td><%= other[1] %></td>
-            </tr>
-          <% end %>
+            <% @top_10_other.each do |other| %>
+              <tr>
+                <td><%= other[0] %></td>
+                <td><%= other[1] %></td>
+              </tr>
+            <% end %>
           </tbody>
         </table>
         <div class="text-center">
@@ -202,7 +201,6 @@
     <div class="card">
       <div class="card-header border-transparent">
         <h3 class="card-title"><strong>Recently Active Users</strong></h3>
-
         <div class="card-tools">
           <button type="button" class="btn btn-tool" data-card-widget="collapse">
             <i class="fas fa-minus"></i>
@@ -217,22 +215,22 @@
         <!-- /.table-responsive -->
         <table class="table">
           <thead>
-          <tr>
-            <th>User</th>
-            <th>Email</th>
-            <th>Organization</th>
-            <th>Last Active</th>
-          </tr>
+            <tr>
+              <th>User</th>
+              <th>Email</th>
+              <th>Organization</th>
+              <th>Last Active</th>
+            </tr>
           </thead>
           <tbody>
-          <% @active_users.each do |user| %>
-            <tr>
-              <td><%= user.name %></td>
-              <td><%= user.email %></td>
-              <td><%= user.organization&.name %></td>
-              <td><%= time_ago_in_words user.last_request_at %></td>
-            </tr>
-          <% end %>
+            <% @active_users.each do |user| %>
+              <tr>
+                <td><%= user.name %></td>
+                <td><%= user.email %></td>
+                <td><%= user.organization&.name %></td>
+                <td><%= time_ago_in_words user.last_request_at %></td>
+              </tr>
+            <% end %>
           </tbody>
         </table>
         <div class="text-center">

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -95,11 +95,7 @@
             <% @recent_users.each do |user| %>
               <li>
                 <%= image_tag gravatar_url(user.email, 32) %>
-                <% if !user.name.nil? %>
-                  <%= link_to user.email, edit_admin_user_path(user), class: "users-list-name" %>
-                <% else %>
-                  <%= link_to user.name, edit_admin_user_path(user), class: "users-list-name" %>
-                <% end %>
+                <%= link_to recently_added_user_display_text(user), edit_admin_user_path(user), class: "users-list-name" %>
                 <span class="users-list-date"><%= time_ago_in_words(user.created_at) %></span>
               </li>
             <% end %>

--- a/spec/requests/admin_requests_spec.rb
+++ b/spec/requests/admin_requests_spec.rb
@@ -11,26 +11,19 @@ RSpec.describe "Admin", type: :request do
 
     context "with rendered views" do
       let!(:users_list) { create_list(:user, 25) }
-      let!(:user) { create(:user) }
+      let!(:user) { create(:user, name: "Name Not Provided") }
+      edit_user_path_regex = Regexp.new('admin/users/[0-9]+/edit\\?organization_id=admin')
 
       it "shows a logout button" do
         get admin_dashboard_path
         expect(response.body).to match(/log out/im)
       end
 
-      it "shows recently added users email" do
+      it "shows the recently added users email " do
         get admin_dashboard_path
-        expect(response.body).to match(/#{user.email}/im)
-      end
 
-      it "shows only 20 users within recently added users ssection" do
-        get admin_dashboard_path
         expect(response.body).to match(/20 New users/im)
-      end
-
-      it "displays edit users path on recently added users ssection" do
-        get admin_dashboard_path
-        edit_user_path_regex = Regexp.new('admin/users/[0-9]+/edit\\?organization_id=admin')
+        expect(response.body).to match(/#{user.email}/im)
         expect(response.body).to match(edit_user_path_regex)
       end
     end

--- a/spec/requests/admin_requests_spec.rb
+++ b/spec/requests/admin_requests_spec.rb
@@ -8,10 +8,30 @@ RSpec.describe "Admin", type: :request do
       get admin_dashboard_path
       expect(response).to be_successful
     end
+
     context "with rendered views" do
+      let!(:users_list) { create_list(:user, 25) }
+      let!(:user) { create(:user) }
+
       it "shows a logout button" do
         get admin_dashboard_path
         expect(response.body).to match(/log out/im)
+      end
+
+      it "shows recently added users email" do
+        get admin_dashboard_path
+        expect(response.body).to match(/#{user.email}/im)
+      end
+
+      it "shows only 20 users within recently added users ssection" do
+        get admin_dashboard_path
+        expect(response.body).to match(/20 New users/im)
+      end
+
+      it "displays edit users path on recently added users ssection" do
+        get admin_dashboard_path
+        edit_user_path_regex = Regexp.new('admin/users/[0-9]+/edit\\?organization_id=admin')
+        expect(response.body).to match(edit_user_path_regex)
       end
     end
   end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3473 

### Description
In this PR, I fixed the superuser dashboard section "Recently added users" to display an email instead of "No Provided Name" and limited the total users displayed in this section to 20. Also, now the email text it is a link to edit user path as required in the issue.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tests are located in `admin_request_spec.rb` from lines 21 to 36

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
![image](https://user-images.githubusercontent.com/58452911/229889512-1666a9f6-ae11-4c97-a5d1-3871d07b5a34.png)

