### PR TITLE
Extend max delayed job from 5 mins to 20 mins

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,7 +1,7 @@
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 60
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 5.minutes
+Delayed::Worker.max_run_time = 20.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.delay_jobs = !Rails.env.test?


### PR DESCRIPTION
We have been getting a lot of timeouts, https://app.bugsnag.com/ruby-for-good/human-essentials/errors/64e437ef88578c00083d0b99?filters[event.unhandled]=true&filters[event.since]=30d&filters[app.release_stage]=production&sort=events

We should separately do a check to see if the particular job, HistoricalDataCacheJob, can be made more efficient. But this is an easy fix.