### PR TITLE
Create dashboard/card partial

### DIFF
--- a/.github/workflows/rspec-system.yml
+++ b/.github/workflows/rspec-system.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - 'doc/**'
       - '*.md'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - 'doc/**'
       - '*.md'

--- a/app/views/dashboard/_card.html.erb
+++ b/app/views/dashboard/_card.html.erb
@@ -5,8 +5,8 @@
   header_div ||= nil
   id ||= nil
   subtitle ||= nil
-  table ||= false
   title ||= nil
+  type ||= :box # or :table or :plain
 
   options ||= {}
   options.symbolize_keys!
@@ -42,19 +42,27 @@
         <% end
       end
   %>
-  <% if table %>
-    <div class="box-body table-responsive no-padding">
-      <%= yield %>
-    </div>
-  <% else %>
-    <div class="card-body">
-      <div class="position-relative mb-4">
-        <div class="box-body text-center float-center">
-          <%= yield %>
+  <% case type.to_sym
+    when :box %>
+      <div class="card-body">
+        <div class="position-relative mb-4">
+          <div class="box-body text-center float-center">
+            <%= yield %>
+          </div>
         </div>
       </div>
-    </div>
-  <% end %>
+    <% when :plain %>
+      <div class="card-body">
+        <%= yield %>
+      </div>
+    <% when :table %>
+      <div class="box-body table-responsive no-padding">
+        <%= yield %>
+      </div>
+  <% else
+    raise "Unknown card type: #{type}"
+  end %>
+
   <%=
     footer_div ||
       if footer

--- a/app/views/dashboard/_card.html.erb
+++ b/app/views/dashboard/_card.html.erb
@@ -1,0 +1,68 @@
+<%
+  # Allows locals to be optional
+  footer ||= nil
+  footer_div ||= nil
+  header_div ||= nil
+  id ||= nil
+  subtitle ||= nil
+  table ||= false
+  title ||= nil
+
+  options ||= {}
+  options.symbolize_keys!
+  options[:class] ||= ""
+  options[:class] += " card"
+  options[:id] = id if id
+%>
+<%= content_tag(:div, **options) do %>
+  <%=
+    header_div ||
+      begin
+        gradient ||= "primary"
+
+        header_options ||= {}
+        header_options.symbolize_keys!
+        header_options[:class] ||= ""
+        header_options[:class] += " card-header border-0 bg-gradient-#{gradient}"
+
+        header ||=
+          begin
+            title = h title
+            title += " ".html_safe + content_tag(:small, subtitle) if subtitle
+            content_tag :h3, title, class: "card-title"
+          end
+
+        content_tag(:div, **header_options) do %>
+          <%= header %>
+          <div class="card-tools">
+            <button type="button" class="btn btn-tool" data-card-widget="collapse">
+              <i class="fas fa-minus"></i>
+            </button>
+          </div>
+        <% end
+      end
+  %>
+  <% if table %>
+    <div class="box-body table-responsive no-padding">
+      <%= yield %>
+    </div>
+  <% else %>
+    <div class="card-body">
+      <div class="position-relative mb-4">
+        <div class="box-body text-center float-center">
+          <%= yield %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  <%=
+    footer_div ||
+      if footer
+        footer_options ||= {}
+        footer_options.symbolize_keys!
+        footer_options[:class] ||= ""
+        footer_options[:class] += " card-footer"
+        content_tag(:div, footer, **footer_options)
+      end
+  %>
+<% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -109,7 +109,7 @@
                     <strong><%= if announcement.created_at.strftime("%Y") == DateTime.now.strftime("%Y")
                                   announcement.created_at.strftime("%B %d")
                                 else
-                                  announcement.created_at.strftime("%B %d %Y") 
+                                  announcement.created_at.strftime("%B %d %Y")
                                 end %></strong>
                     <br />
                     <%= announcement.message %>
@@ -124,264 +124,206 @@
           </div>
         <% end %>
 
