### PR TITLE
3554 Allow superadmins to manage roles

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -59,13 +59,13 @@ class Admin::UsersController < AdminController
 
   def resource_ids
     klass = case params[:resource_type]
-            when 'org_admin', 'org_user'
-              Organization
-            when 'partner'
-              Partner
-            else
-              raise "Unknown resource type #{params[:resource_type]}"
-            end
+    when "org_admin", "org_user"
+      Organization
+    when "partner"
+      Partner
+    else
+      raise "Unknown resource type #{params[:resource_type]}"
+    end
 
     objects = klass.where("name LIKE ?", "%#{params[:q]}%").select(:id, :name)
     object_json = objects.map do |obj|
@@ -80,23 +80,20 @@ class Admin::UsersController < AdminController
   def add_role
     begin
       AddRoleService.call(user_id: params[:user_id],
-                          resource_type: params[:resource_type],
-                          resource_id: params[:resource_id]
-      )
+        resource_type: params[:resource_type],
+        resource_id: params[:resource_id])
     rescue => e
       redirect_back(fallback_location: admin_users_path, alert: e.message)
       return
     end
-    redirect_back(fallback_location: admin_users_path, notice: 'Role added!')
+    redirect_back(fallback_location: admin_users_path, notice: "Role added!")
   end
 
   def remove_role
-    begin
-      RemoveRoleService.call(user_id: params[:user_id], role_id: params[:role_id])
-      redirect_back(fallback_location: admin_users_path, notice: 'Role removed!')
-    rescue => e
-      redirect_back(fallback_location: admin_users_path, alert: e.message)
-    end
+    RemoveRoleService.call(user_id: params[:user_id], role_id: params[:role_id])
+    redirect_back(fallback_location: admin_users_path, notice: "Role removed!")
+  rescue => e
+    redirect_back(fallback_location: admin_users_path, alert: e.message)
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -56,6 +56,20 @@ class Admin::UsersController < AdminController
     end
   end
 
+  def remove_role
+    user_role = UsersRole.find_by(user_id: params[:user_id], role_id: params[:role_id])
+    if user_role
+      user_role.destroy
+      if user_role.role.name.to_sym == :org_user # they can't be an admin if they're not a user
+        admin_role = Role.find_by(resource_id: user_role.role.resource_id, name: :org_admin)
+        UsersRole.find_by(user_id: params[:user_id], role_id: admin_role.id)&.destroy
+      end
+      redirect_back(fallback_location: admin_users_path, notice: 'Role removed!')
+    else
+      redirect_back(fallback_location: admin_users_path, alert: 'Could not find role!')
+    end
+  end
+
   private
 
   def user_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   def current_organization
     return @current_organization if @current_organization
 
-    return current_role.resource if current_role.resource.is_a?(Organization)
+    return current_role.resource if current_role&.resource&.is_a?(Organization)
 
     Organization.find_by(short_name: params[:organization_id])
   end
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
   def default_url_options(options = {})
     # Early return if the request is not authenticated and no
     # current_user is defined
-    return options if current_user.blank?
+    return options if current_user.blank? || current_role.blank?
 
     if current_organization.present? && !options.key?(:organization_id)
       options[:organization_id] = current_organization.to_param
@@ -63,6 +63,8 @@ class ApplicationController < ActionController::Base
   end
 
   def dashboard_path_from_current_role
+    return root_path if current_role.blank?
+    
     if current_role.name == Role::SUPER_ADMIN.to_s
       admin_dashboard_path
     elsif current_role.name == Role::PARTNER.to_s

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,7 +64,7 @@ class ApplicationController < ActionController::Base
 
   def dashboard_path_from_current_role
     return root_path if current_role.blank?
-    
+
     if current_role.name == Role::SUPER_ADMIN.to_s
       admin_dashboard_path
     elsif current_role.name == Role::PARTNER.to_s

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -41,21 +41,16 @@ class OrganizationsController < ApplicationController
 
   def promote_to_org_admin
     user = User.find(params[:user_id])
-    raise ActiveRecord::RecordNotFound unless user.has_role?(Role::ORG_USER, current_organization)
-    user.add_role(Role::ORG_ADMIN, current_organization)
+    AddRoleService.call(user_id: user.id,
+                        resource_type: :org_admin,
+                        resource_id: current_organization.id)
     redirect_to user_update_redirect_path, notice: "User has been promoted!"
   end
 
   def demote_to_user
