### PR TITLE
fix: renames Itemizable.to_a to line_item_hashes (#3909)

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -38,8 +38,8 @@ class AuditsController < ApplicationController
 
     increasing_adjustment, decreasing_adjustment = @audit.adjustment.split_difference
     ActiveRecord::Base.transaction do
-      @audit.storage_location.increase_inventory(increasing_adjustment.line_item_hashes)
-      @audit.storage_location.decrease_inventory(decreasing_adjustment.line_item_hashes)
+      @audit.storage_location.increase_inventory(increasing_adjustment.line_item_values)
+      @audit.storage_location.decrease_inventory(decreasing_adjustment.line_item_values)
       AuditEvent.publish(@audit)
     end
     @audit.finalized!

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -38,8 +38,8 @@ class AuditsController < ApplicationController
 
     increasing_adjustment, decreasing_adjustment = @audit.adjustment.split_difference
     ActiveRecord::Base.transaction do
-      @audit.storage_location.increase_inventory increasing_adjustment
-      @audit.storage_location.decrease_inventory decreasing_adjustment
+      @audit.storage_location.increase_inventory(increasing_adjustment.line_item_hashes)
+      @audit.storage_location.decrease_inventory(decreasing_adjustment.line_item_hashes)
       AuditEvent.publish(@audit)
     end
     @audit.finalized!

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -104,7 +104,6 @@ module Itemizable
 
   def line_item_hashes
     line_items.map do |l|
-      # When the item isn't found, it's probably just inactive. This ensures it's available.
       item = Item.find(l.item_id)
       { item_id: item.id, name: item.name, quantity: l.quantity, active: item.active }.with_indifferent_access
     end

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -102,12 +102,19 @@ module Itemizable
     line_items.total
   end
 
-  def to_a
+  def line_item_hashes
     line_items.map do |l|
       # When the item isn't found, it's probably just inactive. This ensures it's available.
       item = Item.find(l.item_id)
       { item_id: item.id, name: item.name, quantity: l.quantity, active: item.active }.with_indifferent_access
     end
+  end
+
+  # TODO: I'm not sure if this should just be removed or leave as a warning for now?
+  def to_a
+    Rails.logger.error("Calling Itemizable#to_a is deprecated. Use Itemizable#line_item_hashes instead.")
+    Rails.logger.error("Called on #{inspect} by #{caller}")
+    line_item_hashes
   end
 
   private

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -109,13 +109,12 @@ module Itemizable
     end
   end
 
-  # TODO: I'm not sure if this should just be removed or leave as a warning for now?
   def to_a
-    line_item_values unless Flipper.enabled?(:deprecate_to_a)
+    line_item_hashes unless Flipper.enabled?(:deprecate_to_a)
 
     Rails.logger.warn "Called #to_a on an Itemizable #{inspect}."
     Rails.logger.warn caller.join("\n")
-    raise StandardError, "Calling to_a on an Itemizable is deprecated. Use #line_item_values instead."
+    raise StandardError, "Calling to_a on an Itemizable is deprecated. Use #line_item_hashes instead."
   end
 
   private

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -110,11 +110,11 @@ module Itemizable
   end
 
   def to_a
-    line_item_hashes unless Flipper.enabled?(:deprecate_to_a)
+    return line_item_values unless Flipper.enabled?(:deprecate_to_a)
 
     Rails.logger.warn "Called #to_a on an Itemizable #{inspect}."
     Rails.logger.warn caller.join("\n")
-    raise StandardError, "Calling to_a on an Itemizable is deprecated. Use #line_item_hashes instead."
+    raise StandardError, "Calling to_a on an Itemizable is deprecated. Use #line_item_values instead."
   end
 
   private

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -102,7 +102,7 @@ module Itemizable
     line_items.total
   end
 
-  def line_item_hashes
+  def line_item_values
     line_items.map do |l|
       item = Item.find(l.item_id)
       { item_id: item.id, name: item.name, quantity: l.quantity, active: item.active }.with_indifferent_access
@@ -111,9 +111,11 @@ module Itemizable
 
   # TODO: I'm not sure if this should just be removed or leave as a warning for now?
   def to_a
-    Rails.logger.error("Calling Itemizable#to_a is deprecated. Use Itemizable#line_item_hashes instead.")
-    Rails.logger.error("Called on #{inspect} by #{caller}")
-    line_item_hashes
+    line_item_values unless Flipper.enabled?(:deprecate_to_a)
+
+    Rails.logger.warn "Called #to_a on an Itemizable #{inspect}."
+    Rails.logger.warn caller.join("\n")
+    raise StandardError, "Calling to_a on an Itemizable is deprecated. Use #line_item_values instead."
   end
 
   private

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -46,7 +46,7 @@ class StorageLocation < ApplicationRecord
   validates :name, :address, :organization, presence: true
   validates :warehouse_type, inclusion: { in: WAREHOUSE_TYPES },
                              allow_blank: true
-  before_destroy :verify_inventory_items, prepend: true
+  before_destroy :validate_empty_inventory, prepend: true
 
   include Discard::Model
   include Geocodable
@@ -173,8 +173,8 @@ class StorageLocation < ApplicationRecord
     change_log
   end
 
-  def verify_inventory_items
-    unless empty_inventory_items?
+  def validate_empty_inventory
+    unless empty_inventory?
       errors.add(:base, "Cannot delete storage location containing inventory items with non-zero quantities")
       throw(:abort)
     end
@@ -190,8 +190,8 @@ class StorageLocation < ApplicationRecord
     attributes
   end
 
-  def empty_inventory_items?
-    inventory_items.map(&:quantity).uniq.reject(&:zero?).empty?
+  def empty_inventory?
+    inventory_items.map(&:quantity).all?(&:zero?)
   end
 
   def active_inventory_items

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -136,48 +136,25 @@ class StorageLocation < ApplicationRecord
   end
 
   # FIXME: After this is stable, revisit how we do logging
-  def increase_inventory(itemizable_array)
-    # This is, at least for now, how we log changes to the inventory made in this call
-    log = {}
-    # Iterate through each of the line-items in the moving box
-    Item.reactivate(itemizable_array.map { |item_hash| item_hash[:item_id] })
-    itemizable_array.each do |item_hash|
-      # Locate the storage box for the item, or create a new storage box for it
-      inventory_item = inventory_items.find_or_create_by!(item_id: item_hash[:item_id])
-      # Increase the quantity-on-record for that item
-      new_quantity = inventory_item.quantity + item_hash[:quantity].to_i
-      inventory_item.update!(quantity: new_quantity)
-      # Record in the log that this has occurred
-      log[item_hash[:item_id]] = "+#{item_hash[:quantity]}"
-    end
+  def increase_inventory(item_hash_array)
+    change_log = {}
+
+    Item.reactivate(item_hash_array.map { |item| item[:item_id] })
+
+    item_hash_array.each { |item| update_item_quantity(change_log, item, increase: true) }
     # log could be pulled from dirty AR stuff?
     # Save the final changes -- does this need to occur here?
     save
-    # return log
-    log
+
+    change_log
   end
 
   # TODO: re-evaluate this for optimization
-  def decrease_inventory(itemizable_array)
-    # This is, at least for now, how we log changes to the inventory made in this call
-    log = {}
-    # This tracks items that have insufficient inventory counts to be reduced as much
-    insufficient_items = []
-    # Iterate through each of the line-items in the moving box
-    itemizable_array.each do |item_hash|
-      # Locate the storage box for the item, or create an empty storage box
-      inventory_item = inventory_items.find_by(item_id: item_hash[:item_id]) || inventory_items.build
-      # If we've got sufficient inventory in the storage box to fill the moving box, then continue
-      next unless inventory_item.quantity < item_hash[:quantity]
+  def decrease_inventory(item_hash_array)
+    change_log = {}
 
-      # Otherwise, we need to record that there was insufficient inventory on-hand
-      insufficient_items << {
-        item_id: item_hash[:item_id],
-        item_name: item_hash[:name],
-        quantity_on_hand: inventory_item.quantity,
-        quantity_requested: item_hash[:quantity]
-      }
-    end
+    # This tracks items that have insufficient inventory counts to be reduced as much
+    insufficient_items = item_hash_array.filter_map { |item| amount_insufficient(item) }
     # NOTE: Could this be handled by a validation instead?
     # If we found any insufficiencies
     unless insufficient_items.empty?
@@ -189,22 +166,11 @@ class StorageLocation < ApplicationRecord
       )
     end
 
