### PR TITLE
#3426 - Fix error handling on registration 

### DIFF
--- a/app/controllers/account_requests_controller.rb
+++ b/app/controllers/account_requests_controller.rb
@@ -32,7 +32,6 @@ class AccountRequestsController < ApplicationController
       redirect_to received_account_requests_path(token: @account_request.identity_token),
                   notice: 'Account request was successfully created.'
     else
-      flash[:alert] = "Name, email, and request details required"
       render :new
     end
   end

--- a/app/controllers/account_requests_controller.rb
+++ b/app/controllers/account_requests_controller.rb
@@ -18,12 +18,11 @@ class AccountRequestsController < ApplicationController
 
   def new
     @account_request = AccountRequest.new
-    @bank_selected
   end
 
   def create
     @account_request = AccountRequest.new(account_request_params)
-    bank_selected if params[:account_request][:bank_selected] == "true"
+    @bank_selected = true
 
     if !verify_recaptcha(model: @account_request)
       flash[:alert] = "Invalid captcha submission"
@@ -51,11 +50,6 @@ class AccountRequestsController < ApplicationController
     end
 
     @account_request
-  end
-
-  # Pass parameter through to 'render :new' action to expand account_request form upon form or captcha error reload
-  def bank_selected
-    @bank_selected = true 
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/account_requests_controller.rb
+++ b/app/controllers/account_requests_controller.rb
@@ -18,10 +18,12 @@ class AccountRequestsController < ApplicationController
 
   def new
     @account_request = AccountRequest.new
+    @bank_selected
   end
 
   def create
     @account_request = AccountRequest.new(account_request_params)
+    bank_selected if params[:account_request][:bank_selected] == "true"
 
     if !verify_recaptcha(model: @account_request)
       flash[:alert] = "Invalid captcha submission"
@@ -49,6 +51,11 @@ class AccountRequestsController < ApplicationController
     end
 
     @account_request
+  end
+
+  # Pass parameter through to 'render :new' action to expand account_request form upon form or captcha error reload
+  def bank_selected
+    @bank_selected = true 
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/account_requests_controller.rb
+++ b/app/controllers/account_requests_controller.rb
@@ -32,6 +32,7 @@ class AccountRequestsController < ApplicationController
       redirect_to received_account_requests_path(token: @account_request.identity_token),
                   notice: 'Account request was successfully created.'
     else
+      flash[:alert] = "Name, email, and request details required"
       render :new
     end
   end

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -13,15 +13,36 @@
         <%= radio_button_tag(:account, :partner, false, class: 'form-check-input account_type') %>
         <%= label_tag(:account, "I am a Partner Agency to an Essentials Bank. I distribute the diapers/period supplies that I receive from essentials banks directly to the public.", class: 'form-check-label') %>
       </div>
+      
+      <% if @bank_selected %>
+        <script type="module">
+            $(document).ready(function() {
+                const bankRadioButtons = $('.account_type[value="bank"]:not(:checked)');
+
+                if (bankRadioButtons.length > 0) {
+                    bankRadioButtons.eq(0).click();
+                }
+            });
+        </script>
+      <% else %>
+        <script type="module">
+            $(document).ready(function() {
+                $('#create_bank').hide()
+                $('#partner_info').hide()
+            });
+        </script>
+      <% end %>
 
       <script type="module">
           $('.account_type').change(function() {
               if (this.value === 'bank') {
                   $('#create_bank').show()
                   $('#partner_info').hide()
+                  $('#bank-selected').val(true);
               } else {
                   $('#create_bank').hide()
                   $('#partner_info').show()
+                  $('#bank-selected').val(false);
               }
           })
       </script>
@@ -39,28 +60,11 @@
         </p>
 
       <%= simple_form_for(@account_request) do |f| %>
-        <% if f.error_notification.present? %>
-          <script type="module">
-              $(document).ready(function() {
-                  const bankRadioButtons = $('.account_type[value="bank"]:not(:checked)');
-
-                  if (bankRadioButtons.length > 0) {
-                      bankRadioButtons.eq(0).click();
-                  }
-              });
-          </script>
-        <% else %>
-          <script type="module">
-              $(document).ready(function() {
-                    $('#create_bank').hide()
-                    $('#partner_info').hide()
-              })
-          </script>
-        <% end %>
-
         <%= f.error_notification %>
         <%= render partial: "shared/flash" %>
 
