### PR TITLE
3969 number of diapers purchased

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -71,6 +71,11 @@ class Item < ApplicationRecord
       .where.not("lower(base_items.category) LIKE '%cloth%' OR lower(base_items.name) LIKE '%cloth%'")
   }
 
+  scope :cloth_diapers, -> {
+    joins(:base_item)
+      .where("lower(base_items.category) LIKE '%cloth%' OR lower(base_items.name) LIKE '%cloth%'")
+  }
+
   scope :adult_incontinence, -> {
     joins(:base_item)
       .where(items: { partner_key: %w(adult_incontinence underpads liners) })

--- a/app/services/reports/acquisition_report_service.rb
+++ b/app/services/reports/acquisition_report_service.rb
@@ -14,16 +14,22 @@ module Reports
     def report
       @report ||= { name: 'Diaper Acquisition',
                     entries: {
-                      'Disposable diapers distributed' => number_with_delimiter(distributed_diapers),
+                      'Disposable diapers distributed' => number_with_delimiter(distributed_disposable_diapers),
+                      'Cloth diapers distributed' => number_with_delimiter(distributed_cloth_diapers),
                       'Average monthly disposable diapers distributed' => number_with_delimiter(monthly_disposable_diapers),
+                      'Average monthly cloth diapers distributed' => number_with_delimiter(monthly_cloth_diapers),
                       'Total product drives' => annual_drives.count,
                       'Disposable diapers collected from drives' => number_with_delimiter(disposable_diapers_from_drives),
+                      'Cloth diapers collected from drives' => number_with_delimiter(cloth_diapers_from_drives),
                       'Money raised from product drives' => number_to_currency(money_from_drives),
                       'Total product drives (virtual)' => virtual_product_drives.count,
                       'Money raised from product drives (virtual)' => number_to_currency(money_from_virtual_drives),
                       'Disposable diapers collected from drives (virtual)' => number_with_delimiter(disposable_diapers_from_virtual_drives),
+                      'Cloth diapers collected from drives (virtual)' => number_with_delimiter(cloth_diapers_from_virtual_drives),
                       '% diapers donated' => "#{percent_donated.round}%",
-                      '% diapers bought' => "#{percent_bought.round}%",
+                      '% diapers purchased' => "#{percent_purchased.round}%",
+                      '% disposable diapers purchased' => "#{percent_disposable_diapers_purchased.round}%",
+                      '% cloth diapers purchased' => "#{percent_cloth_diapers_purchased.round}%",
                       'Money spent purchasing diapers' => number_to_currency(money_spent_on_diapers),
                       'Purchased from' => purchased_from,
                       'Vendors diapers purchased through' => vendors_purchased_from
@@ -31,8 +37,8 @@ module Reports
     end
 
     # @return [Integer]
-    def distributed_diapers
-      @distributed_diapers ||= organization
+    def distributed_disposable_diapers
+      @distributed_disposable_diapers ||= organization
                                .distributions
                                .for_year(year)
                                .joins(line_items: :item)
@@ -40,9 +46,22 @@ module Reports
                                .sum('line_items.quantity')
     end
 
+    def distributed_cloth_diapers
+      @distributed_cloth_diapers ||= organization
+                               .distributions
+                               .for_year(year)
+                               .joins(line_items: :item)
+                               .merge(Item.cloth_diapers)
+                               .sum('line_items.quantity')
+    end
+
     # @return [Integer]
     def monthly_disposable_diapers
-      (distributed_diapers / 12.0).round
+      (distributed_disposable_diapers / 12.0).round
+    end
+
+    def monthly_cloth_diapers
+      (distributed_cloth_diapers / 12.0).round
     end
 
     # @return [ActiveRecord::Relation]
@@ -54,6 +73,11 @@ module Reports
     def disposable_diapers_from_drives
       @disposable_diapers_from_drives ||=
         annual_drives.joins(donations: { line_items: :item }).merge(Item.disposable).sum(:quantity)
+    end
+
+    def cloth_diapers_from_drives
+      @cloth_diapers_from_drives ||=
+        annual_drives.joins(donations: { line_items: :item }).merge(Item.cloth_diapers).sum(:quantity)
     end
 
     # @return [Float]
@@ -79,18 +103,36 @@ module Reports
                                                   .sum(:quantity)
     end
 
+    # @return [Integer]
+    def cloth_diapers_from_virtual_drives
+      @cloth_diapers_from_virtual_drives ||= virtual_product_drives
+                                                  .joins(donations: { line_items: :item })
+                                                  .merge(Item.cloth_diapers)
+                                                  .sum(:quantity)
+    end
+
     # @return [Float]
     def percent_donated
       return 0.0 if total_diapers.zero?
 
-      (donated_diapers / total_diapers.to_f) * 100
+      ((donated_disposable_diapers + donated_cloth_diapers) / total_diapers.to_f) * 100
     end
 
     # @return [Float]
-    def percent_bought
+    def percent_purchased
       return 0.0 if total_diapers.zero?
 
-      (purchased_diapers / total_diapers.to_f) * 100
+      ((purchased_cloth_diapers + purchased_disposable_diapers) / total_diapers.to_f) * 100
+    end
+
+    # @return [Float]
+    def percent_cloth_diapers_purchased
+      (purchased_cloth_diapers / total_diapers.to_f) * 100
+    end
+
+    # @return [Float]
+    def percent_disposable_diapers_purchased
+      (purchased_disposable_diapers / total_diapers.to_f) * 100
     end
 
     # @return [Float]
@@ -126,7 +168,7 @@ module Reports
     ###### HELPER METHODS ######
 
     # @return [Integer]
-    def purchased_diapers
+    def purchased_disposable_diapers
       @purchased_diapers ||= LineItem.joins(:item)
                                      .merge(Item.disposable)
                                      .where(itemizable: organization.purchases.for_year(year))
@@ -134,16 +176,42 @@ module Reports
     end
 
     # @return [Integer]
-    def total_diapers
-      @total_diapers ||= purchased_diapers + donated_diapers
+    def purchased_cloth_diapers
+      @purchased_cloth_diapers ||= LineItem.joins(:item)
+                                           .merge(Item.cloth_diapers)
+                                           .where(itemizable: organization.purchases.for_year(year))
+                                           .sum(:quantity)
     end
 
     # @return [Integer]
-    def donated_diapers
+    def total_disposable_diapers
+      @total_disposable_diapers ||= purchased_dispsable_diapers + donated_disposable_diapers
+    end
+
+    # @return [Integer]
+    def total_cloth_diapers
+      @total_cloth_diapers ||= purchased_cloth_diapers + donated_cloth_diapers
+    end
+
+    # @return [Integer]
+    def total_diapers
+      @total_diapers ||= (purchased_cloth_diapers + donated_cloth_diapers) + (purchased_disposable_diapers + donated_disposable_diapers)
+    end
+
+    # @return [Integer]
+    def donated_disposable_diapers
       @donated_diapers ||= LineItem.joins(:item)
                                    .merge(Item.disposable)
                                    .where(itemizable: organization.donations.for_year(year))
                                    .sum(:quantity)
+    end
+
+    # @return [Integer]
+    def donated_cloth_diapers
+      @donated_cloth_diapers ||= LineItem.joins(:item)
+                                          .merge(Item.cloth_diapers)
+                                          .where(itemizable: organization.donations.for_year(year))
+                                          .sum(:quantity)
     end
   end
 end

--- a/app/services/reports/acquisition_report_service.rb
+++ b/app/services/reports/acquisition_report_service.rb
@@ -26,6 +26,7 @@ module Reports
                       'Disposable diapers collected from drives (virtual)' => number_with_delimiter(disposable_diapers_from_virtual_drives),
                       'Cloth diapers collected from drives (virtual)' => number_with_delimiter(cloth_diapers_from_virtual_drives),
                       '% disposable diapers donated' => "#{percent_disposable_donated.round}%",
+                      '% cloth diapers donated' => "#{percent_cloth_diapers_donated.round}%",
                       '% disposable diapers purchased' => "#{percent_disposable_diapers_purchased.round}%",
                       '% cloth diapers purchased' => "#{percent_cloth_diapers_purchased.round}%",
                       'Money spent purchasing diapers' => number_to_currency(money_spent_on_diapers),
@@ -110,6 +111,13 @@ module Reports
       return 0.0 if total_disposable_diapers.zero?
 
       (donated_disposable_diapers / total_disposable_diapers.to_f) * 100
+    end
+
+    # @return [Float]
+    def percent_cloth_diapers_donated
+      return 0.0 if total_cloth_diapers.zero?
+
+      (donated_cloth_diapers / total_cloth_diapers.to_f) * 100
     end
 
     # @return [Float]

--- a/app/services/reports/acquisition_report_service.rb
+++ b/app/services/reports/acquisition_report_service.rb
@@ -17,7 +17,6 @@ module Reports
                       'Disposable diapers distributed' => number_with_delimiter(distributed_disposable_diapers),
                       'Cloth diapers distributed' => number_with_delimiter(distributed_cloth_diapers),
                       'Average monthly disposable diapers distributed' => number_with_delimiter(monthly_disposable_diapers),
-                      'Average monthly cloth diapers distributed' => number_with_delimiter(monthly_cloth_diapers),
                       'Total product drives' => annual_drives.count,
                       'Disposable diapers collected from drives' => number_with_delimiter(disposable_diapers_from_drives),
                       'Cloth diapers collected from drives' => number_with_delimiter(cloth_diapers_from_drives),
@@ -26,8 +25,7 @@ module Reports
                       'Money raised from product drives (virtual)' => number_to_currency(money_from_virtual_drives),
                       'Disposable diapers collected from drives (virtual)' => number_with_delimiter(disposable_diapers_from_virtual_drives),
                       'Cloth diapers collected from drives (virtual)' => number_with_delimiter(cloth_diapers_from_virtual_drives),
-                      '% diapers donated' => "#{percent_donated.round}%",
-                      '% diapers purchased' => "#{percent_purchased.round}%",
+                      '% disposable diapers donated' => "#{percent_disposable_donated.round}%",
                       '% disposable diapers purchased' => "#{percent_disposable_diapers_purchased.round}%",
                       '% cloth diapers purchased' => "#{percent_cloth_diapers_purchased.round}%",
                       'Money spent purchasing diapers' => number_to_currency(money_spent_on_diapers),
@@ -58,10 +56,6 @@ module Reports
     # @return [Integer]
     def monthly_disposable_diapers
       (distributed_disposable_diapers / 12.0).round
-    end
-
-    def monthly_cloth_diapers
-      (distributed_cloth_diapers / 12.0).round
     end
 
     # @return [ActiveRecord::Relation]
@@ -112,31 +106,24 @@ module Reports
     end
 
     # @return [Float]
-    def percent_donated
-      return 0.0 if total_diapers.zero?
+    def percent_disposable_donated
+      return 0.0 if total_disposable_diapers.zero?
 
-      ((donated_disposable_diapers + donated_cloth_diapers) / total_diapers.to_f) * 100
-    end
-
-    # @return [Float]
-    def percent_purchased
-      return 0.0 if total_diapers.zero?
-
-      ((purchased_cloth_diapers + purchased_disposable_diapers) / total_diapers.to_f) * 100
+      (donated_disposable_diapers / total_disposable_diapers.to_f) * 100
     end
 
     # @return [Float]
     def percent_cloth_diapers_purchased
       return 0.0 if purchased_cloth_diapers.zero?
 
-      (purchased_cloth_diapers / total_diapers.to_f) * 100
+      (purchased_cloth_diapers / total_cloth_diapers.to_f) * 100
     end
 
     # @return [Float]
     def percent_disposable_diapers_purchased
       return 0.0 if purchased_disposable_diapers.zero?
 
-      (purchased_disposable_diapers / total_diapers.to_f) * 100
+      (purchased_disposable_diapers / total_disposable_diapers.to_f) * 100
     end
 
     # @return [Float]
@@ -189,17 +176,12 @@ module Reports
 
     # @return [Integer]
     def total_disposable_diapers
-      @total_disposable_diapers ||= purchased_dispsable_diapers + donated_disposable_diapers
+      @total_disposable_diapers ||= purchased_disposable_diapers + donated_disposable_diapers
     end
 
     # @return [Integer]
     def total_cloth_diapers
       @total_cloth_diapers ||= purchased_cloth_diapers + donated_cloth_diapers
-    end
-
-    # @return [Integer]
-    def total_diapers
-      @total_diapers ||= (purchased_cloth_diapers + donated_cloth_diapers) + (purchased_disposable_diapers + donated_disposable_diapers)
     end
 
     # @return [Integer]

--- a/app/services/reports/acquisition_report_service.rb
+++ b/app/services/reports/acquisition_report_service.rb
@@ -127,11 +127,15 @@ module Reports
 
     # @return [Float]
     def percent_cloth_diapers_purchased
+      return 0.0 if purchased_cloth_diapers.zero?
+
       (purchased_cloth_diapers / total_diapers.to_f) * 100
     end
 
     # @return [Float]
     def percent_disposable_diapers_purchased
+      return 0.0 if purchased_disposable_diapers.zero?
+
       (purchased_disposable_diapers / total_diapers.to_f) * 100
     end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -103,6 +103,44 @@ RSpec.describe Item, type: :model do
         expect(Item.active.size).to be > 1
       end
     end
+
+    describe "->disposable" do
+      it "returns records associated with disposable diapers" do
+        Item.delete_all
+        base_1 = create(:base_item, category: "Diapers - Childrens")
+        base_2 = create(:base_item, category: "Diapers - Adult")
+        cloth_base = create(:base_item, category: "Diapers - Cloth (Adult)")
+
+        disposable_1 = create(:item, :active, name: "Disposable Diaper 1", partner_key: base_1.partner_key)
+        disposable_2 = create(:item, :active, name: "Disposable Diaper 2", partner_key: base_2.partner_key)
+        cloth_1 = create(:item, :active, name: "Cloth Diaper", partner_key: cloth_base.partner_key)
+
+        disposables = Item.disposable
+        
+        expect(disposables.count).to eq(2)
+        expect(disposables).to include(disposable_1, disposable_2)
+        expect(disposables).to_not include(cloth_1)
+      end
+    end
+
+    describe "->cloth_diapers" do
+      it "returns records associated with disposable diapers" do
+        Item.delete_all
+        base_1 = create(:base_item, category: "Diapers - Childrens")
+        cloth_base_1 = create(:base_item, category: "Diapers - Cloth (Adult)")
+        cloth_base_2 = create(:base_item, category: "Diapers - Cloth (Kids)")
+
+        cloth_1 = create(:item, :active, name: "Cloth Diaper", partner_key: cloth_base_1.partner_key)
+        cloth_2 = create(:item, :active, name: "Disposable Diaper 2", partner_key: cloth_base_2.partner_key)
+        disposable_1 = create(:item, :active, name: "Disposable Diaper 1", partner_key: base_1.partner_key)
+
+        cloth_diapers = Item.cloth_diapers
+
+        expect(cloth_diapers.count).to eq(2)
+        expect(cloth_diapers).to include(cloth_1, cloth_2)
+        expect(cloth_diapers).to_not include(disposable_1)
+      end
+    end
   end
 
   context "Methods >" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Item, type: :model do
         cloth_1 = create(:item, :active, name: "Cloth Diaper", partner_key: cloth_base.partner_key)
 
         disposables = Item.disposable
-        
+
         expect(disposables.count).to eq(2)
         expect(disposables).to include(disposable_1, disposable_2)
         expect(disposables).to_not include(cloth_1)

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -128,22 +128,29 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
     end
 
     it 'should return the proper results on #report' do
-      expect(subject.report).to eq({
-        entries: { "% diapers bought" => "22%",
-                   "% diapers donated" => "78%",
-                   "Average monthly disposable diapers distributed" => "17",
-                   "Disposable diapers collected from drives" => "600",
-                   "Disposable diapers collected from drives (virtual)" => "120",
-                   "Disposable diapers distributed" => "200",
-                   "Money raised from product drives" => "$60.00",
-                   "Money raised from product drives (virtual)" => "$20.00",
-                   "Money spent purchasing diapers" => "$60.00",
-                   "Purchased from" => "Google, Walmart",
-                   "Total product drives" => 2,
-                   "Total product drives (virtual)" => 2,
-                   "Vendors diapers purchased through" => "Vendor 1, Vendor 2" },
-        name: "Diaper Acquisition"
-      })
+    # require 'pry'; binding.pry
+    expect(subject.report).to eq({
+      entries: { "Disposable diapers distributed" => "200",
+                 "Cloth diapers distributed" => "300",
+                 "Average monthly disposable diapers distributed" => "17",
+                 "Average monthly cloth diapers distributed" => "25",
+                 "Total product drives" => 2,
+                 "Disposable diapers collected from drives" => "600",
+                 "Cloth diapers collected from drives" => "900",
+                 "Money raised from product drives" => "$60.00",
+                 "Total product drives (virtual)" => 2,
+                 "Money raised from product drives (virtual)" => "$20.00",
+                 "Disposable diapers collected from drives (virtual)" => "120",
+                 "Cloth diapers collected from drives (virtual)" => "60",
+                 "% diapers donated" => "84%",
+                 "% diapers purchased" => "16%",
+                 "% disposable diapers purchased" => "11%",
+                 "% cloth diapers purchased" => "5%",
+                 "Money spent purchasing diapers" => "$60.00",
+                 "Purchased from" => "Google, Walmart",
+                 "Vendors diapers purchased through" => "Vendor 1, Vendor 2"},
+      name: "Diaper Acquisition"
+    })
     end
   end
 end

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
                    "Disposable diapers collected from drives (virtual)" => "120",
                    "Cloth diapers collected from drives (virtual)" => "60",
                    "% disposable diapers donated" => "78%",
+                   "% cloth diapers donated" => "89%",
                    "% disposable diapers purchased" => "22%",
                    "% cloth diapers purchased" => "11%",
                    "Money spent purchasing diapers" => "$60.00",

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -128,7 +128,6 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
     end
 
     it 'should return the proper results on #report' do
-    # require 'pry'; binding.pry
       expect(subject.report).to eq({
         entries: { "Disposable diapers distributed" => "200",
                    "Cloth diapers distributed" => "300",

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -128,11 +128,11 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
     end
 
     it 'should return the proper results on #report' do
+    # require 'pry'; binding.pry
       expect(subject.report).to eq({
         entries: { "Disposable diapers distributed" => "200",
                    "Cloth diapers distributed" => "300",
                    "Average monthly disposable diapers distributed" => "17",
-                   "Average monthly cloth diapers distributed" => "25",
                    "Total product drives" => 2,
                    "Disposable diapers collected from drives" => "600",
                    "Cloth diapers collected from drives" => "900",
@@ -141,10 +141,9 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
                    "Money raised from product drives (virtual)" => "$20.00",
                    "Disposable diapers collected from drives (virtual)" => "120",
                    "Cloth diapers collected from drives (virtual)" => "60",
-                   "% diapers donated" => "84%",
-                   "% diapers purchased" => "16%",
-                   "% disposable diapers purchased" => "11%",
-                   "% cloth diapers purchased" => "5%",
+                   "% disposable diapers donated" => "78%",
+                   "% disposable diapers purchased" => "22%",
+                   "% cloth diapers purchased" => "11%",
                    "Money spent purchasing diapers" => "$60.00",
                    "Purchased from" => "Google, Walmart",
                    "Vendors diapers purchased through" => "Vendor 1, Vendor 2"},

--- a/spec/services/reports/acquisition_report_service_spec.rb
+++ b/spec/services/reports/acquisition_report_service_spec.rb
@@ -128,29 +128,28 @@ RSpec.describe Reports::AcquisitionReportService, type: :service, persisted_data
     end
 
     it 'should return the proper results on #report' do
-    # require 'pry'; binding.pry
-    expect(subject.report).to eq({
-      entries: { "Disposable diapers distributed" => "200",
-                 "Cloth diapers distributed" => "300",
-                 "Average monthly disposable diapers distributed" => "17",
-                 "Average monthly cloth diapers distributed" => "25",
-                 "Total product drives" => 2,
-                 "Disposable diapers collected from drives" => "600",
-                 "Cloth diapers collected from drives" => "900",
-                 "Money raised from product drives" => "$60.00",
-                 "Total product drives (virtual)" => 2,
-                 "Money raised from product drives (virtual)" => "$20.00",
-                 "Disposable diapers collected from drives (virtual)" => "120",
-                 "Cloth diapers collected from drives (virtual)" => "60",
-                 "% diapers donated" => "84%",
-                 "% diapers purchased" => "16%",
-                 "% disposable diapers purchased" => "11%",
-                 "% cloth diapers purchased" => "5%",
-                 "Money spent purchasing diapers" => "$60.00",
-                 "Purchased from" => "Google, Walmart",
-                 "Vendors diapers purchased through" => "Vendor 1, Vendor 2"},
-      name: "Diaper Acquisition"
-    })
+      expect(subject.report).to eq({
+        entries: { "Disposable diapers distributed" => "200",
+                   "Cloth diapers distributed" => "300",
+                   "Average monthly disposable diapers distributed" => "17",
+                   "Average monthly cloth diapers distributed" => "25",
+                   "Total product drives" => 2,
+                   "Disposable diapers collected from drives" => "600",
+                   "Cloth diapers collected from drives" => "900",
+                   "Money raised from product drives" => "$60.00",
+                   "Total product drives (virtual)" => 2,
+                   "Money raised from product drives (virtual)" => "$20.00",
+                   "Disposable diapers collected from drives (virtual)" => "120",
+                   "Cloth diapers collected from drives (virtual)" => "60",
+                   "% diapers donated" => "84%",
+                   "% diapers purchased" => "16%",
+                   "% disposable diapers purchased" => "11%",
+                   "% cloth diapers purchased" => "5%",
+                   "Money spent purchasing diapers" => "$60.00",
+                   "Purchased from" => "Google, Walmart",
+                   "Vendors diapers purchased through" => "Vendor 1, Vendor 2"},
+        name: "Diaper Acquisition"
+      })
     end
   end
 end


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

Resolves #3969 

### Description
I have added the number of cloth diapers and disposable diapers purchased to the annual report. Along with other cloth and disposable metrics to further enhance the annual report. (I realize this was not asked of me and may be overkill, if so, I'll revert some changes.) I have also recalculated total_diapers to reflect both cloth and disposables to that banks can see information related to cloth, disposable, and all diapers. Tests on the newly added Item scope, and the previous disposables scope have been added to ensure functionality. I have also modified the existing report test to reflect the new functionality. 

## Newly added metrics:

- Disposable diapers distributed
- Cloth diapers distributed
- Average monthly disposable diapers distributed 
- Average monthly cloth diapers distributed
- Cloth diapers collected from drives
- Disposable diapers collected from drives
- Disposable diapers collected from drives (virtual)
- Cloth diapers collected from drives (virtual)
- % disposable diapers purchased
- % cloth diapers purchased

These were fairly easy calculations to add to the report, but if all of them are not needed/ wanted I'll just add the requested.
  

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Newly added and previously present scope tested on the Item model
Modified acquisition report service spec to include the newly added fields