-    # Re-run through the items in the moving box again
-    itemizable_array.each do |item_hash|
-      # Look for the moving box for this item -- we know there is sufficient quantity this time
-      # Raise AR:RNF if it fails to find it -- though that seems moot since it would have been
-      # captured by the previous block.
-      inventory_item = inventory_items.find_by(item_id: item_hash[:item_id])
-      # Reduce the inventory box quantity
-      new_quantity = inventory_item.quantity - item_hash[:quantity]
-      inventory_item.update(quantity: new_quantity)
-      # Record in the log that this has occurred
-      log[item_hash[:item_id]] = "-#{item_hash[:quantity]}"
-    end
-    # log could be pulled from dirty AR stuff
+    # Iterate through each of the line-items in the moving box
+    item_hash_array.each { |item_hash| update_item_quantity(change_log, item_hash, increase: false) }
     save!
-    # return log
-    log
+
+    change_log
   end
 
   def verify_inventory_items
@@ -232,5 +198,38 @@ class StorageLocation < ApplicationRecord
     inventory_items
     .includes(:item)
     .where(items: { active: true })
+  end
+
+  private
+
+  # checks if there is enough inventory to remove the requested amount
+  # returns nil if there is enough inventory
+  # returns a hash if there is enough inventory
+  def amount_insufficient(item_hash)
+    inventory_item = inventory_items.find_by(item_id: item_hash[:item_id])
+
+    # If item exists and has sufficient inventory, then continue
+    return if inventory_item && inventory_item.quantity >= item_hash[:quantity]
+
+    # Return hash of insufficiency information
+    {
+      item_id: item_hash[:item_id],
+      item_name: item_hash[:name],
+      quantity_on_hand: inventory_item&.quantity || 0,
+      quantity_requested: item_hash[:quantity]
+    }
+  end
+
+  # takes a log, and item hash and boolean: increase: true/false
+  # updates the log with the new inventory count
+  def update_item_quantity(change_log, item, increase:)
+    inventory_item = inventory_items.find_or_create_by!(item_id: item[:item_id])
+
+    change_amount = increase ? item[:quantity] : item[:quantity] * -1
+    new_quantity = inventory_item.quantity + change_amount
+    inventory_item.update(quantity: new_quantity)
+
+    # Record in the log that this has occurred
+    change_log[item[:item_id]] = new_quantity.to_s
   end
 end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -137,8 +137,6 @@ class StorageLocation < ApplicationRecord
 
   # FIXME: After this is stable, revisit how we do logging
   def increase_inventory(itemizable_array)
-    itemizable_array = itemizable_array.to_a
-
     # This is, at least for now, how we log changes to the inventory made in this call
     log = {}
     # Iterate through each of the line-items in the moving box
@@ -161,8 +159,6 @@ class StorageLocation < ApplicationRecord
 
   # TODO: re-evaluate this for optimization
   def decrease_inventory(itemizable_array)
-    itemizable_array = itemizable_array.to_a
-
     # This is, at least for now, how we log changes to the inventory made in this call
     log = {}
     # This tracks items that have insufficient inventory counts to be reduced as much

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -136,25 +136,48 @@ class StorageLocation < ApplicationRecord
   end
 
   # FIXME: After this is stable, revisit how we do logging
-  def increase_inventory(item_hash_array)
-    change_log = {}
-
-    Item.reactivate(item_hash_array.map { |item| item[:item_id] })
-
-    item_hash_array.each { |item| update_item_quantity(change_log, item, increase: true) }
+  def increase_inventory(itemizable_array)
+    # This is, at least for now, how we log changes to the inventory made in this call
+    log = {}
+    # Iterate through each of the line-items in the moving box
+    Item.reactivate(itemizable_array.map { |item_hash| item_hash[:item_id] })
+    itemizable_array.each do |item_hash|
+      # Locate the storage box for the item, or create a new storage box for it
+      inventory_item = inventory_items.find_or_create_by!(item_id: item_hash[:item_id])
+      # Increase the quantity-on-record for that item
+      new_quantity = inventory_item.quantity + item_hash[:quantity].to_i
+      inventory_item.update!(quantity: new_quantity)
+      # Record in the log that this has occurred
+      log[item_hash[:item_id]] = "+#{item_hash[:quantity]}"
+    end
     # log could be pulled from dirty AR stuff?
     # Save the final changes -- does this need to occur here?
     save
