### PR TITLE
Adjustment inventory drift

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -714,4 +714,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.13
+   2.4.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -714,4 +714,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.15
+   2.4.17

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -39,15 +39,9 @@ class AdjustmentsController < ApplicationController
 
   # POST /adjustments
   def create
-    @adjustment = current_organization.adjustments.new(adjustment_params)
-    @adjustment.user_id = current_user.id
-
-    if @adjustment.valid? && @adjustment.save
-      increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
-      ActiveRecord::Base.transaction do
-        @adjustment.storage_location.increase_inventory increasing_adjustment
-        @adjustment.storage_location.decrease_inventory decreasing_adjustment
-      end
+    result = AdjustmentCreateService.new(adjustment_params.merge(organization: current_organization, user: current_user)).call
+    @adjustment = result.adjustment
+    if @adjustment.errors.none?
       flash[:notice] = "Adjustment was successful."
       redirect_to adjustment_path(@adjustment)
     else
@@ -55,10 +49,6 @@ class AdjustmentsController < ApplicationController
       load_form_collections
       render :new
     end
-  rescue Errors::InsufficientAllotment => e   # TODO:  Can we get rid of this, if we are checking for sufficient allotment in the adjustment validation?
-    flash[:error] = e.message
-    load_form_collections
-    render :new
   end
 
   private

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -55,7 +55,7 @@ class AdjustmentsController < ApplicationController
       load_form_collections
       render :new
     end
-  rescue Errors::InsufficientAllotment => e
+  rescue Errors::InsufficientAllotment => e   # TODO:  Can we get rid of this, if we are checking for sufficient allotment in the adjustment validation?
     flash[:error] = e.message
     load_form_collections
     render :new

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -31,6 +31,12 @@ class Adjustment < ApplicationRecord
   validate :negative_line_items_exist_in_inventory
   validate :storage_locations_belong_to_organization
 
+  before_save :combine_adjustment
+
+  def combine_adjustment
+    line_items.combine!
+  end
+
   def self.storage_locations_adjusted_for(organization)
     includes(:storage_location).joins(:storage_location).where(organization_id: organization.id, storage_location: {discarded_at: nil}).collect(&:storage_location).sort
   end

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -28,14 +28,7 @@ class Adjustment < ApplicationRecord
   scope :during, ->(range) { where(adjustments: { created_at: range }) }
 
   validates :storage_location, :organization, presence: true
-  validate :enough_inventory_for_decreases
   validate :storage_locations_belong_to_organization
-
-  before_validation :combine_adjustment
-
-  def combine_adjustment
-    line_items.combine!
-  end
 
   def self.storage_locations_adjusted_for(organization)
     includes(:storage_location).joins(:storage_location).where(organization_id: organization.id, storage_location: {discarded_at: nil}).collect(&:storage_location).sort
@@ -70,37 +63,6 @@ class Adjustment < ApplicationRecord
 
     unless organization.storage_locations.include?(storage_location)
       errors.add :storage_location, "storage location must belong to organization"
-    end
-  end
-
-  # def negative_line_items_exist_in_inventory
-  #  return if storage_location.nil?
-
-  # line_items.each do |line_item|
-  #   next unless line_item.quantity.negative?
-
-  #   inventory_item = storage_location.inventory_items.find_by(item: line_item.item)
-  #   next unless inventory_item.nil?
-
-  #   errors.add(:inventory,
-  #              "#{line_item.item.name} is not available to be removed from this storage location")
-  #  end
-  # end
-
-  def enough_inventory_for_decreases
-    return if storage_location.nil?
-
-    line_items.each do |line_item|
-      next unless line_item.quantity.negative?
-
-      inventory_item = storage_location.inventory_items.find_by(item: line_item.item)
-      if inventory_item.nil?
-        errors.add(:inventory,
-                   "#{line_item.item.name} is not available to be removed from this storage location")
-      elsif inventory_item.quantity < line_item.quantity * -1
-        errors.add(:inventory,
-                   "The requested reduction of  #{line_item.quantity * -1} #{line_item.item.name}  items exceed the available inventory")
-      end
     end
   end
 end

--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -22,7 +22,6 @@ class AdjustmentCreateService
         @adjustment.storage_location.increase_inventory increasing_adjustment
         @adjustment.storage_location.decrease_inventory decreasing_adjustment
       rescue InsufficientAllotment => e
