### PR TITLE
Remember user's current role across sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,9 @@ class ApplicationController < ActionController::Base
   add_flash_types :error
   include DateHelper
 
+  include CurrentRole
+  helper_method :current_role
+
   protect_from_forgery with: :exception
   before_action :authenticate_user!
   before_action :authorize_user
@@ -10,7 +13,6 @@ class ApplicationController < ActionController::Base
   before_action :swaddled
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_paper_trail_whodunnit
-  helper_method :current_role
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found!
 
@@ -18,13 +20,6 @@ class ApplicationController < ActionController::Base
     @current_organization ||= Organization.find_by(short_name: params[:organization_id]) || current_user&.organization
   end
   helper_method :current_organization
-
-  def current_role
-    role = Role.find_by(id: session[:current_role]) || UsersRole.current_role_for(current_user)
-    session[:current_role] = role&.id
-
-    role
-  end
 
   def organization_url_options(options = {})
     options.merge(organization_id: current_organization.to_param)

--- a/app/controllers/concerns/current_role.rb
+++ b/app/controllers/concerns/current_role.rb
@@ -1,0 +1,44 @@
+module CurrentRole
+  def current_role
+    caching_current_role do
+      deprecating_session_role do
+        _current_role
+      end
+    end
+  end
+
+  def set_current_role(role)
+    caching_current_role { role }
+  end
+
+  private
+
+  def _current_role
+    UsersRole.current_role_for current_user
+  end
+
+  def caching_current_role(&current_role_finder)
+    @previous_role ||= nil
+    role = current_role_finder.call
+    return role if role == @previous_role
+
+    activate_role role
+    @previous_role = role
+  end
+
+  def activate_role(role)
+    return unless role && current_user
+
+    UsersRole.activate! role: role, user: current_user
+    current_user.reload_current_role
+  end
+
+  def deprecating_session_role(&current_role_finder)
+    return current_role_finder.call unless session[:current_role]
+
+    Rails.logger.info "Current role loaded from session"
+    role_id = session.delete :current_role
+    role = current_user&.roles&.find_by id: role_id
+    role || current_role_finder.call
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -16,7 +16,7 @@ class Users::SessionsController < Devise::SessionsController
   # POST /resource/sign_in
   def create
     super
-    session[:current_role] = UsersRole.current_role_for(current_user)&.id
+    set_current_role UsersRole.current_role_for(current_user)
   end
 
   # DELETE /resource/sign_out

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,14 +9,14 @@ class UsersController < ApplicationController
   end
 
   def switch_to_role
-    role = Role.find(params[:role_id])
-    unless current_user.roles.include?(role)
+    role = current_user.roles.find_by id: params[:role_id]
+    if role.blank?
       error_message = "Attempted to switch to a role that doesn't belong to you!"
       redirect_back(fallback_location: root_path, alert: error_message)
       return
     end
 
-    session[:current_role] = params[:role_id]
+    set_current_role role
     redirect_to dashboard_path_from_current_role
   end
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -29,4 +29,11 @@ class Role < ApplicationRecord
   ORG_ADMIN = :org_admin
   SUPER_ADMIN = :super_admin
   PARTNER = :partner
+
+  HIERARCHY = [
+    SUPER_ADMIN,
+    ORG_ADMIN,
+    ORG_USER,
+    PARTNER
+  ].freeze
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,9 @@ class User < ApplicationRecord
   has_one :partner, through: :partner_role, source: :resource, source_type: "Partner"
   has_many :partners, through: :roles, source: :resource, source_type: "Partner"
 
+  has_one :current_role, -> { merge(UsersRole.by_last_active) },
+          class_name: "Role", through: :partner_role_join, source: :role
+
   attr_accessor :organization_admin # for creation / update time
 
   # :invitable is from the devise_invitable gem

--- a/app/models/users_role.rb
+++ b/app/models/users_role.rb
@@ -2,25 +2,51 @@
 #
 # Table name: users_roles
 #
-#  id      :bigint           not null, primary key
-#  role_id :bigint
-#  user_id :bigint
+#  id             :bigint           not null, primary key
+#  last_active_at :datetime
+#  role_id        :bigint
+#  user_id        :bigint
 #
 class UsersRole < ApplicationRecord
+  scope :by_last_active, -> { where.not(last_active_at: nil).order(last_active_at: :desc) }
+
   belongs_to :user
   belongs_to :role
 
   accepts_nested_attributes_for :user
 
-  # @param user [User]
-  # @return [Role,nil]
-  def self.current_role_for(user)
-    role_order = [Role::SUPER_ADMIN, Role::ORG_ADMIN, Role::ORG_USER, Role::PARTNER]
-    role_order.each do |role|
-      found_role = user&.roles&.find { |r| r.name.to_sym == role }
-      return found_role if found_role
+  class << self
+    # @param user [User]
+    # @return [Role,nil]
+    def current_role_for(user)
+      return if user.blank?
+
+      user.current_role || default_role_for(user)
     end
 