-
-    change_log
+    # return log
+    log
   end
 
   # TODO: re-evaluate this for optimization
-  def decrease_inventory(item_hash_array)
-    change_log = {}
-
+  def decrease_inventory(itemizable_array)
+    # This is, at least for now, how we log changes to the inventory made in this call
+    log = {}
     # This tracks items that have insufficient inventory counts to be reduced as much
-    insufficient_items = item_hash_array.filter_map { |item| amount_insufficient(item) }
+    insufficient_items = []
+    # Iterate through each of the line-items in the moving box
+    itemizable_array.each do |item_hash|
+      # Locate the storage box for the item, or create an empty storage box
+      inventory_item = inventory_items.find_by(item_id: item_hash[:item_id]) || inventory_items.build
+      # If we've got sufficient inventory in the storage box to fill the moving box, then continue
+      next unless inventory_item.quantity < item_hash[:quantity]
+
+      # Otherwise, we need to record that there was insufficient inventory on-hand
+      insufficient_items << {
+        item_id: item_hash[:item_id],
+        item_name: item_hash[:name],
+        quantity_on_hand: inventory_item.quantity,
+        quantity_requested: item_hash[:quantity]
+      }
+    end
     # NOTE: Could this be handled by a validation instead?
     # If we found any insufficiencies
     unless insufficient_items.empty?
@@ -166,11 +189,22 @@ class StorageLocation < ApplicationRecord
       )
     end
 
-    # Iterate through each of the line-items in the moving box
-    item_hash_array.each { |item_hash| update_item_quantity(change_log, item_hash, increase: false) }
+    # Re-run through the items in the moving box again
+    itemizable_array.each do |item_hash|
+      # Look for the moving box for this item -- we know there is sufficient quantity this time
+      # Raise AR:RNF if it fails to find it -- though that seems moot since it would have been
+      # captured by the previous block.
+      inventory_item = inventory_items.find_by(item_id: item_hash[:item_id])
+      # Reduce the inventory box quantity
+      new_quantity = inventory_item.quantity - item_hash[:quantity]
+      inventory_item.update(quantity: new_quantity)
+      # Record in the log that this has occurred
+      log[item_hash[:item_id]] = "-#{item_hash[:quantity]}"
+    end
+    # log could be pulled from dirty AR stuff
     save!
-
-    change_log
+    # return log
+    log
   end
 
   def validate_empty_inventory
@@ -198,38 +232,5 @@ class StorageLocation < ApplicationRecord
     inventory_items
     .includes(:item)
     .where(items: { active: true })
-  end
-
-  private
-
-  # checks if there is enough inventory to remove the requested amount
-  # returns nil if there is enough inventory
-  # returns a hash if there is enough inventory
-  def amount_insufficient(item_hash)
-    inventory_item = inventory_items.find_by(item_id: item_hash[:item_id])
-
-    # If item exists and has sufficient inventory, then continue
-    return if inventory_item && inventory_item.quantity >= item_hash[:quantity]
-
-    # Return hash of insufficiency information
-    {
-      item_id: item_hash[:item_id],
-      item_name: item_hash[:name],
-      quantity_on_hand: inventory_item&.quantity || 0,
-      quantity_requested: item_hash[:quantity]
-    }
-  end
-
-  # takes a log, and item hash and boolean: increase: true/false
-  # updates the log with the new inventory count
-  def update_item_quantity(change_log, item, increase:)
-    inventory_item = inventory_items.find_or_create_by!(item_id: item[:item_id])
-
-    change_amount = increase ? item[:quantity] : item[:quantity] * -1
-    new_quantity = inventory_item.quantity + change_amount
-    inventory_item.update(quantity: new_quantity)
-
-    # Record in the log that this has occurred
-    change_log[item[:item_id]] = new_quantity.to_s
   end
 end

--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -25,8 +25,8 @@ class AdjustmentCreateService
         # Split into positive and negative portions.
         # N.B. -- THIS CHANGES THE ORIGINAL LINE ITEMS ON @adjustment DO **NOT** RESAVE AS THAT WILL CHANGE ANY NEGATIVE LINE ITEMS ON THE ADJUSTMENT TO POSITIVES
         increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
-        @adjustment.storage_location.increase_inventory increasing_adjustment
-        @adjustment.storage_location.decrease_inventory decreasing_adjustment
+        @adjustment.storage_location.increase_inventory(increasing_adjustment.line_item_hashes)
+        @adjustment.storage_location.decrease_inventory(decreasing_adjustment.line_item_hashes)
       rescue InsufficientAllotment => e
         @adjustment.errors.add(:base, e.message)
         raise e

--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -25,8 +25,8 @@ class AdjustmentCreateService
         # Split into positive and negative portions.
         # N.B. -- THIS CHANGES THE ORIGINAL LINE ITEMS ON @adjustment DO **NOT** RESAVE AS THAT WILL CHANGE ANY NEGATIVE LINE ITEMS ON THE ADJUSTMENT TO POSITIVES
         increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
-        @adjustment.storage_location.increase_inventory(increasing_adjustment.line_item_hashes)
-        @adjustment.storage_location.decrease_inventory(decreasing_adjustment.line_item_hashes)
+        @adjustment.storage_location.increase_inventory(increasing_adjustment.line_item_values)
+        @adjustment.storage_location.decrease_inventory(decreasing_adjustment.line_item_values)
       rescue InsufficientAllotment => e
         @adjustment.errors.add(:base, e.message)
         raise e

--- a/app/services/allocate_kit_inventory_service.rb
+++ b/app/services/allocate_kit_inventory_service.rb
@@ -78,7 +78,7 @@ class AllocateKitInventoryService
   end
 
   def kit_content
-    kit.line_item_hashes.map do |item|
+    kit.line_item_values.map do |item|
       item.merge({
                    quantity: item[:quantity] * increase_by
                  })

--- a/app/services/allocate_kit_inventory_service.rb
+++ b/app/services/allocate_kit_inventory_service.rb
@@ -78,7 +78,7 @@ class AllocateKitInventoryService
   end
 
   def kit_content
-    kit.to_a.map do |item|
+    kit.line_item_hashes.map do |item|
       item.merge({
                    quantity: item[:quantity] * increase_by
                  })

--- a/app/services/deallocate_kit_inventory_service.rb
+++ b/app/services/deallocate_kit_inventory_service.rb
@@ -83,7 +83,7 @@ class DeallocateKitInventoryService
   end
 
   def kit_content
