### PR TITLE
[FIX] Correcting migration of diaper_pick_up_person

### DIFF
--- a/db/migrate/20230605140424_change_diaper_pick_up_person_to_pick_up_person.rb
+++ b/db/migrate/20230605140424_change_diaper_pick_up_person_to_pick_up_person.rb
@@ -1,0 +1,21 @@
+class ChangeDiaperPickUpPersonToPickUpPerson < ActiveRecord::Migration[7.0]
+  def up
+    Organization.find_each do |organization|
+      if organization.partner_form_fields.include? 'diaper_pick_up_person'
+        index = organization.partner_form_fields.index('diaper_pick_up_person')
+        organization.partner_form_fields[index] = 'pick_up_person'
+        organization.save
+      end
+    end
+  end
+
+  def down
+    Organization.find_each do |organization|
+      if organization.partner_form_fields.include? 'pick_up_person'
+        index = organization.partner_form_fields.index('pick_up_person')
+        organization.partner_form_fields[index] = 'diaper_pick_up_person'
+        organization.save
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_23_192243) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_05_140424) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
# Summary
Fixes issue with migration of diaper_pick_up_person to pick_up_person

# Why fix
Partners/banks can't edit the profiles if they have specified diaper_pick_up_person

# Workaround
Banks should be able to go into My Organization and re-pick their profile parts

### Description
Corrected migration -- was working with diaper_pickup_person .   Now going against diaper_pick_up_person.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Downloaded latest prod copy, ran migration.  Went in as a partner that has experienced this problem.  Was able to bring up the "Edit My Organization" for them.
