### PR TITLE
Move FullStory script after importmaps

### DIFF
--- a/app/views/layouts/_devise_shared.html.erb
+++ b/app/views/layouts/_devise_shared.html.erb
@@ -14,8 +14,11 @@
   <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.11.2/css/all.min.css" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/v4-shims.css" rel="stylesheet" />
 
-  <%= raw fullstory_script(current_user: current_user) if Rails.env.production? %>
-  <%= javascript_importmap_tags %>
+  <%=
+    # DO NOT LOAD ANY JAVASCRIPT BEFORE THIS!!!
+    javascript_importmap_tags
+  %>
+  <%= raw fullstory_script(current_user: current_user) if Rails.env.production?  %>
   <script type="esms-options">
   {
     "noLoadEventRetriggers": true

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,11 @@
   <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/v4-shims.css" rel="stylesheet" />
 
   <%= stylesheet_link_tag 'application', media: 'all' %>
-  <%= raw fullstory_script(current_user: current_user) if Rails.env.production? %>
-  <%= javascript_importmap_tags %>
+  <%=
+    # DO NOT LOAD ANY JAVASCRIPT BEFORE THIS!!!
+    javascript_importmap_tags
+  %>
+  <%= raw fullstory_script(current_user: current_user) if Rails.env.production?  %>
   <script type="esms-options">
   {
     "noLoadEventRetriggers": true

--- a/app/views/layouts/partner.html.erb
+++ b/app/views/layouts/partner.html.erb
@@ -13,8 +13,11 @@
   <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/v4-shims.css" rel="stylesheet" />
 
   <%= stylesheet_link_tag 'application', media: 'all' %>
-  <%= raw fullstory_script(current_user: current_user) if Rails.env.production? %>
-  <%= javascript_importmap_tags %>
+  <%=
+    # DO NOT LOAD ANY JAVASCRIPT BEFORE THIS!!!
+    javascript_importmap_tags
+  %>
+  <%= raw fullstory_script(current_user: current_user) if Rails.env.production?  %>
   <script type="esms-options">
   {
     "noLoadEventRetriggers": true
@@ -70,4 +73,3 @@
 </body>
 <div class="modal fade" id="modal_new" role="dialog"></div>
 </html>
-

--- a/app/views/layouts/partners/application.html.erb
+++ b/app/views/layouts/partners/application.html.erb
@@ -13,15 +13,17 @@
   <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/v4-shims.css" rel="stylesheet" />
 
   <%= stylesheet_link_tag 'application', media: 'all' %>
-  <%= raw fullstory_script(current_user: current_user) if Rails.env.production? %>
-  <%= javascript_importmap_tags %>
+  <%=
+    # DO NOT LOAD ANY JAVASCRIPT BEFORE THIS!!!
+    javascript_importmap_tags
+  %>
+  <%= raw fullstory_script(current_user: current_user) if Rails.env.production?  %>
   <script type="esms-options">
   {
     "noLoadEventRetriggers": true
   }
   </script>
 
-  <%= raw fullstory_script(current_user: current_user) if Rails.env.production? %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
   <%= render 'magic_test/support' if Rails.env.test? %>
@@ -83,5 +85,3 @@
 </body>
 <div class="modal fade" id="modal_new" role="dialog"></div>
 </html>
-
-


### PR DESCRIPTION
Resolves #3767 (on modified dev)

### Description

Running Javascript before the importmap seems to break Firefox's ability to load external modules.

Notes:

1. Minimizing the fullstory_script code to `<script>(function(){})</script>` still failed.
2. The import map works enough to load our application.js but fails to load jQuery (the first import in application.js).

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

1. Remove `if Rails.env.production?` from the `fullstory_script` calls on `main`.
2. Load dashboard in Firefox
3. Open console
4. See error: `Uncaught TypeError: The specifier “jquery” was a bare specifier, but was not remapped to anything. Relative module specifiers must start with “./”, “../” or “/”.`
5. Switch to this branch, repeat above, error does not occur.

Can also test by clicking on `<` collapsed sections in sidebar or any icon in the top bar (hamburger, calendar, or bell).