-    user = User.find(params[:user_id])
-    raise ActiveRecord::RecordNotFound unless user.has_role?(Role::ORG_USER, current_organization)
-    if user.has_role?(Role::SUPER_ADMIN)
-      notice = "Unable to convert super to user."
-    else
-      user.remove_role(Role::ORG_ADMIN, current_organization)
-      notice = "Admin has been changed to User!"
-    end
-
+    RemoveRoleService.call(user_id: params[:user_id],
+                           resource_type: Role::ORG_ADMIN,
+                           resource_id: current_organization.id)
     redirect_to user_update_redirect_path, notice: notice
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -42,15 +42,15 @@ class OrganizationsController < ApplicationController
   def promote_to_org_admin
     user = User.find(params[:user_id])
     AddRoleService.call(user_id: user.id,
-                        resource_type: :org_admin,
-                        resource_id: current_organization.id)
+      resource_type: :org_admin,
+      resource_id: current_organization.id)
     redirect_to user_update_redirect_path, notice: "User has been promoted!"
   end
 
   def demote_to_user
     RemoveRoleService.call(user_id: params[:user_id],
-                           resource_type: Role::ORG_ADMIN,
-                           resource_id: current_organization.id)
+      resource_type: Role::ORG_ADMIN,
+      resource_id: current_organization.id)
     redirect_to user_update_redirect_path, notice: notice
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -41,17 +41,28 @@ class OrganizationsController < ApplicationController
 
   def promote_to_org_admin
     user = User.find(params[:user_id])
-    AddRoleService.call(user_id: user.id,
-      resource_type: :org_admin,
-      resource_id: current_organization.id)
-    redirect_to user_update_redirect_path, notice: "User has been promoted!"
+    raise ActiveRecord::RecordNotFound unless user.has_role?(Role::ORG_USER, current_organization)
+    begin
+      AddRoleService.call(user_id: user.id,
+        resource_type: Role::ORG_ADMIN,
+        resource_id: current_organization.id)
+      redirect_to user_update_redirect_path, notice: "User has been promoted!"
+    rescue => e
+      redirect_back(fallback_location: organization_path(current_organization), alert: e.message)
+    end
   end
 
   def demote_to_user
-    RemoveRoleService.call(user_id: params[:user_id],
-      resource_type: Role::ORG_ADMIN,
-      resource_id: current_organization.id)
-    redirect_to user_update_redirect_path, notice: notice
+    user = User.find(params[:user_id])
+    raise ActiveRecord::RecordNotFound unless user.has_role?(Role::ORG_ADMIN, current_organization)
+    begin
+      RemoveRoleService.call(user_id: params[:user_id],
+        resource_type: Role::ORG_ADMIN,
+        resource_id: current_organization.id)
+      redirect_to user_update_redirect_path, notice: notice
+    rescue => e
+      redirect_back(fallback_location: organization_path(current_organization), alert: e.message)
+    end
   end
 
   def deactivate_user

--- a/app/javascript/controllers/double_select_controller.js
+++ b/app/javascript/controllers/double_select_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+import $ from 'jquery';
+import "select2"
+
+export default class extends Controller {
+  static targets = ['source', 'destination']
+  static values = {
+    url: String
+  }
+
+  sourceChanged() {
+    const val = $(this.sourceTarget).val()
+    const url = new URL(this.urlValue)
+    url.searchParams.append('resource_type', val);
+    $(this.destinationTarget).select2({
+      ajax: {
+        url: url.toString(),
+        dataType: 'json'
+      }
+    });
+
+  }
+
+  connect() {
+    /**
+     * This is a workaround to auto focus on the select2 input when it is opened.
+     */
+    $(this.destinationTarget).on('select2:open', function (e) {
+      $(".select2-search__field")[0].focus();
+    })
+    this.sourceChanged();
+  }
+
+}

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -31,26 +31,25 @@ class Role < ApplicationRecord
   PARTNER = :partner
 
   TITLES = {
-      :org_user => 'Organization',
-      :org_admin => 'Organization Admin',
-      :partner => 'Partner',
-      :super_admin => 'Super admin'
-    }.freeze
+    org_user: "Organization",
+    org_admin: "Organization Admin",
+    partner: "Partner",
+    super_admin: "Super admin"
+  }.freeze
 
   TITLE_TO_RESOURCE = {
-    :org_user => ::Organization,
-    :org_admin => ::Organization,
-    :partner => ::Partner,
+    org_user: ::Organization,
+    org_admin: ::Organization,
+    partner: ::Partner
   }.freeze
 
   # @return [String]
   def title
-    TITLES[self.name.to_sym]
+    TITLES[name.to_sym]
   end
 
   # @return [Hash<Symbol, String>]
   def self.resources_for_select
     TITLES.without(:super_admin).invert
   end
-
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -37,9 +37,20 @@ class Role < ApplicationRecord
       :super_admin => 'Super admin'
     }.freeze
 
+  TITLE_TO_RESOURCE = {
+    :org_user => ::Organization,
+    :org_admin => ::Organization,
+    :partner => ::Partner,
+  }.freeze
+
   # @return [String]
   def title
     TITLES[self.name.to_sym]
