### PR TITLE
Fix tests jun13

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,10 +31,12 @@ class ApplicationController < ActionController::Base
   helper_method :current_partner
 
   def current_role
-    role = Role.find_by(id: session[:current_role]) || UsersRole.current_role_for(current_user)
-    session[:current_role] = role&.id
+    return @role if @role
 
-    role
+    @role = Role.find_by(id: session[:current_role]) || UsersRole.current_role_for(current_user)
+    session[:current_role] = @role&.id
+
+    @role
   end
 
   def organization_url_options(options = {})

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,7 @@ class UsersController < ApplicationController
       return
     end
 
+    @role = role
     session[:current_role] = params[:role_id]
     redirect_to dashboard_path_from_current_role
   end

--- a/spec/factories/partners/profile.rb
+++ b/spec/factories/partners/profile.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :partner_profile, class: Partners::Profile do
     partner { Partner.first || create(:partner) }
     essentials_bank_id { Organization.try(:first).id || create(:organization).id }
+    website { 'http://some-site.org' }
   end
 end

--- a/spec/factories/partners/profile.rb
+++ b/spec/factories/partners/profile.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :partner_profile, class: Partners::Profile do
     partner { Partner.first || create(:partner) }
     essentials_bank_id { Organization.try(:first).id || create(:organization).id }
-    website { 'http://some-site.org' }
+    website { "http://some-site.org" }
   end
 end

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Admin::Organizations", type: :request do
           expect {
             post admin_organizations_path({ organization: valid_organization_params })
           }.to change(Organization, :count).by(1)
-          expect(response).to redirect_to(admin_organizations_path(organization_id: Organization.first.short_name))
+          expect(response).to redirect_to(admin_organizations_path(organization_id: 'admin'))
         end
       end
 


### PR DESCRIPTION
Issues were:
* New validation failing partners if no social media was selected - default factory now includes a website
* New test missing behavior that was changed a while back (different organization_id for admin pages)
* Regression from the partner merge - before it was relying on `current_user`, which was memoized per request. The new code which relies on roles wasn't being memoized, meaning the changes that happen to the model were being blown away whenever `current_partner` was called again.