### PR TITLE
#3910 Auto-thanking has bugs

### DIFF
--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -13,9 +13,10 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: chriskarlin/github-release-commenter@v1.3.2
+      - uses: chriskarlin/github-release-commenter@v1.3.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          skip-linked: true
           comment-template: |
             @{author}: Your PR/Issue `{title}` is part of today's Human Essentials production release: {release_link}. 
             Thank you very much for your contribution!


### PR DESCRIPTION
Resolves #3910

### Description
Updated GHA `chriskarlin/github-release-commenter` used in this project with its newest version that contains:
- GHA input to skip commenting in linked events (Issues)
- code guaranteeing each PR only gets commented on once

([PR](https://github.com/chriskarlin/github-release-commenter/pull/2) that updated the Action)

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Tested in my own project via: create Issue, fix via (and link) PR, create release -> observe comments added
  - [Issue](https://github.com/chriskarlin/release-test/issues/31)
  - [PR](https://github.com/chriskarlin/release-test/pull/32)


### Screenshots

#### PR
![Screenshot 2023-10-17 at 8 52 04 AM](https://github.com/rubyforgood/human-essentials/assets/46851840/574b6859-df3e-4687-ae8f-04dfb374cbf4)

#### Issue
![Screenshot 2023-10-17 at 8 51 57 AM](https://github.com/rubyforgood/human-essentials/assets/46851840/5ca60253-8c08-42cb-adda-cdeb78ff7dc5)