+  end
+
+  # @return [Hash<Symbol, String>]
+  def self.resources_for_select
+    TITLES.without(:super_admin).invert
   end
 
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -29,4 +29,17 @@ class Role < ApplicationRecord
   ORG_ADMIN = :org_admin
   SUPER_ADMIN = :super_admin
   PARTNER = :partner
+
+  TITLES = {
+      :org_user => 'Organization',
+      :org_admin => 'Organization Admin',
+      :partner => 'Partner',
+      :super_admin => 'Super admin'
+    }.freeze
+
+  # @return [String]
+  def title
+    TITLES[self.name.to_sym]
+  end
+
 end

--- a/app/services/add_role_service.rb
+++ b/app/services/add_role_service.rb
@@ -26,5 +26,4 @@ class AddRoleService
     end
     user.add_role(Role::SUPER_ADMIN)
   end
-
 end

--- a/app/services/add_role_service.rb
+++ b/app/services/add_role_service.rb
@@ -1,0 +1,30 @@
+class AddRoleService
+  # @param user_id [Integer]
+  # @param resource_id [Integer]
+  # @param resource_type [String]
+  def self.call(user_id:, resource_type:, resource_id: nil)
+    user = User.find(user_id)
+    if resource_type.to_sym == Role::SUPER_ADMIN
+      add_super_admin(user)
+      return
+    end
+    klass = Role::TITLE_TO_RESOURCE[resource_type.to_sym]
+    resource = klass.find(resource_id)
+    if user.has_role?(resource_type, resource)
+      raise "User #{user.name} already has role for #{resource.name}"
+    end
+    user.add_role(resource_type, resource)
+    if resource_type.to_sym == Role::ORG_ADMIN
+      user.add_role(:org_user, resource)
+    end
+  end
+
+  # @param user [User]
+  def self.add_super_admin(user)
+    if user.has_role?(Role::SUPER_ADMIN)
+      raise "User #{user.name} already has super admin role!"
+    end
+    user.add_role(Role::SUPER_ADMIN)
+  end
+
+end

--- a/app/services/remove_role_service.rb
+++ b/app/services/remove_role_service.rb
@@ -1,0 +1,26 @@
+class RemoveRoleService
+  # @param user_id [Integer]
+  # @param role_id [Integer]
+  # @param resource_type [String]
+  # @param resource_id [Integer]
+  def self.call(user_id:, role_id: nil, resource_type: nil, resource_id: nil)
+    if role_id.nil? && resource_id.nil?
+      raise 'Must provide either a role ID or resource ID!'
+    end
+    if role_id.nil?
+      role_id = Role.find_by(name: resource_type, resource_id: resource_id).id
+    end
+    user_role = UsersRole.find_by(user_id: user_id, role_id: role_id)
+    unless user_role
+      raise "User ID #{user_id} does not have role #{role_id}!"
+    end
+
+    user_role.destroy
+    if user_role.role.name.to_sym == Role::ORG_USER # they can't be an admin if they're not a user
+      admin_role = Role.find_by(resource_id: user_role.role.resource_id, name: Role::ORG_ADMIN)
+      if admin_role
+        UsersRole.find_by(user_id: user_id, role_id: admin_role.id)&.destroy
+      end
+    end
+  end
+end

--- a/app/services/remove_role_service.rb
+++ b/app/services/remove_role_service.rb
@@ -5,7 +5,7 @@ class RemoveRoleService
   # @param resource_id [Integer]
   def self.call(user_id:, role_id: nil, resource_type: nil, resource_id: nil)
     if role_id.nil? && resource_id.nil?
-      raise 'Must provide either a role ID or resource ID!'
+      raise "Must provide either a role ID or resource ID!"
     end
     if role_id.nil?
       role_id = Role.find_by(name: resource_type, resource_id: resource_id).id

--- a/app/services/remove_role_service.rb
+++ b/app/services/remove_role_service.rb
@@ -12,7 +12,9 @@ class RemoveRoleService
     end
     user_role = UsersRole.find_by(user_id: user_id, role_id: role_id)
     unless user_role
-      raise "User ID #{user_id} does not have role #{role_id}!"
+      user = User.find(user_id)
+      role = Role.find(role_id)
+      raise "User #{user.name} does not have role for #{role.resource.name}!"
     end
 
     user_role.destroy

