### PR TITLE
Fix: Allow Knapsack Pro Fallback Mode for retried nodes for forked repositories

### DIFF
--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -4,6 +4,7 @@ if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
   KNAPSACK_PRO_ENDPOINT=https://api-disabled-for-fork.knapsackpro.com \
     KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
     KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
+    KNAPSACK_PRO_CI_NODE_RETRY_COUNT=0 \
     bundle exec rake knapsack_pro:rspec 
 else
   bundle exec rake knapsack_pro:rspec


### PR DESCRIPTION
**This fixes the bug with tests not running for forked repositories.**

Allow Knapsack Pro Fallback Mode for retried Github Actions jobs for forked repositories.

Github Actions does not share secrets with forked repositories so you can't connect to Knapsack Pro API due to missing API token.
For a fork repositories we use a fake API endpoint and a fake API token to trigger the Fallback Mode in Knapsack Pro to run tests.
https://docs.knapsackpro.com/ruby/troubleshooting/#knapsack-pro-does-not-work-on-a-forked-repository

When you rerun workflow on Github Actions then knapsack_pro 4.1.0 does not allow running tests in Fallback Mode to prevent running a wrong set of tests for a retried node (this could happen when some nodes connected to API and others do not). 

But in our case for forked repositories, we run fallback mode always for all parallel jobs so it's safe to run tests in Fallback Mode.

Let's override the Github Actions attempts count (retry jobs count) so that Knapsack Pro assumes you run tests for the first time and it allows running in Fallback Mode.


# related

Changes introduced in the knapsack_pro gem 4.1.0 version.

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/197
