### PR TITLE
Fix snapshot logic

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -53,6 +53,7 @@ class Admin::OrganizationsController < AdminController
                                        email: user_params[:email],
                                        roles: [Role::ORG_USER, Role::ORG_ADMIN],
                                        resource: @organization)
+      SnapshotEvent.publish(@organization) # need one to start with
       redirect_to admin_organizations_path, notice: "Organization added!"
     else
       flash[:error] = "Failed to create Organization."

--- a/app/events/snapshot_event.rb
+++ b/app/events/snapshot_event.rb
@@ -22,6 +22,17 @@ class SnapshotEvent < Event
   end
 
   # @param organization [Organization]
+  def self.publish_from_events(organization)
+    inventory = InventoryAggregate.inventory_for(organization.id)
+    create(
+      eventable: organization,
+      organization_id: organization.id,
+      event_time: Time.zone.now,
+      data: inventory
+    )
+  end
+
+  # @param organization [Organization]
   def self.publish(organization)
     create(
       eventable: organization,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,7 @@
 #
 class Event < ApplicationRecord
   scope :for_organization, ->(organization_id) { where(organization_id: organization_id).order(:event_time) }
+  scope :without_snapshots, -> { where("type != 'SnapshotEvent'") }
 
   serialize :data, EventTypes::StructCoder.new(EventTypes::InventoryPayload)
 
@@ -23,6 +24,33 @@ class Event < ApplicationRecord
 
   before_create do
     self.user_id = PaperTrail.request&.whodunnit
+  end
+
+  # Returns the most recent "usable" snapshot. A snapshot is unusable if there is another event
+  # that was originally made before the snapshot, but was later updated/edited after the snapshot
+  # (i.e. there is a correction event whose event_time is before the snapshot, but whose
+  # updated_at time is after it).
+  # In this case, the values in the snapshot can't be used to start the inventory because they
+  # wouldn't reflect the updates.
+  # There should always be at least one usable snapshot since the very first event we have in the
+  # DB for any organization should be a SnapshotEvent.
+  # @param organization_id [Integer]
+  # @return [SnapshotEvent]
+  def self.most_recent_snapshot(organization_id)
+    query = <<-SQL
+        select *
+        FROM events as snapshots
+        WHERE type='SnapshotEvent' AND organization_id=$1
+        AND NOT EXISTS (
+            SELECT id
+            FROM events
+            WHERE type != 'SnapshotEvent'
+            AND event_time < snapshots.event_time AND updated_at > snapshots.event_time
+        )
+        ORDER BY event_time DESC
+        LIMIT 1
+    SQL
+    SnapshotEvent.find_by_sql(query, [organization_id]).first
   end
 
   after_create_commit do

--- a/spec/events/inventory_aggregate_spec.rb
+++ b/spec/events/inventory_aggregate_spec.rb
@@ -573,7 +573,7 @@ RSpec.describe InventoryAggregate do
       ))
     end
 
-    it 'should ignore unusable snapshots' do
+    it "should ignore unusable snapshots" do
       freeze_time do
         donation = FactoryBot.create(:donation, organization: organization, storage_location: storage_location1)
         donation.line_items << build(:line_item, quantity: 50, item: item1)
@@ -592,7 +592,7 @@ RSpec.describe InventoryAggregate do
               id: storage_location1.id,
               items: {
                 item1.id => EventTypes::EventItem.new(item_id: item1.id, quantity: 50),
-                item2.id => EventTypes::EventItem.new(item_id: item2.id, quantity: 30),
+                item2.id => EventTypes::EventItem.new(item_id: item2.id, quantity: 30)
               }
             )
           }
@@ -617,6 +617,5 @@ RSpec.describe InventoryAggregate do
         }
       ))
     end
-
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,29 +1,46 @@
 RSpec.describe Event, type: :model do
   let(:organization) { FactoryBot.create(:organization) }
-  describe '#most_recent_snapshot' do
+  describe "#most_recent_snapshot" do
+    let(:eventable) { FactoryBot.create(:distribution, organization_id: organization.id) }
+    let(:data) { EventTypes::Inventory.new(storage_locations: {}, organization_id: organization.id) }
+    let(:payload) { EventTypes::InventoryPayload.new(items: []) }
 
-    it 'should include the last usable snapshot' do
+    it "should include the last usable snapshot" do
       freeze_time do
-        snapshot1 = SnapshotEvent.create(organization_id: organization.id, event_time: 1.week.ago, updated_at: 1.week.ago)
-        donation = DonationEvent.create(organization_id: organization.id, event_time: 3.days.ago, updated_at: 3.days.ago)
-        snapshot2 = SnapshotEvent.create(organization_id: organization.id, event_time: 2.days.ago, updated_at: 2.days.ago)
-        donation2 = DonationEvent.create(organization_id: organization.id, event_time: 1.minute.ago, updated_at: 1.minute.ago)
+        SnapshotEvent.create!(organization_id: organization.id, eventable: eventable,
+          data: data,
+          event_time: 1.week.ago, updated_at: 1.week.ago)
+        DonationEvent.create!(organization_id: organization.id, eventable: eventable,
+          data: payload,
+          event_time: 3.days.ago, updated_at: 3.days.ago)
+        snapshot2 = SnapshotEvent.create!(organization_id: organization.id, eventable: eventable,
+          data: data,
+          event_time: 2.days.ago, updated_at: 2.days.ago)
+        DonationEvent.create!(organization_id: organization.id, eventable: eventable,
+          data: payload,
+          event_time: 1.minute.ago, updated_at: 1.minute.ago)
 
         expect(described_class.most_recent_snapshot(organization.id)).to eq(snapshot2)
       end
     end
 