-        @adjustment.errors.add(:base, e.message)
         raise InsufficientAllotment
       end
     end

--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -21,7 +21,7 @@ class AdjustmentCreateService
         @adjustment.save
         @adjustment.storage_location.increase_inventory increasing_adjustment
         @adjustment.storage_location.decrease_inventory decreasing_adjustment
-      rescue InsufficientAllotment => e
+      rescue InsufficientAllotment
         raise InsufficientAllotment
       end
     end

--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -21,8 +21,9 @@ class AdjustmentCreateService
         @adjustment.save
         @adjustment.storage_location.increase_inventory increasing_adjustment
         @adjustment.storage_location.decrease_inventory decreasing_adjustment
-      rescue InsufficientAllotment
-        raise InsufficientAllotment
+      rescue InsufficientAllotment => e
+        @adjustment.errors.add(:base, e.message)
+        raise e
       end
     end
     self

--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class AdjustmentCreateService
+  include ServiceObjectErrorsMixin
+  attr_reader :adjustment
+
+  def initialize(adjustment_params)
+    @adjustment = Adjustment.new(adjustment_params)
+  end
+
+  def call
+    # Combine line items for adjustment
+    combine_adjustment
+    # Check for validity, and save the actual adjustment
+
+    if @adjustment.valid? && enough_inventory_for_decreases? && @adjustment.save
+      # Split into positive and negative portions
+      increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
+      ActiveRecord::Base.transaction do
+        # Make the necessary changes in the db
+        @adjustment.save
+        @adjustment.storage_location.increase_inventory increasing_adjustment
+        @adjustment.storage_location.decrease_inventory decreasing_adjustment
+      rescue InsufficientAllotment => e
+        @adjustment.errors.add(:base, e.message)
+        raise InsufficientAllotment
+      end
+    end
+    self
+  end
+
+  def combine_adjustment
+    @adjustment.line_items.combine!
+  end
+end
+
+def enough_inventory_for_decreases?
+  return false if @adjustment.storage_location.nil?
+  @adjustment.line_items.each do |line_item|
+    next unless line_item.quantity.negative?
+
+    inventory_item = @adjustment.storage_location.inventory_items.find_by(item: line_item.item)
+    if inventory_item.nil?
+      @adjustment.errors.add(:inventory, "#{line_item.item.name} is not available to be removed from this storage location")
+    elsif inventory_item.quantity < line_item.quantity * -1
+      @adjustment.errors.add(:inventory, "The requested reduction of  #{line_item.quantity * -1} #{line_item.item.name}  items exceed the available inventory")
+    end
+  end
+  return true if @adjustment.errors.none?
+  false
+end

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,4 +1,4 @@
-<section class="nested-fields">
+<section class="nested-fields line_item_section">
   <div class="row mt-2 d-flex flex-row align-items-center justify-content-between">
     <div class='d-flex flex-column justify-content-center'>
       <div class='d-flex flex-row align-items-center'>
@@ -8,7 +8,7 @@
       <label class='my-1 mx-auto font-weight-normal'>OR</label>
       <div class='d-flex flex-row'>
         <span class="li-name w-100">
-          <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false, input_html: { class: "my-0", "data-controller": "select2" } %>
+          <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false, input_html: { class: "my-0 line_item_name", "data-controller": "select2" } %>
         </span>
         <div class="li-quantity mx-2">
           <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity my-0"} %>

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -25,20 +25,12 @@ RSpec.describe Adjustment, type: :model do
       expect(build(:adjustment, :with_items, item_quantity: 10, item: create(:item), storage_location: create(:storage_location))).to be_valid
     end
 
-    it "disallows you from removing inventory that doesn't exist in the storage location" do
-      expect(build(:adjustment, :with_items, item_quantity: -10, item: create(:item), storage_location: create(:storage_location))).not_to be_valid
-    end
+
     it "allows you to remove all the inventory that exists in the storage location" do
       storage_location1 = create(:storage_location, organization: @organization)
       item1 = create(:item)
       storage_location1.inventory_items << create(:inventory_item, item: item1, quantity: 10)
       expect(build(:adjustment, :with_items, item_quantity: -10, item: item1, storage_location: storage_location1)).to be_valid
