### PR TITLE
Revert "add mandatory fields for partner profile"

### DIFF
--- a/app/models/partners/profile.rb
+++ b/app/models/partners/profile.rb
@@ -94,9 +94,7 @@ module Partners
     accepts_nested_attributes_for :served_areas, allow_destroy: true
 
     has_many_attached :documents
-
     validate :check_social_media, on: :edit
-    validates :agency_type, :city, :state, :zip_code, :address1, :program_name, :program_description, presence: true, on: :edit
 
     validate :client_share_is_0_or_100
     validate :has_at_least_one_request_setting
@@ -123,7 +121,7 @@ module Partners
 
     def check_social_media
       return if website.present? || twitter.present? || facebook.present? || instagram.present?
-      return if partner&.partials_to_show&.exclude?("media_information")
+      return if partner.partials_to_show.exclude?("media_information")
 
       unless no_social_media_presence
         errors.add(:no_social_media_presence, "must be checked if you have not provided any of Website, Twitter, Facebook, or Instagram.")

--- a/app/views/partners/profiles/edit/_agency_information.html.erb
+++ b/app/views/partners/profiles/edit/_agency_information.html.erb
@@ -8,7 +8,7 @@
           </div>
           <div class="card-body">
             <%= form.input :name, label: "Agency Name", class: "form-control", wrapper: :input_group %>
-            <%= profile_form.input :agency_type, required: true, collection: Partner::AGENCY_TYPES.values, label: "Agency Type", class: "form-control", wrapper: :input_group %>
+            <%= profile_form.input :agency_type, collection: Partner::AGENCY_TYPES.values, label: "Agency Type", class: "form-control", wrapper: :input_group %>
             <%= profile_form.input :other_agency_type, label: "Other Agency Type", class: "form-control", wrapper: :input_group %>
             <div class="form-group row">
               <label class="control-label col-md-3">501(c)(3) IRS Determination Letter</label>
@@ -25,11 +25,11 @@
               <% end %>
             </div>
             <%= profile_form.input :agency_mission, label: "Agency Mission", class: "form-control", wrapper: :input_group %>
-            <%= profile_form.input :address1, label: "Address (line 1)", required: true, class: "form-control", wrapper: :input_group %>
+            <%= profile_form.input :address1, label: "Address (line 1)", class: "form-control", wrapper: :input_group %>
             <%= profile_form.input :address2, label: "Address (line 2)", class: "form-control", wrapper: :input_group %>
-            <%= profile_form.input :city, label: "City", required: true, class: "form-control", wrapper: :input_group %>
-            <%= profile_form.input :state, label: "State", required: true, class: "form-control", wrapper: :input_group %>
-            <%= profile_form.input :zip_code, label: "Zip Code", required: true, class: "form-control", wrapper: :input_group %>
+            <%= profile_form.input :city, label: "City", class: "form-control", wrapper: :input_group %>
+            <%= profile_form.input :state, label: "State", class: "form-control", wrapper: :input_group %>
+            <%= profile_form.input :zip_code, label: "Zip Code", class: "form-control", wrapper: :input_group %>
           </div>
         </div>
       </div>

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -22,8 +22,8 @@
                 <%= form.file_field :proof_of_form_990, class: "form-control-file" %>
               </div>
             <% end %>
-            <%= form.input :program_name, label: "Program Name(s)", required: true, class: "form-control", wrapper: :input_group %>
-            <%= form.input :program_description, label: "Program Description(s)", required: true, class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_name, label: "Program Name(s)", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_description, label: "Program Description(s)", class: "form-control", wrapper: :input_group %>
             <%= form.input :program_age, label: "Agency Age", class: "form-control", wrapper: :input_group %>
             <%= form.input :evidence_based, label: "Evidence Based?", as: :radio_buttons, class: "form-control",
                            wrapper: :input_group, wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>