-    it 'should not include an unusable snapshot' do
+    it "should not include an unusable snapshot" do
       freeze_time do
-        snapshot1 = SnapshotEvent.create(organization_id: organization.id, event_time: 1.week.ago, updated_at: 1.week.ago)
-        donation = DonationEvent.create(organization_id: organization.id, event_time: 3.days.ago, updated_at: 1.hour.ago)
-        snapshot2 = SnapshotEvent.create(organization_id: organization.id, event_time: 2.days.ago, updated_at: 2.days.ago)
-        donation2 = DonationEvent.create(organization_id: organization.id, event_time: 1.minute.ago, updated_at: 1.minute.ago)
+        snapshot1 = SnapshotEvent.create!(organization_id: organization.id, eventable: eventable,
+          data: data,
+          event_time: 1.week.ago, updated_at: 1.week.ago)
+        DonationEvent.create!(organization_id: organization.id, eventable: eventable,
+          data: payload,
+          event_time: 3.days.ago, updated_at: 1.hour.ago)
+        SnapshotEvent.create!(organization_id: organization.id, eventable: eventable,
+          data: data,
+          event_time: 2.days.ago, updated_at: 2.days.ago)
+        DonationEvent.create!(organization_id: organization.id, eventable: eventable,
+          data: payload,
+          event_time: 1.minute.ago, updated_at: 1.minute.ago)
 
         expect(described_class.most_recent_snapshot(organization.id)).to eq(snapshot1)
       end
-
     end
   end
-
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Event, type: :model do
+  let(:organization) { FactoryBot.create(:organization) }
+  describe '#most_recent_snapshot' do
+
+    it 'should include the last usable snapshot' do
+      freeze_time do
+        snapshot1 = SnapshotEvent.create(organization_id: organization.id, event_time: 1.week.ago, updated_at: 1.week.ago)
+        donation = DonationEvent.create(organization_id: organization.id, event_time: 3.days.ago, updated_at: 3.days.ago)
+        snapshot2 = SnapshotEvent.create(organization_id: organization.id, event_time: 2.days.ago, updated_at: 2.days.ago)
+        donation2 = DonationEvent.create(organization_id: organization.id, event_time: 1.minute.ago, updated_at: 1.minute.ago)
+
+        expect(described_class.most_recent_snapshot(organization.id)).to eq(snapshot2)
+      end
+    end
+
+    it 'should not include an unusable snapshot' do
+      freeze_time do
+        snapshot1 = SnapshotEvent.create(organization_id: organization.id, event_time: 1.week.ago, updated_at: 1.week.ago)
+        donation = DonationEvent.create(organization_id: organization.id, event_time: 3.days.ago, updated_at: 1.hour.ago)
+        snapshot2 = SnapshotEvent.create(organization_id: organization.id, event_time: 2.days.ago, updated_at: 2.days.ago)
+        donation2 = DonationEvent.create(organization_id: organization.id, event_time: 1.minute.ago, updated_at: 1.minute.ago)
+
+        expect(described_class.most_recent_snapshot(organization.id)).to eq(snapshot1)
+      end
+
+    end
+  end
+
+end

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe "Admin::Organizations", type: :request do
         it "creates an organization and redirects to #index" do
           expect {
             post admin_organizations_path({ organization: valid_organization_params })
-          }.to change(Organization, :count).by(1)
+          }.to change(Organization, :count).by(1).
+            and change(SnapshotEvent, :count).by(1)
           expect(response).to redirect_to(admin_organizations_path(organization_id: 'admin'))
         end
       end

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe "Admin::Organizations", type: :request do
         it "creates an organization and redirects to #index" do
           expect {
             post admin_organizations_path({ organization: valid_organization_params })
-          }.to change(Organization, :count).by(1).
-            and change(SnapshotEvent, :count).by(1)
+          }.to change(Organization, :count).by(1)
+            .and change(SnapshotEvent, :count).by(1)
           expect(response).to redirect_to(admin_organizations_path(organization_id: 'admin'))
         end
       end


### PR DESCRIPTION
Event logic assumed that whenever we see a SnapshotEvent, we can effectively ignore everything that came before it and use it as the new "source of truth", with other events applied after it.

Unfortunately, there is a case where this doesn't work: if a correction event comes in *after* the snapshot, referencing something that happened *before* it.

Example:

* Donation happens on Jan. 10 setting item 1 quantity to 50.
* Snapshot happens on Jan. 11 recording item 1 quantity as 50.
* Donation correction event for the original donation happens on Jan. 12 recording item 1 quantity as 30.

In this case, if we take the snapshot as truth, it will have the wrong value for item 1. This is because we group the events by updated_at, but we're only looking at event_time, not updated_at time. Trying to change this part gets even more complicated (e.g. getting all events by updated_at time, but reordering them by event_time).

This PR makes a change so that any SnapshotEvent that is deemed "unusable" (i.e. falls into this category where there is any event that references an earlier action but was corrected after the snapshot) is ignored.