### PR TITLE
3583 fix partner crash

### DIFF
--- a/app/controllers/partners/base_controller.rb
+++ b/app/controllers/partners/base_controller.rb
@@ -27,5 +27,12 @@ module Partners
 
       redirect_to partners_requests_path, notice: "Please review your application details and submit for approval in order to make a new request."
     end
+
+    def not_found!
+      respond_to do |format|
+        format.html { render template: "errors/404", layout: "layouts/partners/application", status: :not_found }
+        format.json { render body: nil, status: :not_found }
+      end
+    end
   end
 end

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe "/partners/requests", type: :request do
       get partners_request_path(other_request)
       expect(response.code).to eq("404")
     end
-
   end
 
   describe "POST #create" do

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -47,11 +47,33 @@ RSpec.describe "/partners/requests", type: :request do
     end
   end
 
-  describe "GET #shows" do
-    # TODO: write this spec
-    # Ensure to cover that:
-    # - Authorization, other partners should not be able to see this
-    # - Ensure it shows 404 if the partner request id doesn't exist
+  describe "GET #show" do
+    let(:partner_user) { partner.primary_user }
+    let(:partner) { create(:partner) }
+    let!(:request) { create(:request, partner: partner) }
+
+    before do
+      sign_in(partner_user)
+    end
+
+    it 'should render without any issues' do
+      get partners_request_path(request)
+      expect(response.body).to include(request.id.to_s)
+    end
+
+    it 'should give a 404 error if not found' do
+      id = Request.last.id + 1
+      get partners_request_path(id)
+      expect(response.code).to eq("404")
+    end
+
+    it 'should give a 404 error if forbidden' do
+      other_partner = FactoryBot.create(:partner)
+      other_request = FactoryBot.create(:request, partner: other_partner)
+      get partners_request_path(other_request)
+      expect(response.code).to eq("404")
+    end
+
   end
 
   describe "POST #create" do


### PR DESCRIPTION
Resolves #3583 

### Description

When partners were getting 404 errors, they were getting into crashes because the system would try to display a page to them using the organization layout instead of the partner layout.