### PR TITLE
3655 Change the default test organization's name to avoid false positives

### DIFF
--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe DistributionMailer, type: :mailer do
       expect(mail.to).to eq([@distribution.request.user_email])
       expect(mail.cc).to eq([@distribution.partner.email])
       expect(mail.from).to eq(["no-reply@humanessentials.app"])
-      expect(mail.subject).to eq("test subject from DEFAULT")
+      expect(mail.subject).to eq("test subject from STARTER")
     end
 
     it "renders the body with distributions text" do
       expect(mail.body.encoded).to match("Distribution comment")
-      expect(mail.subject).to eq("test subject from DEFAULT")
+      expect(mail.subject).to eq("test subject from STARTER")
     end
 
     context "with deliver_method: :pick_up" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,7 +108,7 @@ RSpec.configure do |config|
   # Disable this rubocop rule here so we are permitted to set constants within
   # the RSpec.configure block.
   # rubocop:disable Lint/ConstantDefinitionInBlock
-  DEFAULT_TEST_ORGANIZATION_NAME = "DEFAULT"
+  DEFAULT_TEST_ORGANIZATION_NAME = "STARTER"
   DEFAULT_TEST_USER_NAME = "DEFAULT USER"
   DEFAULT_TEST_ORG_ADMIN_USER_NAME = "DEFAULT ORG ADMIN"
   DEFAULT_TEST_SUPER_ADMIN_USER_NAME = "DEFAULT SUPERADMIN"


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3655  <!--fill issue number-->

### Description
As requested in the issue, changed the default test organization's name from `DEFAULT` to something not containing the word `default`.

- [x] Change the default names so that the default org name does not appear in the default user and partner names
- [x] Confirm the test suite passes after this change

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Updated related specs.

