### PR TITLE
#3726 Thank everyone when the release goes out automagically

### DIFF
--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -11,10 +11,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
-      - uses: apexskier/github-release-commenter@v1
+      - uses: chriskarlin/github-release-commenter@v1.3.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           comment-template: |
-            {author}: Your PR is part of today's Human Essentials production release: {release_link}. 
+            @{author}: Your PR/Issue `{title}` is part of today's Human Essentials production release: {release_link}. 
             Thank you very much for your contribution!

--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -1,0 +1,20 @@
+name: Release Contribution Notifier
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Release Commenter
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: apexskier/github-release-commenter@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-template: |
+            {author}: Your PR is part of today's Human Essentials production release: {release_link}. 
+            Thank you very much for your contribution!


### PR DESCRIPTION
Resolves #3726

### Description
Added github action workflow file with a job that will be run on `release/publish` and comment on each pull request, that is part of the release, with a thank you note.
-> using my own fork of the github action since my [PR](https://github.com/apexskier/github-release-commenter/pull/460)  to add author and title template var was not getting looked at
-> Known limitation: when PRs are linked to issue via linking by keywords, my forked action will not be able to pull author+title

### Type of change
* New feature (non-breaking change which adds functionality)
-> Github Action


### How Has This Been Tested?
Tested the workflow within a private repository of mine through creation of issues -> pull request -> releases

### Screenshots
See comments below

