### PR TITLE
3686 - fix for error after clicking approve request for a new partner…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,13 @@ class ApplicationController < ActionController::Base
     @role
   end
 
+  # gets organization associated with user either directly or through partner association. fixes issue in shared sidebar menu view
+  def get_users_organization
+    org = current_user.organization.present? ? current_user.organization : current_user.partner.organization
+    return org
+  end
+  helper_method :get_users_organization
+
   def organization_url_options(options = {})
     options.merge(organization_id: current_organization.to_param)
   end

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
   <li class="nav-item">
-    <%= link_to(dashboard_path(organization_id: current_user.organization), class: "nav-link #{active_class(['dashboard'])}") do %>
+    <%= link_to(dashboard_path(organization_id: get_users_organization), class: "nav-link #{active_class(['dashboard'])}") do %>
       <i class="nav-icon fas fa-tachometer-alt"></i>
       <p>Dashboard</p>
     <% end %>
@@ -13,7 +13,7 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= 'active' if current_page?(product_drives_path) %>">
-        <%= link_to(product_drives_path, class: "nav-link #{"active" if current_page?(product_drives_path(organization_id: current_user.organization))}") do %>
+        <%= link_to(product_drives_path, class: "nav-link #{"active" if current_page?(product_drives_path(organization_id: get_users_organization))}") do %>
           <i class="nav-icon far fa-circle"></i>
           <p>All Product Drives</p>
         <% end %>
@@ -34,12 +34,12 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= 'active' if current_page?(donations_path) %>">
-        <%= link_to(donations_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(donations_path(organization_id: current_user.organization))}") do %>
+        <%= link_to(donations_path(organization_id: get_users_organization), class: "nav-link #{"active" if current_page?(donations_path(organization_id: get_users_organization))}") do %>
           <i class="nav-icon fa fa-circle-o"></i> All Donations
         <% end %>
       </li>
-      <li class="nav-item <%= 'active' if current_page?(new_donation_path(organization_id: current_user.organization)) %>">
-        <%= link_to(new_donation_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(new_donation_path)}") do %>
+      <li class="nav-item <%= 'active' if current_page?(new_donation_path(organization_id: get_users_organization)) %>">
+        <%= link_to(new_donation_path(organization_id: get_users_organization), class: "nav-link #{"active" if current_page?(new_donation_path)}") do %>
           <i class="nav-icon fa fa-circle-o"></i> New Donation
         <% end %>
       </li>
@@ -53,12 +53,12 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= 'active' if current_page?(donations_path) %>">
-        <%= link_to(purchases_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(purchases_path(organization_id: current_user.organization))}") do %>
+        <%= link_to(purchases_path(organization_id: get_users_organization), class: "nav-link #{"active" if current_page?(purchases_path(organization_id: get_users_organization))}") do %>
           <i class="nav-icon fa fa-circle-o"></i> All Purchases
         <% end %>
       </li>
-      <li class="nav-item <%= 'active' if current_page?(new_purchase_path(organization_id: current_user.organization)) %>">
-        <%= link_to(new_purchase_path(organization_id: current_user.organization), class: "nav-link #{"active" if current_page?(new_purchase_path)}") do %>
+      <li class="nav-item <%= 'active' if current_page?(new_purchase_path(organization_id: get_users_organization)) %>">
+        <%= link_to(new_purchase_path(organization_id: get_users_organization), class: "nav-link #{"active" if current_page?(new_purchase_path)}") do %>
           <i class="nav-icon fa fa-circle-o"></i> New Purchase
         <% end %>
       </li>
