### PR TITLE
Adds query for all an organization's items to the CSV export service, updates spec to test new behavior

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -66,7 +66,7 @@ class DistributionsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportDistributionsCSVService.new(distributions: @distributions, filters: filter_params).generate_csv, filename: "Distributions-#{Time.zone.today}.csv"
+        send_data Exports::ExportDistributionsCSVService.new(distributions: @distributions, organization: current_organization, filters: filter_params).generate_csv, filename: "Distributions-#{Time.zone.today}.csv"
       end
     end
   end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -59,7 +59,7 @@ class PartnersController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportDistributionsCSVService.new(distributions: @partner_distributions, filters: filter_params).generate_csv, filename: "PartnerDistributions-#{Time.zone.today}.csv"
+        send_data Exports::ExportDistributionsCSVService.new(distributions: @partner_distributions, organization: current_organization, filters: filter_params).generate_csv, filename: "PartnerDistributions-#{Time.zone.today}.csv"
       end
     end
   end

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -10,6 +10,7 @@ module Exports
       # service object.
       @distributions = distributions
       @filters = filters
+      @organization = @distributions.first.organization
     end
 
     def generate_csv
@@ -114,15 +115,7 @@ module Exports
     def item_headers
       return @item_headers if @item_headers
 
-      item_names = Set.new
-
-      distributions.each do |distribution|
-        distribution.line_items.each do |line_item|
-          item_names.add(line_item.item.name)
-        end
-      end
-
-      @item_headers = item_names.sort
+      @item_headers = @organization.items.uniq.sort_by(&:created_at).pluck(:name)
     end
 
     def build_row_data(distribution)
@@ -133,6 +126,8 @@ module Exports
       distribution.line_items.each do |line_item|
         item_name = line_item.item.name
         item_column_idx = headers_with_indexes[item_name]
+        next unless item_column_idx
+
         row[item_column_idx] += line_item.quantity
       end
 

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -1,7 +1,7 @@
 module Exports
   class ExportDistributionsCSVService
     include DistributionHelper
-    def initialize(distributions:, filters: [])
+    def initialize(distributions:, organization:, filters: [])
       # Currently, the @distributions are already loaded by the controllers that are delegating exporting
       # to this service object; this is happening within the same request/response cycle, so it's already
       # in memory, so we can pass that collection in directly. Should this be moved to a background / async
@@ -10,14 +10,10 @@ module Exports
       # service object.
       @distributions = distributions
       @filters = filters
-      @organization = @distributions&.first&.organization
+      @organization = organization
     end
 
     def generate_csv
-      # TODO: we may want some error handling here in case there are none, but I'm not sure what the process is;
-      # should we do a flash[:error]?
-      return if distributions.blank?
-
       csv_data = generate_csv_data
 
       CSV.generate(headers: true) do |csv|

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -10,10 +10,14 @@ module Exports
       # service object.
       @distributions = distributions
       @filters = filters
-      @organization = @distributions.first.organization
+      @organization = @distributions&.first&.organization
     end
 
     def generate_csv
+      # TODO: we may want some error handling here in case there are none, but I'm not sure what the process is;
+      # should we do a flash[:error]?
+      return if distributions.blank?
+
       csv_data = generate_csv_data
 
       CSV.generate(headers: true) do |csv|
@@ -115,7 +119,7 @@ module Exports
     def item_headers
       return @item_headers if @item_headers
 
-      @item_headers = @organization.items.uniq.sort_by(&:created_at).pluck(:name)
+      @item_headers = @organization.items.order(:created_at).distinct.select([:created_at, :name]).map(&:name)
     end
 
     def build_row_data(distribution)

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe "Partners", type: :request do
 
     context "csv" do
       let(:response_format) { 'csv' }
+      before { create(:distribution, partner: partner) }
 
       it { is_expected.to be_successful }
     end

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -141,7 +141,6 @@ RSpec.describe "Partners", type: :request do
 
     context "csv" do
       let(:response_format) { 'csv' }
-      before { create(:distribution, partner: partner) }
 
       it { is_expected.to be_successful }
     end

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -51,9 +51,13 @@ describe Exports::ExportDistributionsCSVService do
     let(:item_id) { distributions.flatten.first.line_items.first.item_id }
     let(:filters) { {by_item_id: item_id} }
     let(:item_name) { Item.find(item_id).name }
