### PR TITLE
Event Source pt. 2: Inventory Discrepancies

### DIFF
--- a/app/events/event_differ.rb
+++ b/app/events/event_differ.rb
@@ -3,7 +3,6 @@ module Types
 end
 
 module EventDiffer
-
   # Used to indicate that a storage location exists in one source but not the other.
   class LocationDiff < Dry::Struct
     attribute :storage_location_id, Types::Integer
@@ -12,7 +11,7 @@ module EventDiffer
 
     # @param options [Object]
     # @return [Hash]
-    def as_json(options=nil)
+    def as_json(options = nil)
       super.merge(type: "location")
     end
   end
@@ -26,13 +25,12 @@ module EventDiffer
 
     # @param options [Object]
     # @return [Hash]
-    def as_json(options=nil)
+    def as_json(options = nil)
       super.merge(type: "item")
     end
   end
 
   class << self
-
     # @param locations [Array<StorageLocation>]
     # @param inventory [EventTypes::Inventory]
     # @return [Array<LocationDiff>]
@@ -61,9 +59,9 @@ module EventDiffer
 
         if inventory_item.quantity != db_item.quantity
           diffs.push(ItemDiff.new(item_id: db_item.item_id,
-                                  storage_location_id: db_loc.id,
-                                  database: db_item.quantity,
-                                  aggregate: inventory_item.quantity))
+            storage_location_id: db_loc.id,
+            database: db_item.quantity,
+            aggregate: inventory_item.quantity))
         end
       end
       diffs

--- a/app/events/event_differ.rb
+++ b/app/events/event_differ.rb
@@ -1,0 +1,106 @@
+module Types
+  include Dry.Types()
+end
+
+module EventDiffer
+
+  # Used to indicate that a storage location exists in one source but not the other.
+  class LocationDiff < Dry::Struct
+    attribute :storage_location_id, Types::Integer
+    attribute :database, Types::Bool
+    attribute :aggregate, Types::Bool
+
+    # @param options [Object]
+    # @return [Hash]
+    def as_json(options=nil)
+      super.merge(type: "location")
+    end
+  end
+
+  # Used to indicate that the quantity of an item in one source doesn't match the other.
+  class ItemDiff < Dry::Struct
+    attribute :storage_location_id, Types::Integer
+    attribute :item_id, Types::Integer
+    attribute :database, Types::Integer
+    attribute :aggregate, Types::Integer
+
+    # @param options [Object]
+    # @return [Hash]
+    def as_json(options=nil)
+      super.merge(type: "item")
+    end
+  end
+
+  class << self
+
+    # @param locations [Array<StorageLocation>]
+    # @param inventory [EventTypes::Inventory]
+    # @return [Array<LocationDiff>]
+    def check_location_ids(locations, inventory)
+      db_ids = locations.map(&:id)
+      inventory_ids = inventory.storage_locations.keys
+      diffs = []
+      (db_ids - inventory_ids).each do |id|
+        diffs.push(LocationDiff.new(storage_location_id: id, database: true, aggregate: false))
+      end
+      (inventory_ids - db_ids).each do |id|
+        diffs.push(LocationDiff.new(storage_location_id: id, database: false, aggregate: true))
+      end
+      diffs
+    end
+
+    # @param inventory_loc [EventTypes::EventStorageLocation]
+    # @param db_loc [StorageLocation]
+    # @return [Array<ItemDiff>]
+    def check_items(inventory_loc, db_loc)
+      diffs = []
+      diffs += check_item_ids(inventory_loc, db_loc)
+      db_loc.inventory_items.each do |db_item|
+        inventory_item = inventory_loc.items[db_item.item_id]
+        next if inventory_item.nil?
+
+        if inventory_item.quantity != db_item.quantity
+          diffs.push(ItemDiff.new(item_id: db_item.item_id,
+                                  storage_location_id: db_loc.id,
+                                  database: db_item.quantity,
+                                  aggregate: inventory_item.quantity))
+        end
+      end
+      diffs
+    end
+
+    # @param inventory_loc [EventTypes::EventStorageLocation]
+    # @param db_loc [StorageLocation]
+    # @return [Array<ItemDiff>]
+    def check_item_ids(inventory_loc, db_loc)
+      inventory_ids = inventory_loc.items.keys
+      db_ids = db_loc.inventory_items.map(&:item_id)
+      diffs = []
+      (db_ids - inventory_ids).each do |id|
+        item = db_loc.inventory_items.find { |f| f.item_id == id }
+        diffs.push(ItemDiff.new(item_id: id, storage_location_id: db_loc.id, database: item&.quantity, aggregate: 0))
+      end
+      (inventory_ids - db_ids).each do |id|
+        item = inventory_loc.items[id]
+        diffs.push(ItemDiff.new(item_id: id, storage_location_id: db_loc.id, database: 0, aggregate: item.quantity))
+      end
+      diffs
+    end
+
+    # @param inventory [EventTypes::Inventory]
+    # @return [Array<ItemDiff, LocationDiff>]
+    def check_difference(inventory)
+      diffs = []
+      org = Organization.find(inventory.organization_id)
+      locations = org.storage_locations.to_a
+      diffs += check_location_ids(locations, inventory)
+      locations.each do |db_loc|
+        inventory_loc = inventory.storage_locations[db_loc.id]
+        next if inventory_loc.nil?
+
+        diffs += check_items(inventory_loc, db_loc)
+      end
+      diffs
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -26,15 +26,14 @@ class Event < ApplicationRecord
   end
 
   after_create_commit do