-    kit.to_a.map do |item|
+    kit.line_item_hashes.map do |item|
       item.merge({
                    quantity: item[:quantity] * decrease_by
                  })

--- a/app/services/deallocate_kit_inventory_service.rb
+++ b/app/services/deallocate_kit_inventory_service.rb
@@ -83,7 +83,7 @@ class DeallocateKitInventoryService
   end
 
   def kit_content
-    kit.line_item_hashes.map do |item|
+    kit.line_item_values.map do |item|
       item.merge({
                    quantity: item[:quantity] * decrease_by
                  })

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -14,7 +14,7 @@ class DistributionCreateService < DistributionService
 
       DistributionEvent.publish(distribution)
 
-      distribution.storage_location.decrease_inventory(distribution.line_item_hashes)
+      distribution.storage_location.decrease_inventory(distribution.line_item_values)
       distribution.reload
       @request&.update!(distribution_id: distribution.id, status: 'fulfilled')
       send_notification if distribution.partner&.send_reminders

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -14,7 +14,7 @@ class DistributionCreateService < DistributionService
 
       DistributionEvent.publish(distribution)
 
-      distribution.storage_location.decrease_inventory distribution
+      distribution.storage_location.decrease_inventory(distribution.line_item_hashes)
       distribution.reload
       @request&.update!(distribution_id: distribution.id, status: 'fulfilled')
       send_notification if distribution.partner&.send_reminders

--- a/app/services/distribution_destroy_service.rb
+++ b/app/services/distribution_destroy_service.rb
@@ -7,7 +7,7 @@ class DistributionDestroyService < DistributionService
     perform_distribution_service do
       DistributionDestroyEvent.publish(distribution)
       distribution.destroy!
-      distribution.storage_location.increase_inventory(distribution.line_item_hashes)
+      distribution.storage_location.increase_inventory(distribution.line_item_values)
     end
   end
 end

--- a/app/services/distribution_destroy_service.rb
+++ b/app/services/distribution_destroy_service.rb
@@ -7,7 +7,7 @@ class DistributionDestroyService < DistributionService
     perform_distribution_service do
       DistributionDestroyEvent.publish(distribution)
       distribution.destroy!
-      distribution.storage_location.increase_inventory(distribution)
+      distribution.storage_location.increase_inventory(distribution.line_item_hashes)
     end
   end
 end

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -2,7 +2,7 @@ class DistributionUpdateService < DistributionService
   def initialize(old_distribution, new_distribution_params)
     @distribution = old_distribution
     @params = new_distribution_params
-    @old_line_items = old_distribution.line_item_hashes
+    @old_line_items = old_distribution.line_item_values
   end
 
   def call
@@ -27,7 +27,7 @@ class DistributionUpdateService < DistributionService
   end
 
   def distribution_content
-    @distribution_content ||= DistributionContentChangeService.new(@old_line_items, distribution.line_item_hashes).call
+    @distribution_content ||= DistributionContentChangeService.new(@old_line_items, distribution.line_item_values).call
   end
 
   private

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -2,7 +2,7 @@ class DistributionUpdateService < DistributionService
   def initialize(old_distribution, new_distribution_params)
     @distribution = old_distribution
     @params = new_distribution_params
-    @old_line_items = old_distribution.to_a
+    @old_line_items = old_distribution.line_item_hashes
   end
 
   def call
@@ -27,7 +27,7 @@ class DistributionUpdateService < DistributionService
   end
 
   def distribution_content
-    @distribution_content ||= DistributionContentChangeService.new(@old_line_items, distribution.to_a).call
+    @distribution_content ||= DistributionContentChangeService.new(@old_line_items, distribution.line_item_hashes).call
   end
 
   private

--- a/app/services/donation_create_service.rb
+++ b/app/services/donation_create_service.rb
@@ -2,7 +2,7 @@ module DonationCreateService
   class << self
     def call(donation)
       if donation.save
-        donation.storage_location.increase_inventory(donation)
+        donation.storage_location.increase_inventory(donation.line_item_hashes)
         DonationEvent.publish(donation)
       end
     end

--- a/app/services/donation_create_service.rb
+++ b/app/services/donation_create_service.rb
@@ -2,7 +2,7 @@ module DonationCreateService
   class << self
     def call(donation)
       if donation.save
-        donation.storage_location.increase_inventory(donation.line_item_hashes)
+        donation.storage_location.increase_inventory(donation.line_item_values)
         DonationEvent.publish(donation)
       end
     end

--- a/app/services/donation_destroy_service.rb
+++ b/app/services/donation_destroy_service.rb
@@ -10,7 +10,7 @@ class DonationDestroyService
     ActiveRecord::Base.transaction do
       organization = Organization.find(organization_id)
       donation = organization.donations.find(donation_id)
-      donation.storage_location.decrease_inventory(donation.line_item_hashes)
+      donation.storage_location.decrease_inventory(donation.line_item_values)
       DonationDestroyEvent.publish(donation)
       donation.destroy!
     end

--- a/app/services/donation_destroy_service.rb
+++ b/app/services/donation_destroy_service.rb
@@ -10,7 +10,7 @@ class DonationDestroyService
     ActiveRecord::Base.transaction do
       organization = Organization.find(organization_id)
       donation = organization.donations.find(donation_id)
-      donation.storage_location.decrease_inventory(donation)
+      donation.storage_location.decrease_inventory(donation.line_item_hashes)
       DonationDestroyEvent.publish(donation)
       donation.destroy!
     end

--- a/app/services/itemizable_update_service.rb
+++ b/app/services/itemizable_update_service.rb
@@ -36,13 +36,13 @@ module ItemizableUpdateService
   # @param to_location [StorageLocation]
   def self.update_storage_location(itemizable:, apply_change_method:, undo_change_method:,
     params:, from_location:, to_location:)
-    from_location.public_send(undo_change_method, itemizable.to_a)
+    from_location.public_send(undo_change_method, itemizable.line_item_hashes)
     # Delete the line items -- they'll be replaced later
     itemizable.line_items.delete_all
     # Update the current model with the new parameters
     itemizable.update!(params)
     itemizable.reload
     # Apply the new changes to the storage location inventory
-    to_location.public_send(apply_change_method, itemizable.to_a)
+    to_location.public_send(apply_change_method, itemizable.line_item_hashes)
   end
 end