+        <%= f.hidden_field :bank_selected, value: false , id: 'bank-selected' %>
+        
         <div class="form-inputs">
           <div class="form-inputs">
             <%= f.input :name, autofocus: true %>

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -38,11 +38,9 @@
               if (this.value === 'bank') {
                   $('#create_bank').show()
                   $('#partner_info').hide()
-                  $('#bank-selected').val(true);
               } else {
                   $('#create_bank').hide()
                   $('#partner_info').show()
-                  $('#bank-selected').val(false);
               }
           })
       </script>
@@ -62,8 +60,6 @@
       <%= simple_form_for(@account_request) do |f| %>
         <%= f.error_notification %>
         <%= render partial: "shared/flash" %>
-
-        <%= f.hidden_field :bank_selected, value: false , id: 'bank-selected' %>
         
         <div class="form-inputs">
           <div class="form-inputs">

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -57,46 +57,47 @@
           <span class='text-bold'>Do you <span class='text-italic'>partner</span> with diaper and/or period supply banks? If so please go to the <%= link_to 'partner app', new_user_session_path %> to login.</span>
         </p>
 
-      <%= simple_form_for(@account_request) do |f| %>
-        <%= f.error_notification %>
-        <%= render partial: "shared/flash" %>
+        <%= simple_form_for(@account_request) do |f| %>
+          <%= f.error_notification %>
+          <%= render partial: "shared/flash" %>
         
-        <div class="form-inputs">
           <div class="form-inputs">
-            <%= f.input :name, autofocus: true %>
+            <div class="form-inputs">
+              <%= f.input :name, autofocus: true %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :email %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :organization_name %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :organization_website %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :ndbn_member, label: 'NDBN Membership', wrapper: :input_group do %>
+                <%= f.association :ndbn_member, label_method: :full_name, value_method: :id, label: false %>
+              <% end %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :request_details, placeholder: 'Tell us more about your organization and how you would use Human Essentials', label: "Request Details (min 50 characters)" %>
+            </div>
           </div>
 
-          <div class="form-inputs">
-            <%= f.input :email %>
+          <div class="my-2">
+            <%= recaptcha_tags %>
           </div>
 
-          <div class="form-inputs">
-            <%= f.input :organization_name %>
+          <div class="card-footer">
+            <%= submit_button({text: 'Submit', icon: nil}) %>
           </div>
-
-          <div class="form-inputs">
-            <%= f.input :organization_website %>
-          </div>
-
-          <div class="form-inputs">
-            <%= f.input :ndbn_member, label: 'NDBN Membership', wrapper: :input_group do %>
-              <%= f.association :ndbn_member, label_method: :full_name, value_method: :id, label: false %>
-            <% end %>
-          </div>
-
-          <div class="form-inputs">
-            <%= f.input :request_details, placeholder: 'Tell us more about your organization and how you would use Human Essentials', label: "Request Details (min 50 characters)" %>
-          </div>
-        </div>
-
-        <div class="my-2">
-          <%= recaptcha_tags %>
-        </div>
-
-        <div class="card-footer">
-          <%= submit_button({text: 'Submit', icon: nil}) %>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
 <% else %>

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -6,29 +6,13 @@
       </div>
 
       <div class="form-check">
-        <%= radio_button_tag(:account, :bank, flash.present?, class: 'form-check-input account_type') %>
+        <%= radio_button_tag(:account, :bank, false, class: 'form-check-input account_type') %>
         <%= label_tag(:account, "I am an Essentials Bank. I do NOT distribute diapers/period supplies directly to the public, I distribute them to partner agencies who distribute them to the public.", class: 'form-check-label') %>
       </div>
       <div class="form-check">
         <%= radio_button_tag(:account, :partner, false, class: 'form-check-input account_type') %>
         <%= label_tag(:account, "I am a Partner Agency to an Essentials Bank. I distribute the diapers/period supplies that I receive from essentials banks directly to the public.", class: 'form-check-label') %>
       </div>
