### PR TITLE
3986: Disallow duplicate items in audit

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -93,7 +93,7 @@ class AuditsController < ApplicationController
 
   def handle_audit_errors
     error_message = @audit.errors.uniq(&:attribute).map do |error|
-      attr = error.attribute.to_s == 'base' ? '' : error.attribute.capitalize
+      attr = (error.attribute.to_s == 'base') ? '' : error.attribute.capitalize
       "#{attr} ".tr("_", " ") + error.message
     end
     flash[:error] = error_message.join(", ")

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -51,7 +51,7 @@ class AuditsController < ApplicationController
     if @audit.update(audit_params)
       save_audit_status_and_redirect(params)
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash[:error] = @audit.errors.full_messages.join("\n")
       @storage_locations = [@audit.storage_location]
       set_items
       @audit.line_items.build if @audit.line_items.empty?

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -93,7 +93,8 @@ class AuditsController < ApplicationController
 
   def handle_audit_errors
     error_message = @audit.errors.uniq(&:attribute).map do |error|
-      "#{error.attribute.capitalize} ".tr("_", " ") + error.message
+      attr = error.attribute.to_s == 'base' ? '' : error.attribute.capitalize
+      "#{attr} ".tr("_", " ") + error.message
     end
     flash[:error] = error_message.join(", ")
   end

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -64,6 +64,20 @@ RSpec.describe Audit, type: :model do
       expect(audit.save).to be_falsey
     end
 
+    it 'cannot have duplicate line items' do
+      item = create(:item, name: "Dupe Item")
+      storage_location = create(:storage_location, :with_items, item: item, item_quantity: 10)
+      audit = build(:audit,
+                    storage_location: storage_location,
+                    line_items_attributes: [
+                      { item_id: item.id, quantity: 3 },
+                      { item_id: item.id, quantity: 5 }
+                    ])
+
+      expect(audit.save).to be_falsey
+      expect(audit.errors.full_messages).to eq(["You have entered at least one duplicate item: Dupe Item"])
+    end
+
     it "can have line items that has quantity as a positive integer" do
       item = create(:item)
       storage_location = create(:storage_location, :with_items, item: item, item_quantity: 10)


### PR DESCRIPTION

Resolves #3986. <!--fill issue number-->

### Description
This change disallows audits from having multiple of the same item entered. This is almost certainly a mistake.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Unit tests.