### PR TITLE
Restore remove button to dashboard cards

### DIFF
--- a/app/views/dashboard/_card.html.erb
+++ b/app/views/dashboard/_card.html.erb
@@ -35,9 +35,15 @@
         content_tag(:div, **header_options) do %>
           <%= header %>
           <div class="card-tools">
-            <button type="button" class="btn btn-tool" data-card-widget="collapse">
-              <i class="fas fa-minus"></i>
-            </button>
+            <% if type == :table %>
+              <button type="button" class="btn btn-tool" data-card-widget="remove">
+                <i class="fas fa-times"></i>
+              </button>
+            <% else %>
+              <button type="button" class="btn btn-tool" data-card-widget="collapse">
+                <i class="fas fa-minus"></i>
+              </button>
+            <% end %>
           </div>
         <% end
       end


### PR DESCRIPTION
### Description

The +/- collapse doesn't work with the layout of the table cards.  Instead, those cards had a remove button.  That button got lost with my card refactor and this PR restores it.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

View organization dashboard, check the button at the top right of the cards containing a table.