+    let(:organization) { distributions.first.organization }
+
+    let(:all_org_items) { Item.where(organization:).uniq.sort_by(&:created_at) }
 
     let(:total_item_quantities) do
-      template = item_names.index_with(0)
+      # binding.pry
+      template = all_org_items.pluck(:name).index_with(0)
 
       items_lists.map do |items_list|
         row = template.dup
@@ -64,7 +68,7 @@ describe Exports::ExportDistributionsCSVService do
       end
     end
 
-    let(:expected_headers) do
+    let(:non_item_headers) do
       [
         "Partner",
         "Date of Distribution",
@@ -76,14 +80,10 @@ describe Exports::ExportDistributionsCSVService do
         "State",
         "Agency Representative",
         "Comments"
-      ] + expected_item_headers
+      ]
     end
 
-    let(:expected_item_headers) do
-      expect(item_names).not_to be_empty
-
-      item_names
-    end
+    let(:expected_headers) { non_item_headers + all_org_items.pluck(:name) }
 
     it 'should match the expected content for the csv' do
       expect(subject[0]).to eq(expected_headers)
@@ -105,6 +105,43 @@ describe Exports::ExportDistributionsCSVService do
         row += total_item_quantity
 
         expect(subject[idx + 1]).to eq(row)
+      end
+    end
+
+    context 'when a new item is added' do
+      let!(:original_columns_count) { organization.items.size + non_item_headers.size }
+      let(:new_item_name) { "new item" }
+      before do
+        create(:item, name: new_item_name, organization:)
+      end
+
+      it 'should add it to the end of the row' do
+        expect(subject[0].uniq).to eq(expected_headers)
+          .and end_with(new_item_name)
+          .and have_attributes(size: original_columns_count + 1)
+      end
+
+      it 'should show up with a 0 quantity if there are no distributions' do
+        distributions.zip(total_item_quantities).each_with_index do |(distribution, total_item_quantity), idx|
+          row = [
+            distribution.partner.name,
+            distribution.issued_at.strftime("%m/%d/%Y"),
+            distribution.storage_location.name,
+            distribution.line_items.where(item_id: item_id).total,
+            distribution.cents_to_dollar(distribution.line_items.total_value),
+            distribution.delivery_method,
+            "$#{distribution.shipping_cost.to_f}",
+            distribution.state,
+            distribution.agency_rep,
+            distribution.comment
+          ]
+
+          row += total_item_quantity
+
+          expect(subject[idx + 1]).to eq(row)
+            .and end_with(0)
+            .and have_attributes(size: original_columns_count + 1)
+        end
       end
     end
   end

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -1,6 +1,6 @@
 describe Exports::ExportDistributionsCSVService do
   describe '#generate_csv_data' do
-    subject { described_class.new(distributions: distributions, filters: filters).generate_csv_data }
+    subject { described_class.new(distributions: distributions, organization: Organization.first, filters: filters).generate_csv_data }
     let(:distributions) { distributions }
 
     let(:duplicate_item) do

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -115,12 +115,12 @@ describe Exports::ExportDistributionsCSVService do
       end
 
       it 'should add it to the end of the row' do
-        expect(subject[0].uniq).to eq(expected_headers)
+        expect(subject[0]).to eq(expected_headers)
           .and end_with(new_item_name)
           .and have_attributes(size: original_columns_count + 1)
       end
 
