### PR TITLE
Replace webdrivers with newer selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -198,8 +198,8 @@ group :test do
   gem 'simplecov'
   # More concise test ("should") matchers
   gem 'shoulda-matchers', '~> 5.3'
-  # Selenium webdriver automatic installation and update.
-  gem 'webdrivers', '~> 5.2'
+  # Nice interface to Chrome, handles updates itself now
+  gem 'selenium-webdriver'
   # Mock HTTP requests and ensure they are not called during tests.
   gem "webmock", "~> 3.18"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,6 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    childprocess (4.1.0)
     choice (0.2.0)
     clockwork (3.0.2)
       activesupport
@@ -462,7 +461,7 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rolify (6.0.1)
     rouge (4.1.2)
     rspec (3.12.0)
@@ -527,8 +526,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.5.0)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -597,10 +595,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -621,6 +615,7 @@ PLATFORMS
   arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -697,6 +692,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails (~> 2.20.1)
   sass-rails
+  selenium-webdriver
   shoulda-matchers (~> 5.3)
   simple_form
   simplecov
@@ -707,11 +703,10 @@ DEPENDENCIES
   terser
   turbo-rails
   web-console
-  webdrivers (~> 5.2)
   webmock (~> 3.18)
 
 RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.16
+   2.4.17

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,6 @@ require "capybara/rails"
 require "capybara/rspec"
 require "capybara-screenshot/rspec"
 require "pry"
-require 'webdrivers'
 require 'knapsack_pro'
 
 KnapsackPro::Adapters::RSpecAdapter.bind
@@ -53,7 +52,7 @@ Capybara.register_driver :chrome do |app|
   capabilities.add_preference(:download, prompt_for_download: false, default_directory: DownloadHelper::PATH.to_s)
   capabilities.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: capabilities)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: capabilities)
 end
 
 # Enable JS for Capybara tests


### PR DESCRIPTION
Fixes issue with running specs with Chrome 115.

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->


### Description

Removes webdrivers gem so that selenium-webdriver can handle finding the appropriate chromedriver on it's own.  Based on discussion in [webdrivers#247](https://github.com/titusfortner/webdrivers/issues/247)

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Was able to run `bin/rspec` without issues after this change.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
