### PR TITLE
Create remove-help-wanted.yml

### DIFF
--- a/.github/workflows/remove-help-wanted.yml
+++ b/.github/workflows/remove-help-wanted.yml
@@ -1,0 +1,13 @@
+name: Remove Help Wanted Label on Issue Assignment
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: andymckay/labeler@master
+        with:
+          remove-labels: "Help Wanted"


### PR DESCRIPTION
Looks like our old workflows for removing Help Wanted from issues are no longer working. I *think* this should bring back the functionality.

Shamelessly copy/pasted from elsewhere -- hopefully it works :)