### PR TITLE
Add warning for intervening audits on distribution edit

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -141,9 +141,9 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @items = current_organization.items.alphabetized
       @storage_locations = current_organization.storage_locations.active_locations.has_inventory_items.alphabetized
-      @audit_warning = current_organization.audits.
-        where(storage_location_id: @distribution.storage_location_id).
-        where("updated_at > ?", @distribution.created_at).any?
+      @audit_warning = current_organization.audits
+        .where(storage_location_id: @distribution.storage_location_id)
+        .where("updated_at > ?", @distribution.created_at).any?
     else
       redirect_to distributions_path, error: 'To edit a distribution,
       you must be an organization admin or the current date must be later than today.'

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -141,6 +141,7 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @items = current_organization.items.alphabetized
       @storage_locations = current_organization.storage_locations.active_locations.has_inventory_items.alphabetized
+      @audit_warning = current_organization.audits.where("updated_at > ?", @distribution.created_at).any?
     else
       redirect_to distributions_path, error: 'To edit a distribution,
       you must be an organization admin or the current date must be later than today.'

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -141,7 +141,9 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @items = current_organization.items.alphabetized
       @storage_locations = current_organization.storage_locations.active_locations.has_inventory_items.alphabetized
-      @audit_warning = current_organization.audits.where("updated_at > ?", @distribution.created_at).any?
+      @audit_warning = current_organization.audits.
+        where(storage_location_id: @distribution.storage_location_id).
+        where("updated_at > ?", @distribution.created_at).any?
     else
       redirect_to distributions_path, error: 'To edit a distribution,
       you must be an organization admin or the current date must be later than today.'

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -27,10 +27,18 @@
 <section class="content">
 
   <% unless @distribution.future? %>
-    <div class="alert alert-warning" , role="alert">
+    <div class="alert alert-warning" role="alert">
       The current date is past the date this distribution was scheduled for.
       Please be very careful when editing this record;
       the contents should match what was given to the recipient.
+    </div>
+  <% end %>
+  <% if @audit_warning %>
+    <div class="alert alert-warning" role="alert">
+      You’ve had an audit since this distribution was started.
+      In the rare case that you are correcting a typo,
+      rather than recording that the physical amounts being distributed have changed,
+      you’ll need to make an adjustment to the inventory as well.
     </div>
   <% end %>
 
@@ -48,7 +56,8 @@
               <div class="box-body">
                 <%= render 'form', distribution: @distribution, date_place_holder: @distribution.issued_at %>
               </div>
-          </div><!-- /.box -->
+            </div><!-- /.box -->
+          </div>
         </div>
       </div>
     </div>

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -347,9 +347,16 @@ RSpec.describe "Distributions", type: :request do
 
       it "should show a warning if there is an inteverning audit" do
         distribution.update!(created_at: 1.week.ago)
-        create(:audit)
+        create(:audit, storage_location: distribution.storage_location)
         get edit_distribution_path(default_params.merge(id: distribution.id))
         expect(response.body).to include("You’ve had an audit since this distribution was started.")
+      end
+
+      it "should not show a warning if the audit is for another location" do
+        distribution.update!(created_at: 1.week.ago)
+        create(:audit, storage_location: create(:storage_location))
+        get edit_distribution_path(default_params.merge(id: distribution.id))
+        expect(response.body).not_to include("You’ve had an audit since this distribution was started.")
       end
     end
   end

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -332,6 +332,26 @@ RSpec.describe "Distributions", type: :request do
         end
       end
     end
+
+    describe "GET #edit" do
+      let(:location) { create(:storage_location) }
+      let(:partner) { create(:partner) }
+
+      let(:distribution) { create(:distribution, partner: partner) }
+
+      it "should show the distribution" do
+        get edit_distribution_path(default_params.merge(id: distribution.id))
+        expect(response).to be_successful
+        expect(response.body).not_to include("You’ve had an audit since this distribution was started.")
+      end
+
+      it "should show a warning if there is an inteverning audit" do
+        distribution.update!(created_at: 1.week.ago)
+        create(:audit)
+        get edit_distribution_path(default_params.merge(id: distribution.id))
+        expect(response.body).to include("You’ve had an audit since this distribution was started.")
+      end
+    end
   end
 
   context "While not signed in" do


### PR DESCRIPTION
As per discussion in Slack about the confusion around distribution edits.

The assumption when editing a distribution is that it actually represents **movement of goods** - in other words, the distribution was set up, but when it actually happens, the things that move around are different (e.g. the partner asks for more things or doesn't want as much).

If this isn't the case - if the person editing actually means to correct an administrative error - this can cause inventory issues if there was an intervening audit. The audit forces the inventory quantity to a particular amount, and editing the inventory will actually do a diff of the current and previous values and increase/decrease by that amount. This makes sense if it represents movement of goods, but not if it represents fixing an error.

This PR adds a warning when editing a distribution with an intervening audit indicating that inventory might be messed up in this case, and asking them to adjust it after the fact.

### How Has This Been Tested?

Local and unit testing.

### Screenshots
<img width="1232" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/1986893/33a614d7-bc5a-47f8-94cc-3409106fd333">