--- a/app/views/admin/users/_roles.html.erb
+++ b/app/views/admin/users/_roles.html.erb
@@ -1,0 +1,41 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <!-- left column -->
+      <div class="col-md-12">
+        <!-- jquery validation -->
+        <div class="card card-primary card-outline">
+          <div class="card-header">
+            <h5 class="card-title"><%= user.name %> - Roles
+            </h5>
+          </div>
+          <!-- /.card-header -->
+          <!-- form start -->
+          <div class="card-body p-0">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Role Type</th>
+                  <th>Resource</th>
+                  <th class="text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% user.roles.each do |role| %>
+                  <tr>
+                    <td><%= role.title %></td>
+                    <td><%= link_to role.resource.name, role.resource %></td>
+                    <td class="text-right">
+                      <%= delete_button_to admin_user_remove_role_path(user, role_id: role.id),
+                                           confirm: "Are you sure you want to remove this role?" %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/admin/users/_roles.html.erb
+++ b/app/views/admin/users/_roles.html.erb
@@ -11,7 +11,7 @@
           </div>
           <!-- /.card-header -->
           <!-- form start -->
-          <div class="card-body p-0">
+          <div class="card-body">
             <table class="table">
               <thead>
                 <tr>
@@ -33,9 +33,36 @@
                 <% end %>
               </tbody>
             </table>
+            <div data-controller="double-select" data-double-select-url-value="<%= resource_ids_admin_users_url %>">
+            <h3>Add Role</h3>
+            <%= form_tag admin_user_add_role_path(user) do %>
+              <div class="form-inputs">
+                <div class="form-group">
+                  <label>Type</label>
+                  <div class="input-group">
+                    <%= select_tag :resource_type, options_for_select(@resources),
+                                     class: 'select form-control',
+                                     data: { 'double-select-target': 'source',
+                                             'action': 'double-select#sourceChanged'
+                                     }
+                    %>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label>Resource</label>
+                  <div class="input-group">
+                    <%= select_tag :resource_id, [], class: 'form-control', data: {
+                      'double-select-target': 'destination'
+                    } %>
+                  </div>
+                </div>
+              </div>
+              <%= submit_tag 'Add Role', class: 'btn btn-md btn-primary' %>
+            <% end %>
           </div>
         </div>
       </div>
+    </div>
     </div>
   </div>
 </section>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -55,3 +55,8 @@
     <!-- /.row -->
   </div><!-- /.container-fluid -->
 </section>
+
+<% unless @user == current_user %>
+  <%= render partial: 'roles', object: @user, as: :user %>
+<% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,10 @@ Rails.application.routes.draw do
     resources :base_items
     resources :organizations
     resources :partners, except: %i[new create]
-    resources :users
+    resources :users do
+      delete :remove_role
+      post :add_role
+    end
     resources :barcode_items
     resources :account_requests, only: [:index] do
       post :reject, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
     resources :users do
       delete :remove_role
       post :add_role
+      get :resource_ids, on: :collection
     end
     resources :barcode_items
     resources :account_requests, only: [:index] do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -51,7 +51,9 @@ FactoryBot.define do
     factory :organization_admin do
       name { "Very Organized Admin" }
       after(:create) do |user, evaluator|
-        user.add_role(Role::ORG_ADMIN, evaluator.organization)
+        AddRoleService.call(user_id: user.id,
+          resource_id: evaluator.organization.id,
+          resource_type: Role::ORG_ADMIN)
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,15 +45,19 @@ FactoryBot.define do
     end
 
     after(:create) do |user, evaluator|
-      user.add_role(Role::ORG_USER, evaluator.organization)
+      if evaluator.organization
+        user.add_role(Role::ORG_USER, evaluator.organization)
+      end
     end
 
     factory :organization_admin do
       name { "Very Organized Admin" }
       after(:create) do |user, evaluator|
-        AddRoleService.call(user_id: user.id,
-          resource_id: evaluator.organization.id,
-          resource_type: Role::ORG_ADMIN)
+        if evaluator.organization
+          AddRoleService.call(user_id: user.id,
+            resource_id: evaluator.organization.id,
+            resource_type: Role::ORG_ADMIN)
+        end
       end
     end
 

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -4,11 +4,85 @@ RSpec.describe "Admin::UsersController", type: :request do
   let(:default_params) do
     { organization_id: @organization.id }
   end
+  let(:org) { FactoryBot.create(:organization, name: 'Org ABC') }
+  let(:partner) { FactoryBot.create(:partner, name: 'Partner XYZ') }
+  let(:user) { FactoryBot.create(:user, organization: org, name: 'User 123') }
 
   context "When logged in as a super admin" do
     before do
       sign_in(@super_admin)
       create(:organization)
