### PR TITLE
Pickup problem (3557)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -714,4 +714,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.13
+   2.4.16

--- a/app/services/itemizable_update_service.rb
+++ b/app/services/itemizable_update_service.rb
@@ -42,8 +42,5 @@ module ItemizableUpdateService
     itemizable.reload
     # Apply the new changes to the storage location inventory
     to_location.public_send(apply_change_method, itemizable.to_a)
-
-    #    from_location.remove_empty_items
-    #   to_location.remove_empty_items
   end
 end

--- a/app/services/itemizable_update_service.rb
+++ b/app/services/itemizable_update_service.rb
@@ -43,7 +43,7 @@ module ItemizableUpdateService
     # Apply the new changes to the storage location inventory
     to_location.public_send(apply_change_method, itemizable.to_a)
 
-    from_location.remove_empty_items
-    to_location.remove_empty_items
+    #    from_location.remove_empty_items
+    #   to_location.remove_empty_items
   end
 end

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -116,23 +116,6 @@ RSpec.describe "Purchases", type: :request do
             put purchase_path(default_params.merge(id: purchase.id, purchase: purchase_params))
           end.to change { purchase.storage_location.inventory_items.first.quantity }.by(-10)
         end
-
-        it "deletes inventory item if line item and inventory item quantities are equal" do
-          purchase = create(:purchase, :with_items, item_quantity: 1)
-          line_item = purchase.line_items.first
-          inventory_item = purchase.storage_location.inventory_items.first
-          inventory_item.update(quantity: line_item.quantity)
-          line_item_params = {
-            "0" => {
-              "_destroy" => "true",
-              item_id: line_item.item_id,
-              id: line_item.id
-            }
-          }
-          purchase_params = { source: "Purchase Site", line_items_attributes: line_item_params }
-          put purchase_path(default_params.merge(id: purchase.id, purchase: purchase_params))
-          expect { inventory_item.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        end
       end
 
       describe "when changing storage location" do

--- a/spec/services/itemizable_update_service_spec.rb
+++ b/spec/services/itemizable_update_service_spec.rb
@@ -102,16 +102,5 @@ RSpec.describe ItemizableUpdateService do
       expect(storage_location.size).to eq(30)
       expect(new_storage_location.size).to eq(16)
     end
-
-    it "should delete empty inventory items" do
-      attributes[:storage_location_id] = new_storage_location.id
-      attributes[:line_items_attributes] =
-        {"0": {item_id: item1.id, quantity: 10}, "1": {item_id: item2.id, quantity: 10}}
-
-      subject
-
-      expect(new_storage_location.size).to eq(0)
-      expect(new_storage_location.inventory_items.count).to eq(0)
-    end
   end
 end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -592,4 +592,36 @@ RSpec.feature "Distributions", type: :system do
       expect(page).to have_no_content "Inactive R Us"
     end
   end
+
+
+
+  it "allows completion of corrected distribution with depleted inventory item" do
+    visit @url_prefix + "/distributions/new"
+    item = @storage_location.inventory_items.first.item
+    @storage_location.inventory_items.first.update!(quantity: 20)
+
+    select @partner.name, from: "Partner"
+    select @storage_location.name, from: "From storage location"
+    choose "Delivery"
+    select item.name, from: "distribution_line_items_attributes_0_item_id"
+    fill_in "distribution_line_items_attributes_0_quantity", with: 15
+
+    click_button "Save"
+
+    click_link "Make a Correction"
+
+    fill_in "distribution_line_items_attributes_0_quantity", with: 20
+
+    click_button "Save"
+
+    expect(page).to have_content("Distribution Complete")
+    expect(page).to have_link("Distribution Complete")
+
+    expect(@storage_location.inventory_items.first.quantity).to eq(0)
+
+    click_link "Distribution Complete"
+
+    expect(page).to have_content("This distribution has been marked as being completed!")
+  end
+
 end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -593,8 +593,6 @@ RSpec.feature "Distributions", type: :system do
     end
   end
 
-
-
   it "allows completion of corrected distribution with depleted inventory item" do
     visit @url_prefix + "/distributions/new"
     item = @storage_location.inventory_items.first.item
@@ -623,5 +621,4 @@ RSpec.feature "Distributions", type: :system do
 
     expect(page).to have_content("This distribution has been marked as being completed!")
   end
-
 end


### PR DESCRIPTION
Partially Resolves #3557

### Description

This is a partial fix for an issue is occurring dozens of times a week -- though I think most of those are frurstrated retries.

If there is no inventory item for a particular item when we attempt to complete a distribution,  an exception is thrown, and the distribution does not complete (silently)

It turns out that we are deleting the inventory items when there is no current inventory.  This has some other side effects (e.g. not seeing the inventory history)

## To be discussed

Do we 1/  create new 0-quantity inventory items for the items that would have this problem (find by crawling the scheduled distributions),  2/ try somehow to connect back to existing history, or 3/ just let it ride?

I'm  for  option 1, I think -- option 2 is practically impossible, and option 3 will take some time to actually resolve.


***NB**** 
 This PR only fixes the base issue on a go-forward basis.    
**********

There are some side effects of having deleted the inventory items, though.
- not seeing the inventory history anymore
- there wouldn't be an entry in the audit (might not be that big a deal)

This solution does mean that if someone corrects a purchase back to 0, the inventory item will not be removed.   I think that's fine -- Again, for reasons of keeping the history.  

It also means that 0-quantity items will appear in the distribution drop downs.    We could filter those out.  I'm not sure how big a problem that will be perceived to be.



### Type of change

<!-- Please delete options that are not relevant. -->

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?
- automated system test added.  Some tests deleted
