### PR TITLE
3611: Refactor of storage location inventory updates

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -75,11 +75,11 @@ class DonationsController < ApplicationController
 
   def update
     @donation = Donation.find(params[:id])
-    if @donation.replace_increase!(donation_params)
-      redirect_to donations_path
-    else
-      render "edit"
-    end
+    ItemizableUpdateService.call(itemizable: @donation, params: donation_params, type: :increase)
+    redirect_to donations_path
+  rescue => e
+    flash[:alert] = "Error updating donation: #{e.message}"
+    render "edit"
   end
 
   def destroy

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -64,12 +64,12 @@ class PurchasesController < ApplicationController
 
   def update
     @purchase = current_organization.purchases.find(params[:id])
-    if @purchase.replace_increase!(purchase_params)
-      redirect_to purchases_path
-    else
-      load_form_collections
-      render "edit"
-    end
+    ItemizableUpdateService.call(itemizable: @purchase, params: purchase_params, type: :increase)
+    redirect_to purchases_path
+  rescue => e
+    load_form_collections
+    flash[:alert] = "Error updating purchase: #{e.message}"
+    render "edit"
   end
 
   def destroy

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -103,26 +103,6 @@ class Donation < ApplicationRecord
                       .sum("line_items.quantity")
   end
 
-  def replace_increase!(new_donation_params)
-    old_data = to_a
-    item_ids = line_items_attributes(new_donation_params).map { |i| i[:item_id].to_i }
-    original_storage_location = storage_location
-
-    ActiveRecord::Base.transaction do
-      line_items.map(&:destroy!)
-      reload
-      Item.reactivate(item_ids)
-      line_items_attributes(new_donation_params).map { |i| i.delete(:id) }
-      update! new_donation_params
-      # Roll back distribution output by increasing storage location
-      storage_location.increase_inventory(to_a)
-      # Apply the new changes to the storage location inventory
-      original_storage_location.decrease_inventory(old_data)
-    end
-  rescue ActiveRecord::RecordInvalid
-    false
-  end
-
   def remove(item)
     # doing this will handle either an id or an object
     item_id = item.to_i

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -80,30 +80,6 @@ class Purchase < ApplicationRecord
     line_item&.destroy
   end
 
-  def replace_increase!(new_purchase_params)
-    old_data = to_a
-    item_ids = line_items_attributes(new_purchase_params).map { |i| i[:item_id].to_i }
-    original_storage_location = storage_location
-
-    ActiveRecord::Base.transaction do
-      line_items.map(&:destroy!)
-      reload
-      Item.reactivate(item_ids)
-      line_items_attributes(new_purchase_params).map { |i| i.delete(:id) }
-
-      update! new_purchase_params
-
-      # Roll back distribution output by increasing storage location
-      storage_location.increase_inventory(to_a)
-      # Apply the new changes to the storage location inventory
-      original_storage_location.decrease_inventory(old_data)
-      # TODO: Discuss this -- *should* we be removing InventoryItems when they hit 0 count?
-      original_storage_location.inventory_items.where(quantity: 0).destroy_all
-    end
-  rescue ActiveRecord::RecordInvalid
-    false
-  end
-
   private
 
   def combine_duplicates

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -129,6 +129,10 @@ class StorageLocation < ApplicationRecord
     adjustment.storage_location.increase_inventory(adjustment)
   end
 
+  def remove_empty_items
+    inventory_items.where(quantity: 0).delete_all
+  end
+
   # FIXME: After this is stable, revisit how we do logging
   def increase_inventory(itemizable_array)
     itemizable_array = itemizable_array.to_a

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -5,22 +5,19 @@ class DistributionUpdateService < DistributionService
     @old_line_items = old_distribution.to_a
   end
 
-  # FIXME: This doesn't allow for the storage location to be changed.
   def call
     perform_distribution_service do
       @old_issued_at = distribution.issued_at
       @old_delivery_method = distribution.delivery_method
