### PR TITLE
Change checkboxes to radio buttons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -161,3 +161,15 @@ select.selectpicker + .dropdown-toggle::after {
 .percentage-selector {
   width: 110px;
 }
+
+.form-yesno {
+  .radio-yesno {
+    width: 3rem;
+  }
+  .input-group {
+    text-align: center;
+  }
+  .collection_radio_buttons {
+    font-weight: normal !important;
+  }
+}

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -12,6 +12,14 @@ module PartnersHelper
     boolean ? 'Yes' : 'No'
   end
 
+  def humanize_boolean_3state(boolean)
+    if boolean.nil?
+      "Unspecified"
+    else
+      boolean ? 'Yes' : 'No'
+    end
+  end
+
   def partner_status_badge(partner)
     if partner.status == "approved"
       tag.span partner.display_status, class: %w(badge badge-pill badge-primary float-right)

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -8,7 +8,8 @@
           </div>
           <div class="card-body">
             <%= form.input :founded, label: "Year Founded", class: "form-control", wrapper: :input_group %>
-            <%= form.input :form_990, label: "Form 990 Filed", as: :boolean, class: "form-control", wrapper: :input_group %>
+            <%= form.input :form_990, label: "Form 990 Filed", as: :radio_buttons, class: "form-control",
+                           wrapper: :input_group, wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
             <label class="control-label col-md-3">Form 990</label>
             <% if profile.proof_of_form_990.attached? %>
               <div class="col-md-8">
@@ -24,16 +25,16 @@
             <%= form.input :program_name, label: "Program Name(s)", class: "form-control", wrapper: :input_group %>
             <%= form.input :program_description, label: "Program Description(s)", class: "form-control", wrapper: :input_group %>
             <%= form.input :program_age, label: "Agency Age", class: "form-control", wrapper: :input_group %>
-            <%= form.input :evidence_based, label: "Evidence Based?", as: :boolean,
-                           class: "form-control", wrapper: :input_group %>
-            <%= form.input :case_management, label: "Case Management", class: "form-control", wrapper: :input_group %>
+            <%= form.input :evidence_based, label: "Evidence Based?", as: :radio_buttons, class: "form-control",
+                           wrapper: :input_group, wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
+            <%= form.input :case_management, label: "Case Management", as: :radio_buttons, class: "form-control",
+                           wrapper: :input_group, wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
             <%= form.input :essentials_use, label: "How Are Essentials (e.g. diapers, period supplies) Used In Your Program?", as: :text,
                            class: "form-control", wrapper: :input_group %>
             <%= form.input :receives_essentials_from_other, label: "Do You Receive Essentials From Other Sources?",
                            class: "form-control", wrapper: :input_group %>
-            <%= form.input :currently_provide_diapers, label: "Currently Providing Diapers?", as: :boolean,
-                           class: "form-control", wrapper: :input_group %>
-          </div>
+            <%= form.input :currently_provide_diapers, label: "Currently Providing Diapers?", as: :radio_buttons,
+                           class: "form-control", wrapper: :input_group, wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
         </div>
       </div>
     </div>

--- a/app/views/partners/profiles/edit/_organizational_capacity.html.erb
+++ b/app/views/partners/profiles/edit/_organizational_capacity.html.erb
@@ -8,8 +8,8 @@
           </div>
           <div class="card-body">
             <%= form.input :client_capacity, label: "Client Capacity", class: "form-control", wrapper: :input_group %>
-            <%= form.input :storage_space, label: "Storage Space", as: :boolean,
-                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :storage_space, label: "Storage Space", as: :radio_buttons, class: "form-control",
+                           wrapper: :input_group, wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
             <%= form.input :describe_storage_space, label: "Storage Space Description", class: "form-control", wrapper: :input_group %>
 
           </div>

--- a/app/views/partners/profiles/edit/_population_served.html.erb
+++ b/app/views/partners/profiles/edit/_population_served.html.erb
@@ -8,9 +8,11 @@
           </div>
           <div class="card-body">
             <%= form.input :income_requirement_desc, label: "Clients Have An Income Requirement to Work With You?",
-                           as: :boolean, class: "form-control", wrapper: :input_group %>
-            <%= form.input :income_verification,label: "Do You Verify The Income Of Your Clients?",
-                           as: :boolean, class: "form-control", wrapper: :input_group %>
+                           as: :radio_buttons, class: "form-control", wrapper: :input_group,
+                           wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
+            <%= form.input :income_verification, label: "Do You Verify The Income Of Your Clients?",
+                           as: :radio_buttons, class: "form-control", wrapper: :input_group,
+                           wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
           </div>
         </div>
       </div>

--- a/app/views/partners/profiles/show/_agency_stability.html.erb
+++ b/app/views/partners/profiles/show/_agency_stability.html.erb
@@ -6,7 +6,7 @@
       <dd><%= profile.founded %></dd>
 
       <dt>Form 990 Filed</dt>
-      <dd><%= humanize_boolean(profile.form_990) %></dd>
+      <dd><%= humanize_boolean_3state(profile.form_990) %></dd>
 
       <dt>Form 990</dt>
       <% if profile.proof_of_form_990.attached? %>
@@ -26,10 +26,10 @@
       <dd><%= profile.program_age %></dd>
 
       <dt>Case Management</dt>
-      <dd><%= humanize_boolean(profile.case_management) %></dd>
+      <dd><%= humanize_boolean_3state(profile.case_management) %></dd>
 
       <dt>Evidence Based</dt>
-      <dd><%= humanize_boolean(profile.evidence_based) %></dd>
+      <dd><%= humanize_boolean_3state(profile.evidence_based) %></dd>
 
       <dt>How Are Essentials (e.g. diapers, period supplies) Used In Your Program?</dt>
       <dd><%= profile.essentials_use %></dd>
@@ -38,7 +38,7 @@
       <dd><%= profile.receives_essentials_from_other %></dd>
 
       <dt>Current Providing Diapers</dt>
-      <dd><%= humanize_boolean(profile.currently_provide_diapers) %></dd>
+      <dd><%= humanize_boolean_3state(profile.currently_provide_diapers) %></dd>
 
       <address>
         <strong>Program Address (if different)</strong> <br>

--- a/app/views/partners/profiles/show/_organizational_capacity.html.erb
+++ b/app/views/partners/profiles/show/_organizational_capacity.html.erb
@@ -6,7 +6,7 @@
       <dd><%= profile.client_capacity %></dd>
 
       <dt>Storage Space</dt>
-      <dd><%= humanize_boolean(profile.storage_space) %></dd>
+      <dd><%= humanize_boolean_3state(profile.storage_space) %></dd>
 
       <dt>Storage Space Description</dt>
       <dd><%= profile.describe_storage_space %></dd>

--- a/app/views/partners/profiles/show/_population_served.html.erb
+++ b/app/views/partners/profiles/show/_population_served.html.erb
@@ -3,10 +3,10 @@
   <div class="card-body">
     <dl>
       <dt>Clients Have An Income Requirement to Work With You</dt>
-      <dd><%= humanize_boolean(profile.income_requirement_desc) %></dd>
+      <dd><%= humanize_boolean_3state(profile.income_requirement_desc) %></dd>
 
       <dt>Do You Verify The Income Of Your Clients</dt>
-      <dd><%= humanize_boolean(profile.income_verification) %></dd>
+      <dd><%= humanize_boolean_3state(profile.income_verification) %></dd>
 
       <h6>Race/Ethnicity of Client Base</h6>
       <dt>African American</dt>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -45,11 +45,11 @@
       <p>Program Name(s): <%= partner_profile.program_name %></p>
       <p>Program Description(s): <%= partner_profile.program_description %></p>
       <p>Program Age: <%= partner_profile.program_age %></p>
-      <p>Case Management: <%= humanize_boolean(partner_profile.case_management) %></p>
-      <p>Evidence Based: <%= humanize_boolean(partner_profile.evidence_based) %></p>
+      <p>Case Management: <%= humanize_boolean_3state(partner_profile.case_management) %></p>
+      <p>Evidence Based: <%= humanize_boolean_3state(partner_profile.evidence_based) %></p>
       <p>How Are Essentials (e.g. diapers, period supplies) Used In Your Program? <%= partner_profile.essentials_use %></p>
       <p>Do You Receive Essentials from Other Sources? <%= partner_profile.receives_essentials_from_other %></p>
-      <p>Currently Providing Diapers: <%= humanize_boolean(partner_profile.currently_provide_diapers) %></p>
+      <p>Currently Providing Diapers: <%= humanize_boolean_3state(partner_profile.currently_provide_diapers) %></p>
       <br>
       <h3>Program Address (if different)</h3>
       <p>Program Address: <%= partner_profile.program_address1 %></p>
@@ -62,7 +62,7 @@
     <% if partner_profile_fields.include?('organizational_capacity') || partner_profile_fields.empty? %>
       <h2 class='text-2xl underline'>Organizational Capacity</h2>
       <p>Client Capacity: <%= partner_profile.client_capacity %></p>
-      <p>Storage Space: <%= humanize_boolean(partner_profile.storage_space) %></p>
+      <p>Storage Space: <%= humanize_boolean_3state(partner_profile.storage_space) %></p>
       <p>Storage Space Description: <%= partner_profile.describe_storage_space %></p>
       <br>
     <% end %>
@@ -84,8 +84,8 @@
 
     <% if partner_profile_fields.include?('population_served') || partner_profile_fields.empty? %>
       <h2 class='text-2xl underline'>Population Served</h2>
-      <p>Income Requirement: <%= humanize_boolean(partner_profile.income_requirement_desc) %></p>
-      <p>Income Verification: <%= humanize_boolean(partner_profile.income_verification) %></p>
+      <p>Income Requirement: <%= humanize_boolean_3state(partner_profile.income_requirement_desc) %></p>
+      <p>Income Verification: <%= humanize_boolean_3state(partner_profile.income_verification) %></p>
       <br>
     <% end %>
   </div>

--- a/spec/requests/partners/profiles_requests_spec.rb
+++ b/spec/requests/partners/profiles_requests_spec.rb
@@ -13,12 +13,41 @@ RSpec.describe "/partners/profiles", type: :request do
       get partners_profile_path(partner)
       expect(response.body).to include("Partnerrific")
     end
+
+    it "shows correct values for yes/no buttons" do
+      partner.profile.update!(currently_provide_diapers: nil, form_990: false, income_verification: true)
+      get partners_profile_path(partner)
+      expect(response.body).to include("<dt>Current Providing Diapers</dt>\n      <dd>Unspecified</dd>")
+      expect(response.body).to include("<dt>Form 990 Filed</dt>\n      <dd>No</dd>")
+      expect(response.body).to include("<dt>Do You Verify The Income Of Your Clients</dt>\n      <dd>Yes</dd>")
+    end
   end
 
   describe "GET #edit" do
     it "displays the partner" do
       get edit_partners_profile_path(partner)
       expect(response.body).to include("Partnerrific")
+    end
+
+    it "does not have default radio button value when value is nil" do
+      partner.profile.update!(storage_space: nil)
+      get edit_partners_profile_path(partner)
+      expect(response.body).not_to include("type=\"radio\" value=\"true\" checked=\"checked\" name=\"partner[profile][storage_space]\" id=\"partner_profile_storage_space_true\" />")
+      expect(response.body).not_to include("type=\"radio\" value=\"false\" checked=\"checked\" name=\"partner[profile][storage_space]\" id=\"partner_profile_storage_space_false\"")
+    end
+
+    it "has \"Yes\" radio button value when value is true" do
+      partner.profile.update!(storage_space: true)
+      get edit_partners_profile_path(partner)
+      expect(response.body).to include("type=\"radio\" value=\"true\" checked=\"checked\" name=\"partner[profile][storage_space]\" id=\"partner_profile_storage_space_true\" />")
+      expect(response.body).not_to include("type=\"radio\" value=\"false\" checked=\"checked\" name=\"partner[profile][storage_space]\" id=\"partner_profile_storage_space_false\"")
+    end
+
+    it "has \"No\" radio button value when value is false" do
+      partner.profile.update!(storage_space: false)
+      get edit_partners_profile_path(partner)
+      expect(response.body).not_to include("type=\"radio\" value=\"true\" checked=\"checked\" name=\"partner[profile][storage_space]\" id=\"partner_profile_storage_space_true\" />")
+      expect(response.body).to include("type=\"radio\" value=\"false\" checked=\"checked\" name=\"partner[profile][storage_space]\" id=\"partner_profile_storage_space_false\"")
     end
   end
 


### PR DESCRIPTION
Resolves #3804 

### Description

- Checkboxes changed to yes/no buttons on Partner Profile form to reduce confusion
- Existing styles did not work well with radio buttons on this form (width property was getting set to 0 on the enclosing DIVs, causing odd display of the buttons).  New styles added to better match the general style of the form.  
- Partner profile show view updated to include "Unspecified" when the boolean field is still null.  Previous behavior was to show "No" for any falsey value, including null.
- Added tests to verify these fields are null on creation, and that they change to the proper values when the radio buttons are selected.

   
List any dependencies that are required for this change. (gems, js libraries, etc.)
No new dependencies

Include anything else we should know about. -->

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Manual: Create new partner, verify that neither option is checked when editing profile.  Verify that if no options are selected for any particular field that viewing profile shows "Unspecified" for that field.  Choose an option for each pair of radio buttons.  Verify correct results when viewing.
RSpec:
spec/models/partners/profile_spec.rb `#Edited to add new test for null at creation`
spec/system/partners/profile_radio_spec.rb `#New system test to verify proper form operation`

Do we need to do anything else to verify your changes? No
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
Before:
Edit:
![before_checkbox](https://github.com/rubyforgood/human-essentials/assets/140783697/03d046fc-8f67-4cc6-a698-0a479b5c0806)
Show:

![before_show](https://github.com/rubyforgood/human-essentials/assets/140783697/d72c82ee-ce76-44ef-85c3-ce36a6d993ad)

After:
Edit:
![after_edit](https://github.com/rubyforgood/human-essentials/assets/140783697/11d86cdc-7e81-441b-b24d-846432dc5122)
Show:


![after_show](https://github.com/rubyforgood/human-essentials/assets/140783697/ce6d7f2d-484f-45dd-981d-7e3266438f0e)

