### PR TITLE
Fix adjustment logic

### DIFF
--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -21,12 +21,12 @@ class AdjustmentCreateService
       ActiveRecord::Base.transaction do
         # Make the necessary changes in the db
         @adjustment.save
+        AdjustmentEvent.publish(adjustment)
         # Split into positive and negative portions.
         # N.B. -- THIS CHANGES THE ORIGINAL LINE ITEMS ON @adjustment DO **NOT** RESAVE AS THAT WILL CHANGE ANY NEGATIVE LINE ITEMS ON THE ADJUSTMENT TO POSITIVES
         increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
         @adjustment.storage_location.increase_inventory increasing_adjustment
         @adjustment.storage_location.decrease_inventory decreasing_adjustment
-        AdjustmentEvent.publish(adjustment)
       rescue InsufficientAllotment => e
         @adjustment.errors.add(:base, e.message)
         raise e

--- a/db/migrate/20231110194231_clear_events.rb
+++ b/db/migrate/20231110194231_clear_events.rb
@@ -1,0 +1,9 @@
+class ClearEvents < ActiveRecord::Migration[7.0]
+  def change
+    InventoryDiscrepancy.delete_all
+    Event.delete_all
+    Organization.all.each do |org|
+      SnapshotEvent.publish(org)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_22_140444) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_10_194231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/services/adjustment_create_service_spec.rb
+++ b/spec/services/adjustment_create_service_spec.rb
@@ -18,16 +18,15 @@ RSpec.describe AdjustmentCreateService, type: :service do
       event = AdjustmentEvent.last
       expect(event.data).to eq(EventTypes::InventoryPayload.new(
         items: [
-                 EventTypes::EventLineItem.new(
-                   quantity: 5,
-                   item_id: item_1.id,
-                   from_storage_location: nil,
-                   to_storage_location: storage_location.id,
-                   item_value_in_cents: 0
-                 )
-               ]
-      )
-    )
+          EventTypes::EventLineItem.new(
+            quantity: 5,
+            item_id: item_1.id,
+            from_storage_location: nil,
+            to_storage_location: storage_location.id,
+            item_value_in_cents: 0
+          )
+        ]
+      ))
     end
 
     it "saves a new adjustment with line items relating to the current (simple case) positive adjustment" do
@@ -49,16 +48,15 @@ RSpec.describe AdjustmentCreateService, type: :service do
       event = AdjustmentEvent.last
       expect(event.data).to eq(EventTypes::InventoryPayload.new(
         items: [
-                 EventTypes::EventLineItem.new(
-                   quantity: -5,
-                   item_id: item_1.id,
-                   from_storage_location: nil,
-                   to_storage_location: storage_location.id,
-                   item_value_in_cents: 0
-                 )
-               ]
-      )
-    )
+          EventTypes::EventLineItem.new(
+            quantity: -5,
+            item_id: item_1.id,
+            from_storage_location: nil,
+            to_storage_location: storage_location.id,
+            item_value_in_cents: 0
+          )
+        ]
+      ))
     end
 
     it "saves a new adjustment with line items relating to the current (simple case) negative adjustment" do

--- a/spec/services/adjustment_create_service_spec.rb
+++ b/spec/services/adjustment_create_service_spec.rb
@@ -14,6 +14,20 @@ RSpec.describe AdjustmentCreateService, type: :service do
         adjustment_params = {user_id: @user.id, organization_id: @organization.id, storage_location_id: storage_location.id, line_items_attributes: {"0": {item_id: storage_location.items.first.id, quantity: 5}}}
         subject.new(adjustment_params).call
       end.to change { inventory_item_1.reload.quantity }.by(5)
+      expect(AdjustmentEvent.count).to eq(1)
+      event = AdjustmentEvent.last
+      expect(event.data).to eq(EventTypes::InventoryPayload.new(
+        items: [
+                 EventTypes::EventLineItem.new(
+                   quantity: 5,
+                   item_id: item_1.id,
+                   from_storage_location: nil,
+                   to_storage_location: storage_location.id,
+                   item_value_in_cents: 0
+                 )
+               ]
+      )
+    )
     end
 
     it "saves a new adjustment with line items relating to the current (simple case) positive adjustment" do
@@ -31,6 +45,20 @@ RSpec.describe AdjustmentCreateService, type: :service do
         adjustment_params = {user_id: @user.id, organization_id: @organization.id, storage_location_id: storage_location.id, line_items_attributes: {"0": {item_id: storage_location.items.first.id, quantity: -5}}}
         subject.new(adjustment_params).call
       end.to change { inventory_item_1.reload.quantity }.by(-5)
+      expect(AdjustmentEvent.count).to eq(1)
+      event = AdjustmentEvent.last
+      expect(event.data).to eq(EventTypes::InventoryPayload.new(
+        items: [
+                 EventTypes::EventLineItem.new(
+                   quantity: -5,
+                   item_id: item_1.id,
+                   from_storage_location: nil,
+                   to_storage_location: storage_location.id,
+                   item_value_in_cents: 0
+                 )
+               ]
+      )
+    )
     end
 
     it "saves a new adjustment with line items relating to the current (simple case) negative adjustment" do


### PR DESCRIPTION
The logic for creating adjustments had a bug where it would always record a positive quantity even if the quantity was being removed (negative).

The logic has been fixed, plus I want to clear out all events and discrepancies and start fresh so we aren't confused by the buggy data.