### PR TITLE
3669 outstanding requests

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -29,5 +29,7 @@ class DashboardController < ApplicationController
 
     # passing nil here filters the announcements that didn't come from an organization
     @broadcast_announcements = BroadcastAnnouncement.filter_announcements(nil)
+
+    @outstanding_requests = Request.where(status: %i[pending started]).order(:created_at)
   end
 end

--- a/app/views/dashboard/_outstanding_requests.html.erb
+++ b/app/views/dashboard/_outstanding_requests.html.erb
@@ -1,0 +1,20 @@
+<table class="table table-hover striped">
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Partner</th>
+      <th>Requestor</th>
+      <th>Comments</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% outstanding_requests.each do |item| %>
+      <tr>
+        <td class="date"><%= link_to item.created_at.strftime("%m/%d/%Y"), item %></td>
+        <td><%= item.partner.name %></td>
+        <td><%= item.partner_user&.name %></td>
+        <td><%= item.comments %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -117,19 +117,26 @@
 
         <%=
           outstanding_type = @outstanding_requests.empty? ? :box : :table
+          outstanding_footer =
+            if @outstanding_requests.count > 25
+              "And #{@outstanding_requests.count - 25} more..."
+            else
+              "See more..."
+            end
           render(
             "card",
             id: "outstanding",
             gradient: "warning",
             title: "Outstanding Requests",
             type: outstanding_type,
-            footer: link_to("See more...", requests_path),
+            footer: link_to(outstanding_footer, requests_path),
             footer_options: { class: "text-center" },
           ) do
             if @outstanding_requests.empty?
               "No outstanding requests!"
             else
-              render "outstanding_requests", outstanding_requests: @outstanding_requests
+              render "outstanding_requests",
+                outstanding_requests: @outstanding_requests.take(25)
             end
           end
         %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -115,6 +115,25 @@
           </div>
         <% end %>
 
+        <%=
+          outstanding_type = @outstanding_requests.empty? ? :box : :table
+          render(
+            "card",
+            id: "outstanding",
+            gradient: "warning",
+            title: "Outstanding Requests",
+            type: outstanding_type,
+            footer: link_to("See more...", requests_path),
+            footer_options: { class: "text-center" },
+          ) do
+            if @outstanding_requests.empty?
+              "No outstanding requests!"
+            else
+              render "outstanding_requests", outstanding_requests: @outstanding_requests
+            end
+          end
+        %>
+
         <%= render(
           "card",
           id: "distributions",

--- a/spec/support/pages/organization_dashboard_page.rb
+++ b/spec/support/pages/organization_dashboard_page.rb
@@ -84,6 +84,10 @@ class OrganizationDashboardPage < OrganizationPage
     has_selector? org_logo_selector
   end
 
+  def has_outstanding_section?
+    has_selector? outstanding_selector
+  end
+
   def manufacturers_total_donations
     within manufacturers_section do
       parse_formatted_integer find(".total_received_donations").text
@@ -164,6 +168,22 @@ class OrganizationDashboardPage < OrganizationPage
     end
   end
 
+  def outstanding_section
+    find outstanding_selector
+  end
+
+  def outstanding_requests
+    within outstanding_section do
+      all('tbody > tr')
+    end
+  end
+
+  def outstanding_requests_link
+    within outstanding_section do
+      find('.card-footer a')
+    end
+  end
+
   private
 
   def product_drives_section
@@ -200,5 +220,9 @@ class OrganizationDashboardPage < OrganizationPage
 
   def purchases_section
     find "#purchases"
+  end
+
+  def outstanding_selector
+    "#outstanding"
   end
 end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -812,6 +812,80 @@ RSpec.describe "Dashboard", type: :system, js: true do
         end
       end
     end
+
+    describe "Outstanding Requests" do
+      it "has a card" do
+        org_dashboard_page.visit
+        expect(org_dashboard_page).to have_outstanding_section
+      end
+
+      context "when empty" do
+        before { org_dashboard_page.visit }
+
+        it "displays a message" do
+          expect(org_dashboard_page.outstanding_section).to have_content "No outstanding requests!"
+        end
+
+        it "has a See More link" do
+          expect(org_dashboard_page.outstanding_requests_link).to have_content "See more"
+        end
+      end
+
+      context "with a pending request" do
+        let!(:request) { create :request, :pending }
+        let!(:outstanding_request) do
+          org_dashboard_page.visit
+          requests = org_dashboard_page.outstanding_requests
+          expect(requests.length).to eq 1
+          requests.first
+        end
+
+        it "displays the date" do
+          date = outstanding_request.find "td.date"
+          expect(date.text).to eq request.created_at.strftime("%m/%d/%Y")
+        end
+
+        it "displays the partner" do
+          expect(outstanding_request).to have_content request.partner.name
+        end
+
+        it "displays the requestor" do
+          expect(outstanding_request).to have_content request.partner_user.name
+        end
+
+        it "displays the comment" do
+          expect(outstanding_request).to have_content request.comments
+        end
+
+        it "links to the request" do
+          expect { outstanding_request.find('a').click }
+            .to change { page.current_path }
+            .to "/#{org_short_name}/requests/#{request.id}"
+        end
+
+        it "has a See More link" do
+          expect(org_dashboard_page.outstanding_requests_link).to have_content "See more"
+        end
+      end
+
+      it "does display a started request" do
+        create :request, :started
+        org_dashboard_page.visit
+        expect(org_dashboard_page.outstanding_requests.length).to eq 1
+      end
+
+      it "does not display a fulfilled request" do
+        create :request, :fulfilled
+        org_dashboard_page.visit
+        expect(org_dashboard_page.outstanding_requests).to be_empty
+      end
+
+      it "does not display a discarded request" do
+        create :request, :discarded
+        org_dashboard_page.visit
+        expect(org_dashboard_page.outstanding_requests).to be_empty
+      end
+    end
   end
 
   def valid_bracketing_dates(date_range_info)

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -885,6 +885,23 @@ RSpec.describe "Dashboard", type: :system, js: true do
         org_dashboard_page.visit
         expect(org_dashboard_page.outstanding_requests).to be_empty
       end
+
+      context "with many pending requests" do
+        let(:num_requests) { 50 }
+        let(:limit) { 25 }
+        before do
+          create_list :request, num_requests, :pending
+          org_dashboard_page.visit
+        end
+
+        it "displays a limited number of requests" do
+          expect(org_dashboard_page.outstanding_requests.length).to eq limit
+        end
+
+        it "has a link with the number of other requests" do
+          expect(org_dashboard_page.outstanding_requests_link).to have_content num_requests - limit
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #3669 

### Description

Lists the pending and started requests right on the main page so that the user has an idea of what they need to work on now.  I included a limit to how many are shown because with the sample data in dev the table was very very long.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Manually verified the look, and added system tests to verify that the correct information is displayed and that the limit works correctly.

### Screenshots

<img width="658" alt="Screenshot 2023-07-29 at 2 06 00 PM" src="https://github.com/rubyforgood/human-essentials/assets/133455/b8db2102-a8af-438f-8198-f04f235458f5">