-    nil
+    def activate!(role:, user:)
+      # rubocop:disable Rails/SkipsModelValidations
+      where(role: role, user: user).update_all last_active_at: Time.current
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    private
+
+    def default_role_for(user)
+      return if user.roles.blank?
+
+      ::Role::HIERARCHY.each do |role|
+        found_role = user.roles.find { |r| r.name.to_sym == role }
+        return found_role if found_role
+      end
+
+      nil
+    end
+  end
+
+  def activate!
+    # rubocop:disable Rails/SkipsModelValidations
+    update_column :last_active_at, Time.current
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/db/migrate/20230419040251_add_last_active_at_to_users_roles.rb
+++ b/db/migrate/20230419040251_add_last_active_at_to_users_roles.rb
@@ -1,0 +1,9 @@
+class AddLastActiveAtToUsersRoles < ActiveRecord::Migration[7.0]
+  def up
+    add_column :users_roles, :last_active_at, :timestamp, if_not_exists: true
+  end
+
+  def down
+    remove_column :users_roles, :last_active_at, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_16_135543) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_19_040251) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -750,6 +750,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_16_135543) do
   create_table "users_roles", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "role_id"
+    t.datetime "last_active_at", precision: nil
     t.index ["role_id"], name: "index_users_roles_on_role_id"
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
     t.index ["user_id"], name: "index_users_roles_on_user_id"

--- a/spec/controllers/concerns/current_role_spec.rb
+++ b/spec/controllers/concerns/current_role_spec.rb
@@ -1,0 +1,131 @@
+describe CurrentRole do
+  let(:controller_class) do
+    described_module = described_class
+
+    Class.new do
+      include described_module
+
+      def initialize(current_user, session)
+        self.current_user = current_user
+        self.session = session
+      end
+
+      private
+
+      attr_accessor :current_user, :session
+    end
+  end
+
+  let(:controller) { controller_class.new current_user, session }
+  let(:current_user) { user }
+  let(:user) { create :user }
+  let(:session) { {} }
+
+  def user_role_for(role)
+    UsersRole.find_or_create_by! role: role, user: user
+  end
+
+  let!(:current_role) { user.roles.first || create(:role) }
+  let!(:other_role) { create :role }
+  let!(:current_user_role) { user_role_for(current_role).tap(&:activate!) }
+  let!(:other_user_role) { user_role_for(other_role) if may_access_session_role? }
+  let(:may_access_session_role?) { true }
+
+  describe "#current_role" do
+    subject { controller.current_role }
+
+    context "when current user is present and session does not have current_role" do
+      it { is_expected.to eq current_role }
+    end
+
+    context "when current user is blank" do
+      let(:current_user) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when session has current_role" do
+      let(:session) { {current_role: other_role.id}.with_indifferent_access }
+
+      shared_examples "session clearing" do
+        it "removes current_role from session" do
+          expect { controller.current_role }
+            .to change { session }.to({})
+        end
+      end
+
+      context "when user may access session role" do
+        it { is_expected.to eq other_role }
+        include_examples "session clearing"
+      end
+
+      context "when user may not access session role" do
+        let(:may_access_session_role?) { false }
+
+        it { is_expected.to eq current_role }
+        include_examples "session clearing"
+      end
+    end
+
+    describe "caching" do
+      def set_current_user_role(role)
+        allow(user).to receive(:current_role).and_return role
+      end
+
+      before { set_current_user_role current_role }
+
+      context "when first called" do
+        it "activates the appropriate user role" do
+          expect { controller.current_role }
+            .to change { current_user_role.reload.last_active_at }
+        end
+
+        it "does not update other user roles" do
+          expect { controller.current_role }
+            .not_to change { other_user_role.reload }
+        end
+      end
+
+      context "when called again" do
+        before { controller.current_role }
+
+        context "with no change to current role" do
+          it "does not update active user role" do
+            expect { controller.current_role }
+              .not_to change { current_user_role.reload }
+          end
+        end
+
+        context "when current user role changes" do
+          before { set_current_user_role other_role }
+
+          it "activates new user role" do
+            expect { controller.current_role }
+              .to change { other_user_role.reload.last_active_at }
+          end
+
+          it "does not update previous user role" do
+            expect { controller.current_role }
+              .not_to change { current_user_role.reload }
+          end
+        end
+      end
+    end
+  end
+
+  describe "#set_current_role" do
+    let(:role) { current_role }
+    let(:user_role) { current_user_role }
+
+    it "activates role" do
+      expect { controller.set_current_role role }
+        .to change { user_role.reload.last_active_at }
+    end
+
+    it "reloads user's current role" do
+      allow(user).to receive(:reload_current_role).and_call_original
+      controller.set_current_role role
+      expect(user).to have_received :reload_current_role
+    end
+  end
+end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,0 +1,38 @@
+describe Users::SessionsController do
+  before do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  describe "post create" do
+    let(:user) { create :user }
+    let(:role) { Object.new }
+
+    before do
+      allow(controller).to receive(:set_current_role).and_call_original
+      allow(UsersRole)
+        .to receive(:current_role_for)
+        .with(user)
+        .and_return role
+      post :create, params: {user: user_params}
+    end
+
+    context "with valid credentials" do
+      let(:user_params) { {email: user.email, password: user.password} }
+
+      it "sets current role" do
+        expect(controller)
+          .to have_received(:set_current_role)
+          .with role
+      end
+    end
+
+    context "with invalid credentials" do
+      let(:user_params) { {email: user.email, password: Faker::Internet.password} }
+
+      it "does not set current role" do
+        expect(controller)
+          .not_to have_received :set_current_role
+      end
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,38 @@
+describe UsersController, type: :controller do
+  describe "get switch_to_role" do
+    let(:user) { create :organization_admin, organization: organization }
+    let(:organization) { create :organization }
+    let(:role) { create :role }
+    let(:switch_to_role_id) { role.id }
+
+    before do
+      sign_in user
+      user.roles << role
+      allow(controller)
+        .to receive(:set_current_role)
+        .and_call_original
+      get :switch_to_role, params: {
+        organization_id: organization.id,
+        role_id: switch_to_role_id
+      }
+    end
+
+    context "when user may access role" do
+      it "sets current role" do
+        expect(controller)
+          .to have_received(:set_current_role)
+          .with(role)
+          .at_least(1).time
+      end
+    end
+
+    context "when user may not access role" do
+      let(:switch_to_role_id) { -1 }
+
+      it "does not set current role" do
+        expect(controller)
+          .not_to have_received :set_current_role
+      end
+    end
+  end
+end