--- a/app/services/itemizable_update_service.rb
+++ b/app/services/itemizable_update_service.rb
@@ -36,13 +36,13 @@ module ItemizableUpdateService
   # @param to_location [StorageLocation]
   def self.update_storage_location(itemizable:, apply_change_method:, undo_change_method:,
     params:, from_location:, to_location:)
-    from_location.public_send(undo_change_method, itemizable.line_item_hashes)
+    from_location.public_send(undo_change_method, itemizable.line_item_values)
     # Delete the line items -- they'll be replaced later
     itemizable.line_items.delete_all
     # Update the current model with the new parameters
     itemizable.update!(params)
     itemizable.reload
     # Apply the new changes to the storage location inventory
-    to_location.public_send(apply_change_method, itemizable.line_item_hashes)
+    to_location.public_send(apply_change_method, itemizable.line_item_values)
   end
 end

--- a/app/services/purchase_create_service.rb
+++ b/app/services/purchase_create_service.rb
@@ -2,7 +2,7 @@ class PurchaseCreateService
   class << self
     def call(purchase)
       if purchase.save
-        purchase.storage_location.increase_inventory(purchase.line_item_hashes)
+        purchase.storage_location.increase_inventory(purchase.line_item_values)
         PurchaseEvent.publish(purchase)
       end
     end

--- a/app/services/purchase_create_service.rb
+++ b/app/services/purchase_create_service.rb
@@ -2,7 +2,7 @@ class PurchaseCreateService
   class << self
     def call(purchase)
       if purchase.save
-        purchase.storage_location.increase_inventory(purchase)
+        purchase.storage_location.increase_inventory(purchase.line_item_hashes)
         PurchaseEvent.publish(purchase)
       end
     end

--- a/app/services/purchase_destroy_service.rb
+++ b/app/services/purchase_destroy_service.rb
@@ -2,7 +2,7 @@ class PurchaseDestroyService
   class << self
     def call(purchase)
       ActiveRecord::Base.transaction do
-        purchase.storage_location.decrease_inventory(purchase.line_item_hashes)
+        purchase.storage_location.decrease_inventory(purchase.line_item_values)
         PurchaseDestroyEvent.publish(purchase)
         purchase.destroy!
       end

--- a/app/services/purchase_destroy_service.rb
+++ b/app/services/purchase_destroy_service.rb
@@ -2,7 +2,7 @@ class PurchaseDestroyService
   class << self
     def call(purchase)
       ActiveRecord::Base.transaction do
-        purchase.storage_location.decrease_inventory(purchase)
+        purchase.storage_location.decrease_inventory(purchase.line_item_hashes)
         PurchaseDestroyEvent.publish(purchase)
         purchase.destroy!
       end

--- a/app/services/transfer_create_service.rb
+++ b/app/services/transfer_create_service.rb
@@ -4,8 +4,8 @@ class TransferCreateService
       if transfer.valid?
         ActiveRecord::Base.transaction do
           transfer.save
-          transfer.from.decrease_inventory transfer
-          transfer.to.increase_inventory transfer
+          transfer.from.decrease_inventory(transfer.line_item_hashes)
+          transfer.to.increase_inventory(transfer.line_item_hashes)
           TransferEvent.publish(transfer)
         end
       else

--- a/app/services/transfer_create_service.rb
+++ b/app/services/transfer_create_service.rb
@@ -4,8 +4,8 @@ class TransferCreateService
       if transfer.valid?
         ActiveRecord::Base.transaction do
           transfer.save
-          transfer.from.decrease_inventory(transfer.line_item_hashes)
-          transfer.to.increase_inventory(transfer.line_item_hashes)
+          transfer.from.decrease_inventory(transfer.line_item_values)
+          transfer.to.increase_inventory(transfer.line_item_values)
           TransferEvent.publish(transfer)
         end
       else

--- a/app/services/transfer_destroy_service.rb
+++ b/app/services/transfer_destroy_service.rb
@@ -24,7 +24,7 @@ class TransferDestroyService
   end
 
   def revert_inventory_transfer!
-    transfer.to.decrease_inventory(transfer.line_item_hashes)
-    transfer.from.increase_inventory(transfer.line_item_hashes)
+    transfer.to.decrease_inventory(transfer.line_item_values)
+    transfer.from.increase_inventory(transfer.line_item_values)
   end
 end

--- a/app/services/transfer_destroy_service.rb
+++ b/app/services/transfer_destroy_service.rb
@@ -24,7 +24,7 @@ class TransferDestroyService
   end
 
   def revert_inventory_transfer!
-    transfer.to.decrease_inventory(transfer)
-    transfer.from.increase_inventory(transfer)
+    transfer.to.decrease_inventory(transfer.line_item_hashes)
+    transfer.from.increase_inventory(transfer.line_item_hashes)
   end
 end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       end
 
       after(:create) do |instance, evaluator|
-        evaluator.storage_location.increase_inventory(instance)
+        evaluator.storage_location.increase_inventory(instance.line_item_hashes)
       end
     end
   end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       end
 
       after(:create) do |instance, evaluator|
-        evaluator.storage_location.increase_inventory(instance.line_item_hashes)
+        evaluator.storage_location.increase_inventory(instance.line_item_values)
       end
     end
   end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
       end
 
       after(:create) do |instance, evaluator|
-        evaluator.storage_location.increase_inventory(instance.line_item_hashes)
+        evaluator.storage_location.increase_inventory(instance.line_item_values)
       end
     end
   end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
       end
 
       after(:create) do |instance, evaluator|
-        evaluator.storage_location.increase_inventory(instance)
+        evaluator.storage_location.increase_inventory(instance.line_item_hashes)
       end
     end
   end

--- a/spec/factories/transfers.rb
+++ b/spec/factories/transfers.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
       end
 
       after(:create) do |instance, evaluator|
-        evaluator.from.increase_inventory(instance)
+        evaluator.from.increase_inventory(instance.line_item_hashes)
       end
     end
   end

--- a/spec/factories/transfers.rb
+++ b/spec/factories/transfers.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
       end
 
       after(:create) do |instance, evaluator|
-        evaluator.from.increase_inventory(instance.line_item_hashes)
+        evaluator.from.increase_inventory(instance.line_item_values)
       end
     end
   end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe StorageLocation, type: :model do
 
         it "increases inventory quantities from an itemizable object" do
           expect do
