### PR TITLE
Allow for partial audits (don't blow away existing inventory)

### DIFF
--- a/app/events/event_types/inventory.rb
+++ b/app/events/event_types/inventory.rb
@@ -16,6 +16,19 @@ module EventTypes
         storage_locations: org.storage_locations.map { |s| [s.id, EventTypes::EventStorageLocation.from(s)] }.to_h)
     end
 
+    # @param item_id [Integer]
+    # @param quantity [Integer]
+    # @param location [Integer]
+    def set_item_quantity(item_id:, quantity:, location:)
+      storage_locations[location] ||= EventTypes::EventStorageLocation.new(id: location, items: {})
+      storage_locations[location].set_inventory(item_id, quantity)
+    end
+
+    # @param item_id [Integer]
+    # @param quantity [Integer]
+    # @param from_location [Integer]
+    # @param to_location [Integer]
+    # @param validate [Boolean]
     def move_item(item_id:, quantity:, from_location: nil, to_location: nil, validate: true)
       if from_location
         if storage_locations[from_location].nil? && validate

--- a/app/events/inventory_aggregate.rb
+++ b/app/events/inventory_aggregate.rb
@@ -43,6 +43,17 @@ module InventoryAggregate
           validate: validate)
       end
     end
+
+    # @param payload [EventTypes::InventoryPayload]
+    # @param inventory [EventTypes::Inventory]
+    # @param validate [Boolean]
+    def handle_audit_event(payload, inventory)
+      payload.items.each do |line_item|
+        inventory.set_item_quantity(item_id: line_item.item_id,
+          quantity: line_item.quantity,
+          location: line_item.to_storage_location)
+      end
+    end
   end
 
   on DonationEvent, DistributionEvent, AdjustmentEvent, PurchaseEvent,
@@ -53,8 +64,7 @@ module InventoryAggregate
   end
 
   on AuditEvent do |event, inventory|
-    inventory.storage_locations[event.data.storage_location_id].reset!
-    handle_inventory_event(event.data, inventory, validate: false)
+    handle_audit_event(event.data, inventory)
   end
 
   on SnapshotEvent do |event, inventory|

--- a/spec/events/inventory_aggregate_spec.rb
+++ b/spec/events/inventory_aggregate_spec.rb
@@ -336,6 +336,7 @@ RSpec.describe InventoryAggregate do
             id: storage_location1.id,
             items: {
               item1.id => EventTypes::EventItem.new(item_id: item1.id, quantity: 20),
+              item2.id => EventTypes::EventItem.new(item_id: item2.id, quantity: 10),
               item3.id => EventTypes::EventItem.new(item_id: item3.id, quantity: 10)
             }
           ),


### PR DESCRIPTION
Currently, the inventory logic for audit events blows away the inventory of a storage location and replaces it with the audit's line items. This doesn't actually match the intended audit logic: when an audit happens, it's supposed to only reset the quantities of the items in the audit, but leave everything else alone.

This PR fixes this issue.