### PR TITLE
Add automated email message for password reset

### DIFF
--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,5 +1,7 @@
 <p>Hello <%= @resource.email %>!</p>
 
+<p>This is an automated email from the human essentials application. Please contact your diaper bank directly with any request-related questions.</p>
+
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
 <p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my code,
- I have commented on my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title includes "WIP" if work is in progress.


Resolves #3956 

### Description
Improvement of user experience now receives updated instructions on where to find the needed help.

### Type of change

* E-mail text Change for end users.

### How Has This Been Tested?

Reset the password of an existing user from a database.

### Screenshots
<img width="728" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/96393104/bf85bee6-ef15-49e5-9f3b-3ed0a15b8046">