-    inventory = InventoryAggregate.inventory_for(self.organization_id)
+    inventory = InventoryAggregate.inventory_for(organization_id)
     diffs = EventDiffer.check_difference(inventory)
     if diffs.any?
       InventoryDiscrepancy.create!(
-        event_id: self.id,
-        organization_id: self.organization_id,
+        event_id: id,
+        organization_id: organization_id,
         diff: diffs
       )
     end
   end
-
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,7 @@
 #  updated_at      :datetime         not null
 #  eventable_id    :bigint
 #  organization_id :bigint
+#  user_id         :bigint
 #
 class Event < ApplicationRecord
   scope :for_organization, ->(organization_id) { where(organization_id: organization_id).order(:event_time) }
@@ -18,4 +19,22 @@ class Event < ApplicationRecord
   serialize :data, EventTypes::StructCoder.new(EventTypes::InventoryPayload)
 
   belongs_to :eventable, polymorphic: true
+  belongs_to :user, optional: true
+
+  before_create do
+    self.user_id = PaperTrail.request&.whodunnit
+  end
+
+  after_create_commit do
+    inventory = InventoryAggregate.inventory_for(self.organization_id)
+    diffs = EventDiffer.check_difference(inventory)
+    if diffs.any?
+      InventoryDiscrepancy.create!(
+        event_id: self.id,
+        organization_id: self.organization_id,
+        diff: diffs
+      )
+    end
+  end
+
 end

--- a/app/models/inventory_discrepancy.rb
+++ b/app/models/inventory_discrepancy.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: inventory_discrepancies
+#
+#  id              :bigint           not null, primary key
+#  diff            :json
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  event_id        :bigint           not null
+#  organization_id :bigint           not null
+#
+class InventoryDiscrepancy < ApplicationRecord
+  belongs_to :event
+  belongs_to :organization
+end

--- a/db/migrate/20231020193728_create_inventory_discrepancies.rb
+++ b/db/migrate/20231020193728_create_inventory_discrepancies.rb
@@ -1,0 +1,12 @@
+class CreateInventoryDiscrepancies < ActiveRecord::Migration[7.0]
+  def change
+    create_table :inventory_discrepancies do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true, name: 'event_id'
+      t.json :diff
+      t.timestamps
+
+      t.index [:organization_id, :created_at]
+    end
+  end
+end

--- a/db/migrate/20231022140444_add_user_to_events.rb
+++ b/db/migrate/20231022140444_add_user_to_events.rb
@@ -1,0 +1,7 @@
+class AddUserToEvents < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :events, :user, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_22_203313) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_22_140444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -284,8 +283,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_22_203313) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "organization_id"
+    t.bigint "user_id"
     t.index ["organization_id", "event_time"], name: "index_events_on_organization_id_and_event_time"
     t.index ["organization_id"], name: "index_events_on_organization_id"
+    t.index ["user_id"], name: "index_events_on_user_id"
   end
 
   create_table "families", force: :cascade do |t|