-            subject.increase_inventory(donation.line_item_hashes)
+            subject.increase_inventory(donation.line_item_values)
           end.to change { subject.size }.by(66)
         end
       end
@@ -83,7 +83,7 @@ RSpec.describe StorageLocation, type: :model do
 
         it "creates those new inventory items in the storage location" do
           expect do
-            subject.increase_inventory(donation_with_new_items.line_item_hashes)
+            subject.increase_inventory(donation_with_new_items.line_item_values)
           end.to change { subject.inventory_items.count }.by(1)
         end
       end
@@ -94,7 +94,7 @@ RSpec.describe StorageLocation, type: :model do
 
         it "re-activates the item as part of the creation process" do
           expect do
-            subject.increase_inventory(donation_with_inactive_item.line_item_hashes)
+            subject.increase_inventory(donation_with_inactive_item.line_item_values)
           end.to change { subject.inventory_items.count }.by(1)
                                                          .and change { Item.count }.by(1)
         end
@@ -108,7 +108,7 @@ RSpec.describe StorageLocation, type: :model do
       it "decreases inventory quantities from an itemizable object" do
         storage_location = create(:storage_location, :with_items, item_quantity: 100, item: item, organization: @organization)
         expect do
-          storage_location.decrease_inventory(distribution.line_item_hashes)
+          storage_location.decrease_inventory(distribution.line_item_values)
         end.to change { storage_location.size }.by(-66)
       end
 
@@ -118,7 +118,7 @@ RSpec.describe StorageLocation, type: :model do
         it "gives informative errors" do
           storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
           expect do
-            storage_location.decrease_inventory(distribution_but_too_much.line_item_hashes).errors
+            storage_location.decrease_inventory(distribution_but_too_much.line_item_values).errors
           end.to raise_error(Errors::InsufficientAllotment)
         end
 
@@ -126,7 +126,7 @@ RSpec.describe StorageLocation, type: :model do
           storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
           starting_size = storage_location.size
           begin
-            storage_location.decrease_inventory(distribution.line_item_hashes)
+            storage_location.decrease_inventory(distribution.line_item_values)
           rescue Errors::InsufficientAllotment
           end
           storage_location.reload

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe StorageLocation, type: :model do
 
         it "increases inventory quantities from an itemizable object" do
           expect do
-            subject.increase_inventory(donation.to_a)
+            subject.increase_inventory(donation.line_item_hashes)
           end.to change { subject.size }.by(66)
         end
       end
@@ -83,7 +83,7 @@ RSpec.describe StorageLocation, type: :model do
 
         it "creates those new inventory items in the storage location" do
           expect do
-            subject.increase_inventory(donation_with_new_items.to_a)
+            subject.increase_inventory(donation_with_new_items.line_item_hashes)
           end.to change { subject.inventory_items.count }.by(1)
         end
       end
@@ -94,7 +94,7 @@ RSpec.describe StorageLocation, type: :model do
 
         it "re-activates the item as part of the creation process" do
           expect do
-            subject.increase_inventory(donation_with_inactive_item.to_a)
+            subject.increase_inventory(donation_with_inactive_item.line_item_hashes)
           end.to change { subject.inventory_items.count }.by(1)
                                                          .and change { Item.count }.by(1)
         end
@@ -108,7 +108,7 @@ RSpec.describe StorageLocation, type: :model do
       it "decreases inventory quantities from an itemizable object" do
         storage_location = create(:storage_location, :with_items, item_quantity: 100, item: item, organization: @organization)
         expect do
-          storage_location.decrease_inventory(distribution.to_a)
+          storage_location.decrease_inventory(distribution.line_item_hashes)
         end.to change { storage_location.size }.by(-66)
       end
 
@@ -118,7 +118,7 @@ RSpec.describe StorageLocation, type: :model do
         it "gives informative errors" do
           storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
           expect do
-            storage_location.decrease_inventory(distribution_but_too_much.to_a).errors
+            storage_location.decrease_inventory(distribution_but_too_much.line_item_hashes).errors
           end.to raise_error(Errors::InsufficientAllotment)
         end
 
@@ -126,7 +126,7 @@ RSpec.describe StorageLocation, type: :model do
           storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
           starting_size = storage_location.size
           begin
-            storage_location.decrease_inventory(distribution.to_a)
+            storage_location.decrease_inventory(distribution.line_item_hashes)
           rescue Errors::InsufficientAllotment
           end
           storage_location.reload

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -132,6 +132,20 @@ RSpec.describe StorageLocation, type: :model do
           storage_location.reload
           expect(storage_location.size).to eq(starting_size)
         end
+
+        context "when the item is does not exist" do
+          it "it raises insufficient allotment error if item does not exist" do
+            nonexistent_item = {item_id: nil, quantity: 1, name: "Nonexistent Item"}
+            storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
+            starting_size = storage_location.size
+            begin
+              storage_location.decrease_inventory([nonexistent_item])
+            rescue Errors::InsufficientAllotment
+            end
+            storage_location.reload
+            expect(storage_location.size).to eq(starting_size)
+          end
+        end
       end
     end
 

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -125,20 +125,12 @@ RSpec.describe StorageLocation, type: :model do
         it "does not change inventory quantities if there is an error" do
           storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
           starting_size = storage_location.size
-          expect { storage_location.decrease_inventory(distribution.line_item_values) }.to raise_error(Errors::InsufficientAllotment)
+          begin
+            storage_location.decrease_inventory(distribution.line_item_values)
+          rescue Errors::InsufficientAllotment
+          end
           storage_location.reload
           expect(storage_location.size).to eq(starting_size)
-        end
-
-        context "when the item is does not exist" do
-          it "it raises insufficient allotment error if item does not exist" do
-            nonexistent_item = {item_id: nil, quantity: 1, name: "Nonexistent Item"}
-            storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
-            starting_size = storage_location.size
-            expect { storage_location.decrease_inventory([nonexistent_item]) }.to raise_error(Errors::InsufficientAllotment)
-            storage_location.reload
-            expect(storage_location.size).to eq(starting_size)
-          end
         end
       end
     end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -125,10 +125,7 @@ RSpec.describe StorageLocation, type: :model do
         it "does not change inventory quantities if there is an error" do
           storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
           starting_size = storage_location.size
-          begin
-            storage_location.decrease_inventory(distribution.line_item_values)
-          rescue Errors::InsufficientAllotment
-          end
+          expect { storage_location.decrease_inventory(distribution.line_item_values) }.to raise_error(Errors::InsufficientAllotment)
           storage_location.reload
           expect(storage_location.size).to eq(starting_size)
         end
