### PR TITLE
finalizing audits should not zero out uncounted items

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -25,11 +25,13 @@ class AuditsController < ApplicationController
     @audit.save
 
     inventory_items = @audit.storage_location.inventory_items
+
     inventory_items.each do |inventory_item|
       line_item = @audit.line_items.find_by(item: inventory_item.item)
-      if line_item.nil?
-        @audit.adjustment.line_items.create(item_id: inventory_item.item.id, quantity: -inventory_item.quantity)
-      elsif line_item.quantity != inventory_item.quantity
+
+      next if line_item.nil?
+
+      if line_item.quantity != inventory_item.quantity
         @audit.adjustment.line_items.create(item_id: inventory_item.item.id, quantity: line_item.quantity - inventory_item.quantity)
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -209,6 +209,10 @@ RSpec.configure do |config|
     define_global_variables
   end
 
+  config.before do
+    Faker::UniqueGenerator.clear # Clears used values to avoid retry limit exceeded error
+  end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -236,6 +236,26 @@ RSpec.describe "Audit management", type: :system, js: true do
           expect(page).not_to have_content("Delete Audit")
           # Actual Deletion(`delete :destroy`) Check is done in audits_controller_spec
         end
+
+        context "with a storage location containing multiple items" do
+          let(:item2) { create(:item) }
+
+          before do
+            create(:inventory_item, storage_location_id: storage_location.id, item_id: item2.id, quantity: 50)
+          end
+
+          it "creates an adjustment with the differential of only the audited item" do
+            item_quantity = 10
+
+            visit subject
+            expect do
+              accept_confirm do
+                click_link "Finalize Audit"
+              end
+              expect(page).to have_content("Audit is Finalized.")
+            end.to change { storage_location.size }.by(quantity - item_quantity)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3654 

### Description
- Adjusted the controller so that it doesn't change the storage quantity of an item if it has not been edited, and added a corresponding system test

- Tests were failing because too many unique faker values were requested in the item category factory (see https://github.com/faker-ruby/faker for more details). Added a clear of all used generator values in the rails helper, this problem should not occur again. 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Added system tests, also reproduced manually