+      AddRoleService.call(user_id: user.id, resource_type: Role::PARTNER, resource_id: partner.id)
+    end
+
+    describe "GET #edit" do
+      it "renders edit template and shows roles" do
+        get edit_admin_user_path(user)
+        expect(response).to render_template(:edit)
+        expect(response.body).to include('User 123')
+        expect(response.body).to include('Org ABC')
+        expect(response.body).to include('Partner XYZ')
+      end
+    end
+
+    describe '#add_role' do
+      context 'with no errors' do
+        it 'should call the service and redirect back' do
+          allow(AddRoleService).to receive(:call)
+          post admin_user_add_role_path(user_id: user.id,
+                                        resource_type: Role::ORG_ADMIN,
+                                        resource_id: org.id),
+               headers: { 'HTTP_REFERER' => '/back/url'}
+          expect(AddRoleService).to have_received(:call).with(user_id: user.id.to_s,
+                                        resource_type: Role::ORG_ADMIN.to_s,
+                                        resource_id: org.id.to_s)
+          expect(flash[:notice]).to eq('Role added!')
+          expect(response).to redirect_to('/back/url')
+        end
+      end
+
+      context 'with errors' do
+        it 'should redirect back with error' do
+          allow(AddRoleService).to receive(:call).and_raise('OH NOES')
+          post admin_user_add_role_path(user_id: user.id,
+                                        resource_type: Role::ORG_ADMIN,
+                                        resource_id: org.id),
+               headers: { 'HTTP_REFERER' => '/back/url'}
+          expect(AddRoleService).to have_received(:call).with(user_id: user.id.to_s,
+                                        resource_type: Role::ORG_ADMIN.to_s,
+                                        resource_id: org.id.to_s)
+          expect(flash[:alert]).to eq('OH NOES')
+          expect(response).to redirect_to('/back/url')
+        end
+      end
+    end
+
+    describe '#remove_role' do
+      context 'with no errors' do
+        it 'should call the service and redirect back' do
+          allow(RemoveRoleService).to receive(:call)
+          delete admin_user_remove_role_path(user_id: user.id,
+                                           role_id: 123),
+               headers: { 'HTTP_REFERER' => '/back/url'}
+          expect(RemoveRoleService).to have_received(:call).with(user_id: user.id.to_s,
+                                                              role_id: '123')
+          expect(flash[:notice]).to eq('Role removed!')
+          expect(response).to redirect_to('/back/url')
+        end
+      end
+
+      context 'with errors' do
+        it 'should redirect back with error' do
+          allow(RemoveRoleService).to receive(:call).and_raise('OH NOES')
+          delete admin_user_remove_role_path(user_id: user.id,
+                                        role_id: 123),
+               headers: { 'HTTP_REFERER' => '/back/url'}
+          expect(RemoveRoleService).to have_received(:call).with(user_id: user.id.to_s,
+                                                              role_id: '123')
+          expect(flash[:alert]).to eq('OH NOES')
+          expect(response).to redirect_to('/back/url')
+        end
+      end
     end
 
     describe "GET #new" do

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe "Admin::UsersController", type: :request do
         it 'should call the service and redirect back' do
           allow(AddRoleService).to receive(:call)
           post admin_user_add_role_path(user_id: user.id,
-                                        resource_type: Role::ORG_ADMIN,
-                                        resource_id: org.id),
-               headers: { 'HTTP_REFERER' => '/back/url'}
+            resource_type: Role::ORG_ADMIN,
+            resource_id: org.id),
+            headers: { 'HTTP_REFERER' => '/back/url'}
           expect(AddRoleService).to have_received(:call).with(user_id: user.id.to_s,
-                                        resource_type: Role::ORG_ADMIN.to_s,
-                                        resource_id: org.id.to_s)
+            resource_type: Role::ORG_ADMIN.to_s,
+            resource_id: org.id.to_s)
           expect(flash[:notice]).to eq('Role added!')
           expect(response).to redirect_to('/back/url')
         end
@@ -45,12 +45,12 @@ RSpec.describe "Admin::UsersController", type: :request do
         it 'should redirect back with error' do
           allow(AddRoleService).to receive(:call).and_raise('OH NOES')
           post admin_user_add_role_path(user_id: user.id,
-                                        resource_type: Role::ORG_ADMIN,
-                                        resource_id: org.id),
-               headers: { 'HTTP_REFERER' => '/back/url'}
+            resource_type: Role::ORG_ADMIN,
+            resource_id: org.id),
+            headers: { 'HTTP_REFERER' => '/back/url'}
           expect(AddRoleService).to have_received(:call).with(user_id: user.id.to_s,
-                                        resource_type: Role::ORG_ADMIN.to_s,
-                                        resource_id: org.id.to_s)
+            resource_type: Role::ORG_ADMIN.to_s,
+            resource_id: org.id.to_s)
           expect(flash[:alert]).to eq('OH NOES')
           expect(response).to redirect_to('/back/url')
         end