--- a/spec/factories/partners/profile.rb
+++ b/spec/factories/partners/profile.rb
@@ -3,13 +3,5 @@ FactoryBot.define do
     partner { Partner.first || create(:partner) }
     essentials_bank_id { Organization.try(:first).id || create(:organization).id }
     website { "http://some-site.org" }
-    name { Faker::Company.name }
-    agency_type { Partner::AGENCY_TYPES["CAREER"] }
-    city { Faker::Address.city }
-    state { Faker::Address.state }
-    zip_code { Faker::Address.zip }
-    address1 { Faker::Address.street_address }
-    program_name { Faker::Lorem.characters(number: 5) }
-    program_description { Faker::Lorem.characters(number: 15) }
   end
 end

--- a/spec/models/partners/profile_spec.rb
+++ b/spec/models/partners/profile_spec.rb
@@ -90,16 +90,6 @@ RSpec.describe Partners::Profile, type: :model do
     it { should have_many(:served_areas) }
   end
 
-  describe "validations" do
-    it { should validate_presence_of(:agency_type).on(:edit) }
-    it { should validate_presence_of(:city).on(:edit) }
-    it { should validate_presence_of(:state).on(:edit) }
-    it { should validate_presence_of(:zip_code).on(:edit) }
-    it { should validate_presence_of(:address1).on(:edit) }
-    it { should validate_presence_of(:program_name).on(:edit) }
-    it { should validate_presence_of(:program_description).on(:edit) }
-  end
-
   it "must allow deleting served_areas" do
     should accept_nested_attributes_for(:served_areas).allow_destroy(true)
   end

--- a/spec/requests/partners/profiles_requests_spec.rb
+++ b/spec/requests/partners/profiles_requests_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe "/partners/profiles", type: :request do
 
     context "when updating an existing value to a blank value" do
       before do
-        partner.profile.update!(instagram: "")
+        partner.profile.update!(city: "")
         put partners_profile_path(partner,
-          partner: {name: "Partnerdude", profile: {instagram: "", website: "N/A"}})
+          partner: {name: "Partnerdude", profile: {city: "", website: "N/A"}})
       end
 
       it "updates the partner profile attribute to a blank value" do
-        expect(partner.profile.reload.instagram).to eq ""
+        expect(partner.profile.reload.city).to eq ""
       end
 
       it "does not update other partner profile attributes to blank" do

--- a/spec/services/partners/request_approval_service_spec.rb
+++ b/spec/services/partners/request_approval_service_spec.rb
@@ -23,7 +23,9 @@ describe Partners::RequestApprovalService do
           .to include("No social media presence must be checked if you have not provided any of Website, Twitter, Facebook, or Instagram.")
       end
 
-      it 'should return an error re agency_type' do
+      # TODO: This test is disabled until we sort out required fields, per
+      # https://github.com/rubyforgood/human-essentials/issues/3875
+      xit 'should return an error re agency_type' do
         partner.profile.update(agency_type: "")
 
         expect(subject.errors.full_messages)

--- a/spec/services/profile_update_service_spec.rb
+++ b/spec/services/profile_update_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ProfileUpdateService do
     let(:params) { {address2: "Washington, DC"} }
 
     it "updates the profile with the filtered and prepared params" do
-      expect(partner.profile.instagram).to be_nil
+      expect(partner.profile.address1).to be_nil
 
       result = described_class.update(partner.profile, params)
       expect(result).to eq(true)


### PR DESCRIPTION
Reverts rubyforgood/human-essentials#3691

Unfortunately this validates for all record saves, not limited to new partner applications. This caused issues with HE Banks that then couldn't edit Partner Agency Information without filling in the now-manditory fields (and surprised them). I think the intention was to only apply this validation of required fields during the initial application?

In any case, I'm going to hopefully-temporarily revert this so that the Banks are unblocked. I'll open a new issue to refresh this and maybe apply the rules only at the time of application (ex using AR validation context).