### PR TITLE
Tab on Items and Inventory fixed

### DIFF
--- a/app/views/items/_item_categories.html.erb
+++ b/app/views/items/_item_categories.html.erb
@@ -1,4 +1,4 @@
-<div class="tab-pane fade show active" id="custom-tabs-three-categories" role="tabpanel" aria-labelledby="custom-tabs-three-categories">
+<div class="tab-pane fade" id="custom-tabs-three-categories" role="tabpanel" aria-labelledby="custom-tabs-three-categories">
 
   <div class='flex justify-end mb-4'>
     <%= new_button_to new_item_category_path(organization_id: current_organization), {text: "New Item Category"} %>


### PR DESCRIPTION
**Resolves** https://github.com/rubyforgood/human-essentials/issues/3813

**Description**

div `id=custom-tabs-three-categories` was always active by default. Changed to active only when div's tab selected.

**Type of change**

Changed HTML attributes.

**How Has This Been Tested?**

Tested manually.