--- a/spec/factories/item_categories.rb
+++ b/spec/factories/item_categories.rb
@@ -12,7 +12,7 @@
 FactoryBot.define do
   factory :item_category do
     association :organization
-    name { Faker::Appliance.unique.brand }
+    sequence(:name) { |n| "#{Faker::Appliance.brand} #{n}" }
     description { Faker::Lorem.paragraph_by_chars(number: 250) }
   end
 end

--- a/spec/models/users_role_spec.rb
+++ b/spec/models/users_role_spec.rb
@@ -2,12 +2,13 @@
 #
 # Table name: users_roles
 #
-#  id      :bigint           not null, primary key
-#  role_id :bigint
-#  user_id :bigint
+#  id             :bigint           not null, primary key
+#  last_active_at :datetime
+#  role_id        :bigint
+#  user_id        :bigint
 #
 RSpec.describe UsersRole, type: :model do
-  describe "#current_role_for" do
+  describe ".current_role_for" do
     context "for org user" do
       it "should return org user" do
         user = FactoryBot.create(:user)
@@ -33,6 +34,29 @@ RSpec.describe UsersRole, type: :model do
       it "should return partner user" do
         user = FactoryBot.create(:partner_user)
         expect(described_class.current_role_for(user).name).to eq("partner")
+      end
+    end
+  end
+
+  describe ".activate!" do
+    subject(:activate!) { described_class.activate! role:, user: }
+
+    let(:user) { create :user }
+    let(:role) { create :role }
+
+    context "when user has role" do
+      let(:user_role) { described_class.find_by! role: role, user: user }
+
+      before { user.roles << role }
+
+      it "updates last_active_at" do
+        expect { activate! }.to change { user_role.reload.last_active_at }
+      end
+    end
+
+    context "when user does not have role" do
+      it "does not raise" do
+        expect { activate! }.not_to raise_error
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -227,10 +227,6 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-def current_role
-  current_user.roles.first
-end
-
 def html_body(mail)
   mail.body.parts.find { |p| p.content_type =~ /html/ }.body.encoded
 end


### PR DESCRIPTION
Resolves #3345 

### Description

Before this commit, users starting a new session would be assigned the highest role available to them from a hierarchy of roles. This role would then be stored in, and later referenced from, the session. With this commit, users will be assigned their most recently active role.
- "Active" role is recorded via the new `last_active_at` timestamp field on `users_roles`.
- If a role is stored in the session, the user will be assigned to that role (if it is available to them) and the role will be removed from the session.
- Otherwise the user is assigned a role using the most recent `users_roles.last_active_at`.
- If all available `users_roles.last_active_at` are null, the user is assigned the default role available to them by hierarchy.
- The current role's `last_active_at` field is updated on each request.
- After a reasonable amount of time has passed, the session check should be removed.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- Controller and model tests