### PR TITLE
Add events to seeds + make DistributionCreateService consistent

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -72,7 +72,8 @@ class DistributionsController < ApplicationController
   end
 
   def create
-    result = DistributionCreateService.new(distribution_params.merge(organization: current_organization), request_id).call
+    dist = Distribution.new(distribution_params.merge(organization: current_organization))
+    result = DistributionCreateService.new(dist, request_id).call
 
     if result.success?
       session[:created_distribution_id] = result.distribution.id

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -1,8 +1,8 @@
 class DistributionCreateService < DistributionService
   attr_reader :distribution
 
-  def initialize(distribution_params, request_id = nil)
-    @distribution = Distribution.new(distribution_params)
+  def initialize(distribution, request_id = nil)
+    @distribution = distribution
     @request = Request.find(request_id) if request_id
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -335,7 +335,7 @@ note = [
       partner_user_id: p.primary_user.id
     )
 
-    item_requests = [] 
+    item_requests = []
     Array.new(Faker::Number.within(range: 5..15)) do
       item = p.organization.items.sample
       new_item_request = Partners::ItemRequest.new(
@@ -458,13 +458,8 @@ def seed_quantity(item_name, organization, storage_location, quantity)
     storage_location: storage_location,
     user: User.with_role(:org_admin, organization).first
   )
-
-  LineItem.create!(quantity: quantity, item: item, itemizable: adjustment)
-
-  adjustment.reload
-  increasing_adjustment, decreasing_adjustment = adjustment.split_difference
-  adjustment.storage_location.increase_inventory increasing_adjustment
-  adjustment.storage_location.decrease_inventory decreasing_adjustment
+  adjustment.line_items = [LineItem.new(quantity: quantity, item: item, itemizable: adjustment)]
+  AdjustmentCreateService.new(adjustment).call
 end
 
 items_by_category.each do |_category, entries|
@@ -508,38 +503,23 @@ end
 20.times.each do
   source = Donation::SOURCES.values.sample
   # Depending on which source it uses, additional data may need to be provided.
-  donation = case source
-             when Donation::SOURCES[:product_drive]
-               Donation.create! source: source,
-                                product_drive: ProductDrive.first,
-                                product_drive_participant: random_record_for_org(pdx_org, ProductDriveParticipant),
-                                storage_location: random_record_for_org(pdx_org, StorageLocation),
-                                organization: pdx_org,
-                                issued_at: Time.zone.now
-             when Donation::SOURCES[:donation_site]
-               Donation.create! source: source,
-                                donation_site: random_record_for_org(pdx_org, DonationSite),
-                                storage_location: random_record_for_org(pdx_org, StorageLocation),
-                                organization: pdx_org,
-                                issued_at: Time.zone.now
-             when Donation::SOURCES[:manufacturer]
-               Donation.create! source: source,
-                                manufacturer: random_record_for_org(pdx_org, Manufacturer),
-                                storage_location: random_record_for_org(pdx_org, StorageLocation),
-                                organization: pdx_org,
-                                issued_at: Time.zone.now
-             else
-               Donation.create! source: source,
-                                storage_location: random_record_for_org(pdx_org, StorageLocation),
-                                organization: pdx_org,
-                                issued_at: Time.zone.now
-             end
+  donation = Donation.new(source: source,
+                          storage_location: random_record_for_org(pdx_org, StorageLocation),
+                          organization: pdx_org, issued_at: Time.zone.now)
+  case source
+  when Donation::SOURCES[:product_drive]
+    donation.product_drive = ProductDrive.first
+    donation.product_drive_participant = random_record_for_org(pdx_org, ProductDriveParticipant)
+  when Donation::SOURCES[:donation_site]
+    donation.donation_site = random_record_for_org(pdx_org, DonationSite)
+  when Donation::SOURCES[:manufacturer]
+    donation.manufacturer = random_record_for_org(pdx_org, Manufacturer)
+  end
 
   rand(1..5).times.each do
