### PR TITLE
3537 remove incorrect address

### DIFF
--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -30,9 +30,7 @@ class DistributionPdf
     text "Issued to:", style: :bold
     font_size 12
     text @distribution.partner.name
-    font_size 10
-    text @distribution.partner.organization.address
-    move_up 34
+    move_up 24
 
     text "Partner Primary Contact:", style: :bold, align: :right
     font_size 12


### PR DESCRIPTION
Resolves #3537 

### Description
Correcting an error in a recent release -- partner was paired with organization address.   Removing address as it wasn't part of the original ask.
### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Visual confirmation
Test suite passes