@@ -62,10 +62,10 @@ RSpec.describe "Admin::UsersController", type: :request do
         it 'should call the service and redirect back' do
           allow(RemoveRoleService).to receive(:call)
           delete admin_user_remove_role_path(user_id: user.id,
-                                           role_id: 123),
-               headers: { 'HTTP_REFERER' => '/back/url'}
+            role_id: 123),
+            headers: { 'HTTP_REFERER' => '/back/url'}
           expect(RemoveRoleService).to have_received(:call).with(user_id: user.id.to_s,
-                                                              role_id: '123')
+            role_id: '123')
           expect(flash[:notice]).to eq('Role removed!')
           expect(response).to redirect_to('/back/url')
         end
@@ -75,10 +75,10 @@ RSpec.describe "Admin::UsersController", type: :request do
         it 'should redirect back with error' do
           allow(RemoveRoleService).to receive(:call).and_raise('OH NOES')
           delete admin_user_remove_role_path(user_id: user.id,
-                                        role_id: 123),
-               headers: { 'HTTP_REFERER' => '/back/url'}
+            role_id: 123),
+            headers: { 'HTTP_REFERER' => '/back/url'}
           expect(RemoveRoleService).to have_received(:call).with(user_id: user.id.to_s,
-                                                              role_id: '123')
+            role_id: '123')
           expect(flash[:alert]).to eq('OH NOES')
           expect(response).to redirect_to('/back/url')
         end

--- a/spec/services/add_role_service_spec.rb
+++ b/spec/services/add_role_service_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe AddRoleService, type: :service do
+
+  let(:user) { FactoryBot.create(:user, name: 'User XYZ') }
+  let(:org) { FactoryBot.create(:organization, name: 'Org ABC') }
+  let(:partner) { FactoryBot.create(:partner, name: 'Partner 123')}
+
+  describe '#call' do
+    context 'when the role does not yet exist' do
+      it 'should add the role' do
+        described_class.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+        expect(user.reload.has_role?(:org_user, org)).to eq(true)
+        expect(user.has_role?(:org_admin)).to eq(false)
+        expect(user.has_role?(:partner)).to eq(false)
+        expect(user.has_role?(:super_admin)).to eq(false)
+      end
+
+      it 'should add the user role when asked to add admin' do
+        described_class.call(user_id: user.id, resource_type: 'org_admin', resource_id: org.id)
+        expect(user.reload.has_role?(:org_user, org)).to eq(true)
+        expect(user.reload.has_role?(:org_admin, org)).to eq(true)
+        expect(user.has_role?(:partner)).to eq(false)
+        expect(user.has_role?(:super_admin)).to eq(false)
+      end
+
+      it 'works with a partner' do
+        described_class.call(user_id: user.id, resource_type: 'partner', resource_id: partner.id)
+        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+        expect(user.has_role?(:org_admin)).to eq(false)
+        expect(user.has_role?(:partner, partner)).to eq(true)
+        expect(user.has_role?(:super_admin)).to eq(false)
+      end
+
+      it 'works with super admin' do
+        described_class.call(user_id: user.id, resource_type: 'super_admin')
+        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+        expect(user.has_role?(:org_admin)).to eq(false)
+        expect(user.has_role?(:partner)).to eq(false)
+        expect(user.has_role?(:super_admin)).to eq(true)
+      end
+
+    end
+
+    context 'when the role already exists' do
+      it 'should raise an error' do
+        user.add_role(:org_user, org)
+        expect {
+          described_class.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+        }.to raise_error("User User XYZ already has role for Org ABC")
+        expect(user.reload.has_role?(:org_user, org)).to eq(true)
+        expect(user.reload.has_role?(:org_admin)).to eq(false)
+        expect(user.reload.has_role?(:partner)).to eq(false)
+        expect(user.reload.has_role?(:super_admin)).to eq(false)
+      end
+
+      it 'should raise an error for super admin' do
+        user.add_role(:super_admin)
+        expect {
+          described_class.call(user_id: user.id, resource_type: 'super_admin')
+        }.to raise_error("User User XYZ already has super admin role!")
+        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+        expect(user.reload.has_role?(:org_admin)).to eq(false)
+        expect(user.reload.has_role?(:partner)).to eq(false)
+        expect(user.reload.has_role?(:super_admin)).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/add_role_service_spec.rb
+++ b/spec/services/add_role_service_spec.rb
@@ -1,50 +1,48 @@
 RSpec.describe AddRoleService, type: :service do
+  let(:user) { FactoryBot.create(:user, name: "User XYZ") }
+  let(:org) { FactoryBot.create(:organization, name: "Org ABC") }
+  let(:partner) { FactoryBot.create(:partner, name: "Partner 123") }
 