-    end
-    it "disallows you from removing more inventory than exists in the storage location" do
-      storage_location1 = create(:storage_location, organization: @organization)
-      item1 = create(:item)
-      storage_location1.inventory_items << create(:inventory_item, item: item1, quantity: 10)
-      expect(build(:adjustment, :with_items, item_quantity: -11, item: item1, storage_location: storage_location1)).not_to be_valid
     end
   end
 

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Adjustment, type: :model do
     it "disallows you from removing inventory that doesn't exist in the storage location" do
       expect(build(:adjustment, :with_items, item_quantity: -10, item: create(:item), storage_location: create(:storage_location))).not_to be_valid
     end
+    it "allows you to remove all the inventory that exists in the storage location" do
+      storage_location1 = create(:storage_location, organization: @organization)
+      item1 = create(:item)
+      storage_location1.inventory_items << create(:inventory_item, item: item1, quantity: 10)
+      expect(build(:adjustment, :with_items, item_quantity: -10, item: item1, storage_location: storage_location1)).to be_valid
+    end
+    it "disallows you from removing more inventory than exists in the storage location" do
+      storage_location1 = create(:storage_location, organization: @organization)
+      item1 = create(:item)
+      storage_location1.inventory_items << create(:inventory_item, item: item1, quantity: 10)
+      expect(build(:adjustment, :with_items, item_quantity: -11, item: item1, storage_location: storage_location1)).not_to be_valid
+    end
   end
 
   context "Scopes >" do

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Adjustment, type: :model do
       expect(build(:adjustment, :with_items, item_quantity: 10, item: create(:item), storage_location: create(:storage_location))).to be_valid
     end
 
-
     it "allows you to remove all the inventory that exists in the storage location" do
       storage_location1 = create(:storage_location, organization: @organization)
       item1 = create(:item)

--- a/spec/services/adjustment_create_service_spec.rb
+++ b/spec/services/adjustment_create_service_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe AdjustmentCreateService, type: :service do
+  include ActiveJob::TestHelper
+
+  subject { AdjustmentCreateService }
+  describe "call" do
+    let!(:storage_location) { create(:storage_location, :with_items, item_count: 2) }
+    let!(:item_1) { storage_location.items.first }
+    let!(:item_2) { storage_location.items.second }
+    let!(:inventory_item_1) { InventoryItem.where(storage_location_id: storage_location.id, item_id: storage_location.items.first.id).first }
+    let!(:inventory_item_2) { InventoryItem.where(storage_location_id: storage_location.id, item_id: storage_location.items.second.id).first }
+
+    it "increases stored inventory on a positive adjustment" do
+      expect do
+        adjustment_params = {user_id: @user.id, organization_id: @organization.id, storage_location_id: storage_location.id, line_items_attributes: {"0": {item_id: storage_location.items.first.id, quantity: 5}}}
+        subject.new(adjustment_params).call
+      end.to change { inventory_item_1.reload.quantity }.by(5)
+    end
+
+    it "decreases stored inventory on a negative adjustment" do
+      expect do
+        adjustment_params = {user_id: @user.id, organization_id: @organization.id, storage_location_id: storage_location.id, line_items_attributes: {"0": {item_id: storage_location.items.first.id, quantity: -5}}}
+        subject.new(adjustment_params).call
+      end.to change { inventory_item_1.reload.quantity }.by(-5)
+    end
+
+    it "increases handles mixed adjustments to same item appropriately (total is positive version)" do
+      expect do
+        adjustment_params = {user_id: @user.id,
+                             organization_id: @organization.id,
+                             storage_location_id: storage_location.id,
+                             line_items_attributes: {
+                               "0": {item_id: storage_location.items.first.id, quantity: 4},
+                               "1": {item_id: storage_location.items.first.id, quantity: -5},
+                               "2": {item_id: storage_location.items.first.id, quantity: 2}
+                             }}
+        subject.new(adjustment_params).call
+      end.to change { inventory_item_1.reload.quantity }.by(1)
+    end
+
+    it "increases handles mixed adjustments to same appropriately (total is negative version)" do
+      expect do
+        adjustment_params = {user_id: @user.id,
+                             organization_id: @organization.id,
+                             storage_location_id: storage_location.id,
+                             line_items_attributes: {
+                               "0": {item_id: item_1.id, quantity: -4},
+                               "1": {item_id: item_1.id, quantity: -5},
+                               "2": {item_id: item_1.id, quantity: 2}
+                             }}
+        subject.new(adjustment_params).call
+      end.to change { inventory_item_1.reload.quantity }.by(-7)
+    end
+    it "does not allow inventory to be adjusted below 0" do
+      quantity = -1 * (inventory_item_1.quantity + 1)
+      expect do
+        adjustment_params = {user_id: @user.id,
+                             organization_id: @organization.id,
+                             storage_location_id: storage_location.id,
+                             line_items_attributes: {
+                               "0": {item_id: item_1.id, quantity: quantity}
+                             }}
+        subject.new(adjustment_params).call
+      end.to change { inventory_item_1.reload.quantity }.by(0)
+    end
+
+    it "handles adjustments to multiple items" do
+      quantity_1 = inventory_item_1.quantity
+      quantity_2 = inventory_item_2.quantity
+
+      adjustment_params = {user_id: @user.id,
+                           organization_id: @organization.id,
+                           storage_location_id: storage_location.id,
+                           line_items_attributes: {
+                             "0": {item_id: item_1.id, quantity: 5},
+                             "1": {item_id: item_2.id, quantity: 3},
+                             "2": {item_id: item_1.id, quantity: 2}
+                           }}
+      subject.new(adjustment_params).call
+      expect(inventory_item_1.reload.quantity).to eq(quantity_1 + 7)
+      expect(inventory_item_2.reload.quantity).to eq(quantity_2 + 3)
+    end
+  end
+end

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -118,12 +118,6 @@ RSpec.describe "Adjustment management", type: :system, js: true do
       end
     end
 
