### PR TITLE
Label changes done for Reminder day and Deadline Day

### DIFF
--- a/app/views/shared/_deadline_day_fields.html.erb
+++ b/app/views/shared/_deadline_day_fields.html.erb
@@ -8,7 +8,7 @@
             }) do %>
   <div class="deadline-day-pickers__reminder-container">
     <%= f.input :reminder_day, wrapper: :input_group, wrapper_html: { class: 'mb-0' },
-                label: 'Reminder day (Day an e-mail reminder is sent to partners to submit requests)' do %>
+                label: 'Reminder day (Day of month an e-mail reminder is sent to partners to submit requests)' do %>
       <span class="input-group-text"><i class="fa fa-calendar"></i></span>
       <%= f.number_field :reminder_day,
                          class: "deadline-day-pickers__reminder-day form-control",
@@ -19,7 +19,7 @@
 
   <div class="deadline-day-pickers__deadline-container">
     <%= f.input :deadline_day, wrapper: :input_group, wrapper_html: { class: 'mb-0' },
-                label: 'Deadline day (Final day to submit requests)' do %>
+                label: 'Deadline day (Final day of month to submit requests)' do %>
       <span class="input-group-text"><i class="fa fa-calendar"></i></span>
       <%= f.number_field :deadline_day,
                          class: "deadline-day-pickers__deadline-day form-control",


### PR DESCRIPTION

Resolves #3685 

### Description
The label modifications were requested for the edit organization form, and this has been completed within the scope of this pull request.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

- Login as Admin User
- Click on Organizations
- Click on All Organizations
- Click on the Edit button
-  You should be able to see the text changes displayed in screenshot.

<img width="1565" alt="AfterChanges" src="https://github.com/rubyforgood/human-essentials/assets/3184984/c52ac8b1-5f59-44e6-8886-872fa1328e3c">

### Screenshots
Before the text changes in this PR:

<img width="1568" alt="Before" src="https://github.com/rubyforgood/human-essentials/assets/3184984/2288adee-1be8-4725-8001-e669de56c9ec">

After the text changes in this PR:

<img width="1565" alt="AfterChanges" src="https://github.com/rubyforgood/human-essentials/assets/3184984/c52ac8b1-5f59-44e6-8886-872fa1328e3c">