-  let(:user) { FactoryBot.create(:user, name: 'User XYZ') }
-  let(:org) { FactoryBot.create(:organization, name: 'Org ABC') }
-  let(:partner) { FactoryBot.create(:partner, name: 'Partner 123')}
-
-  describe '#call' do
-    context 'when the role does not yet exist' do
-      it 'should add the role' do
-        described_class.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+  describe "#call" do
+    context "when the role does not yet exist" do
+      it "should add the role" do
+        described_class.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
         expect(user.reload.has_role?(:org_user, org)).to eq(true)
         expect(user.has_role?(:org_admin)).to eq(false)
         expect(user.has_role?(:partner)).to eq(false)
         expect(user.has_role?(:super_admin)).to eq(false)
       end
 
-      it 'should add the user role when asked to add admin' do
-        described_class.call(user_id: user.id, resource_type: 'org_admin', resource_id: org.id)
+      it "should add the user role when asked to add admin" do
+        described_class.call(user_id: user.id, resource_type: "org_admin", resource_id: org.id)
         expect(user.reload.has_role?(:org_user, org)).to eq(true)
         expect(user.reload.has_role?(:org_admin, org)).to eq(true)
         expect(user.has_role?(:partner)).to eq(false)
         expect(user.has_role?(:super_admin)).to eq(false)
       end
 
-      it 'works with a partner' do
-        described_class.call(user_id: user.id, resource_type: 'partner', resource_id: partner.id)
+      it "works with a partner" do
+        described_class.call(user_id: user.id, resource_type: "partner", resource_id: partner.id)
         expect(user.reload.has_role?(:org_user, org)).to eq(false)
         expect(user.has_role?(:org_admin)).to eq(false)
         expect(user.has_role?(:partner, partner)).to eq(true)
         expect(user.has_role?(:super_admin)).to eq(false)
       end
 
-      it 'works with super admin' do
-        described_class.call(user_id: user.id, resource_type: 'super_admin')
+      it "works with super admin" do
+        described_class.call(user_id: user.id, resource_type: "super_admin")
         expect(user.reload.has_role?(:org_user, org)).to eq(false)
         expect(user.has_role?(:org_admin)).to eq(false)
         expect(user.has_role?(:partner)).to eq(false)
         expect(user.has_role?(:super_admin)).to eq(true)
       end
-
     end
 
-    context 'when the role already exists' do
-      it 'should raise an error' do
+    context "when the role already exists" do
+      it "should raise an error" do
         user.add_role(:org_user, org)
         expect {
-          described_class.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+          described_class.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
         }.to raise_error("User User XYZ already has role for Org ABC")
         expect(user.reload.has_role?(:org_user, org)).to eq(true)
         expect(user.reload.has_role?(:org_admin)).to eq(false)
@@ -52,10 +50,10 @@ RSpec.describe AddRoleService, type: :service do
         expect(user.reload.has_role?(:super_admin)).to eq(false)
       end
 
-      it 'should raise an error for super admin' do
+      it "should raise an error for super admin" do
         user.add_role(:super_admin)
         expect {
-          described_class.call(user_id: user.id, resource_type: 'super_admin')
+          described_class.call(user_id: user.id, resource_type: "super_admin")
         }.to raise_error("User User XYZ already has super admin role!")
         expect(user.reload.has_role?(:org_user, org)).to eq(false)
         expect(user.reload.has_role?(:org_admin)).to eq(false)

--- a/spec/services/remove_role_service_spec.rb
+++ b/spec/services/remove_role_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RemoveRoleService, type: :service do
       it "should raise an error" do
         expect {
           described_class.call(user_id: user.id, role_id: role.id)
-        }.to raise_error("User ID #{user.id} does not have role #{role.id}!")
+        }.to raise_error("User User XYZ does not have role for Org ABC!")
         expect(user.reload.has_role?(:org_user, org)).to eq(false)
       end
     end

--- a/spec/services/remove_role_service_spec.rb
+++ b/spec/services/remove_role_service_spec.rb
@@ -1,42 +1,40 @@
 RSpec.describe RemoveRoleService, type: :service do
+  let(:user) { FactoryBot.create(:user, name: "User XYZ") }
+  let(:org) { FactoryBot.create(:organization, name: "Org ABC") }
+  let!(:role) { Role.create!(resource_type: "Organization", name: "org_user", resource_id: org.id) }
 
-  let(:user) { FactoryBot.create(:user, name: 'User XYZ') }
-  let(:org) { FactoryBot.create(:organization, name: 'Org ABC') }
-  let!(:role) { Role.create!(resource_type: 'Organization', name: 'org_user', resource_id: org.id) }
-
-  describe '#call' do
-    context 'when the role exists' do
-      it 'should remove the role' do
-        AddRoleService.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+  describe "#call" do
+    context "when the role exists" do
+      it "should remove the role" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
         described_class.call(user_id: user.id, role_id: role.id)
         expect(user.reload.has_role?(:org_user, org)).to eq(false)
       end
 
