### PR TITLE
 In Item selection on distribution -- make the item selection box wide enough to show both the description and the number of items

### DIFF
--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -7,7 +7,7 @@
       </div>
       <label class='my-1 mx-auto font-weight-normal'>OR</label>
       <div class='d-flex flex-row'>
-        <span class="li-name">
+        <span class="li-name w-100">
           <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false, input_html: { class: "my-0", "data-controller": "select2" } %>
         </span>
         <div class="li-quantity mx-2">


### PR DESCRIPTION

Resolves #3627 

### Description
made item selection box wide enough to show both the decryption and number of items

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### Screenshots

#Before:

![Screenshot from 2023-05-29 15-32-59](https://github.com/rubyforgood/human-essentials/assets/82927963/0be212fa-d72b-4072-8d98-cd9f17f0d7de)


#After:

![Screenshot from 2023-05-29 15-34-25](https://github.com/rubyforgood/human-essentials/assets/82927963/a8454efa-5c41-43b2-b0c1-75417aa1ba1d)


