### PR TITLE
Fix issue with lograge usage on activestorage endpoint

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,13 +100,12 @@ Rails.application.configure do
   #
   config.lograge.formatter = LogFormatter.new
   config.lograge.enabled = true
-  config.lograge.base_controller_class = 'ApplicationController'
   config.lograge.custom_payload do |controller|
     {
       host: controller.request.host,
       user_id: controller.current_user.try(:id),
-      org_id: controller.current_organization.try(:id),
-      partner_id: controller.current_partner.try(:id)
+      org_id: controller.try(:current_organization).try(:id),
+      partner_id: controller.try(:current_partner).try(:id)
     }
   end
   config.lograge.custom_options = lambda do |event|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,7 @@ Rails.application.configure do
   #
   config.lograge.formatter = LogFormatter.new
   config.lograge.enabled = true
+  config.lograge.base_controller_class = 'ApplicationController'
   config.lograge.custom_payload do |controller|
     {
       host: controller.request.host,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -83,8 +83,8 @@ Rails.application.configure do
     {
       host: controller.request.host,
       user_id: controller.current_user.try(:id),
-      org_id: controller.current_organization.try(:id),
-      partner_id: controller.current_partner.try(:id)
+      org_id: controller.try(:current_organization).try(:id),
+      partner_id: controller.try(:current_partner).try(:id)
     }
   end
   config.lograge.custom_options = lambda do |event|


### PR DESCRIPTION
We ran into an issue where (at least) logos are not being displayed, detected by bugsnag. This started in the most recent release and appears to be related to the activestorage controller not inheriting from the ApplicationController.

This immediate fix limits logging to the ApplicationController.