-        <div class="card" id="distributions">
-          <div class="card-header border-0 bg-gradient-info">
-            <h3 class="card-title">Distributions
-              <small><%= @selected_date_range %></small></h3>
-            <div class="card-tools">
-              <button type="button" class="btn btn-tool" data-card-widget="collapse">
-                <i class="fas fa-minus"></i>
-              </button>
-            </div>
-          </div>
-          <div class="card-body">
-            <div class="position-relative mb-4">
-              <div class="box-body text-center float-center">
-                <%= new_button_to new_distribution_path, {text: "New Distribution"} %>
-                <%= print_button_to distributions_by_county_report_path(filters: { date_range: date_range_params }), {text: "Distributions by County", size: "md"} %>
+        <%= render(
+          "card",
+          id: "distributions",
+          gradient: "info",
+          title: "Distributions",
+          subtitle: @selected_date_range,
+          footer: link_to("See more...", distributions_path),
+          footer_options: { class: "text-center" },
+        ) do %>
+          <%= new_button_to new_distribution_path, {text: "New Distribution"} %>
+          <%= print_button_to distributions_by_county_report_path(filters: { date_range: date_range_params }), {text: "Distributions by County", size: "md"} %>
 
-                <h3 class="text-center">
-                  <span class="total_distributed">
-                    <%= total_distributed %>
-                  </span>
-                  items distributed <%= @selected_date_range_label %>
-                </h3>
-                <h4 class="text-center">(<%= future_distributed %> items scheduled for future distribution)</h4>
-                <div class="box-body">
-                  <h4>Recent distributions</h4>
-                  <%= render partial: "distribution", collection: @recent_distributions, as: :distribution %>
-                </div>
+          <h3 class="text-center">
+            <span class="total_distributed">
+              <%= total_distributed %>
+            </span>
+            items distributed <%= @selected_date_range_label %>
+          </h3>
+          <h4 class="text-center">(<%= future_distributed %> items scheduled for future distribution)</h4>
+          <div class="box-body">
+            <h4>Recent distributions</h4>
+            <%= render partial: "distribution", collection: @recent_distributions, as: :distribution %>
+          </div>
+        <% end %>
+
+        <%= render(
+          "card",
+          gradient: "success",
+          title: "Itemized Distributions",
+          subtitle: @selected_date_range,
+          table: true,
+        ) do %>
+          <div class='p-2 pull-right'>
+            <%= download_button_to(itemized_breakdown_distributions_path(format: :csv, filters: { date_range: date_range_params }), {text: "Export To CSV"}) %>
+          </div>
+
+          <%= render partial: "itemized_distributions_partial", locals: { itemized_breakdown: @itemized_distribution_data } %>
+        <% end %>
+
+        <%= render(
+          "card",
+          gradient: "warning",
+          title: "Activity",
+          subtitle: @selected_date_range,
+        ) do %>
+          <div class="box-body">
+            <div class="box-body text-center">
+              <h5 class="text-center"></h5>
+              <%
+                  activity_chart_config = {
+                    chart: {
+                      type: "bar"
+                    },
+                    title: "",
+                    xAxis: {
+                      categories: @distribution_data.keys,
+                      title: {
+                        text: nil
+                      }
+                    },
+                    yAxis: {
+                      title: {
+                        text: nil
+                      }
+                    },
+                    legend: {
+                      enabled: false
+                    },
+                    series: [
+                      {
+                        data: @distribution_data.values
+                      }
+                    ]
+                  }.to_json
+                %>
+              <div data-controller="highchart" data-highchart-config-value="<%= activity_chart_config %>" >
+                <div data-highchart-target="chart"></div>
               </div>
-            </div>
-          </div>
-          <div class="card-footer text-center">
-            <%= link_to "See more...", distributions_path %>
-          </div>
-        </div>
 
-        <div class="card">
-          <div class="card-header border-0 bg-gradient-success">
-            <h3 class="card-title">Itemized Distributions
-              <small><%= @selected_date_range %></small></h3>
-            <div class="card-tools">
-              <button type="button" class="btn btn-tool" data-card-widget="remove">
-                <i class="fas fa-times"></i>
-              </button>
             </div>
           </div>
-          <div class="box-body table-responsive no-padding">
-            <div class='p-2 pull-right'>
-              <%= download_button_to(itemized_breakdown_distributions_path(format: :csv, filters: { date_range: date_range_params }), {text: "Export To CSV"}) %>
-            </div>
-            
-            <%= render partial: "itemized_distributions_partial", locals: { itemized_breakdown: @itemized_distribution_data } %>
-          </div>
-        </div>
+        <% end %>
 
