### PR TITLE
Use db:reset instead of db:setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -60,7 +60,7 @@ FileUtils.chdir APP_ROOT do
 
   log "== Preparing database =="
   log "⚠️  If you use docker to run postgres, make sure your database is running ⚠️"
-  system! 'bin/rails db:setup'
+  system! 'bin/rails db:reset'
   system! 'bin/rails db:test:prepare'
 
   log "== Removing old logs, tempfiles, and jobs =="


### PR DESCRIPTION
Resolves #3565 

### Description

`rails db:reset` drops the db before rebuilding it, so all meta tables are fresh.