-      it 'should show up with a 0 quantity if there are no distributions' do
+      it 'should show up with a 0 quantity if there are none of this item in any distribution' do
         distributions.zip(total_item_quantities).each_with_index do |(distribution, total_item_quantity), idx|
           row = [
             distribution.partner.name,
@@ -141,6 +141,16 @@ describe Exports::ExportDistributionsCSVService do
             .and end_with(0)
             .and have_attributes(size: original_columns_count + 1)
         end
+      end
+    end
+
+    context 'when there are no distributions but the report is requested' do
+      subject { described_class.new(distributions: [], organization: Organization.first, filters: filters).generate_csv_data }
+      it 'returns a csv with only headers and no rows' do
+        header_row = subject[0]
+        expect(header_row).to eq(expected_headers)
+        expect(header_row.last).to eq(all_org_items.last.name)
+        expect(subject.size).to eq(1)
       end
     end
   end

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -56,7 +56,6 @@ describe Exports::ExportDistributionsCSVService do
     let(:all_org_items) { Item.where(organization:).uniq.sort_by(&:created_at) }
 
     let(:total_item_quantities) do
-      # binding.pry
       template = all_org_items.pluck(:name).index_with(0)
 
       items_lists.map do |items_list|


### PR DESCRIPTION
# Checklist:

* [X] I have performed a self-review of my own code,
* [X] I have commented my code, particularly in hard-to-understand areas,
  > I don't think there are any comments necessary but I'm happy to add them if the group would like me to
* [X] I have made corresponding changes to the documentation,
  > There didn't seem to be any documentation about this specific export, other than "Partners can export distribution PDFs" - happy to fill in if the group wants
* [X] I have added tests that prove my fix is effective or that my feature works,
* [X] New and existing unit tests pass locally with my changes ("bundle exec rake"),
* [X] Title include "WIP" if work is in progress.

Resolves #3388  <!--fill issue number-->

### Description
* What motivated this change (if not already described in an issue)?
    > See issue #3388 
* What alternative solutions did you consider?
    > One discussion that was had is what order to put the columns in; we decided on "created_at" as a sort column because that way when our users are exporting after adding new items, it doesn't change the column the existing items are in.
* What are the tradeoffs for your solution?
    > Larger (column-wise) CSVs, but I don't necessarily think that's a trade-off.  There might be a performance hit, I did some query benchmarking and it seemed fine but it's hard to tell unless it's in production or if we have some better performance monitoring tools.

_One concern I have is that Bullet is yelling about eager loading items.  I looked through the stack trace and tried to investigate which `includes` was the culprit, but removing the likeliest ones didn't solve the issue.  I know Bullet can be finicky, but I'm including the stack trace below.  My theory is that it's included somewhere in a scope and we don't need it *all* the time, so Bullet yells on some queries that use that scope.  Not sure if that's important to fix or not.  Also it's referencing the `GET /diaper_bank/distrbutions.csv` endpoint, which by all accounts doesn't exist, so I'm a little baffled._

```
Item Load (15.9ms)  SELECT "items".* FROM "items" WHERE "items"."organization_id" = $1  [["organization_id", 1]]
23:11:21 web.1    |   ↳ app/services/exports/export_distributions_csv_service.rb:118:in `uniq'
23:11:21 web.1    |   Rendering text template
23:11:21 web.1    |   Rendered text template (Duration: 0.1ms | Allocations: 17)
23:11:21 web.1    | Sent data Distributions-2024-01-31.csv (1.3ms)
23:11:21 web.1    | Completed 200 OK in 526ms (Views: 1.1ms | ActiveRecord: 90.8ms | Allocations: 189078)

23:11:21 web.1    | GET /diaper_bank/distributions.csv?filters%5Bby_item_category_id%5D=&filters%5Bby_item_id%5D=&filters%5Bby_location%5D=&filters%5Bby_partner%5D=&filters%5Bby_state%5D=&filters%5Bdate_range%5D=January+30%2C+2024+-+January+30%2C+2024
23:11:21 web.1    | AVOID eager loading detected
23:11:21 web.1    |   Distribution => [:items]
23:11:21 web.1    |   Remove from your query: .includes([:items])
23:11:21 web.1    | Call stack
23:11:21 web.1    |   /Projects/human-essentials/app/services/exports/export_distributions_csv_service.rb:126:in `build_row_data'
23:11:21 web.1    |   /Projects/human-essentials/app/services/exports/export_distributions_csv_service.rb:29:in `block in generate_csv_data'
23:11:21 web.1    |   /Projects/human-essentials/app/services/exports/export_distributions_csv_service.rb:28:in `generate_csv_data'
23:11:21 web.1    |   /Projects/human-essentials/app/services/exports/export_distributions_csv_service.rb:17:in `generate_csv'
23:11:21 web.1    |   /Projects/human-essentials/app/controllers/distributions_controller.rb:69:in `block (2 levels) in index'
23:11:21 web.1    |   /Projects/human-essentials/app/controllers/distributions_controller.rb:66:in `index'
```
   
List any dependencies that are required for this change. (gems, js libraries, etc.)
> N/A

### Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

* Ran local server and downloaded distributions to ensure it showed all columns, with 0s for items that weren't on any of the requested distributions.  An easy way to reproduce is to filter to one day, and then see any columns with 0s in them.

* Also rspec tests for the behavior.