-        <div class="card">
-          <div class="card-header border-0 bg-gradient-warning">
-            <h3 class="card-title">Activity
-              <small><%= @selected_date_range %></small>
-            </h3>
-            <div class="card-tools">
-              <button type="button" class="btn btn-tool" data-card-widget="collapse">
-                <i class="fas fa-minus"></i>
-              </button>
-            </div>
-          </div>
-          <div class="card-body">
-            <div class="position-relative mb-4">
-              <div class="box-body text-center float-center">
-                <div class="box-body">
-                  <div class="box-body text-center">
-                    <h5 class="text-center"></h5>
-                    <% 
-                        activity_chart_config = {
-                          chart: {
-                            type: "bar"
-                          },
-                          title: "",
-                          xAxis: {
-                            categories: @distribution_data.keys,
-                            title: {
-                              text: nil
-                            }
-                          },
-                          yAxis: {
-                            title: {
-                              text: nil
-                            }
-                          },
-                          legend: {
-                            enabled: false
-                          },
-                          series: [
-                            {
-                              data: @distribution_data.values
-                            }
-                          ]
-                        }.to_json
-                      %>
-                    <div data-controller="highchart" data-highchart-config-value="<%= activity_chart_config %>" >
-                      <div data-highchart-target="chart"></div>
-                    </div>
-
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
       <div class="col-lg-6">
 
-        <div class="card" id="donations">
-          <div class="card-header border-0 bg-gradient-primary">
-            <h3 class="card-title">Donations (All Sources)
-              <small><%= @selected_date_range %></small></h3>
-            <div class="card-tools">
-              <button type="button" class="btn btn-tool" data-card-widget="collapse">
-                <i class="fas fa-minus"></i>
-              </button>
-            </div>
+        <%= render(
+          "card",
+          id: "donations",
+          title: "Donations (All Sources)",
+          subtitle: @selected_date_range,
+          footer_options: { class: "text-center" },
+          footer: link_to("See more...", donations_path),
+        ) do %>
+          <%= new_button_to new_donation_path, {text: "New Donation"} %>
+          <h3 class="text-center">
+            <span class="total_received_donations">
+              <%= total_received_donations %>
+            </span>
+            items
+            received <%= @selected_date_range_label %>
+          </h3>
+          <h4 class="text-center">
+            <%= dollar_presentation(total_received_money_donations) %>
+            raised  <%= @selected_date_range_label %>
+          </h4>
+          <div class="box-body">
+            <h4>Recent Donations</h4>
+            <%= render partial: "donation", collection: @recent_donations, as: :donation %>
           </div>
-          <div class="card-body">
-            <div class="position-relative mb-4">
-              <div class="box-body text-center float-center">
-                <%= new_button_to new_donation_path, {text: "New Donation"} %>
-                <h3 class="text-center">
-                  <span class="total_received_donations">
-                    <%= total_received_donations %>
-                  </span>
-                  items
-                  received <%= @selected_date_range_label %></h3>
-                <h4 class="text-center"><%= dollar_presentation(total_received_money_donations) %>
-                  raised  <%= @selected_date_range_label %></h4>
-                <div class="box-body">
-                  <h4>Recent Donations</h4>
-                  <%= render partial: "donation", collection: @recent_donations, as: :donation %>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card-footer text-center">
-            <%= link_to "See more...", donations_path %>
-          </div>
-        </div>
+        <% end %>
 
-        <div class="card" id="product_drives">
-          <div class="card-header border-0 bg-gradient-info">
-            <h3 class="card-title">Product Drives <small><%= @selected_date_range %></small></h3>
-            <div class="card-tools">
-              <button type="button" class="btn btn-tool" data-card-widget="collapse">
-                <i class="fas fa-minus"></i>
-              </button>
-            </div>
+        <%= render(
+          "card",
+          id: "product_drives",
+          gradient: "info",
+          title: "Product Drives",
+          subtitle: @selected_date_range,
+          footer_options: { class: "text-center" },
+          footer: link_to("See more...", donations_path(
+              filters: {
+                by_source: "Product Drive"
+              }
+            )),
+        ) do %>
+          <h3 class="text-center">
+            <span class="total_received_donations">
+              <%= total_received_from_product_drives %>
+            </span> items
+            received <%= @selected_date_range_label %>
+          </h3>
+          <h4 class="text-center">
+            <span class="total_money_raised">
+              <%= dollar_presentation( total_received_money_donations_from_product_drives) %>
+            </span> raised  <%= @selected_date_range_label %>
+          </h4>
+          <div class="box-body">
+            <h4>Recent Donations from Product Drives</h4>
+            <%= render partial: "product_drive", collection: @recent_donations.by_source(:product_drive), as: :donation %>
           </div>
