### PR TITLE
Memoize item headers to speed up export

### DIFF
--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -108,13 +108,14 @@ module Exports
     end
 
     def item_headers
+      return @item_headers if @item_headers
       # Define the item_headers by taking each item name
       # and sort them alphabetically
       item_names = distributions.map do |distribution|
         distribution.line_items.map(&:item).map(&:name)
       end.flatten
 
-      item_names.sort.uniq
+      @item_headers = item_names.sort.uniq
     end
 
     def build_row_data(distribution)


### PR DESCRIPTION
The code was re-calculating item headers for each distribution by looping over each distribution (so O(n^2)). I memoized the results of this so this becomes O(n). The results come back in about 4 seconds instead of 4 minutes.