### PR TITLE
3686 reroute user to error page fix

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -3,6 +3,7 @@
 # of which Partners are associated with which Diaperbanks.
 class PartnersController < ApplicationController
   include Importable
+  before_action :validate_user_role, only: :show
 
   def index
     @unfiltered_partners_for_statuses = Partner.where(organization: current_organization)
@@ -163,6 +164,13 @@ class PartnersController < ApplicationController
   end
 
   private
+
+  def validate_user_role
+    if current_user.kind == 'partner'
+      redirect_to partner_user_root_path,
+        error: "You must be logged in as the essentials bank's organization administrator to approve partner applications."
+    end
+  end
 
   def partner_params
     params.require(:partner).permit(:name, :email, :send_reminders, :quota,

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -166,7 +166,7 @@ class PartnersController < ApplicationController
   private
 
   def validate_user_role
-    if current_user.kind == 'partner'
+    if current_role.name == "partner"
       redirect_to partner_user_root_path,
         error: "You must be logged in as the essentials bank's organization administrator to approve partner applications."
     end

--- a/app/views/organization_mailer/partner_approval_request.html.erb
+++ b/app/views/organization_mailer/partner_approval_request.html.erb
@@ -2,4 +2,4 @@
 
 <br>
 
-<%= link_to 'Review This Organization', partner_url(organization_id: @organization.short_name, id: @partner.id, anchor: "partner-information") %>
+<%= link_to 'Review This Partner', partner_url(organization_id: @organization.short_name, id: @partner.id, anchor: "partner-information") %>

--- a/app/views/organization_mailer/partner_approval_request.text.erb
+++ b/app/views/organization_mailer/partner_approval_request.text.erb
@@ -1,3 +1,3 @@
 You've received a request to approve the account for <%= @partner.name %>.
 
-Review This Organization: <%=partner_url(organization_id: @organization.short_name, id: @partner.id, anchor: "partner-information") %>
+Review This Partner: <%=partner_url(organization_id: @organization.short_name, id: @partner.id, anchor: "partner-information") %>

--- a/spec/mailers/organization_mailer_spec.rb
+++ b/spec/mailers/organization_mailer_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe OrganizationMailer, type: :mailer do
     it "renders the body with correct text with partner information" do
       html = html_body(subject)
       expect(html).to include("<h1> You've received a request to approve the account for #{partner.name}. </h1>")
-      expect(html).to include("Review This Organization")
-      expect(html).to include("#{organization.short_name}/partners/#{partner.id}#partner-information\">Review This Organization</a>")
+      expect(html).to include("Review This Partner")
+      expect(html).to include("#{organization.short_name}/partners/#{partner.id}#partner-information\">Review This Partner</a>")
       text = text_body(subject)
       expect(text).to include("You've received a request to approve the account for #{partner.name}.")
-      expect(text).to include("Review This Organization")
+      expect(text).to include("Review This Partner")
       expect(text).to include("#{organization.short_name}/partners/#{partner.id}#partner-information")
     end
 

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -231,7 +231,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           sign_in(partner.users.first)
         end
         it "redirects user to partners page root page (dashboard) with error message" do
-          visit url_prefix+"/partners/#{partner.id}"
+          visit url_prefix + "/partners/#{partner.id}"
           expect(page).to have_content("Dashboard - #{partner.name}")
           expect(page.find(".alert-danger")).to have_content("You must be logged in as the essentials bank's organization administrator to approve partner applications.")
         end

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -224,6 +224,19 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         end
       end
 
+      context "when viewing an invited partner as a partner" do
+        let(:partner) { create(:partner, name: "Invited Partner", status: :invited) }
+        before do
+          sign_out(@user)
+          sign_in(partner.users.first)
+        end
+        it "redirects user to partners page root page (dashboard) with error message" do
+          visit url_prefix+"/partners/#{partner.id}"
+          expect(page).to have_content("Dashboard - #{partner.name}")
+          expect(page.find(".alert-danger")).to have_content("You must be logged in as the essentials bank's organization administrator to approve partner applications.")
+        end
+      end
+
       context "when viewing a deactivated partner" do
         let(:deactivated) { create(:partner, name: "Deactivated Partner", status: :deactivated) }
         subject { url_prefix + "/partners/#{deactivated.id}" }


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3686 

### Description
Gracefully handles error when a partner clicks the Review This Partner link from email. User is taken to partners root path (dashboard) with an error message stating they must be logged in as an org admin to approve a partner application.

Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
    -  fixing a bug 
  - What alternative solutions did you consider?
    - I considered providing the missing data for the necessary links that were breaking.
  - What are the tradeoffs for your solution?
    -  that solution exposed pages that shouldn't be
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Yes.
<!-- Please describe the tests that you ran to verify your changes. 
RSPEC tests. New tests were written for this and all passed.
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