-          <div class="card-body">
-            <div class="position-relative mb-4">
-              <div class="box-body text-center float-center">
-                <h3 class="text-center">
-                  <span class="total_received_donations">
-                    <%= total_received_from_product_drives %>
-                  </span> items
-                  received <%= @selected_date_range_label %></h3>
-                <h4 class="text-center">
-                  <span class="total_money_raised">
-                    <%= dollar_presentation( total_received_money_donations_from_product_drives) %>
-                  </span> raised  <%= @selected_date_range_label %></h4>
-                <div class="box-body">
-                  <h4>Recent Donations from Product Drives</h4>
-                  <%= render partial: "product_drive", collection: @recent_donations.by_source(:product_drive), as: :donation %>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card-footer text-center">
-            <%= link_to "See more...", donations_path(
-                filters: {
-                    by_source: "Product Drive"
-                }) %>
-          </div>
-        </div>
+        <% end %>
 
-        <div class="card" id="manufacturers">
-          <div class="card-header border-0 bg-gradient-success">
-            <h3 class="card-title">Manufacturer Donations <small><%= @selected_date_range %></small></h3>
-            <div class="card-tools">
-              <button type="button" class="btn btn-tool" data-card-widget="collapse">
-                <i class="fas fa-minus"></i>
-              </button>
-            </div>
+        <%= render(
+          "card",
+          id: "manufacturers",
+          gradient: "success",
+          title: "Manufacturer Donations",
+          subtitle: @selected_date_range,
+          footer_options: { class: "text-center" },
+          footer: link_to("See more...", donations_path(
+              filters: {
+                  by_source: "Manufacturer"
+              }
+            )),
+        ) do %>
+          <h3 class="text-center">
+            <span class="total_received_donations">
+              <%= number_with_delimiter(@recent_donations_from_manufacturers.sum { |d| d.line_items.total }) %>
+            </span>
+            items donated <%= @selected_date_range_label %>
+            by
+            <span class="num_manufacturers_donated">
+              <%= pluralize(@recent_donations_from_manufacturers.group_by(&:manufacturer).count, 'Manufacturer') %>
+            </span>
+          </h3>
+          <div class="box-body">
+            <h4>Top Manufacturer Donations</h4>
+            <%= render partial: "manufacturer", collection: @top_manufacturers, as: :manufacturer %>
           </div>
-          <div class="card-body">
-            <div class="position-relative mb-4">
-              <div class="box-body text-center float-center">
-                <h3 class="text-center">
-                  <span class="total_received_donations">
-                    <%= number_with_delimiter(@recent_donations_from_manufacturers.sum { |d| d.line_items.total }) %>
-                  </span>
-                  items donated <%= @selected_date_range_label %>
-                  by
-                  <span class="num_manufacturers_donated">
-                    <%= pluralize(@recent_donations_from_manufacturers.group_by(&:manufacturer).count, 'Manufacturer') %>
-                  </span>
-                </h3>
-                <div class="box-body">
-                  <h4>Top Manufacturer Donations</h4>
-                  <%= render partial: "manufacturer", collection: @top_manufacturers, as: :manufacturer %>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card-footer text-center">
-            <%= link_to "See more...", donations_path(
-                filters: {
-                    by_source: "Manufacturer"
-                }) %>
-          </div>
-        </div>
+        <% end %>
 
-        <div class="card" id="purchases">
-          <div class="card-header border-0 bg-gradient-secondary">
-            <h3 class="card-title">Purchases <small><%= @selected_date_range %></small></h3>
-            <div class="card-tools">
-              <button type="button" class="btn btn-tool" data-card-widget="collapse">
-                <i class="fas fa-minus"></i>
-              </button>
-            </div>
+        <%= render(
+          "card",
+          id: "purchases",
+          gradient: "secondary",
+          title: "Purchases",
+          subtitle: @selected_date_range,
+          footer_options: { class: "text-center" },
+          footer: link_to("See more...", purchases_path),
+        ) do %>
+          <%= new_button_to new_purchase_path, {text: "New Purchase"} %>
+          <h3 class="text-center"><%= dollar_presentation(@purchases.sum(&:amount_spent_in_cents)) %>
+            spent
+            <%= @selected_date_range_label %>
+          </h3>
+          <div class="box-body">
+            <h4>Recent purchases</h4>
+            <%= render partial: "purchase", collection: @recent_purchases, as: :purchase %>
           </div>
