### PR TITLE
Adding 5T/6T Pull-ups to seed, plus migration for prod.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -744,4 +744,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.20
+   2.4.22

--- a/db/base_items.json
+++ b/db/base_items.json
@@ -24,6 +24,7 @@
     { "key": "pullup_23t", "name": "Kids Pull-Ups (2T-3T)", "qty": { "arbor": 0, "pdxdb": 1532 } },
     { "key": "pullup_34t", "name": "Kids Pull-Ups (3T-4T)", "qty": { "arbor": 0, "pdxdb": 787 } },
     { "key": "pullup_45t", "name": "Kids Pull-Ups (4T-5T)", "qty": { "arbor": 0, "pdxdb": 124 } },
+    { "key": "pullup_56t", "name": "Kids Pull-Ups (5T-6T)", "qty": { "arbor": 0, "pdxdb": 258 } },
     { "key": "k_sm", "name": "Kids S/M (38-65 lbs)", "qty": { "arbor": 0, "pdxdb": 264 } },
     { "key": "swimmers", "name": "Swimmers", "qty": { "arbor": 0, "pdxdb": 459 } }
   ],

--- a/db/migrate/20231117141301_add5_t6_t_pullups_to_base_items.rb
+++ b/db/migrate/20231117141301_add5_t6_t_pullups_to_base_items.rb
@@ -1,0 +1,8 @@
+class Add5T6TPullupsToBaseItems < ActiveRecord::Migration[7.0]
+  def up
+    BaseItem.find_or_create_by!(name: "Kids Pull-Ups (5T-6T)", category: "Diapers - Childrens", partner_key: "pullup_56t")
+  end
+  def down
+    BaseItem.where(partner_key:"pullup_56t").destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_10_194231) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_17_141301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
### Description

Adds the 5T / 6T size of pull ups to the base items.   This is a reasonable extension of the preexisting selection.

-- migration so it gets added to prod
-- addition to base _items.json so it will be present in seeded data.

Migration is required because the superuser's base item form is missing the category,  which is needed for some reports.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Visual confirmation through the drop down in the Inventory|Items & Inventory|New Item
