### PR TITLE
Shipping cost added for distributions with shipping

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -550,11 +550,14 @@ end
 20.times.each do
   storage_location = random_record_for_org(pdx_org, StorageLocation)
   stored_inventory_items_sample = storage_location.inventory_items.sample(20)
+  delivery_method = Distribution.delivery_methods.keys.sample
+  shipping_cost = delivery_method == "shipped" ? (rand(20.0..100.0)).round(2).to_s : nil
   distribution = Distribution.create!(storage_location: storage_location,
                                       partner: random_record_for_org(pdx_org, Partner),
                                       organization: pdx_org,
                                       issued_at: Faker::Date.between(from: 4.days.ago, to: Time.zone.today),
-                                      delivery_method: Distribution.delivery_methods.keys.sample,
+                                      delivery_method: delivery_method,
+                                      shipping_cost: shipping_cost,
                                       comment: 'Urgent')
 
   stored_inventory_items_sample.each do |stored_inventory_item|


### PR DESCRIPTION
Resolves #[3846](https://github.com/rubyforgood/human-essentials/issues/3846) 


### Description
Revised the seed file to include shipping costs for distributions with a delivery_method of 'shipped'.

### Type of change

- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

- Clear the local database.
- Execute the bin/setup command.
- Run a query within the Rails console:
 `Distribution.where(delivery_method: "shipped").pluck(:shipping_cost)`
- Review the Distribution screen.


### Screenshots

<img width="1680" alt="shipping_cost_screen" src="https://github.com/rubyforgood/human-essentials/assets/3184984/0c7dcd5e-7ec5-44b0-8869-bd834541186a">

