### PR TITLE
Capybara disable animations

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,9 @@ Dir[Rails.root.join("spec/controllers/shared_examples/*.rb")].sort.each { |f| re
 # If an element is hidden, Capybara should ignore it
 Capybara.ignore_hidden_elements = true
 
+# disable CSS transitions and jQuery animations
+Capybara.disable_animation = true
+
 # https://docs.travis-ci.com/user/chrome
 Capybara.register_driver :chrome do |app|
   args = %w[no-sandbox disable-gpu disable-site-isolation-trials window-size=1680,1050]


### PR DESCRIPTION
### Description

Fixes failing specs where animations were preventing modals from closing.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Before this change running `spec/system/purchase_system_spec.rb` produces 2 failing specs  on lines `99` and `255`. After this change all specs are passing.