-
-
-
-
-
-
     it "should not display inactive storage locations in dropdown" do
       create(:storage_location, name: "Inactive R Us", discarded_at: Time.zone.now)
       visit url_prefix + "/adjustments/new"

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe "Adjustment management", type: :system, js: true do
           click_button "Save"
         end.not_to change { storage_location.size }
         expect(page).to have_content("items exceed the available inventory")
+        expect(page).to have_field("adjustment_line_items_attributes_0_quantity", with: "-18")
       end
     end
 

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -91,7 +91,38 @@ RSpec.describe "Adjustment management", type: :system, js: true do
         end.not_to change { storage_location.size }
         expect(page).to have_content("items exceed the available inventory")
       end
+
+      it "politely informs the user if they try to adjust down below zero, even if they use multiple adjustments to do so" do
+        sub_quantity = -9
+
+        storage_location = create(:storage_location, :with_items, name: "PICK THIS ONE", item_quantity: 10, organization: @organization)
+        visit url_prefix + "/adjustments"
+        click_on "New Adjustment"
+        select storage_location.name, from: "From storage location"
+        fill_in "Comment", with: "something"
+        select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
+        fill_in "adjustment_line_items_attributes_0_quantity", with: sub_quantity.to_s
+        click_on "Add another item"
+        within all(".line_item_section").last do
+          element_1 = find(".line_item_name")
+          expect(page).to have_select(element_1[:id])
+          select Item.last.name, from: element_1[:id]
+          element_2 = find(".quantity")
+          element_2.set sub_quantity.to_s
+        end
+
+        expect do
+          click_button "Save"
+        end.not_to change { storage_location.size }
+        expect(page).to have_content("items exceed the available inventory")
+      end
     end
+
+
+
+
+
+
 
     it "should not display inactive storage locations in dropdown" do
       create(:storage_location, name: "Inactive R Us", discarded_at: Time.zone.now)


### PR DESCRIPTION
Resolves #3712 

### Description

The problem....
If you enter two negative values in an inventory adjustment, each of which are independently allowable, but  with a total that would cause the inventory to go below zero,  it does not throw an error.   It obviously should.

Also...  if you enter negative values in an inventory adjustment,   and it has an error, it comes back with the values flipped.

Aaand,  if you enter negative values in an inventory,  and it has an error,  you correct the error and submit,  you get a routing error.   (I think this is because there is no update)

Steps I took toward  solution:
- combine the line items before attempting to save inventory adjustments.
- move the combination before validation
- add validation that inventory decreases are not more than the available inventory 

Checking whether the adjustment is valid before we do the split_difference -- which basically does an absolute value on the line items on the adjustment,  means that when we present the user with the error,  the negative adjustments are still negative.

I think we can probably do a bit more cleanup in adjustments_controller -- the Errors::InsufficientAllotment shouldn't ever get thrown.  

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- manual testing plus
- adding automatic tests as I go along