-
-      <% if flash.present? %>
-        <script type="module">
-            $(document).ready(function() {
-                $('#create_bank').show()
-                $('#partner_info').hide()
-            })
-        </script>
-      <% else %>
-        <script type="module">
-            $(document).ready(function() {
-                $('#create_bank').hide()
-                $('#partner_info').hide()
-            })
-        </script>
-      <% end %>
 
       <script type="module">
           $('.account_type').change(function() {
@@ -54,47 +38,65 @@
           <span class='text-bold'>Do you <span class='text-italic'>partner</span> with diaper and/or period supply banks? If so please go to the <%= link_to 'partner app', new_user_session_path %> to login.</span>
         </p>
 
-        <%= simple_form_for(@account_request) do |f| %>
-          <%= f.error_notification %>
-          <%= render partial: "shared/flash" %>
+      <%= simple_form_for(@account_request) do |f| %>
+        <% if f.error_notification.present? %>
+          <script type="module">
+              $(document).ready(function() {
+                  const bankRadioButtons = $('.account_type[value="bank"]:not(:checked)');
+
+                  if (bankRadioButtons.length > 0) {
+                      bankRadioButtons.eq(0).click();
+                  }
+              });
+          </script>
+        <% else %>
+          <script type="module">
+              $(document).ready(function() {
+                    $('#create_bank').hide()
+                    $('#partner_info').hide()
+              })
+          </script>
+        <% end %>
+
+        <%= f.error_notification %>
+        <%= render partial: "shared/flash" %>
+
+        <div class="form-inputs">
+          <div class="form-inputs">
+            <%= f.input :name, autofocus: true %>
+          </div>
 
           <div class="form-inputs">
-            <div class="form-inputs">
-              <%= f.input :name, autofocus: true %>
-            </div>
-
-            <div class="form-inputs">
-              <%= f.input :email %>
-            </div>
-
-            <div class="form-inputs">
-              <%= f.input :organization_name %>
-            </div>
-
-            <div class="form-inputs">
-              <%= f.input :organization_website %>
-            </div>
-
-            <div class="form-inputs">
-              <%= f.input :ndbn_member, label: 'NDBN Membership', wrapper: :input_group do %>
-                <%= f.association :ndbn_member, label_method: :full_name, value_method: :id, label: false %>
-              <% end %>
-            </div>
-
-            <div class="form-inputs">
-              <%= f.input :request_details, placeholder: 'Tell us more about your organization and how you would use Human Essentials', label: "Request Details (min 50 characters)" %>
-            </div>
+            <%= f.input :email %>
           </div>
 
-          <div class="my-2">
-            <%= recaptcha_tags %>
+          <div class="form-inputs">
+            <%= f.input :organization_name %>
           </div>
 
-          <div class="card-footer">
-            <%= submit_button({text: 'Submit', icon: nil}) %>
+          <div class="form-inputs">
+            <%= f.input :organization_website %>
           </div>
-        <% end %>
-      </div>
+
+          <div class="form-inputs">
+            <%= f.input :ndbn_member, label: 'NDBN Membership', wrapper: :input_group do %>
+              <%= f.association :ndbn_member, label_method: :full_name, value_method: :id, label: false %>
+            <% end %>
+          </div>
+
+          <div class="form-inputs">
+            <%= f.input :request_details, placeholder: 'Tell us more about your organization and how you would use Human Essentials', label: "Request Details (min 50 characters)" %>
+          </div>
+        </div>
+
+        <div class="my-2">
+          <%= recaptcha_tags %>
+        </div>
+
+        <div class="card-footer">
+          <%= submit_button({text: 'Submit', icon: nil}) %>
+        </div>
+      <% end %>
     </div>
   </div>
 <% else %>

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -6,13 +6,29 @@
       </div>
 
       <div class="form-check">
-        <%= radio_button_tag(:account, :bank, false, class: 'form-check-input account_type') %>
+        <%= radio_button_tag(:account, :bank, flash.present?, class: 'form-check-input account_type') %>
         <%= label_tag(:account, "I am an Essentials Bank. I do NOT distribute diapers/period supplies directly to the public, I distribute them to partner agencies who distribute them to the public.", class: 'form-check-label') %>
       </div>
       <div class="form-check">
         <%= radio_button_tag(:account, :partner, false, class: 'form-check-input account_type') %>
         <%= label_tag(:account, "I am a Partner Agency to an Essentials Bank. I distribute the diapers/period supplies that I receive from essentials banks directly to the public.", class: 'form-check-label') %>
       </div>
+
+      <% if flash.present? %>
+        <script type="module">
+            $(document).ready(function() {
+                $('#create_bank').show()
+                $('#partner_info').hide()
+            })
+        </script>
+      <% else %>
+        <script type="module">
+            $(document).ready(function() {
+                $('#create_bank').hide()
+                $('#partner_info').hide()
+            })
+        </script>
+      <% end %>
 
       <script type="module">
           $('.account_type').change(function() {
@@ -23,11 +39,6 @@
                   $('#create_bank').hide()
                   $('#partner_info').show()
               }
-          })
-
-          $(document).ready(function() {
-              $('#create_bank').hide()
-              $('#partner_info').hide()
           })
       </script>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -550,11 +550,14 @@ end
 20.times.each do
   storage_location = random_record_for_org(pdx_org, StorageLocation)
   stored_inventory_items_sample = storage_location.inventory_items.sample(20)
+  delivery_method = Distribution.delivery_methods.keys.sample
+  shipping_cost = delivery_method == "shipped" ? (rand(20.0..100.0)).round(2).to_s : nil
   distribution = Distribution.create!(storage_location: storage_location,
                                       partner: random_record_for_org(pdx_org, Partner),
                                       organization: pdx_org,
                                       issued_at: Faker::Date.between(from: 4.days.ago, to: Time.zone.today),
-                                      delivery_method: Distribution.delivery_methods.keys.sample,
+                                      delivery_method: delivery_method,
+                                      shipping_cost: shipping_cost,
                                       comment: 'Urgent')
 
   stored_inventory_items_sample.each do |stored_inventory_item|

--- a/spec/system/account_request_system_spec.rb
+++ b/spec/system/account_request_system_spec.rb
@@ -79,6 +79,23 @@ RSpec.describe 'Account request flow', type: :system, js: true do
         expect(page).to have_link('here', href: 'https://humanessentials.app/users/sign_in')
       end
     end
+
+    context 'renders the #new template with the form and errors visible' do
+      it 'shows create bank form info and errors when required fields are missing' do
+        visit('/account_requests/new')
+        choose('account_bank')
+
+        fill_in 'Name', with: "Barbara Smith"
+        click_button 'Submit'
+
+        expect(find_field('account_bank')).to be_checked
+        expect(find_field('account_partner')).to_not be_checked
+        expect(page).to have_css('#create_bank', visible: true)
+        expect(page).to have_css('#partner_info', visible: :hidden)
+        expect(page).to have_content('Please review the problems below')
+        expect(page).to have_content('Name, email, and request details required')
+      end
+    end
   end
 end
 

--- a/spec/system/account_request_system_spec.rb
+++ b/spec/system/account_request_system_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe 'Account request flow', type: :system, js: true do
         expect(page).to have_css('#create_bank', visible: true)
         expect(page).to have_css('#partner_info', visible: :hidden)
         expect(page).to have_content('Please review the problems below')
-        expect(page).to have_content('Name, email, and request details required')
       end
     end
   end


### PR DESCRIPTION
Resolves #3426

### Description
We want users to be directed back to the Account Request Form with direct feedback on what error(s) occurred, without having to click "I am an essentials bank" again.


### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
- RSpec: Added test via the account_requests_system spec
- Locally tested in server to ensure render shows form and errors (see loom video below):
  - Go to `/account_requests/new` & select `I am an essentials bank`
  - Test 1: submit the form without entering anything or completing captcha
  - Test 2: complete the captcha only and submit the form
  - Test 3: enter valid information form data, but do not complete captcha


### Screenshots
https://www.loom.com/share/cb83cce88b66484cb035950966382a1e
<img width="1416" alt="Screenshot 2023-09-14 at 4 38 19 PM" src="https://github.com/rubyforgood/human-essentials/assets/117330008/b4a30091-23d5-4d22-aa9d-dc0850f57251">