-      distribution.storage_location.increase_inventory(distribution.to_a)
-      # Delete the line items -- they'll be replaced later
-      distribution.line_items.each(&:destroy!)
-      distribution.reload
-      # Replace the current distribution with the new parameters
-      distribution.update! @params
-      distribution.reload
+
+      ItemizableUpdateService.call(
+        itemizable: distribution,
+        params: @params,
+        type: :decrease
+      )
+
       @new_issued_at = distribution.issued_at
       @new_delivery_method = distribution.delivery_method
-      # Apply the new changes to the storage location inventory
-      distribution.storage_location.decrease_inventory(distribution.to_a)
     end
   end
 

--- a/app/services/itemizable_update_service.rb
+++ b/app/services/itemizable_update_service.rb
@@ -1,0 +1,49 @@
+module ItemizableUpdateService
+  # @param itemizable [Itemizable]
+  # @param type [Symbol] :increase or :decrease - if the original line items added quantities (purchases or
+  # donations), use :increase. If the original line_items reduced quantities (distributions) use :decrease.
+  # @param params [Hash] Parameters passed from the controller. Should include `line_item_attributes`.
+  def self.call(itemizable:, type: :increase, params: {})
+    StorageLocation.transaction do
+      item_ids = params[:line_items_attributes]&.values&.map { |i| i[:item_id].to_i } || []
+      Item.reactivate(item_ids)
+
+      from_location = to_location = itemizable.storage_location
+      to_location = StorageLocation.find(params[:storage_location_id]) if params[:storage_location_id]
+
+      increase_method = (type == :increase) ? :increase_inventory : :decrease_inventory
+      decrease_method = (type == :increase) ? :decrease_inventory : :increase_inventory
+
+      line_item_attrs = Array.wrap(params[:line_items_attributes]&.values)
+      line_item_attrs.each { |attr| attr.delete(:id) }
+
+      update_storage_location(itemizable: itemizable,
+        increase_method: increase_method,
+        decrease_method: decrease_method,
+        params: params,
+        from_location: from_location,
+        to_location: to_location)
+    end
+  end
+
+  # @param itemizable [Itemizable]
+  # @param increase_method [Symbol]
+  # @param decrease_method [Symbol]
+  # @param params [Hash] Parameters passed from the controller. Should include `line_item_attributes`.
+  # @param from_location [StorageLocation]
+  # @param to_location [StorageLocation]
+  def self.update_storage_location(itemizable:, increase_method:, decrease_method:,
+    params:, from_location:, to_location:)
+    from_location.public_send(decrease_method, itemizable.to_a)
+    # Delete the line items -- they'll be replaced later
+    itemizable.line_items.delete_all
+    # Update the current model with the new parameters
+    itemizable.update!(params)
+    itemizable.reload
+    # Apply the new changes to the storage location inventory
+    to_location.public_send(increase_method, itemizable.to_a)
+
+    from_location.remove_empty_items
+    to_location.remove_empty_items
+  end
+end

--- a/app/services/itemizable_update_service.rb
+++ b/app/services/itemizable_update_service.rb
@@ -18,11 +18,11 @@ module ItemizableUpdateService
       line_item_attrs.each { |attr| attr.delete(:id) }
 
       update_storage_location(itemizable:          itemizable,
-                              apply_change_method: apply_change_method,
-                              undo_change_method:  undo_change_method,
-                              params:              params,
-                              from_location:       from_location,
-                              to_location:         to_location)
+        apply_change_method: apply_change_method,
+        undo_change_method:  undo_change_method,
+        params:              params,
+        from_location:       from_location,
+        to_location:         to_location)
     end
   end
 