-    LineItem.create! quantity: rand(250..500), item: random_record_for_org(pdx_org, Item), itemizable: donation
+    donation.line_items.push(LineItem.new(quantity: rand(250..500), item: random_record_for_org(pdx_org, Item)))
   end
-  donation.reload
-  donation.storage_location.increase_inventory(donation)
+  DonationCreateService.call(donation)
 end
 
 # ----------------------------------------------------------------------------
@@ -552,20 +532,24 @@ end
   stored_inventory_items_sample = storage_location.inventory_items.sample(20)
   delivery_method = Distribution.delivery_methods.keys.sample
   shipping_cost = delivery_method == "shipped" ? (rand(20.0..100.0)).round(2).to_s : nil
-  distribution = Distribution.create!(storage_location: storage_location,
-                                      partner: random_record_for_org(pdx_org, Partner),
-                                      organization: pdx_org,
-                                      issued_at: Faker::Date.between(from: 4.days.ago, to: Time.zone.today),
-                                      delivery_method: delivery_method,
-                                      shipping_cost: shipping_cost,
-                                      comment: 'Urgent')
+  distribution = Distribution.new(
+    storage_location: storage_location,
+    partner: random_record_for_org(pdx_org, Partner),
+    organization: pdx_org,
+    issued_at: Faker::Date.between(from: 4.days.ago, to: Time.zone.today),
+    delivery_method: delivery_method,
+    shipping_cost: shipping_cost,
+    comment: 'Urgent'
+  )
 
   stored_inventory_items_sample.each do |stored_inventory_item|
     distribution_qty = rand(stored_inventory_item.quantity / 2)
-    LineItem.create! quantity: distribution_qty, item: stored_inventory_item.item, itemizable: distribution if distribution_qty >= 1
+    if distribution_qty >= 1
+      distribution.line_items.push(LineItem.new(quantity: distribution_qty,
+                                                item: stored_inventory_item.item))
+    end
   end
-  distribution.reload
-  distribution.storage_location.decrease_inventory(distribution)
+  DistributionCreateService.new(distribution).call
 end
 
 # ----------------------------------------------------------------------------
