### PR TITLE
Extract sidebar markup into helper

### DIFF
--- a/app/views/layouts/_lte_admin_sidebar.html.erb
+++ b/app/views/layouts/_lte_admin_sidebar.html.erb
@@ -1,145 +1,47 @@
-<ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
+<%= sidebar do %>
+  <%= sidebar_item 'Admin Dashboard', admin_dashboard_path, icon: 'tachometer-alt fas' %>
 
-  <li class="nav-item">
-    <%= link_to(admin_dashboard_path, class: "nav-link #{active_class(['dashboard'])}") do %>
-      <i class="nav-icon fas fa-tachometer-alt"></i>
-      <p>Admin Dashboard</p>
-    <% end %>
-  </li>
+  <%= sidebar_group 'Barcode Items', [
+    { name: 'All Barcodes', path: admin_barcode_items_path },
+    { name: 'New Barcode Item', path: new_admin_barcode_item_path, icon: 'plus-circle' },
+  ], icon: 'barcode', controller: 'admin/barcode_items' %>
 
-  <li class="nav-item has-treeview <%= menu_open?(['barcode_items']) %>">
-    <a href="#" class="nav-link <%= active_class(['barcode_items']) %>">
-      <i class="nav-icon fa fa-barcode"></i>
-      <p>Barcode Items
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(admin_barcode_items_path) %>">
-        <%= link_to(admin_barcode_items_path, class: "nav-link #{"active" if current_page?(admin_barcode_items_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> All Barcodes
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(new_admin_barcode_item_path) %>">
-        <%= link_to(new_admin_barcode_item_path, class: "nav-link #{"active" if current_page?(new_admin_barcode_item_path)}") do %>
-          <i class="nav-icon fa fa-plus-circle"></i> New Barcode Item
-        <% end %>
-      </li>
-    </ul>
-  </li>
+  <%= sidebar_group 'Base Items', [
+    { name: 'All Base Items', path: admin_base_items_path },
+    { name: 'New Base Item', path: new_admin_base_item_path, icon: 'plus-circle' },
+  ], icon: 'box', controller: 'admin/base_items' %>
 
-  <li class="nav-item has-treeview <%= menu_open?(['base_items']) %>">
-    <a href="#" class="nav-link <%= active_class(['base_items']) %>">
-      <i class="nav-icon fas fa-box"></i>
-      <p>Base Items
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(admin_base_items_path) %>">
-        <%= link_to(admin_base_items_path, class: "nav-link #{"active" if current_page?(admin_base_items_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> All Base Items
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(new_admin_base_item_path) %>">
-        <%= link_to(new_admin_base_item_path, class: "nav-link #{"active" if current_page?(new_admin_base_item_path)}") do %>
-          <i class="nav-icon fa fa-plus-circle"></i> New Base Item
-        <% end %>
-      </li>
-    </ul>
-  </li>
+  <%= sidebar_group 'Organizations', [
+    { name: 'All Organizations', path: admin_organizations_path },
+    { name: 'New Organization', path: new_admin_organization_path, icon: 'plus-circle' },
+  ], icon: 'sitemap fas', controller: 'admin/organizations' %>
 
-  <li class="nav-item has-treeview <%= menu_open?(['organizations']) %>">
-    <a href="#" class="nav-link <%= active_class(['organizations']) %>">
-      <i class="nav-icon fas fa-sitemap"></i>
-      <p>Organizations
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(admin_organizations_path) %>">
-        <%= link_to(admin_organizations_path, class: "nav-link #{"active" if current_page?(admin_organizations_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> All Organizations
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(new_admin_organization_path) %>">
-        <%= link_to(new_admin_organization_path, class: "nav-link #{"active" if current_page?(new_admin_organization_path)}") do %>
-          <i class="nav-icon fa fa-plus-circle"></i> New Organization
-        <% end %>
-      </li>
-    </ul>
-  </li>
+  <%= sidebar_group 'Partners', [
+    { name: 'All Partners', path: admin_partners_path },
+  ], icon: 'people-carry fas', controller: 'admin/partners' %>
 
-  <li class="nav-item has-treeview <%= menu_open?(['partners']) %>">
-    <a href="#" class="nav-link <%= active_class(['partners']) %>">
-      <i class="nav-icon fas fa-people-carry"></i>
-      <p>Partners
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(admin_partners_path) %>">
-        <%= link_to(admin_partners_path, class: "nav-link #{"active" if current_page?(admin_partners_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> All Partners
-        <% end %>
-      </li>
-    </ul>
-  </li>
+  <%= sidebar_group 'Users', [
+    { name: 'All Users', path: admin_users_path },
+    { name: 'New User', path: new_admin_user_path, icon: 'plus-circle' },
+  ], icon: 'users fas', controller: 'admin/users' %>
 
-  <li class="nav-item has-treeview <%= menu_open?(['users']) %>">
-    <a href="#" class="nav-link <%= active_class(['users']) %>">
-      <i class="nav-icon fas fa-users"></i>
-      <p>Users
-        <i class="fas fa-angle-left right"></i>
-      </p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(admin_users_path) %>">
-        <%= link_to(admin_users_path, class: "nav-link #{"active" if current_page?(admin_users_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> All Users
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(new_admin_user_path) %>">
-        <%= link_to(new_admin_user_path, class: "nav-link #{"active" if current_page?(new_admin_user_path)}") do %>
-          <i class="nav-icon fa fa-plus-circle"></i> New User
-        <% end %>
-      </li>
-    </ul>
-  </li>
+  <%= sidebar_item 'Announcements',
+    admin_broadcast_announcements_path,
+    icon: 'envelope',
+    controller: true %>
 
-  <li class="nav-item <%= 'active' if current_page?(admin_broadcast_announcements_path) %>">
-        <%= link_to(admin_broadcast_announcements_path, class: "nav-link #{"active" if current_page?(admin_broadcast_announcements_path)}") do %>
-      <i class="nav-icon fa fa-envelope"></i>
-      <p>Announcements</p>
-    <% end %>
-  </li>
+  <%= sidebar_item 'Account Requests',
+    admin_account_requests_path,
+    icon: 'sticky-note',
+    controller: true %>
 
-  <li class="nav-item <%= active_class(['account_requests']) %>">
-    <%= link_to(admin_account_requests_path, class: "nav-link #{"active" if current_page?(admin_account_requests_path)}") do %>
-      <i class="nav-icon fa fa-sticky-note"></i>
-      <p>Account Requests</p>
-    <% end %>
-  </li>
+  <%= sidebar_item 'FAQ', admin_questions_path, controller: true %>
 
-  <li class="nav-item <%= 'active' if current_page?(admin_questions_path) %>">
-    <%= link_to(admin_questions_path, class: "nav-link #{"active" if current_page?(admin_questions_path)}") do %>
-      <i class="nav-icon fa fa-circle-o"></i>
-      <p>FAQ</p>
-    <% end %>
-  </li>
-  
-  <% if Rails.env.production? %>
-    <li class="nav-item">
-      <%= link_to("/coverage", class: "nav-link") do %>
-        <i class="nav-icon fa-solid fa-chart-bar"></i>
-        <p>Coverband</p>
-      <% end %>
-    </li>
-  <% end %>
+  <%= if Rails.env.production?
+    sidebar_item 'Coverband', '/coverage', icon: 'chart-bar fas'
+  end %>
 
-  <% if (current_user.organization.present?) %>
-    <li class="nav-item">
-      <%= link_to(dashboard_path(organization_id: current_user.organization), class: "nav-link") do %>
-        <i class="nav-icon fas fa-home"></i>
-        <p>My Organization</p>
-      <% end %>
-    </li>
-  <% end %>
-
-</ul>
+  <%= if organization = current_user.organization
+    sidebar_item 'My Organization', dashboard_path(organization: organization), icon: 'home'
+  end %>
+<% end %>

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -1,247 +1,81 @@
-<ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
-  <li class="nav-item">
-    <%= link_to(dashboard_path(organization_id: current_user.organization), class: "nav-link #{active_class(['dashboard'])}") do %>
-      <i class="nav-icon fas fa-tachometer-alt"></i>
-      <p>Dashboard</p>
-    <% end %>
-  </li>
-  <li class="nav-item has-treeview <%= menu_open?(['product_drives']) %>">
-    <a href="#" class="nav-link <%= active_class(['product_drives']) %>">
-      <i class="nav-icon fas fa-trophy"></i>
-      <p>Product Drives
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(product_drives_path) %>">
-        <%= link_to(product_drives_path, class: "nav-link #{"active" if current_page?(product_drives_path(organization_id: current_user.organization))}") do %>
-          <i class="nav-icon far fa-circle"></i>
-          <p>All Product Drives</p>
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(new_product_drive_path) %>">
-        <%= link_to(new_product_drive_path, class: "nav-link #{"active" if current_page?(new_product_drive_path)}") do %>
-          <i class="nav-icon far fa-circle"></i>
-          <p>New Product Drive</p>
-        <% end %>
-      </li>
-    </ul>
-  </li>
-  <li class="nav-item has-treeview <%= menu_open?(['donations']) %>">
-    <a href="#" class="nav-link <%= active_class(['donations']) %>">
-      <i class="nav-icon fa fa-gratipay"></i>
-      <p>Donations
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(donations_path) %>">
-        <%= link_to(donations_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(donations_path(organization_id: current_user.organization))}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> All Donations
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(new_donation_path(organization_id: current_user.organization)) %>">
-        <%= link_to(new_donation_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(new_donation_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> New Donation
-        <% end %>
-      </li>
-    </ul>
-  </li>
-  <li class="nav-item has-treeview <%= menu_open?(['purchases']) %>">
-    <a href="#" class="nav-link <%= active_class(['purchases']) %>">
-      <i class="nav-icon fa fa-money"></i>
-      <p>Purchases
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(donations_path) %>">
-        <%= link_to(purchases_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(purchases_path(organization_id: current_user.organization))}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> All Purchases
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(new_purchase_path(organization_id: current_user.organization)) %>">
-        <%= link_to(new_purchase_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(new_purchase_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> New Purchase
-        <% end %>
-      </li>
-    </ul>
-  </li>
-  <li class="nav-item <%= 'active' if current_page?(requests_path) %>">
-    <%= link_to(requests_path, class: "nav-link #{active_class(['requests'])}") do %>
-      <i class="nav-icon fa fa-file-text"></i>
-      <p>Requests</p>
-    <% end %>
-  </li>
-  <li class="nav-item <%= 'active' if current_page?(distributions_path) %>">
-    <%= link_to(distributions_path, class: "nav-link #{"active" if current_page?(distributions_path)}") do %>
-      <i class="nav-icon fa fa-shopping-cart"></i>
-      <p>Distributions</p>
-    <% end %>
-  </li>
-  <li class="nav-item <%= 'active' if current_page?(schedule_distributions_path) %>">
-    <%= link_to(schedule_distributions_path, class: "nav-link #{"active" if current_page?(schedule_distributions_path)}") do %>
-      <i class="nav-icon fa fa-calendar-o"></i>
-      <p>Pick Ups & Deliveries</p>
-    <% end %>
-  </li>
-  <li class="nav-item has-treeview <%= menu_open?(['partners']) %> <%= menu_open?(['broadcast_announcements']) %>">
-    <a href="#" class="nav-link <%= active_class(['partners']) %> <%= active_class(['broadcast_announcements']) %>">
-      <i class="nav-icon fas fa-user-friends"></i>
-      <p>Partner Agencies
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(partners_path) %>">
-        <%= link_to(partners_path, class: "nav-link #{"active" if current_page?(partners_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i>All Partners
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(broadcast_announcements_path) %>">
-        <%= link_to(broadcast_announcements_path, class: "nav-link #{active_class(['broadcast_announcements'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i>Partner Announcement
-        <% end %>
-      </li>
-    </ul>
-  </li>
-  <li class="nav-item has-treeview <%= menu_open?(['items', 'kits', 'barcode_items', 'storage_locations', 'adjustments', 'transfers']) %>">
-    <a href="#" class="nav-link <%= active_class(['items', 'kits', 'barcode_items', 'storage_locations', 'adjustments', 'transfers']) %>">
-      <i class="nav-icon fa fa-pie-chart"></i>
-      <p>Inventory
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= active_class(['items']) %>">
-        <%= link_to(items_path(organization_id: current_user.organization), class: "nav-link #{active_class(['items'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Items &amp; Inventory
-        <% end %>
-      </li>
+<%= sidebar do %>
+  <%= sidebar_item 'Dashboard', dashboard_path, icon: 'tachometer-alt fas' %>
 
-      <li class="nav-item <%= active_class(['kits']) %>">
-        <%= link_to(kits_path(organization_id: current_user.organization), class: "nav-link #{active_class(['kits'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Kits
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['barcode_items']) %>">
-        <%= link_to(barcode_items_path(organization_id: current_user.organization), class: "nav-link #{active_class(['barcode_items'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Barcode Items
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['storage_locations']) %>">
-        <%= link_to(storage_locations_path(organization_id: current_user.organization), class: "nav-link #{active_class(['storage_locations'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Storage Locations
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['adjustments']) %>">
-        <%= link_to(adjustments_path(organization_id: current_user.organization), class: "nav-link #{active_class(['adjustments'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Inventory Adjustments
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['transfers']) %>">
-        <%= link_to(transfers_path(organization_id: current_user.organization), class: "nav-link #{active_class(['transfers'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Transfers
-        <% end %>
-      </li>
-    </ul>
-  </li>
-  <li class="nav-item has-treeview <%= menu_open?(['donation_sites', 'product_drive_participants', 'manufacturers', 'vendors']) %>">
-    <a href="#" class="nav-link <%= active_class(['donation_sites', 'product_drive_participants', 'manufacturers', 'vendors']) %>">
-      <i class="nav-icon fa fa-laptop"></i>
-      <p>Community
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= active_class(['donation_sites']) %>">
-        <%= link_to(donation_sites_path(organization_id: current_user.organization), class: "nav-link #{active_class(['donation_sites'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Donation Sites
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['product_drive_participants']) %>">
-        <%= link_to(product_drive_participants_path(organization_id: current_user.organization), class: "nav-link #{active_class(['product_drive_participants'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Product Drive Participants
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['manufacturers']) %>">
-        <%= link_to(manufacturers_path(organization_id: current_user.organization), class: "nav-link #{active_class(['manufacturers'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Manufacturers
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['vendors']) %>">
-        <%= link_to(vendors_path(organization_id: current_user.organization), class: "nav-link #{active_class(['vendors'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Vendors
-        <% end %>
-      </li>
-    </ul>
-  </li>
-  <li class="nav-item has-treeview <%= menu_open?(['audits', 'reports', "purchases_summary"]) %>">
-    <a href="#" class="nav-link <%= active_class(['audits', 'reports', "purchases_summary"]) %>">
-      <i class="nav-icon fa fa-tasks"></i>
-      <p>Reporting & Auditing
-        <i class="fas fa-angle-left right"></i>
-      </p>
-    </a>
-    <ul class="nav nav-treeview">
-      <% if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
-        <li class="nav-item <%= active_class(['audits']) %>">
-          <%= link_to(audits_path(organization_id: current_user.organization), class: "nav-link #{active_class(['audits'])}") do %>
-            <i class="nav-icon fa fa-circle-o"></i> Inventory Audit
-          <% end %>
-        </li>
-      <% end %>
-      <li class="nav-item <%= active_class(['reports']) %>">
-        <%= link_to(reports_annual_reports_path(organization_id: current_user.organization), class: "nav-link #{active_class(['reports'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Annual Survey
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['reports']) %>">
-        <%= link_to(distributions_by_county_report_path(filters: { date_range: date_range_params }), class: "nav-link #{active_class(['reports'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Distributions by County
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['reports']) %>">
-        <%= link_to(reports_itemized_donations_path(organization_id: current_user.organization), class: "nav-link #{active_class(['reports'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Itemized Donations
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['reports']) %>">
-        <%= link_to(reports_itemized_distributions_path(organization_id: current_user.organization), class: "nav-link #{active_class(['reports'])}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Itemized Distributions
-        <% end %>
-      </li>
-      <li class="nav-item <%= active_class(['purchases_summary']) %>">
-        <%= link_to(purchases_summary_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(purchases_summary_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Purchases Summary
-        <% end %>
-      </li>
-    </ul>
-  </li>
-  <li class="nav-item has-treeview <%= menu_open?(['historical_trends/distributions', 'historical_trends/donations', 'historical_trends/purchases']) %>">
-    <a href="#" class="nav-link <%= active_class(['historical_trends/distributions', 'historical_trends/donations', 'historical_trends/purchases']) %>">
-      <i class="nav-icon fa fa-bar-chart"></i>
-      <p>Historical Trends
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(historical_trends_donations_path) %>">
-        <%= link_to(historical_trends_donations_path, class: "nav-link #{"active" if current_page?(historical_trends_donations_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Donations
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(historical_trends_purchases_path) %>">
-        <%= link_to(historical_trends_purchases_path, class: "nav-link #{"active" if current_page?(historical_trends_purchases_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Purchases
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(historical_trends_distributions_path) %>">
-        <%= link_to(historical_trends_distributions_path, class: "nav-link #{"active" if current_page?(historical_trends_distributions_path)}") do %>
-          <i class="nav-icon fa fa-circle-o"></i> Distributions
-        <% end %>
-      </li>
-    </ul>
-  </li>
-  <% if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
-    <li class="nav-item">
-      <%= link_to(organization_path, class: "nav-link") do %>
-        <i class="nav-icon fas fa-home"></i>
-        <p>My Organization</p>
-      <% end %>
-    </li>
-  <% end %>
-</ul>
+  <%= sidebar_group 'Product Drives', [
+    { name: 'All Product Drives', path: product_drives_path },
+    { name: 'New Product Drive', path: new_product_drive_path },
+  ], icon: 'trophy fas', controller: 'product_drives' %>
+
+  <%= sidebar_group 'Donations', [
+    { name: 'All Donations', path: donations_path },
+    { name: 'New Donations', path: new_donation_path },
+  ], icon: 'gratipay', controller: 'donations' %>
+
+  <%= sidebar_group 'Purchases', [
+    { name: 'All Purchases', path: purchases_path },
+    { name: 'New Purchaces', path: new_purchase_path },
+  ], icon: 'money', controller: 'purchases' %>
+
+  <%= sidebar_item 'Requests', requests_path, icon: 'file-text', controller: true %>
+  <%= sidebar_item 'Distributions', distributions_path, icon: 'shopping-cart' %>
+  <%= sidebar_item 'Pick Ups & Deliveries', schedule_distributions_path, icon: 'calendar-o' %>
+
+  <%= sidebar_group 'Partner Agencies', [
+    { name: 'All Partners', path: partners_path },
+    { name: 'Partner Annoucement', path: broadcast_announcements_path },
+  ], icon: 'user-friends fas', controller: 'broadcast_announcements' %>
+
+  <%= sidebar_group 'Inventory', [
+    { name: 'Items & Inventory', path: items_path, controller: true },
+    { name: 'Kits', path: kits_path, controller: true },
+    { name: 'Barcode Items', path: barcode_items_path, controller: true },
+    { name: 'Storage Locations', path: storage_locations_path, controller: true },
+    { name: 'Inventory Adjustments', path: adjustments_path, controller: true },
+    { name: 'Transfers', path: transfers_path, controller: true },
+  ], icon: 'pie-chart' %>
+
+  <%= sidebar_group 'Community', [
+    { name: 'Donation Sites', path: donation_sites_path, controller: true },
+    { name: 'Product Drive Participants', path: product_drive_participants_path, controller: true },
+    { name: 'Manufacturers', path: manufacturers_path, controller: true },
+    { name: 'Vendors', path: vendors_path, controller: true },
+  ], icon: 'laptop' %>
+
+  <%=
+    # First add role specific reports
+    reports =
+      if current_user.has_role?(Role::ORG_ADMIN, current_organization)
+        [
+          { name: 'Inventory Audit', path: audits_path, controller: true },
+          { name: 'Annual Survey', path: reports_annual_reports_path, controller: true },
+        ]
+      else
+        []
+      end
+    # Add reports for all users
+    reports.concat [{
+      name: 'Distributions by County',
+      path: distributions_by_county_report_path(filters: { date_range: date_range_params }),
+    }, {
+      name: 'Itemized Donations',
+      path: reports_itemized_donations_path,
+    }, {
+      name: 'Itemized Distributions',
+      path: reports_itemized_distributions_path,
+    }, {
+      name: 'Purchases Summary',
+      path: purchases_summary_path,
+    }]
+    sidebar_group 'Reporting & Auditing', reports, icon: 'tasks'
+  %>
+
+  <%= sidebar_group 'Historical Trends', [
+    { name: 'Donations', path: historical_trends_donations_path },
+    { name: 'Purchases', path: historical_trends_purchases_path },
+    { name: 'Distributions', path: historical_trends_distributions_path },
+  ], icon: 'bar-chart' %>
+
+  <%= if current_user.has_role?(Role::ORG_ADMIN, current_organization)
+    sidebar_item 'My Organization', organization_path, icon: 'home fas'
+  end %>
+<% end %>

--- a/app/views/layouts/partners/application.html.erb
+++ b/app/views/layouts/partners/application.html.erb
@@ -51,11 +51,9 @@
     <!-- Sidebar -->
     <div class="sidebar">
       <nav class="mt-2">
-        <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
-          <% if user_signed_in? %>
-            <%= render partial: "layouts/partners/navigation/sidebar" %>
-          <% end %>
-        </ul>
+        <% if user_signed_in? %>
+          <%= render partial: "layouts/partners/navigation/sidebar" %>
+        <% end %>
       </nav>
     </div>
   </aside>
@@ -83,5 +81,3 @@
 </body>
 <div class="modal fade" id="modal_new" role="dialog"></div>
 </html>
-
-

--- a/app/views/layouts/partners/navigation/_sidebar.html.erb
+++ b/app/views/layouts/partners/navigation/_sidebar.html.erb
@@ -1,55 +1,12 @@
-<ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
-
-  <li class="nav-item">
-    <%= link_to(partner_user_root_path, class: "nav-link") do %>
-      <i class="nav-icon fa fa-dashboard"></i>
-      <p>Dashboard</p>
-    <% end %>
-  </li>
-
-  <li class="nav-item">
-    <%= link_to(partners_profile_path, class: "nav-link") do %>
-      <i class="nav-icon fa fa-building"></i>
-      <p>My Organization</p>
-    <% end %>
-  </li>
-
-  <li class="nav-item">
-    <%= link_to(edit_partners_profile_path, class: "nav-link") do %>
-      <i class="nav-icon fa fa-cog"></i>
-      <p>Edit My Organization</p>
-    <% end %>
-  </li>
-
-  <li class="nav-item">
-    <%= link_to(partners_requests_path, class: "nav-link") do %>
-      <i class="nav-icon fa fa-edit"></i>
-      <p>Essentials Requests</p>
-    <% end %>
-  </li>
-
-  <li class="nav-item">
-    <%= link_to(partners_distributions_path, class: "nav-link") do %>
-      <i class="nav-icon fa fa-shopping-cart"></i>
-      <p>Distributions</p>
-    <% end %>
-  </li>
-
-
+<%= sidebar do %>
+  <%= sidebar_item 'Dashboard', partner_user_root_path, icon: 'dashboard' %>
+  <%= sidebar_item 'My Organization', partners_profile_path, icon: 'building' %>
+  <%= sidebar_item 'Edit My Organization', edit_partners_profile_path, icon: 'cog' %>
+  <%= sidebar_item 'Essentials Requests', partners_requests_path, icon: 'edit' %>
+  <%= sidebar_item 'Distributions', partners_distributions_path, icon: 'shopping-cart' %>
 
   <% if current_partner.profile.enable_child_based_requests? %>
-    <li class="nav-item">
-      <%= link_to(partners_families_path, class: "nav-link") do %>
-        <i class="nav-icon fa fa-users"></i>
-        <p>Families</p>
-      <% end %>
-    </li>
-
-    <li class="nav-item">
-      <%= link_to(partners_children_path, class: "nav-link") do %>
-        <i class="nav-icon fa fa-child"></i>
-        <p>Children</p>
-      <% end %>
-    </li>
+    <%= sidebar_item 'Families', partners_families_path, icon: 'users', controller: true %>
+    <%= sidebar_item 'Children', partners_children_path, icon: 'child', controller: true %>
   <% end %>
-</ul>
+<% end %>


### PR DESCRIPTION
### Description

The markup for the sidebar was copy/pasted many many times.  This
PR adds the following helpers:

* `sidebar` - simply adds the appropriate ul wrapper for the sidebar
  to its block, which should have the other two helpers.
* `sidebar_item` - Ensures that whenever the current page is the
  linked path, the item is active.  Has an optional argument to be
  active for any path on the controller.
* `sidebar_group` - Takes a list of items and ensures the group is
  open whenever any item under it is active.  Can also take a
  controller similar to the item, useful if the sub-items are only
  some actions on a controller.

Notably, this fixes:

* Several instances where the path checked was not the path linked
* Several places where an item would be active in a group that wasn't
* The active checks in the admin sidebar all missing the admin/ prefix

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Manually clicking on all the sidebar links and verifying they go to the correct place and highlight afterwards