@@ -138,10 +135,7 @@ RSpec.describe StorageLocation, type: :model do
             nonexistent_item = {item_id: nil, quantity: 1, name: "Nonexistent Item"}
             storage_location = create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization)
             starting_size = storage_location.size
-            begin
-              storage_location.decrease_inventory([nonexistent_item])
-            rescue Errors::InsufficientAllotment
-            end
+            expect { storage_location.decrease_inventory([nonexistent_item]) }.to raise_error(Errors::InsufficientAllotment)
             storage_location.reload
             expect(storage_location.size).to eq(starting_size)
           end

--- a/spec/services/distribution_destroy_service_spec.rb
+++ b/spec/services/distribution_destroy_service_spec.rb
@@ -31,8 +31,19 @@ describe DistributionDestroyService do
 
       context 'and the operations succeed' do
         let(:fake_storage_location) { instance_double(StorageLocation) }
+        let(:fake_items) do
+          [
+            {
+              item_id: Faker::Number.number,
+              item: Faker::Lorem.word,
+              quantity_on_hand: Faker::Number.number,
+              quantity_requested: Faker::Number.number
+            }
+          ]
+        end
         before do
           allow(distribution).to receive(:storage_location).and_return(fake_storage_location)
+          allow(distribution).to receive(:line_item_hashes).and_return(fake_items)
           allow(fake_storage_location).to receive(:increase_inventory)
         end
 
@@ -48,7 +59,7 @@ describe DistributionDestroyService do
 
         it 'should increase the inventory of the storage location' do
           subject
-          expect(fake_storage_location).to have_received(:increase_inventory).with(distribution)
+          expect(fake_storage_location).to have_received(:increase_inventory).with(fake_items)
         end
       end
 
@@ -95,8 +106,9 @@ describe DistributionDestroyService do
 
         before do
           allow(distribution).to receive(:storage_location).and_return(fake_storage_location)
+          allow(distribution).to receive(:line_item_hashes).and_return(fake_insufficient_items)
           allow(fake_storage_location).to receive(:increase_inventory)
-            .with(distribution)
+            .with(fake_insufficient_items)
             .and_raise(fake_insufficient_allotment_error)
         end
 

--- a/spec/services/distribution_destroy_service_spec.rb
+++ b/spec/services/distribution_destroy_service_spec.rb
@@ -43,7 +43,7 @@ describe DistributionDestroyService do
         end
         before do
           allow(distribution).to receive(:storage_location).and_return(fake_storage_location)
-          allow(distribution).to receive(:line_item_hashes).and_return(fake_items)
+          allow(distribution).to receive(:line_item_values).and_return(fake_items)
           allow(fake_storage_location).to receive(:increase_inventory)
         end
 
@@ -106,7 +106,7 @@ describe DistributionDestroyService do
 
         before do
           allow(distribution).to receive(:storage_location).and_return(fake_storage_location)
-          allow(distribution).to receive(:line_item_hashes).and_return(fake_insufficient_items)
+          allow(distribution).to receive(:line_item_values).and_return(fake_insufficient_items)
           allow(fake_storage_location).to receive(:increase_inventory)
             .with(fake_insufficient_items)
             .and_raise(fake_insufficient_allotment_error)

--- a/spec/services/donation_destroy_service_spec.rb
+++ b/spec/services/donation_destroy_service_spec.rb
@@ -67,8 +67,9 @@ describe DonationDestroyService do
         allow(fake_organization_donations).to receive(:find)
           .with(donation_id)
           .and_return(fake_donation)
+        allow(fake_donation).to receive(:line_item_hashes).and_return(fake_insufficient_items)
         allow(fake_storage_location).to receive(:decrease_inventory)
-          .with(fake_donation)
+          .with(fake_insufficient_items)
           .and_raise(fake_insufficient_allotment_error)
       end
 
@@ -90,6 +91,16 @@ describe DonationDestroyService do
           organization_id: organization_id)
       }
       let(:fake_storage_location) { instance_double(StorageLocation) }
+      let(:fake_insufficient_items) do
+        [
+          {
+            item_id: Faker::Number.number,
+            item: Faker::Lorem.word,
+            quantity_on_hand: Faker::Number.number,
+            quantity_requested: Faker::Number.number
+          }
+        ]
+      end
 
       before do
         allow(Organization).to receive(:find)
@@ -98,7 +109,8 @@ describe DonationDestroyService do
         allow(fake_organization_donations).to receive(:find)
           .with(donation_id)
           .and_return(fake_donation)
-        allow(fake_storage_location).to receive(:decrease_inventory).with(fake_donation)
+        allow(fake_donation).to receive(:line_item_hashes).and_return(fake_insufficient_items)
+        allow(fake_storage_location).to receive(:decrease_inventory).with(fake_insufficient_items)
         allow(fake_donation).to receive(:destroy!).and_raise('boom')
       end
 

--- a/spec/services/donation_destroy_service_spec.rb
+++ b/spec/services/donation_destroy_service_spec.rb
@@ -67,7 +67,7 @@ describe DonationDestroyService do
         allow(fake_organization_donations).to receive(:find)
           .with(donation_id)
           .and_return(fake_donation)
-        allow(fake_donation).to receive(:line_item_hashes).and_return(fake_insufficient_items)
+        allow(fake_donation).to receive(:line_item_values).and_return(fake_insufficient_items)
         allow(fake_storage_location).to receive(:decrease_inventory)
           .with(fake_insufficient_items)
           .and_raise(fake_insufficient_allotment_error)
@@ -109,7 +109,7 @@ describe DonationDestroyService do
         allow(fake_organization_donations).to receive(:find)
           .with(donation_id)
           .and_return(fake_donation)
-        allow(fake_donation).to receive(:line_item_hashes).and_return(fake_insufficient_items)
+        allow(fake_donation).to receive(:line_item_values).and_return(fake_insufficient_items)
         allow(fake_storage_location).to receive(:decrease_inventory).with(fake_insufficient_items)
         allow(fake_donation).to receive(:destroy!).and_raise('boom')
       end

--- a/spec/services/transfer_destroy_service_spec.rb
+++ b/spec/services/transfer_destroy_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe TransferDestroyService, type: :service do
       allow(transfer).to receive(:from).and_return(fake_from)
       allow(transfer).to receive(:to).and_return(fake_to)
       allow(transfer).to receive(:destroy!)
