### PR TITLE
Show 'Total Items' instead of 'Total Diapers' on Product Participant, Vendors, and Manufacturers Index page to be inclusive of banks that don't do diapers

### DIFF
--- a/app/views/manufacturers/index.html.erb
+++ b/app/views/manufacturers/index.html.erb
@@ -53,7 +53,7 @@
               <thead>
               <tr>
                 <th>Name</th>
-                <th>Total Diapers</th>
+                <th>Total Items</th>
                 <th class="text-center">Actions</th>
               </tr>
               </thead>

--- a/app/views/product_drive_participants/index.html.erb
+++ b/app/views/product_drive_participants/index.html.erb
@@ -59,7 +59,7 @@
                 <th>Contact Name</th>
                 <th>Phone</th>
                 <th>Email</th>
-                <th>Total Diapers</th>
+                <th>Total Items</th>
                 <th class="text-center">Actions</th>
               </tr>
               </thead>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -56,7 +56,7 @@
                 <th>Contact Name</th>
                 <th>Phone</th>
                 <th>Email</th>
-                <th>Total Diapers</th>
+                <th>Total Items</th>
                 <th class="text-center">Actions</th>
               </tr>
               </thead>


### PR DESCRIPTION
Resolves #3639 

### Description
Show 'Total Items' instead of 'Total Diapers' on Product Participant, Vendors, and Manufacturers Index page to be inclusive of banks that don't do diapers


### How Has This Been Tested?
Checked index pages for "Product Drive Participants", "Vendors" and "Manufacturers" locally

### Screenshots

<img width="1181" alt="Screen Shot 2023-06-05 at 10 14 57 PM" src="https://github.com/rubyforgood/human-essentials/assets/3893822/463a2b81-a03f-4f56-a7ad-4eb38b1330b4">

<img width="1183" alt="Screen Shot 2023-06-05 at 10 14 20 PM" src="https://github.com/rubyforgood/human-essentials/assets/3893822/0c3c6f1d-28d7-47f5-9fd3-0f2d9d8826ba">

<img width="1179" alt="Screen Shot 2023-06-05 at 10 14 11 PM" src="https://github.com/rubyforgood/human-essentials/assets/3893822/56a65cba-1242-4086-9cd8-26c6fa0cf841">

