### PR TITLE
Show Date Entered on Purchase View

### DIFF
--- a/app/views/purchases/show.html.erb
+++ b/app/views/purchases/show.html.erb
@@ -15,7 +15,7 @@
             <% end %>
           </li>
           <li class="breadcrumb-item"><%= link_to "Purchases", (purchases_path) %></li>
-          <li class="breadcrumb-item"><a href="#"><%= @purchase.purchased_from_view %> on <%= @purchase.created_at.to_fs(:distribution_date) %></a></li>
+          <li class="breadcrumb-item"><a href="#"><%= @purchase.purchased_from_view %> on <%= @purchase.issued_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>
     </div>
@@ -39,7 +39,7 @@
               </thead>
               <tbody>
               <tr>
-              <td><%= @purchase.created_at.to_fs(:distribution_date) %></td>
+              <td><%= @purchase.issued_at.to_fs(:distribution_date) %> (entered: <%= @purchase.created_at.to_fs(:distribution_date) %>)</td>
               <td><%= @purchase.purchased_from_view %></td>
               <td><%= @purchase.storage_view %></td>
               </tr>

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -137,7 +137,14 @@ RSpec.describe "Purchases", type: :system, js: true do
             click_button "Save"
           end.to change { Purchase.count }.by(1)
 
-          expect(Purchase.last.issued_at).to eq(Time.zone.parse("2001-01-01"))
+          visit url_prefix + "/purchases/#{Purchase.last.id}"
+
+          expected_date = "January 1 2001 (entered: #{Purchase.last.created_at.to_fs(:distribution_date)})"
+          expected_breadcrumb_date = "#{Vendor.first.business_name} on January 1 2001"
+          aggregate_failures do
+            expect(page).to have_text(expected_date)
+            expect(page).to have_text(expected_breadcrumb_date)
+          end
         end
 
         it "Does not include inactive items in the line item fields" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3697

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Modified template to use `issued_at` rather than `created_at` for the *Purchase Date* column of a purchase view page.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
1. Create a new Purchase with a Purchase Date of 2 weeks prior (e.g. June 14 2023 as shown in the screenshot)
1. Navigate to the Purchase's view page
1. The Purchase Date of the column should list the same purchase date as entered previously. In parentheses, the date of entry should be shown.
1. Observe that the breadcrumb reflects the Purchase Date rather than the date of entry.

Tests have also been included.

### Screenshots
<img width="1331" alt="Screenshot 2023-06-29 at 9 13 52 AM" src="https://github.com/rubyforgood/human-essentials/assets/9038811/1685c0f0-fc09-4357-8948-734e1d7c9532">