-      allow(transfer).to receive(:line_item_hashes).and_return(fake_items)
+      allow(transfer).to receive(:line_item_values).and_return(fake_items)
 
       # Now that that the `transfer.from` and `transfer.to` is stubbed
       # to return the doubles of StorageLocation, we must program them
@@ -73,7 +73,7 @@ RSpec.describe TransferDestroyService, type: :service do
         let(:fake_error) { Errors::InsufficientAllotment.new('msg') }
 
         before do
-          allow(transfer).to receive(:line_item_hashes).and_return(fake_items)
+          allow(transfer).to receive(:line_item_values).and_return(fake_items)
           allow(fake_from).to receive(:increase_inventory).with(fake_items).and_raise(fake_error)
         end
 
@@ -87,8 +87,8 @@ RSpec.describe TransferDestroyService, type: :service do
       context 'because undoing the transfer inventory changes by decreasing the inventory of `to` failed' do
         let(:fake_error) { Errors::InsufficientAllotment.new('random-error') }
         before do
-          allow(transfer).to receive(:line_item_hashes).and_return(fake_items)
-          allow(fake_to).to receive(:decrease_inventory).with(transfer.line_item_hashes).and_raise(fake_error)
+          allow(transfer).to receive(:line_item_values).and_return(fake_items)
+          allow(fake_to).to receive(:decrease_inventory).with(transfer.line_item_values).and_raise(fake_error)
         end
 
         it 'should return a OpenStruct with the raised error' do

--- a/spec/support/itemizable_shared_example.rb
+++ b/spec/support/itemizable_shared_example.rb
@@ -5,6 +5,26 @@ shared_examples_for "itemizable" do
   context ".items" do
   end
 
+  context ".to_a" do
+    let(:storage_location) { create(:storage_location, :with_items, item: item, organization: @organization) }
+    let(:obj) { build(model_f, storage_location: storage_location, organization: @organization) }
+    context "with Flipper flag :deprecate_to_a disabled" do
+      it "calls line_item_values" do
+        allow(Flipper).to receive(:enabled?).with(:deprecate_to_a).and_return(false)
+
+        expect(obj).to receive(:line_item_values)
+        obj.to_a
+      end
+    end
+
+    context "with Flipper flag :deprecate_to_a enabled" do
+      it "raises an error" do
+        allow(Flipper).to receive(:enabled?).with(:deprecate_to_a).and_return(true)
+        expect { obj.to_a }.to raise_error(StandardError, "Calling to_a on an Itemizable is deprecated. Use #line_item_values instead.")
+      end
+    end
+  end
+
   context ".line_items" do
     describe "combine!" do
       it "combines multiple line_items with the same item_id into a single record" do

--- a/spec/support/itemizable_shared_example.rb
+++ b/spec/support/itemizable_shared_example.rb
@@ -5,7 +5,7 @@ shared_examples_for "itemizable" do
   context ".items" do
   end
 
-  context ".to_a" do
+  describe ".to_a" do
     let(:storage_location) { create(:storage_location, :with_items, item: item, organization: @organization) }
     let(:obj) { build(model_f, storage_location: storage_location, organization: @organization) }
     context "with Flipper flag :deprecate_to_a disabled" do


### PR DESCRIPTION
### Description

`Itemizable` has a method `to_a` which returns an array of hashes representing the line items in that `Itemizable` object. `to_a` is meant to convert an object to an array - instead, this returns an array of child members of the record.

This renames the method to `Itemizable.line_item_hashes` so that when we work with the line items inside an `Itemizable`, we explicitly use a array of hashes rather than the parent `Itemizable` itself.

#### Tradeoffs and Considerations

The main methods affected are by this change are [`StorageLocation.increase_inventory`](https://github.com/rubyforgood/human-essentials/blob/ae18b21e6d4939675dca370c43669bd08c3140c7/app/models/storage_location.rb#L139) / [`StorageLocation.decrease_inventory`](https://github.com/rubyforgood/human-essentials/blob/ae18b21e6d4939675dca370c43669bd08c3140c7/app/models/storage_location.rb#L163). These methods were overloaded accepting both `Itemizable` objects and arrays of hashes. 


Now, they will exclusively accept arrays of hashes. But this causes a bunch of ugly looking code because it now passes in the array directly. 

```ruby
@audit.storage_location.increase_inventory(increasing_adjustment.line_item_hashes)
@audit.storage_location.decrease_inventory(decreasing_adjustment.line_item_hashes)
```

There are several other potential ways to approach this:
- `increase` and `decrease` could remain overloaded, check if they were passed an array or `Itemizable` and behave differently. I think this results in complection, the method knows too much about what it is being given. It would cause issues if the method was passed an array of something other than hashes.
- `increase and decrease` could expect an `Itemizable` and call `line_item_hashes` themselves. This cleans up a lot of the code. However, there are several instances where the methods are passed arrays of hashes ([here](https://github.com/rubyforgood/human-essentials/blob/ae18b21e6d4939675dca370c43669bd08c3140c7/app/services/deallocate_kit_inventory_service.rb#L85) and [here](https://github.com/rubyforgood/human-essentials/blob/ae18b21e6d4939675dca370c43669bd08c3140c7/app/services/deallocate_kit_inventory_service.rb#L93)). I am not sure how to approach making in those places.
- Pass the arrays of hashes directly. I opted for this option. While it does add some verbosity I think it clarifies behavior and maybe `increase_inventory` could be `increase_inventory(itemizable_array:)` to better reflect its behavior. That would make it even more verbose.

I am totally open to modifying how this is approached. 

### **Note:**
`to_a` method is not actually removed. I removed all calls to it that I could find but if called it currently logs an error and calls `line_item_hashes`. This is a quick change to fully remove it. 

I was worried that some calls might not get caught by tests and I did not want the application to blow up with a no method error. I can also change that as needed.

Resolves #3909

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->




### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I ran the full suite. But I did not write any tests specifically for my changes, I am not sure how to directly test the renaming of a method. I also clicked around the site a bit as different users to see if `to_a` would get called and it seems fine.

However, I was having a lot of flakiness issues with the systems specs (dashboard, admin/users_system). This was happening even on the main branch for me, so I don't think its related to my code. I think the tests are just not playing nice with me using docker.

I was also unable to run the CSV parsing tests, the setting for downloads to automatically download was not working.


