### PR TITLE
Remove mention of `Issue` from release-notifier.yml template

### DIFF
--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -18,5 +18,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           skip-linked: true
           comment-template: |
-            @{author}: Your PR/Issue `{title}` is part of today's Human Essentials production release: {release_link}. 
+            @{author}: Your PR `{title}` is part of today's Human Essentials production release: {release_link}. 
             Thank you very much for your contribution!


### PR DESCRIPTION
Resolves #XXX

### Description
Update to Comment template change within`release-notifier.yml `.
With the last update to this CI workflow we removed its ability to comment on Issues.
This PR cleans up the comment template used.

cc: @dorner - I did not create an Issue for this, should I?

### Type of change
CI workflow update - update to comment string