@@ -33,7 +33,7 @@ module ItemizableUpdateService
   # @param from_location [StorageLocation]
   # @param to_location [StorageLocation]
   def self.update_storage_location(itemizable:, apply_change_method:, undo_change_method:,
-                                   params:, from_location:, to_location:)
+    params:, from_location:, to_location:)
     from_location.public_send(undo_change_method, itemizable.to_a)
     # Delete the line items -- they'll be replaced later
     itemizable.line_items.delete_all

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe DonationsController, type: :controller do
           expect(new_storage_location.size).to eq 8
         end
 
-        it "rollsback updates if quantity would go below 0" do
+        it "rolls back updates if quantity would go below 0" do
           donation = create(:donation, :with_items, item_quantity: 10)
           original_storage_location = donation.storage_location
 
@@ -110,9 +110,8 @@ RSpec.describe DonationsController, type: :controller do
             }
           }
           donation_params = { source: donation.source, storage_location: new_storage_location, line_items_attributes: line_item_params }
-          expect do
-            put :update, params: default_params.merge(id: donation.id, donation: donation_params)
-          end.to raise_error(Errors::InsufficientAllotment)
+          put :update, params: default_params.merge(id: donation.id, donation: donation_params)
+          expect(response).not_to redirect_to(anything)
           expect(original_storage_location.size).to eq 5
           expect(new_storage_location.size).to eq 0
           expect(donation.reload.line_items.first.quantity).to eq 10

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
       end
 
       after(:create) do |storage_location, evaluator|
-        if evaluator.item.nil? && evaluator.item_count != 0
+        if evaluator.item.nil? && !evaluator.item_count.zero?
           item_count = evaluator.item_count
 
           create_list(:inventory_item, item_count,

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -23,22 +23,24 @@ FactoryBot.define do
     organization { Organization.try(:first) || create(:organization) }
     square_footage { 100 }
     warehouse_type { StorageLocation::WAREHOUSE_TYPES.sample }
+    transient do
+      item_count { 1 }
+    end
 
     trait :with_items do
       transient do
-        item_count { 1 }
         item_quantity { 100 }
         item { nil }
       end
 
       after(:create) do |storage_location, evaluator|
-        if evaluator.item.nil?
+        if evaluator.item.nil? && evaluator.item_count != 0
           item_count = evaluator.item_count
 
           create_list(:inventory_item, item_count,
                       storage_location: storage_location,
                       quantity: evaluator.item_quantity)
-        else
+        elsif evaluator.item
           item = evaluator.item
           item.save if item.new_record?
           create_list(:inventory_item, 1,

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -181,37 +181,6 @@ RSpec.describe Donation, type: :model do
       end
     end
 
-    describe "replace_increase!" do
-      let!(:storage_location) { create(:storage_location, organization: @organization) }
-      subject { create(:donation, :with_items, organization: @organization, item_quantity: 5, storage_location: storage_location) }
-
-      context "changing the donation" do
-        let(:attributes) { { line_items_attributes: { "0": { item_id: subject.line_items.first.item_id, quantity: 2 } } } }
-
-        it "updates the quantity of items" do
-          subject
-          expect do
-            subject.replace_increase!(attributes)
-            storage_location.reload
-          end.to change { storage_location.size }.by(-3)
-        end
-      end
-
-      context "when adding an item that has been previously deleted" do
-        let!(:inactive_item) { create(:item, active: false) }
-        let(:attributes) { { line_items_attributes: { "0": { item_id: inactive_item.to_param, quantity: 10 } } } }
-
-        it "re-creates the item" do
-          subject
-          expect do
-            subject.replace_increase!(attributes)
-            storage_location.reload
-          end.to change { storage_location.size }.by(5) # We had 5 items of a different kind before, now we have 10
-                                                 .and change { Item.active.count }.by(1)
-        end
-      end
-    end
-
     describe "source_view" do
       context "from a drive" do
         let!(:donation) { create(:product_drive_donation, product_drive_participant: product_drive_participant, product_drive: product_drive) }

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -163,42 +163,5 @@ RSpec.describe Purchase, type: :model do
         expect(purchase.storage_view).to eq("Smithsonian Conservation Center")
       end
     end
-
-    describe "replace_increase!" do
-      let!(:storage_location) { create(:storage_location, organization: @organization) }
-      subject { create(:purchase, :with_items, item_quantity: 5, storage_location: storage_location, organization: @organization) }
-
-      it "updates the quantity of items" do
-        attributes = { line_items_attributes: { "0": { item_id: subject.line_items.first.item_id, quantity: 2 } } }
-        subject
-        expect do
-          subject.replace_increase!(attributes)
-          storage_location.reload
-        end.to change { storage_location.size }.by(-3)
-      end
-
-      it "removes the inventory item if the item's removal results in a 0 count" do
-        attributes = { line_items_attributes: {} }
-        subject
-        expect do
-          subject.replace_increase!(attributes)
-          storage_location.reload
-        end.to change { storage_location.inventory_items.size }.by(-1)
-                                                               .and change { InventoryItem.count }.by(-1)
-      end
-
-      context "when adding an item that has been previously deleted" do
-        let!(:inactive_item) { create(:item, active: false, organization: @organization) }
-        let(:attributes) { { line_items_attributes: { "0": { item_id: inactive_item.id, quantity: 10 } } } }
-        it "re-creates the item" do
-          subject
-          expect do
-            subject.replace_increase!(attributes)
-            storage_location.reload
-          end.to change { storage_location.size }.by(5)
-                                                 .and change { Item.active.count }.by(1)
-        end
-      end
-    end
   end
 end

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -176,9 +176,8 @@ RSpec.describe "Purchases", type: :request do
             }
           }
           purchase_params = { storage_location: new_storage_location, line_items_attributes: line_item_params }