-          <div class="card-body">
-            <div class="position-relative mb-4">
-              <div class="box-body text-center float-center">
-                <%= new_button_to new_purchase_path, {text: "New Purchase"} %>
-                <h3 class="text-center"><%= dollar_presentation(@purchases.sum(&:amount_spent_in_cents)) %>
-                  spent
-                  <%= @selected_date_range_label %></h3>
-                <div class="box-body">
-                  <h4>Recent purchases</h4>
-                  <%= render partial: "purchase", collection: @recent_purchases, as: :purchase %>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card-footer text-center">
-            <%= link_to "See more...", purchases_path %>
-          </div>
-        </div>
+        <% end %>
 
-
-      <div class="card">
-          <div class="card-header border-0 bg-gradient-warning">
-            <h3 class="card-title">Itemized Donations
-              <small><%= @selected_date_range %></small></h3>
-            <div class="card-tools">
-            </div>
-          </div>
-          <div class="box-body table-responsive no-padding">
-            <%= render partial: "itemized_donations_partial", locals: { itemized_breakdown: @itemized_donation_data } %>
-          </div>
-        </div>
+        <%= render(
+          "card",
+          gradient: "warning",
+          title: "Itemized Donations",
+          subtitle: @selected_date_range,
+          table: true,
+        ) do %>
+          <%= render partial: "itemized_donations_partial", locals: { itemized_breakdown: @itemized_donation_data } %>
+        <% end %>
 
       </div>
     </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -19,35 +19,11 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-12">
-        <div class="card" id="summary">
-          <div class="card-header">
-            <h5 class="card-title"><%= current_organization.name %></h5>
-            <div class="card-tools">
-              <button type="button" class="btn btn-tool" data-card-widget="collapse">
-                <i class="fas fa-minus"></i>
-              </button>
-              <button type="button" class="btn btn-tool" data-card-widget="remove">
-                <i class="fas fa-times"></i>
-              </button>
-            </div>
-          </div>
-          <!-- /.card-header -->
-          <div class="card-body">
-            <div class="row">
-              <%= render partial: "getting_started_prompt", locals: {org_stats: @org_stats} %>
-
-              <div class="col-md-8">
-                <%== display_logo_or_name %>
-              </div>
-              <!-- /.col -->
-              <div class="col-md-4">
-
-              </div>
-              <!-- /.col -->
-            </div>
-            <!-- /.row -->
-          </div>
-          <div class="card-footer">
+        <%= render(
+          "card",
+          id: "summary",
+          header: content_tag(:h5, current_organization.name, class: "card-title"),
+          footer: capture { %>
             <div class="row">
               <div class="col-sm-3 col-6">
                 <div class="description-block border-right">
@@ -81,8 +57,23 @@
                 </div>
               </div>
             </div>
+          <% },
+          type: :plain,
+        ) do %>
+          <div class="row">
+            <%= render partial: "getting_started_prompt", locals: {org_stats: @org_stats} %>
+
+            <div class="col-md-8">
+              <%== display_logo_or_name %>
+            </div>
+            <!-- /.col -->
+            <div class="col-md-4">
+
+            </div>
+            <!-- /.col -->
           </div>
-        </div>
+          <!-- /.row -->
+        <% end %>
       </div>
     </div>
   </div>
@@ -154,7 +145,7 @@
           gradient: "success",
           title: "Itemized Distributions",
           subtitle: @selected_date_range,
-          table: true,
+          type: :table,
         ) do %>
           <div class='p-2 pull-right'>
             <%= download_button_to(itemized_breakdown_distributions_path(format: :csv, filters: { date_range: date_range_params }), {text: "Export To CSV"}) %>
@@ -320,7 +311,7 @@
           gradient: "warning",
           title: "Itemized Donations",
           subtitle: @selected_date_range,
-          table: true,
+          type: :table,
         ) do %>
           <%= render partial: "itemized_donations_partial", locals: { itemized_breakdown: @itemized_donation_data } %>
         <% end %>


### PR DESCRIPTION
Removes the highly duplicated nested card divs and card-tools.

Results in the same HTML (modulo whitespace)

### Description

The dashboard index had a large amount of copy/paste HTML to define the card structure.  This extracts that into a partial so only the unique text is in the index.

### Type of change

* Refactor (non-breaking change which fixes an annoyance)

### How Has This Been Tested?

Loaded HTML and compared before and after