@@ -327,6 +328,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_22_203313) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "inventory_discrepancies", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.bigint "event_id", null: false
+    t.json "diff"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_inventory_discrepancies_on_event_id"
+    t.index ["organization_id", "created_at"], name: "index_inventory_discrepancies_on_organization_id_and_created_at"
+    t.index ["organization_id"], name: "index_inventory_discrepancies_on_organization_id"
   end
 
   create_table "inventory_items", id: :serial, force: :cascade do |t|
@@ -852,6 +864,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_22_203313) do
   add_foreign_key "donations", "product_drives"
   add_foreign_key "donations", "storage_locations"
   add_foreign_key "families", "partners"
+  add_foreign_key "inventory_discrepancies", "events"
+  add_foreign_key "inventory_discrepancies", "organizations"
   add_foreign_key "item_categories", "organizations"
   add_foreign_key "item_categories_partner_groups", "item_categories"
   add_foreign_key "item_categories_partner_groups", "partner_groups"

--- a/spec/events/event_differ_spec.rb
+++ b/spec/events/event_differ_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe EventDiffer do
+  let(:organization) { create(:organization) }
+  let(:storage_location1) { create(:storage_location, organization: organization) }
+  let(:storage_location2) { create(:storage_location, organization: organization) }
+  let!(:storage_location3) { create(:storage_location, organization: organization) }
+  let(:item1) { create(:item, organization: organization) }
+  let(:item2) { create(:item, organization: organization) }
+  let(:item3) { create(:item, organization: organization) }
+
+  before(:each) do
+    create(:inventory_item, item: item1, storage_location: storage_location1, quantity: 50)
+    create(:inventory_item, item: item2, storage_location: storage_location1, quantity: 50)
+    create(:inventory_item, item: item1, storage_location: storage_location2, quantity: 50)
+  end
+
+  it 'should return a full diff' do
+    aggregate = EventTypes::Inventory.new(
+      organization_id:   organization.id,
+      storage_locations: {
+        storage_location1.id => EventTypes::EventStorageLocation.new(
+          id:    storage_location1.id,
+          items: {
+            item1.id => EventTypes::EventItem.new(item_id: item1.id, quantity: 50), # no diff
+            # missing item2
+            item3.id => EventTypes::EventItem.new(item_id: item2.id, quantity: 70) # added item3
+          }
+        ),
+        storage_location2.id => EventTypes::EventStorageLocation.new(
+          id:    storage_location2.id,
+          items: {
+            item1.id => EventTypes::EventItem.new(item_id: item1.id, quantity: 60), # diff in quantity
+            item2.id => EventTypes::EventItem.new(item_id: item2.id, quantity: 40) # added item2
+          }
+        ),
+        # missing storage_location3
+        # added storage location that doesn't exist
+        StorageLocation.count + 1 => EventTypes::EventStorageLocation.new(
+          id:    StorageLocation.count + 1,
+          items: {}
+        )
+      }
+    )
+    results   = EventDiffer.check_difference(aggregate)
+    expect(results.as_json).to contain_exactly(
+                                 { "aggregate"           => false,
+                                   "database"            => true,
+                                   "storage_location_id" => storage_location3.id,
+                                   :type                 => "location" },
+                                 { "aggregate"           => true,
+                                    "database"            => false,
+                                    "storage_location_id" => StorageLocation.count + 1,
+                                    :type                 => "location" },
+                                 { "aggregate"           => 0,
+                                    "database"            => 50,
+                                    "item_id"             => item2.id,
+                                    "storage_location_id" => storage_location1.id,
+                                    :type                 => "item" },
+                                 { "aggregate"           => 70,
+                                    "database"            => 0,
+                                    "item_id"             => item3.id,
+                                    "storage_location_id" => storage_location1.id,
+                                    :type                 => "item" },
+                                 { "aggregate"           => 40,
+                                    "database"            => 0,
+                                    "item_id"             => item2.id,
+                                    "storage_location_id" => storage_location2.id,
+                                    :type                 => "item" },
+                                 { "aggregate"           => 60,
+                                    "database"            => 50,
+                                    "item_id"             => item1.id,
+                                    "storage_location_id" => storage_location2.id,
+                                    :type                 => "item" }
+                               )
+  end
+
+end