@@ -109,33 +109,33 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= active_class(['items']) %>">
-        <%= link_to(items_path(organization_id: current_user.organization), class: "nav-link #{active_class(['items'])}") do %>
+        <%= link_to(items_path(organization_id: get_users_organization), class: "nav-link #{active_class(['items'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Items &amp; Inventory
         <% end %>
       </li>
 
       <li class="nav-item <%= active_class(['kits']) %>">
-        <%= link_to(kits_path(organization_id: current_user.organization), class: "nav-link #{active_class(['kits'])}") do %>
+        <%= link_to(kits_path(organization_id: get_users_organization), class: "nav-link #{active_class(['kits'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Kits
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['barcode_items']) %>">
-        <%= link_to(barcode_items_path(organization_id: current_user.organization), class: "nav-link #{active_class(['barcode_items'])}") do %>
+        <%= link_to(barcode_items_path(organization_id: get_users_organization), class: "nav-link #{active_class(['barcode_items'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Barcode Items
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['storage_locations']) %>">
-        <%= link_to(storage_locations_path(organization_id: current_user.organization), class: "nav-link #{active_class(['storage_locations'])}") do %>
+        <%= link_to(storage_locations_path(organization_id: get_users_organization), class: "nav-link #{active_class(['storage_locations'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Storage Locations
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['adjustments']) %>">
-        <%= link_to(adjustments_path(organization_id: current_user.organization), class: "nav-link #{active_class(['adjustments'])}") do %>
+        <%= link_to(adjustments_path(organization_id: get_users_organization), class: "nav-link #{active_class(['adjustments'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Inventory Adjustments
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['transfers']) %>">
-        <%= link_to(transfers_path(organization_id: current_user.organization), class: "nav-link #{active_class(['transfers'])}") do %>
+        <%= link_to(transfers_path(organization_id: get_users_organization), class: "nav-link #{active_class(['transfers'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Transfers
         <% end %>
       </li>
@@ -149,22 +149,22 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= active_class(['donation_sites']) %>">
-        <%= link_to(donation_sites_path(organization_id: current_user.organization), class: "nav-link #{active_class(['donation_sites'])}") do %>
+        <%= link_to(donation_sites_path(organization_id: get_users_organization), class: "nav-link #{active_class(['donation_sites'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Donation Sites
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['product_drive_participants']) %>">
-        <%= link_to(product_drive_participants_path(organization_id: current_user.organization), class: "nav-link #{active_class(['product_drive_participants'])}") do %>
+        <%= link_to(product_drive_participants_path(organization_id: get_users_organization), class: "nav-link #{active_class(['product_drive_participants'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Product Drive Participants
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['manufacturers']) %>">
-        <%= link_to(manufacturers_path(organization_id: current_user.organization), class: "nav-link #{active_class(['manufacturers'])}") do %>
+        <%= link_to(manufacturers_path(organization_id: get_users_organization), class: "nav-link #{active_class(['manufacturers'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Manufacturers
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['vendors']) %>">
-        <%= link_to(vendors_path(organization_id: current_user.organization), class: "nav-link #{active_class(['vendors'])}") do %>
+        <%= link_to(vendors_path(organization_id: get_users_organization), class: "nav-link #{active_class(['vendors'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Vendors
         <% end %>
       </li>
@@ -180,12 +180,12 @@
       </a>
       <ul class="nav nav-treeview">
         <li class="nav-item <%= active_class(['audits']) %>">
-          <%= link_to(audits_path(organization_id: current_user.organization), class: "nav-link #{active_class(['audits'])}") do %>
+          <%= link_to(audits_path(organization_id: get_users_organization), class: "nav-link #{active_class(['audits'])}") do %>
             <i class="nav-icon fa fa-circle-o"></i> Inventory Audit
           <% end %>
         </li>
         <li class="nav-item <%= active_class(['reports']) %>">
-          <%= link_to(reports_annual_reports_path(organization_id: current_user.organization), class: "nav-link #{active_class(['reports'])}") do %>
+          <%= link_to(reports_annual_reports_path(organization_id: get_users_organization), class: "nav-link #{active_class(['reports'])}") do %>
             <i class="nav-icon fa fa-circle-o"></i> Annual Survey
           <% end %>
         </li>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -93,5 +93,33 @@ describe ApplicationController do
         expect(controller.dashboard_path_from_current_role).to eq "/#{org_name}/dashboard"
       end
     end
+
+    describe "get_users_organization" do
+      before(:each) do
+        allow(controller).to receive(:current_user).and_return(user)
+        allow(controller).to receive(:current_role).and_return(user.roles.first)
+      end
+      context 'gets organization from user with org role' do
+        let(:org) { create(:organization) }
+        let(:user) { create(:user, organization: org) }
+        before(:each) do
+          user.add_role(Role::ORG_USER, org)
+        end
+        it "should return an organization for a user with an org role" do
+          expect(controller.get_users_organization).to eq(org)
+        end
+      end
+      context 'gets organization from user with only partner role' do
+        let(:partner) { create(:partner) }
+        let(:user) { create(:partners_user, partner: partner) }
+        before(:each) do
+          user.add_role(Role::PARTNER, partner)
+        end
+        it "should return an organization from a user with a partner role" do
+          org = user.partner.organization
+          expect(controller.get_users_organization).to eq(org)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
…. fixed by writing a block to supply organization information for links used in the sidebar menu as opposed to accessing organization data directly from the user which was causing the break. tests also added

3686 - added a comment to method written in the application controller

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3686 

### Description
Issue with this was that the shared sidebar menu was looking for an associated organization for the current_user. The problem being not all users have associated organizations via roles. I wasn't sure about forcing an associated organization role onto a user that maybe shouldn't have that association, so I added a method that returns the associated organization either directly from the user via roles, or through the users associated partner.
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Yes.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
