### PR TITLE
Fix broken Slack links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing  
 We ♥ contributors! By participating in this project, you agree to abide by the Ruby for Good [code of conduct](https://github.com/rubyforgood/human-essentials/blob/main/code-of-conduct.md).
 
-If you have any questions about an issue, comment on the issue, open a new issue or ask in [the RubyForGood slack](https://rubyforgood.herokuapp.com/). human-essentials has a `#human-essentials` channel in the Slack. Our channel in slack also contains a zoom link for office hours every day office hours are held.  
+If you have any questions about an issue, comment on the issue, open a new issue or ask in [the RubyForGood slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA). human-essentials has a `#human-essentials` channel in the Slack. Our channel in slack also contains a zoom link for office hours every day office hours are held.  
   
 You won't be yelled at for giving your best effort. The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contributions, and don't want a wall of rules to get in the way of that.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Thanks for checking us out! If you're new here, here are some things you should 
 - This project relies entirely on volunteers, so please be patient with communication
 
 ### Join us on slack 💬
-You can sign up [here](https://rubyforgood.slack.com/join/shared_invite/zt-1kfeimohe-KL~~~6Lkof7G94_7Ojd_Hw#/shared-invite/email) and find us in #human-essentials. Many helpful members are available to answer your questions. Just ask, and someone will be there to help you!
+You can sign up [here](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) and find us in #human-essentials. Many helpful members are available to answer your questions. Just ask, and someone will be there to help you!
 
 ##  Getting Started 🛠️
 


### PR DESCRIPTION
### Description
This change is motivated by my interest in contributing a few hours a week to this project.
I tried to join Slack and realised the link was broken.
The corrected link was taken from the website.
   
### Type of change
* Documentation update

### How Has This Been Tested?
- Clicked the link. Received an error. 
- Used the updated link and joined the Slack community.

### Screenshots
Before:
![image](https://github.com/rubyforgood/human-essentials/assets/13178700/ef46e023-2962-4e18-a635-30b0dc0800e9)