--- a/spec/events/event_differ_spec.rb
+++ b/spec/events/event_differ_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe EventDiffer do
     create(:inventory_item, item: item1, storage_location: storage_location2, quantity: 50)
   end
 
-  it 'should return a full diff' do
+  it "should return a full diff" do
     aggregate = EventTypes::Inventory.new(
-      organization_id:   organization.id,
+      organization_id: organization.id,
       storage_locations: {
         storage_location1.id => EventTypes::EventStorageLocation.new(
-          id:    storage_location1.id,
+          id: storage_location1.id,
           items: {
             item1.id => EventTypes::EventItem.new(item_id: item1.id, quantity: 50), # no diff
             # missing item2
@@ -26,7 +26,7 @@ RSpec.describe EventDiffer do
           }
         ),
         storage_location2.id => EventTypes::EventStorageLocation.new(
-          id:    storage_location2.id,
+          id: storage_location2.id,
           items: {
             item1.id => EventTypes::EventItem.new(item_id: item1.id, quantity: 60), # diff in quantity
             item2.id => EventTypes::EventItem.new(item_id: item2.id, quantity: 40) # added item2
@@ -35,42 +35,41 @@ RSpec.describe EventDiffer do
         # missing storage_location3
         # added storage location that doesn't exist
         StorageLocation.count + 1 => EventTypes::EventStorageLocation.new(
-          id:    StorageLocation.count + 1,
+          id: StorageLocation.count + 1,
           items: {}
         )
       }
     )
-    results   = EventDiffer.check_difference(aggregate)
+    results = EventDiffer.check_difference(aggregate)
     expect(results.as_json).to contain_exactly(
-                                 { "aggregate"           => false,
-                                   "database"            => true,
-                                   "storage_location_id" => storage_location3.id,
-                                   :type                 => "location" },
-                                 { "aggregate"           => true,
-                                    "database"            => false,
-                                    "storage_location_id" => StorageLocation.count + 1,
-                                    :type                 => "location" },
-                                 { "aggregate"           => 0,
-                                    "database"            => 50,
-                                    "item_id"             => item2.id,
-                                    "storage_location_id" => storage_location1.id,
-                                    :type                 => "item" },
-                                 { "aggregate"           => 70,
-                                    "database"            => 0,
-                                    "item_id"             => item3.id,
-                                    "storage_location_id" => storage_location1.id,
-                                    :type                 => "item" },
-                                 { "aggregate"           => 40,
-                                    "database"            => 0,
-                                    "item_id"             => item2.id,
-                                    "storage_location_id" => storage_location2.id,
-                                    :type                 => "item" },
-                                 { "aggregate"           => 60,
-                                    "database"            => 50,
-                                    "item_id"             => item1.id,
-                                    "storage_location_id" => storage_location2.id,
-                                    :type                 => "item" }
-                               )
+      {"aggregate" => false,
+       "database" => true,
+       "storage_location_id" => storage_location3.id,
+       :type => "location"},
+      {"aggregate" => true,
+       "database" => false,
+       "storage_location_id" => StorageLocation.count + 1,
+       :type => "location"},
+      {"aggregate" => 0,
+       "database" => 50,
+       "item_id" => item2.id,
+       "storage_location_id" => storage_location1.id,
+       :type => "item"},
+      {"aggregate" => 70,
+       "database" => 0,
+       "item_id" => item3.id,
+       "storage_location_id" => storage_location1.id,
+       :type => "item"},
+      {"aggregate" => 40,
+       "database" => 0,
+       "item_id" => item2.id,
+       "storage_location_id" => storage_location2.id,
+       :type => "item"},
+      {"aggregate" => 60,
+       "database" => 50,
+       "item_id" => item1.id,
+       "storage_location_id" => storage_location2.id,
+       :type => "item"}
+    )
   end
-
 end

--- a/spec/events/inventory_aggregate_spec.rb
+++ b/spec/events/inventory_aggregate_spec.rb
@@ -6,6 +6,24 @@ RSpec.describe InventoryAggregate do
   let(:item2) { FactoryBot.create(:item, organization: organization) }
   let(:item3) { FactoryBot.create(:item, organization: organization) }
 
+  describe 'discrepancy', skip_transaction: true do
+    let(:donation) { create(:donation, organization: organization)}
+
+    before(:each) do
+      allow(InventoryAggregate).to receive(:inventory_for).and_return([])
+      allow(EventDiffer).to receive(:check_difference).and_return([{foo: 'bar'}, {baz: 'spam'}])
+    end
+
+    it 'should save a discrepancy' do
+      DonationEvent.publish(donation)
+      expect(InventoryDiscrepancy.count).to eq(1)
+      disc = InventoryDiscrepancy.last
+      expect(disc.event).to eq(DonationEvent.last)
+      expect(disc.diff).to eq([{'foo' => 'bar'}, {'baz' => 'spam'}])
+      expect(disc.organization).to eq(organization)
+    end
+  end
+
   describe "individual events" do
     let(:inventory) do
       EventTypes::Inventory.new(

--- a/spec/events/inventory_aggregate_spec.rb
+++ b/spec/events/inventory_aggregate_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe InventoryAggregate do
   let(:item2) { FactoryBot.create(:item, organization: organization) }
   let(:item3) { FactoryBot.create(:item, organization: organization) }
 
-  describe 'discrepancy', skip_transaction: true do
-    let(:donation) { create(:donation, organization: organization)}
+  describe "discrepancy", skip_transaction: true do
+    let(:donation) { create(:donation, organization: organization) }
 
     before(:each) do
       allow(InventoryAggregate).to receive(:inventory_for).and_return([])
-      allow(EventDiffer).to receive(:check_difference).and_return([{foo: 'bar'}, {baz: 'spam'}])
+      allow(EventDiffer).to receive(:check_difference).and_return([{foo: "bar"}, {baz: "spam"}])
     end
 
-    it 'should save a discrepancy' do
+    it "should save a discrepancy" do
       DonationEvent.publish(donation)
       expect(InventoryDiscrepancy.count).to eq(1)
       disc = InventoryDiscrepancy.last
       expect(disc.event).to eq(DonationEvent.last)
-      expect(disc.diff).to eq([{'foo' => 'bar'}, {'baz' => 'spam'}])
+      expect(disc.diff).to eq([{"foo" => "bar"}, {"baz" => "spam"}])
       expect(disc.organization).to eq(organization)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -100,6 +100,13 @@ RSpec.configure do |config|
 
   # Make FactoryBot easier.
   config.include FactoryBot::Syntax::Methods
+  config.around(:each, skip_transaction: true) do |example|
+    config.use_transactional_fixtures = false
+    example.run
+    config.use_transactional_fixtures = true
+
+    DatabaseCleaner.clean_with(:truncation)
+  end
 
   #
   # --------------------

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -106,6 +106,7 @@ RSpec.configure do |config|
     config.use_transactional_fixtures = true
 
     DatabaseCleaner.clean_with(:truncation)
+    seed_base_data_for_tests
   end
 
   #

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -164,7 +164,8 @@ RSpec.describe "Donations", type: :system, js: true do
           visit @url_prefix + "/donations/new"
         end
 
-        it "Allows donations to be created IN THE PAST" do
+        # using this to also test user ID for events - it needs to be an actual controller action
+        it "Allows donations to be created IN THE PAST", versioning: true do
           select Donation::SOURCES[:misc], from: "donation_source"
           select StorageLocation.first.name, from: "donation_storage_location_id"
           select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
@@ -175,6 +176,7 @@ RSpec.describe "Donations", type: :system, js: true do
             click_button "Save"
           end.to change { Donation.count }.by(1)
 
+          expect(DonationEvent.last.user).to eq(@user)
           expect(Donation.last.issued_at).to eq(Time.zone.parse("2001-01-01"))
         end
 


### PR DESCRIPTION
See #3911 (this needs to be split up into additional issues).

### Description

This adds a new model, InventoryDiscrepancy. Whenever an event is published, the calculated event sourced inventory is checked against the current database-backed inventory. If there are any differences, these are saved in an InventoryDiscrepancy object. For now this will live in a table, which we can pull down and inspect manually. We might want to add a UI in the superadmin area of the app to inspect this.

As part of this PR, we are also adding user_ids to events, piggybacking off of PaperTrail to fetch this information.