### PR TITLE
Remove problem migration

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
 
   require "socket"
   require "ipaddr"
-  config.web_console.whitelisted_ips = Socket.ip_address_list.reduce([]) do |res, addrinfo|
+  config.web_console.allowed_ips = Socket.ip_address_list.reduce([]) do |res, addrinfo|
     addrinfo.ipv4? ? res << IPAddr.new(addrinfo.ip_address).mask(24) : res
   end
 end

--- a/db/migrate/20230401162708_load_u_s_counties.rb
+++ b/db/migrate/20230401162708_load_u_s_counties.rb
@@ -1,8 +1,0 @@
-class LoadUSCounties < ActiveRecord::Migration[7.0]
-  def up
-    Rake::Task['db:load_us_counties'].invoke
-  end
-
-  def down
-  end
-end

--- a/db/migrate/20231218222029_change_flipper_gates_value_to_text.rb
+++ b/db/migrate/20231218222029_change_flipper_gates_value_to_text.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ChangeFlipperGatesValueToText < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def up
+    # Ensure this incremental update migration is idempotent
+    return unless connection.column_exists? :flipper_gates, :value, :string
+    if index_exists? :flipper_gates, [:feature_key, :key, :value]
+    end
+    change_column :flipper_gates, :value, :text
+  end
+
+  def down
+    change_column :flipper_gates, :value, :string
+  end
+end

--- a/db/migrate/20231218222029_change_flipper_gates_value_to_text.rb
+++ b/db/migrate/20231218222029_change_flipper_gates_value_to_text.rb
@@ -5,7 +5,7 @@ class ChangeFlipperGatesValueToText < ActiveRecord::Migration[7.0]
   def up
     # Ensure this incremental update migration is idempotent
     return unless connection.column_exists? :flipper_gates, :value, :string
-    if index_exists? :flipper_gates, [:feature_key, :key, :value]
+      if index_exists? :flipper_gates, [:feature_key, :key, :value]
     end
     change_column :flipper_gates, :value, :text
   end


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

Resolves:  No issue number

### Description

I had a problem with migrating the database, which lead to the discovery of a bug with the new flipper update. I deleted the offending migration that was keeping me from migrating, and implemented changes in the flipper migration file as suggested by one of their maintainers. After implementing changes, and reloading the schema I was able to migrate and successfully run the test suite.


### Type of change

* Bug fix (non-breaking change which fixes an issue.

### How Has This Been Tested?
Provide instructions so we can reproduce. 

I came across this issue by attempting to migrate the DB after having to re clone down the repo. Verified that my changes are working by successfully migrating the database.

### Screenshots
![Screenshot 2023-12-20 at 10 32 09 AM](https://github.com/rubyforgood/human-essentials/assets/114014697/493b6344-2f0f-486a-a849-a8fae37370d0)

