### PR TITLE
3582 order of announcements new

### DIFF
--- a/app/models/broadcast_announcement.rb
+++ b/app/models/broadcast_announcement.rb
@@ -25,6 +25,6 @@ class BroadcastAnnouncement < ApplicationRecord
   def self.filter_announcements(parent_org)
     BroadcastAnnouncement.where(organization_id: [parent_org, nil].uniq)
       .where("expiry IS ? or expiry >= ?", nil, Time.zone.today)
-      .reverse
+      .order(created_at: :desc)
   end
 end

--- a/spec/models/broadcast_announcement_spec.rb
+++ b/spec/models/broadcast_announcement_spec.rb
@@ -61,5 +61,14 @@ RSpec.describe BroadcastAnnouncement, type: :model do
       BroadcastAnnouncement.create!(message: "test", user_id: 1, expiry: Time.zone.today, organization_id: 1)
       expect(BroadcastAnnouncement.filter_announcements(1).count).to eq(2)
     end
+
+    it "sorts announcements from most recently created to last" do 
+      announcement_1 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, created_at: Time.zone.today)
+      announcement_2 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, created_at: 2.days.ago)
+      announcement_3 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, expiry: 1.days.ago, created_at: 3.days.ago)
+      announcement_4 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1,  created_at: 4.days.ago)
+
+      expect(BroadcastAnnouncement.filter_announcements(1)).to eq([announcement_1, announcement_2, announcement_4])
+    end
   end
 end

--- a/spec/models/broadcast_announcement_spec.rb
+++ b/spec/models/broadcast_announcement_spec.rb
@@ -62,13 +62,14 @@ RSpec.describe BroadcastAnnouncement, type: :model do
       expect(BroadcastAnnouncement.filter_announcements(1).count).to eq(2)
     end
 
-    it "sorts announcements from most recently created to last" do 
+    it "sorts announcements from most recently created to last" do
       announcement_1 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, created_at: Time.zone.today)
       announcement_2 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, created_at: 2.days.ago)
-      announcement_3 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, expiry: 1.days.ago, created_at: 3.days.ago)
-      announcement_4 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1,  created_at: 4.days.ago)
+      announcement_3 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, expiry: 1.day.ago, created_at: 3.days.ago)
+      announcement_4 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, created_at: 4.days.ago)
 
       expect(BroadcastAnnouncement.filter_announcements(1)).to eq([announcement_1, announcement_2, announcement_4])
+      expect(BroadcastAnnouncement.filter_announcements(1).include?(announcement_3)).to be(false)
     end
   end
 end


### PR DESCRIPTION

<!--Read comments, before committing pull request read checklist again

# Checklist:

x I have performed a self-review of my own code,
x I have commented my code, particularly in hard-to-understand areas,
x I have made corresponding changes to the documentation,
x I have added tests that prove my fix is effective or that my feature works,
x New and existing unit tests pass locally with my changes ("bundle exec rake"),
x Title include "WIP" if work is in progress.

-->

Resolves #3582 

### Description
Changed how filter_announcements method was ordering the announcements by removing the .reverse and adding a .order(created_at: :desc). This will order announcements from most recently created to last. Added a test to the spec that confirms this is ordering announcements as intended. I looked for a long time and could not find any view tests, so I did not add any. If I am mistaken, please let me know and I will add the necessary testing for the view.
   
List any dependencies that are required for this change. (gems, js libraries, etc.)
None.

Include anything else we should know about. -->

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality

### How Has This Been Tested?

I have added a test to the filter_announcements context that confirms the order in which the announcements are coming through from the model method.

Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
Model Method:
![Screenshot 2023-05-18 at 6 58 33 PM](https://github.com/rubyforgood/human-essentials/assets/114014697/ef1799cc-c421-450d-9b59-5ea8d32d379c)
Model test addition:
![Screenshot 2023-05-18 at 6 59 17 PM](https://github.com/rubyforgood/human-essentials/assets/114014697/2e1350bd-6b80-4da6-93d5-acf5fc803cf4)