### PR TITLE
superusers should not be able to change a users password

### DIFF
--- a/app/views/admin/users/_user_form_fields.html.erb
+++ b/app/views/admin/users/_user_form_fields.html.erb
@@ -6,15 +6,4 @@
   <span class="input-group-text"><%= fa_icon "envelope" %></span>
   <%= f.input_field :email, class: "form-control" %>
 <% end %>
-<!-- Only display password fields when not nested within organization form -->
-<% if @organization.nil? %>
-  <%= f.input :password, label: "Password", wrapper: :input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
-    <span class="input-group-text"><%= fa_icon "lock" %></span>
-    <%= f.input_field :password, class: "form-control" %>
-  <% end %>
-  <%= f.input :password_confirmation, label: "Confirm Password", wrapper: :input_group, required: true do %>
-    <span class="input-group-text"><%= fa_icon "check" %></span>
-    <%= f.input_field :password_confirmation, class: "form-control" %>
-  <% end %>
-<% end %>
 

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -45,17 +45,7 @@
                         <%= f.input_field :organization_id, collection: @organizations, class: "form-control" %>
                       <% end %>
                       <%= render 'admin/users/user_form_fields', f: f %>
-                      <!-- Only display password fields when not nested within organization form -->
-                      <% if @organization.nil? %>
-                        <%= f.input :password, label: "Password", wrapper: :input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
-                          <span class="input-group-text"><%= fa_icon "lock" %></span>
-                          <%= f.input_field :password, class: "form-control" %>
-                        <% end %>
-                        <%= f.input :password_confirmation, label: "Confirm Password", wrapper: :input_group, required: true do %>
-                          <span class="input-group-text"><%= fa_icon "check" %></span>
-                          <%= f.input_field :password_confirmation, class: "form-control" %>
-                        <% end %>
-                      <% end %>
+
                     </div>
                     <div class="card-footer">
                       <%= submit_button %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -45,7 +45,17 @@
                         <%= f.input_field :organization_id, collection: @organizations, class: "form-control" %>
                       <% end %>
                       <%= render 'admin/users/user_form_fields', f: f %>
-
+                      <!-- Only display password fields when not nested within organization form -->
+                      <% if @organization.nil? %>
+                        <%= f.input :password, label: "Password", wrapper: :input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
+                          <span class="input-group-text"><%= fa_icon "lock" %></span>
+                          <%= f.input_field :password, class: "form-control" %>
+                        <% end %>
+                        <%= f.input :password_confirmation, label: "Confirm Password", wrapper: :input_group, required: true do %>
+                          <span class="input-group-text"><%= fa_icon "check" %></span>
+                          <%= f.input_field :password_confirmation, class: "form-control" %>
+                        <% end %>
+                      <% end %>
                     </div>
                     <div class="card-footer">
                       <%= submit_button %>

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       visit admin_users_path(organization_id: @organization.id)
       click_link "Invite a new user"
       find('#user_organization_id option:last-of-type').select_option
+
       fill_in "user_name", with: "TestUser"
       fill_in "user_email", with: "testuser@example.com"
       fill_in "user_password", with: "password!"
@@ -22,11 +23,16 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       click_link "Edit", match: :first
       expect(page).to have_content("Update #{@organization_admin.name}")
       fill_in "user_name", with: "TestUser"
-      fill_in "user_password", with: "123password!"
-      fill_in "user_password_confirmation", with: "123password!"
       click_on "Save"
 
       expect(page.find(".alert")).to have_content "TestUser updated"
+    end
+
+    it "cannot edit a user's password" do
+      visit admin_users_path
+      click_link "Edit", match: :first
+      expect(page).not_to have_field("user_password")
+      expect(page).not_to have_field("user_password_confirmation")
     end
 
     it "deletes an existing user" do

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -8,11 +8,8 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       visit admin_users_path(organization_id: @organization.id)
       click_link "Invite a new user"
       find('#user_organization_id option:last-of-type').select_option
-
       fill_in "user_name", with: "TestUser"
       fill_in "user_email", with: "testuser@example.com"
-      fill_in "user_password", with: "password!"
-      fill_in "user_password_confirmation", with: "password!"
       click_on "Save"
 
       expect(page.find(".alert")).to have_content "Created a new user!"
@@ -26,13 +23,6 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       click_on "Save"
 
       expect(page.find(".alert")).to have_content "TestUser updated"
-    end
-
-    it "cannot edit a user's password" do
-      visit admin_users_path
-      click_link "Edit", match: :first
-      expect(page).not_to have_field("user_password")
-      expect(page).not_to have_field("user_password_confirmation")
     end
 
     it "deletes an existing user" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3690  <!--fill issue number-->

### Description
Removed the password fields for the edit action, kept them for the new action.
Adjusted the tests to reflect this.

Note: changing a users password is still possible on the server side, I only adjusted the client.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Adjusted the tests, also checked manually

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
![image](https://github.com/rubyforgood/human-essentials/assets/9966978/c5760a64-96c2-42e9-abb9-fd08b3c68a91)