@@ -636,7 +620,7 @@ comments = [
 20.times do
   storage_location = random_record_for_org(pdx_org, StorageLocation)
   vendor = random_record_for_org(pdx_org, Vendor)
-  Purchase.create(
+  purchase = Purchase.new(
     purchased_from: suppliers.sample,
     comment: comments.sample,
     organization_id: pdx_org.id,
@@ -647,13 +631,14 @@ comments = [
     updated_at: (Time.zone.today - rand(15).days),
     vendor_id: vendor.id
   )
+  PurchaseCreateService.call(purchase)
 end
 
 #re 2813_update_annual_report add some data for last year (enables system testing of reports)
 5.times do
   storage_location = random_record_for_org(pdx_org, StorageLocation)
   vendor = random_record_for_org(pdx_org, Vendor)
-  Purchase.create(
+  purchase = Purchase.new(
     purchased_from: suppliers.sample,
     comment: comments.sample,
     organization_id: pdx_org.id,
@@ -664,6 +649,7 @@ end
     updated_at: (Time.zone.today - 1.year),
     vendor_id: vendor.id
   )
+  PurchaseCreateService.call(purchase)
 end
 
 
@@ -780,12 +766,13 @@ end
 # ----------------------------------------------------------------------------
 # Transfers
 # ----------------------------------------------------------------------------
-Transfer.create!(
+transfer = Transfer.new(
   comment: Faker::Lorem.sentence,
   organization_id: pdx_org.id,
   from_id: pdx_org.id,
   to_id: sf_org.id,
   line_items: [
-    LineItem.create!(quantity: 5, item: pdx_org.items.first, itemizable: Distribution.first)
+    LineItem.new(quantity: 5, item: pdx_org.items.first)
   ]
 )
+TransferCreateService.call(transfer)

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -4,17 +4,22 @@ RSpec.describe DistributionCreateService, type: :service do
   subject { DistributionCreateService }
   describe "call" do
     let!(:storage_location) { create(:storage_location, :with_items, item_count: 2) }
-    let!(:distribution_params) { { organization_id: @organization.id, partner_id: @partner.id, storage_location_id: storage_location.id, delivery_method: :delivery, line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 5 } } } }
+    let!(:distribution) { Distribution.new(organization_id: @organization.id,
+                                           partner_id: @partner.id,
+                                           storage_location_id: storage_location.id,
+                                           delivery_method: :delivery,
+                                           line_items_attributes: {
+                                             "0": { item_id: storage_location.items.first.id, quantity: 5 } }) }
 
     it "replaces a big distribution with a smaller one, resulting in increased stored quantities" do
       expect do
-        subject.new(distribution_params).call
+        subject.new(distribution).call
       end.to change { storage_location.reload.size }.by(-5)
         .and change { DistributionEvent.count }.by(1)
     end
 
     it "returns a successful object with Scheduled distribution" do
-      result = subject.new(distribution_params).call
+      result = subject.new(distribution).call
       expect(result).to be_instance_of(subject)
       expect(result).to be_success
       expect(result.distribution).to be_scheduled
@@ -26,7 +31,7 @@ RSpec.describe DistributionCreateService, type: :service do
 
         expect do
           perform_enqueued_jobs only: PartnerMailerJob do
-            subject.new(distribution_params).call
+            subject.new(distribution).call
           end
         end.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
@@ -37,7 +42,7 @@ RSpec.describe DistributionCreateService, type: :service do
         @partner.update!(send_reminders: false)
 
         expect(PartnerMailerJob).not_to receive(:perform_later)
-        subject.new(distribution_params).call
+        subject.new(distribution).call
       end
     end
 
@@ -47,7 +52,7 @@ RSpec.describe DistributionCreateService, type: :service do
 
         expect do
           perform_enqueued_jobs only: PartnerMailerJob do
-            subject.new(distribution_params).call
+            subject.new(distribution).call
           end
         end.not_to change { ActionMailer::Base.deliveries.count }
       end
@@ -58,7 +63,7 @@ RSpec.describe DistributionCreateService, type: :service do
 
       it "changes the status of the request" do
         expect do
-          subject.new(distribution_params, request.id).call
+          subject.new(distribution, request.id).call
           request.reload
         end.to change { request.status }
       end
@@ -70,7 +75,7 @@ RSpec.describe DistributionCreateService, type: :service do
         end
 
         it 'should not be successful' do
-          result = subject.new(distribution_params, request.id).call
+          result = subject.new(distribution, request.id).call
           expect(result.error.message).to eq("Request has already been fulfilled by Distribution #{distribution.id}")
           expect(result).not_to be_success
         end
@@ -78,18 +83,23 @@ RSpec.describe DistributionCreateService, type: :service do
     end
 
     context "when there's not sufficient inventory" do
-      let(:too_much_params) { { organization_id: @organization.id, partner_id: @partner.id, storage_location_id: storage_location.id, delivery_method: :delivery, line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 500 } } } }
+      let(:too_much_dist) { Distribution.new(
+        organization_id: @organization.id,
+        partner_id: @partner.id,
+        storage_location_id: storage_location.id,
+        delivery_method: :delivery,
+        line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 500 } }) }
 
       it "preserves the Insufficiency error and is unsuccessful" do
-        result = subject.new(too_much_params).call
+        result = subject.new(too_much_dist).call
         expect(result.error).to be_instance_of(Errors::InsufficientAllotment)
         expect(result).not_to be_success
       end
     end
 
     context "when there's multiple line items and one has insufficient inventory" do
-      let(:too_much_params) do
-        {
+      let(:too_much_dist) do
+        Distribution.new(
           organization_id: @organization.id,
           partner_id: @partner.id,
           storage_location_id: storage_location.id,
@@ -99,39 +109,42 @@ RSpec.describe DistributionCreateService, type: :service do
               "0": { item_id: storage_location.items.first.id, quantity: 2 },
               "1": { item_id: storage_location.items.last.id, quantity: 500 }
             }
-        }
+        )
       end
 
       it "preserves the Insufficiency error and is unsuccessful" do
