### PR TITLE
Update logic for destroy events

### DIFF
--- a/app/events/adjustment_event.rb
+++ b/app/events/adjustment_event.rb
@@ -3,6 +3,7 @@ class AdjustmentEvent < Event
   def self.publish(adjustment)
     create(
       eventable: adjustment,
+      group_id: "adjustment-#{adjustment.id}",
       organization_id: adjustment.organization_id,
       event_time: adjustment.created_at,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/audit_event.rb
+++ b/app/events/audit_event.rb
@@ -5,6 +5,7 @@ class AuditEvent < Event
   def self.publish(audit)
     create(
       eventable: audit,
+      group_id: "audit-#{audit.id}",
       organization_id: audit.organization_id,
       event_time: audit.updated_at,
       data: EventTypes::AuditPayload.new(

--- a/app/events/distribution_destroy_event.rb
+++ b/app/events/distribution_destroy_event.rb
@@ -3,6 +3,7 @@ class DistributionDestroyEvent < Event
   def self.publish(distribution)
     create(
       eventable: distribution,
+      group_id: "dist-destroy-#{distribution.id}",
       organization_id: distribution.organization_id,
       event_time: Time.zone.now,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/distribution_event.rb
+++ b/app/events/distribution_event.rb
@@ -3,6 +3,7 @@ class DistributionEvent < Event
   def self.publish(distribution)
     create(
       eventable: distribution,
+      group_id: "dist-#{distribution.id}",
       organization_id: distribution.organization_id,
       event_time: distribution.created_at,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/donation_destroy_event.rb
+++ b/app/events/donation_destroy_event.rb
@@ -3,6 +3,7 @@ class DonationDestroyEvent < Event
   def self.publish(donation)
     create(
       eventable: donation,
+      group_id: "donation-destroy-#{donation.id}",
       organization_id: donation.organization_id,
       event_time: Time.zone.now,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/donation_event.rb
+++ b/app/events/donation_event.rb
@@ -3,6 +3,7 @@ class DonationEvent < Event
   def self.publish(donation)
     create(
       eventable: donation,
+      group_id: "donation-#{donation.id}",
       organization_id: donation.organization_id,
       event_time: donation.created_at,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/inventory_aggregate.rb
+++ b/app/events/inventory_aggregate.rb
@@ -29,7 +29,7 @@ module InventoryAggregate
       events.unshift(last_snapshot) if last_snapshot
 
       inventory = EventTypes::Inventory.from(organization_id)
-      events.group_by { |e| [e.type, e.eventable_type, e.eventable_id] }.each do |_, event_batch|
+      events.group_by(&:group_id).each do |_, event_batch|
         last_grouped_event = event_batch.max_by(&:updated_at)
         handle(last_grouped_event, inventory, validate: validate)
       end

--- a/app/events/inventory_aggregate.rb
+++ b/app/events/inventory_aggregate.rb
@@ -29,7 +29,7 @@ module InventoryAggregate
       events.unshift(last_snapshot) if last_snapshot
 
       inventory = EventTypes::Inventory.from(organization_id)
-      events.group_by { |e| [e.eventable_type, e.eventable_id] }.each do |_, event_batch|
+      events.group_by { |e| [e.type, e.eventable_type, e.eventable_id] }.each do |_, event_batch|
         last_grouped_event = event_batch.max_by(&:updated_at)
         handle(last_grouped_event, inventory, validate: validate)
       end

--- a/app/events/kit_allocate_event.rb
+++ b/app/events/kit_allocate_event.rb
@@ -22,6 +22,7 @@ class KitAllocateEvent < Event
   def self.publish(kit, storage_location, quantity)
     create(
       eventable: kit,
+      group_id: "kit-allocate-#{kit.id}-#{SecureRandom.hex}",
       organization_id: kit.organization_id,
       event_time: Time.zone.now,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/kit_deallocate_event.rb
+++ b/app/events/kit_deallocate_event.rb
@@ -22,6 +22,7 @@ class KitDeallocateEvent < Event
   def self.publish(kit, storage_location, quantity)
     create(
       eventable: kit,
+      group_id: "kit-deallocate-#{kit.id}-#{SecureRandom.hex}",
       organization_id: kit.organization_id,
       event_time: Time.zone.now,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/purchase_destroy_event.rb
+++ b/app/events/purchase_destroy_event.rb
@@ -3,6 +3,7 @@ class PurchaseDestroyEvent < Event
   def self.publish(purchase)
     create(
       eventable: purchase,
+      group_id: "purchase-destroy-#{purchase.id}",
       organization_id: purchase.organization_id,
       event_time: Time.zone.now,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/purchase_event.rb
+++ b/app/events/purchase_event.rb
@@ -3,6 +3,7 @@ class PurchaseEvent < Event
   def self.publish(purchase)
     create(
       eventable: purchase,
+      group_id: "purchase-#{purchase.id}",
       organization_id: purchase.organization_id,
       event_time: purchase.created_at,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/snapshot_event.rb
+++ b/app/events/snapshot_event.rb
@@ -36,6 +36,7 @@ class SnapshotEvent < Event
   def self.publish(organization)
     create(
       eventable: organization,
+      group_id: "snapshot-#{SecureRandom.hex}",
       organization_id: organization.id,
       event_time: Time.zone.now,
       data: EventTypes::Inventory.new(

--- a/app/events/transfer_destroy_event.rb
+++ b/app/events/transfer_destroy_event.rb
@@ -4,7 +4,7 @@ class TransferDestroyEvent < Event
     create(
       eventable: transfer,
       organization_id: transfer.organization_id,
-      event_time: Time.zone.now,
+      event_time: transfer.created_at,
       data: EventTypes::InventoryPayload.new(
         items: EventTypes::EventLineItem.from_line_items(transfer.line_items,
           from: transfer.to.id,

--- a/app/events/transfer_destroy_event.rb
+++ b/app/events/transfer_destroy_event.rb
@@ -3,6 +3,7 @@ class TransferDestroyEvent < Event
   def self.publish(transfer)
     create(
       eventable: transfer,
+      group_id: "transfer-destroy-#{transfer.id}",
       organization_id: transfer.organization_id,
       event_time: transfer.created_at,
       data: EventTypes::InventoryPayload.new(

--- a/app/events/transfer_event.rb
+++ b/app/events/transfer_event.rb
@@ -3,6 +3,7 @@ class TransferEvent < Event
   def self.publish(transfer)
     create(
       eventable: transfer,
+      group_id: "transfer-#{transfer.id}",
       organization_id: transfer.organization_id,
       event_time: transfer.created_at,
       data: EventTypes::InventoryPayload.new(

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,6 +10,7 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  eventable_id    :bigint
+#  group_id        :string
 #  organization_id :bigint
 #  user_id         :bigint
 #

--- a/db/migrate/20231225011809_fix_destroy_events.rb
+++ b/db/migrate/20231225011809_fix_destroy_events.rb
@@ -1,0 +1,7 @@
+class FixDestroyEvents < ActiveRecord::Migration[7.0]
+  def change
+    TransferDestroyEvent.all.each do |event|
+      event.update!(event_time: event.eventable.created_at) if event.eventable
+    end
+  end
+end

--- a/db/migrate/20231229200106_add_group_id_to_events.rb
+++ b/db/migrate/20231229200106_add_group_id_to_events.rb
@@ -1,0 +1,23 @@
+class AddGroupIdToEvents < ActiveRecord::Migration[7.0]
+  def up
+    add_column :events, :group_id, :string
+    Event.where.not(type: %i(KitAllocateEvent KitDeallocateEvent SnapshotEvent)).find_each do |event|
+      # this is OK for now - it should still group together the right events.
+      event.update_attribute(:group_id, "#{event.type}-#{event.eventable_id}")
+    end
+
+    SnapshotEvent.find_each do |event|
+      event.update_attribute(:group_id, "snapshot-#{SecureRandom.hex}")
+    end
+    KitAllocateEvent.find_each do |event|
+      event.update_attribute(:group_id, "kit-allocate-#{event.eventable_id}-#{SecureRandom.hex}")
+    end
+    KitDeallocateEvent.find_each do |event|
+      event.update_attribute(:group_id, "kit-deallocate-#{event.eventable_id}-#{SecureRandom.hex}")
+    end
+  end
+
+  def down
+    remove_column :events, :group_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_25_011809) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_29_200106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -284,6 +284,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_25_011809) do
     t.datetime "updated_at", null: false
     t.bigint "organization_id"
     t.bigint "user_id"
+    t.string "group_id"
     t.index ["organization_id", "event_time"], name: "index_events_on_organization_id_and_event_time"
     t.index ["organization_id"], name: "index_events_on_organization_id"
     t.index ["user_id"], name: "index_events_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_01_194409) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_25_011809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -324,7 +324,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_01_194409) do
   create_table "flipper_gates", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
-    t.string "value"
+    t.text "value"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true

--- a/spec/services/donation_destroy_service_spec.rb
+++ b/spec/services/donation_destroy_service_spec.rb
@@ -86,6 +86,7 @@ describe DonationDestroyService do
         instance_double(Donation,
           storage_location: fake_storage_location,
           storage_location_id: 12,
+          id: 5,
           line_items: [],
           organization_id: organization_id)
       }


### PR DESCRIPTION
Fixes a bug with destroy events. The inventory aggregate was combining regular and destroy events together into a single one, so it only ever processed the destroy event and not the original event, resulting in a double reduction in the event's items.

This separates out the event types so they are processed separately.

It also fixes a bug where transfer destroy events were treated as new rather than being bundled at the same time as the original transfer. This could have ramifications if there was an audit in between - the transfer would be reversed *after* the audit instead of treated as happening before it.