-          expect do
-            put purchase_path(default_params.merge(id: purchase.id, purchase: purchase_params))
-          end.to raise_error(Errors::InsufficientAllotment)
+          put purchase_path(default_params.merge(id: purchase.id, purchase: purchase_params))
+          expect(response).not_to redirect_to(anything)
           expect(original_storage_location.size).to eq 5
           expect(new_storage_location.size).to eq 0
           expect(purchase.reload.line_items.first.quantity).to eq 10

--- a/spec/services/distribution_update_service_spec.rb
+++ b/spec/services/distribution_update_service_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe DistributionUpdateService, type: :service do
   describe "call" do
-    # TODO: this function was extracted to the service object - do we need a parallel test?
-
     let!(:distribution) { FactoryBot.create(:distribution, :with_items, item_quantity: 10) }
     let!(:new_attributes) { { line_items_attributes: { "0": { item_id: distribution.line_items.first.item_id, quantity: 2 } } } }
 

--- a/spec/services/itemizable_update_service_spec.rb
+++ b/spec/services/itemizable_update_service_spec.rb
@@ -1,0 +1,117 @@
+RSpec.describe ItemizableUpdateService do
+  let(:storage_location) { create(:storage_location, organization: @organization, item_count: 0) }
+  let(:new_storage_location) { create(:storage_location, organization: @organization, item_count: 0) }
+  let(:item1) { create(:item, organization: @organization) }
+  let(:item2) { create(:item, organization: @organization) }
+  let!(:ii1) { create(:inventory_item, storage_location: storage_location, item: item1, quantity: 10) }
+  let!(:ii2) { create(:inventory_item, storage_location: new_storage_location, item: item2, quantity: 10) }
+  let!(:ii3) { create(:inventory_item, storage_location: storage_location, item: item2, quantity: 10) }
+  let!(:ii4) { create(:inventory_item, storage_location: new_storage_location, item: item1, quantity: 10) }
+
+  around(:each) do |ex|
+    freeze_time do
+      ex.run
+    end
+  end
+
+  describe "increases" do
+    let(:itemizable) do
+      line_items = [
+        create(:line_item, item_id: item1.id, quantity: 5),
+        create(:line_item, item_id: item2.id, quantity: 5)
+      ]
+      create(:donation,
+        organization: @organization,
+        storage_location: storage_location,
+        line_items: line_items,
+        issued_at: 1.day.ago)
+    end
+
+    let(:attributes) do
+      {
+        issued_at: 2.days.ago,
+        line_items_attributes: {"0": {item_id: item1.id, quantity: 2}, "1": {item_id: item2.id, quantity: 2}}
+      }
+    end
+
+    subject do
+      described_class.call(itemizable: itemizable, params: attributes, type: :increase)
+    end
+
+    it "should update quantity in same storage location" do
+      expect(storage_location.size).to eq(20)
+      expect(new_storage_location.size).to eq(20)
+      subject
+      expect(itemizable.reload.line_items.count).to eq(2)
+      expect(itemizable.line_items.sum(&:quantity)).to eq(4)
+      expect(storage_location.size).to eq(14)
+      expect(new_storage_location.size).to eq(20)
+      expect(itemizable.issued_at).to eq(2.days.ago)
+    end
+
+    it "should update quantity in different locations" do
+      attributes[:storage_location_id] = new_storage_location.id
+      subject
+      expect(itemizable.reload.line_items.count).to eq(2)
+      expect(itemizable.line_items.sum(&:quantity)).to eq(4)
+      expect(storage_location.size).to eq(10)
+      expect(new_storage_location.size).to eq(24)
+    end
+  end
+
+  describe "decreases" do
+    let(:itemizable) do
+      line_items = [
+        create(:line_item, item_id: item1.id, quantity: 5),
+        create(:line_item, item_id: item2.id, quantity: 5)
+      ]
+      create(:distribution,
+        organization: @organization,
+        storage_location: storage_location,
+        line_items: line_items,
+        issued_at: 1.day.ago)
+    end
+
+    let(:attributes) do
+      {
+        issued_at: 2.days.ago,
+        line_items_attributes: {"0": {item_id: item1.id, quantity: 2}, "1": {item_id: item2.id, quantity: 2}}
+      }
+    end
+
+    subject do
+      described_class.call(itemizable: itemizable, params: attributes, type: :decrease)
+    end
+
+    it "should update quantity in same storage location" do
+      expect(storage_location.size).to eq(20)
+      expect(new_storage_location.size).to eq(20)
+      subject
+      expect(itemizable.reload.line_items.count).to eq(2)
+      expect(itemizable.line_items.sum(&:quantity)).to eq(4)
+      expect(storage_location.size).to eq(26)
+      expect(new_storage_location.size).to eq(20)
+      expect(itemizable.issued_at).to eq(2.days.ago)
+    end
+
+    it "should update quantity in different locations" do
+      attributes[:storage_location_id] = new_storage_location.id
+      subject
+      expect(itemizable.reload.line_items.count).to eq(2)
+      expect(itemizable.line_items.sum(&:quantity)).to eq(4)
+      expect(storage_location.size).to eq(30)
+      expect(new_storage_location.size).to eq(16)
+    end
+
+    it "should delete empty inventory items" do
+      attributes[:storage_location_id] = new_storage_location.id
+      attributes[:line_items_attributes] =
+        {"0": {item_id: item1.id, quantity: 10}, "1": {item_id: item2.id, quantity: 10}}
+
+      subject
+
+      expect(new_storage_location.size).to eq(0)
+      expect(new_storage_location.inventory_items.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #3611 

### Description

This refactors the updating of storage location inventory to move it to a single place that works for distributions, purchases and donations. The centralized place uses the fix discovered in #3601 to address the race condition we found with distributions.

(Note - there are also adjustments, audits and transfers that affect inventory, but these do not make any changes to the line items themselves - in these cases the line items represent the transfer between locations rather than an update to an event that represents an increase or decrease in inventory.)

### Type of change

Internal change

### How Has This Been Tested?

Local and unit tests.