### PR TITLE
Ignore Bootstrap major/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
+  - dependency-name: bootstrap
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - dependency-name: rubocop
     versions:
     - 1.10.0


### PR DESCRIPTION
Bootstrap 5.3 is a "minor" update that actually is more of a major change, and [breaks asset compilation](https://github.com/rubyforgood/human-essentials/pull/3922). We should ignore automated major and minor updates for a big UI framework like this and do it more intentionally.