-      it 'should remove the admin role when removing user role' do
-        AddRoleService.call(user_id: user.id, resource_type: 'org_admin', resource_id: org.id)
+      it "should remove the admin role when removing user role" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_admin", resource_id: org.id)
         described_class.call(user_id: user.id, role_id: role.id)
         expect(user.reload.has_role?(:org_user, org)).to eq(false)
         expect(user.reload.has_role?(:org_admin, org)).to eq(false)
       end
 
-      it 'should work with a type and ID instead of role ID' do
-        AddRoleService.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
-        described_class.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+      it "should work with a type and ID instead of role ID" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+        described_class.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
         expect(user.reload.has_role?(:org_user, org)).to eq(false)
       end
-
     end
 
-    context 'when not enough information provided' do
-      it 'should raise an error' do
-        AddRoleService.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
-        expect { described_class.call(user_id: user.id) }.
-          to raise_error('Must provide either a role ID or resource ID!')
+    context "when not enough information provided" do
+      it "should raise an error" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+        expect { described_class.call(user_id: user.id) }
+          .to raise_error("Must provide either a role ID or resource ID!")
       end
     end
 
-    context 'when the role does not exist' do
-      it 'should raise an error' do
+    context "when the role does not exist" do
+      it "should raise an error" do
         expect {
           described_class.call(user_id: user.id, role_id: role.id)
         }.to raise_error("User ID #{user.id} does not have role #{role.id}!")

--- a/spec/services/remove_role_service_spec.rb
+++ b/spec/services/remove_role_service_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe RemoveRoleService, type: :service do
+
+  let(:user) { FactoryBot.create(:user, name: 'User XYZ') }
+  let(:org) { FactoryBot.create(:organization, name: 'Org ABC') }
+  let!(:role) { Role.create!(resource_type: 'Organization', name: 'org_user', resource_id: org.id) }
+
+  describe '#call' do
+    context 'when the role exists' do
+      it 'should remove the role' do
+        AddRoleService.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+        described_class.call(user_id: user.id, role_id: role.id)
+        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+      end
+
+      it 'should remove the admin role when removing user role' do
+        AddRoleService.call(user_id: user.id, resource_type: 'org_admin', resource_id: org.id)
+        described_class.call(user_id: user.id, role_id: role.id)
+        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+        expect(user.reload.has_role?(:org_admin, org)).to eq(false)
+      end
+
+      it 'should work with a type and ID instead of role ID' do
+        AddRoleService.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+        described_class.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+      end
+
+    end
+
+    context 'when not enough information provided' do
+      it 'should raise an error' do
+        AddRoleService.call(user_id: user.id, resource_type: 'org_user', resource_id: org.id)
+        expect { described_class.call(user_id: user.id) }.
+          to raise_error('Must provide either a role ID or resource ID!')
+      end
+    end
+
+    context 'when the role does not exist' do
+      it 'should raise an error' do
+        expect {
+          described_class.call(user_id: user.id, role_id: role.id)
+        }.to raise_error("User ID #{user.id} does not have role #{role.id}!")
+        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       expect(page.find(".alert")).to have_content "TestUser updated"
     end
 
+    it 'adds a role' do
+      user = FactoryBot.create(:user, name: 'User 123')
+      FactoryBot.create(:partner, name: 'Partner ABC')
+      visit edit_admin_user_path(user)
+      expect(page).to have_content('User 123')
+      select "Partner", from: "resource_type"
+      find("div.input-group:has(.select2-container)").click
+      find('.select2-search__field', wait: 5).set("Partner ABC")
+      find(:xpath,
+           "//li[contains(@class, 'select2-results__option') and contains(., 'Partner ABC')]",
+           wait: 5).click
+      click_on 'Add Role'
+
+      expect(page.find('.alert')).to have_content('Role added')
+    end
+
     it "deletes an existing user" do
       visit admin_users_path
       page.accept_confirm do

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       find("div.input-group:has(.select2-container)").click
       find('.select2-search__field', wait: 5).set("Partner ABC")
       find(:xpath,
-           "//li[contains(@class, 'select2-results__option') and contains(., 'Partner ABC')]",
-           wait: 5).click
+        "//li[contains(@class, 'select2-results__option') and contains(., 'Partner ABC')]",
+        wait: 5).click
       click_on 'Add Role'
 
       expect(page.find('.alert')).to have_content('Role added')


### PR DESCRIPTION
Resolves #3354 

### Description
This adds the ability for superadmins to view, remove and add roles to existing users.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Local testing. Unit/system tests coming next.

### Screenshots
<img width="1243" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/1986893/7145f8f5-f361-4a0a-8978-bf8dec495d0a">

^ This now shows up at the bottom of the Edit User page.