-        result = subject.new(too_much_params).call
+        result = subject.new(too_much_dist).call
         expect(result.error).to be_instance_of(Errors::InsufficientAllotment)
         expect(result).not_to be_success
       end
     end
 
     context "when it fails to save" do
-      let(:bad_params) { { organization_id: @organization.id, storage_location_id: storage_location.id, line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 500 } } } }
+      let(:bad_dist) { Distribution.new(organization_id: @organization.id,
+                                        storage_location_id: storage_location.id,
+                                        line_items_attributes: {
+                                          "0": { item_id: storage_location.items.first.id, quantity: 500 } }) }
 
       it "preserves the error and is unsuccessful" do
-        result = subject.new(bad_params).call
+        result = subject.new(bad_dist).call
         expect(result.error).to be_instance_of(ActiveRecord::RecordInvalid)
         expect(result).not_to be_success
       end
     end
 
     context "when the line item quantity is not positive" do
-      let(:params) {
-        {
+      let(:dist) {
+        Distribution.new(
           organization_id: @organization.id,
           partner_id: @partner.id,
           storage_location_id: storage_location.id,
           delivery_method: :delivery,
           line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 0 } }
-        }
+        )
       }
 
       it "preserves the RecordInvalid error and is unsuccessful" do
-        result = subject.new(params).call
+        result = subject.new(dist).call
         expect(result.error).to be_instance_of(ActiveRecord::RecordInvalid)
         expect(result).not_to be_success
       end

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe DistributionCreateService, type: :service do
   subject { DistributionCreateService }
   describe "call" do
     let!(:storage_location) { create(:storage_location, :with_items, item_count: 2) }
-    let!(:distribution) { Distribution.new(organization_id: @organization.id,
-                                           partner_id: @partner.id,
-                                           storage_location_id: storage_location.id,
-                                           delivery_method: :delivery,
-                                           line_items_attributes: {
-                                             "0": { item_id: storage_location.items.first.id, quantity: 5 } }) }
+    let!(:distribution) {
+      Distribution.new(organization_id: @organization.id,
+        partner_id: @partner.id,
+        storage_location_id: storage_location.id,
+        delivery_method: :delivery,
+        line_items_attributes: {
+          "0": { item_id: storage_location.items.first.id, quantity: 5 }
+        })
+    }
 
     it "replaces a big distribution with a smaller one, resulting in increased stored quantities" do
       expect do
@@ -83,12 +86,15 @@ RSpec.describe DistributionCreateService, type: :service do
     end
 
     context "when there's not sufficient inventory" do
-      let(:too_much_dist) { Distribution.new(
-        organization_id: @organization.id,
-        partner_id: @partner.id,
-        storage_location_id: storage_location.id,
-        delivery_method: :delivery,
-        line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 500 } }) }
+      let(:too_much_dist) {
+        Distribution.new(
+          organization_id: @organization.id,
+          partner_id: @partner.id,
+          storage_location_id: storage_location.id,
+          delivery_method: :delivery,
+          line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 500 } }
+        )
+      }
 
       it "preserves the Insufficiency error and is unsuccessful" do
         result = subject.new(too_much_dist).call
@@ -120,10 +126,13 @@ RSpec.describe DistributionCreateService, type: :service do
     end
 
     context "when it fails to save" do
-      let(:bad_dist) { Distribution.new(organization_id: @organization.id,
-                                        storage_location_id: storage_location.id,
-                                        line_items_attributes: {
-                                          "0": { item_id: storage_location.items.first.id, quantity: 500 } }) }
+      let(:bad_dist) {
+        Distribution.new(organization_id: @organization.id,
+          storage_location_id: storage_location.id,
+          line_items_attributes: {
+            "0": { item_id: storage_location.items.first.id, quantity: 500 }
+          })
+      }
 
       it "preserves the error and is unsuccessful" do
         result = subject.new(bad_dist).call


### PR DESCRIPTION
This PR does the following:

* Add events to seeded data by running all created data through the appropriate service rather than creating it manually.
* Update DistributionCreateService to act the same as all other creation services by taking an ActiveRecord object rather than a set of parameters.