### PR TITLE
Add new column use_single_step_invite_and_approve_partner_process

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,33 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                             :integer          not null, primary key
-#  city                           :string
-#  deadline_day                   :integer
-#  default_storage_location       :integer
-#  distribute_monthly             :boolean          default(FALSE), not null
-#  email                          :string
-#  enable_child_based_requests    :boolean          default(TRUE), not null
-#  enable_individual_requests     :boolean          default(TRUE), not null
-#  enable_quantity_based_requests :boolean          default(TRUE), not null
-#  intake_location                :integer
-#  invitation_text                :text
-#  latitude                       :float
-#  longitude                      :float
-#  name                           :string
-#  partner_form_fields            :text             default([]), is an Array
-#  reminder_day                   :integer
-#  repackage_essentials           :boolean          default(FALSE), not null
-#  short_name                     :string
-#  state                          :string
-#  street                         :string
-#  url                            :string
-#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
-#  zipcode                        :string
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  account_request_id             :integer
-#  ndbn_member_id                 :bigint
+#  id                                                 :integer          not null, primary key
+#  city                                               :string
+#  deadline_day                                       :integer
+#  default_storage_location                           :integer
+#  distribute_monthly                                 :boolean          default(FALSE), not null
+#  email                                              :string
+#  enable_child_based_requests                        :boolean          default(TRUE), not null
+#  enable_individual_requests                         :boolean          default(TRUE), not null
+#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
+#  intake_location                                    :integer
+#  invitation_text                                    :text
+#  latitude                                           :float
+#  longitude                                          :float
+#  name                                               :string
+#  partner_form_fields                                :text             default([]), is an Array
+#  reminder_day                                       :integer
+#  repackage_essentials                               :boolean          default(FALSE), not null
+#  short_name                                         :string
+#  state                                              :string
+#  street                                             :string
+#  url                                                :string
+#  use_single_step_invite_and_approve_partner_process :boolean          default(FALSE)
+#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
+#  zipcode                                            :string
+#  created_at                                         :datetime         not null
+#  updated_at                                         :datetime         not null
+#  account_request_id                                 :integer
+#  ndbn_member_id                                     :bigint
 #
 
 class Organization < ApplicationRecord

--- a/db/migrate/20240131202431_add_use_single_step_invite_and_approve_partner_process_to_organization.rb
+++ b/db/migrate/20240131202431_add_use_single_step_invite_and_approve_partner_process_to_organization.rb
@@ -1,0 +1,6 @@
+class AddUseSingleStepInviteAndApprovePartnerProcessToOrganization < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :use_single_step_invite_and_approve_partner_process, :boolean
+    change_column_default :organizations, :use_single_step_invite_and_approve_partner_process, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_29_200106) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_31_202431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -478,6 +478,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_29_200106) do
     t.boolean "enable_individual_requests", default: true, null: false
     t.boolean "enable_quantity_based_requests", default: true, null: false
     t.boolean "ytd_on_distribution_printout", default: true, null: false
+    t.boolean "use_single_step_invite_and_approve_partner_process", default: false
     t.index ["latitude", "longitude"], name: "index_organizations_on_latitude_and_longitude"
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -2,33 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                             :integer          not null, primary key
-#  city                           :string
-#  deadline_day                   :integer
-#  default_storage_location       :integer
-#  distribute_monthly             :boolean          default(FALSE), not null
-#  email                          :string
-#  enable_child_based_requests    :boolean          default(TRUE), not null
-#  enable_individual_requests     :boolean          default(TRUE), not null
-#  enable_quantity_based_requests :boolean          default(TRUE), not null
-#  intake_location                :integer
-#  invitation_text                :text
-#  latitude                       :float
-#  longitude                      :float
-#  name                           :string
-#  partner_form_fields            :text             default([]), is an Array
-#  reminder_day                   :integer
-#  repackage_essentials           :boolean          default(FALSE), not null
-#  short_name                     :string
-#  state                          :string
-#  street                         :string
-#  url                            :string
-#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
-#  zipcode                        :string
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  account_request_id             :integer
-#  ndbn_member_id                 :bigint
+#  id                                                 :integer          not null, primary key
+#  city                                               :string
+#  deadline_day                                       :integer
+#  default_storage_location                           :integer
+#  distribute_monthly                                 :boolean          default(FALSE), not null
+#  email                                              :string
+#  enable_child_based_requests                        :boolean          default(TRUE), not null
+#  enable_individual_requests                         :boolean          default(TRUE), not null
+#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
+#  intake_location                                    :integer
+#  invitation_text                                    :text
+#  latitude                                           :float
+#  longitude                                          :float
+#  name                                               :string
+#  partner_form_fields                                :text             default([]), is an Array
+#  reminder_day                                       :integer
+#  repackage_essentials                               :boolean          default(FALSE), not null
+#  short_name                                         :string
+#  state                                              :string
+#  street                                             :string
+#  url                                                :string
+#  use_single_step_invite_and_approve_partner_process :boolean          default(FALSE)
+#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
+#  zipcode                                            :string
+#  created_at                                         :datetime         not null
+#  updated_at                                         :datetime         not null
+#  account_request_id                                 :integer
+#  ndbn_member_id                                     :bigint
 #
 
 FactoryBot.define do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id              :bigint           not null, primary key
+#  data            :jsonb
+#  event_time      :datetime         not null
+#  eventable_type  :string
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  eventable_id    :bigint
+#  organization_id :bigint
+#  user_id         :bigint
+#
 RSpec.describe Event, type: :model do
   let(:organization) { FactoryBot.create(:organization) }
   describe "#most_recent_snapshot" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -2,33 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                             :integer          not null, primary key
-#  city                           :string
-#  deadline_day                   :integer
-#  default_storage_location       :integer
-#  distribute_monthly             :boolean          default(FALSE), not null
-#  email                          :string
-#  enable_child_based_requests    :boolean          default(TRUE), not null
-#  enable_individual_requests     :boolean          default(TRUE), not null
-#  enable_quantity_based_requests :boolean          default(TRUE), not null
-#  intake_location                :integer
-#  invitation_text                :text
-#  latitude                       :float
-#  longitude                      :float
-#  name                           :string
-#  partner_form_fields            :text             default([]), is an Array
-#  reminder_day                   :integer
-#  repackage_essentials           :boolean          default(FALSE), not null
-#  short_name                     :string
-#  state                          :string
-#  street                         :string
-#  url                            :string
-#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
-#  zipcode                        :string
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  account_request_id             :integer
-#  ndbn_member_id                 :bigint
+#  id                                                 :integer          not null, primary key
+#  city                                               :string
+#  deadline_day                                       :integer
+#  default_storage_location                           :integer
+#  distribute_monthly                                 :boolean          default(FALSE), not null
+#  email                                              :string
+#  enable_child_based_requests                        :boolean          default(TRUE), not null
+#  enable_individual_requests                         :boolean          default(TRUE), not null
+#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
+#  intake_location                                    :integer
+#  invitation_text                                    :text
+#  latitude                                           :float
+#  longitude                                          :float
+#  name                                               :string
+#  partner_form_fields                                :text             default([]), is an Array
+#  reminder_day                                       :integer
+#  repackage_essentials                               :boolean          default(FALSE), not null
+#  short_name                                         :string
+#  state                                              :string
+#  street                                             :string
+#  url                                                :string
+#  use_single_step_invite_and_approve_partner_process :boolean          default(FALSE)
+#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
+#  zipcode                                            :string
+#  created_at                                         :datetime         not null
+#  updated_at                                         :datetime         not null
+#  account_request_id                                 :integer
+#  ndbn_member_id                                     :bigint
 #
 
 RSpec.describe Organization, type: :model do


### PR DESCRIPTION
https://github.com/rubyforgood/human-essentials/issues/3432

Part 1 of 4 PRs for this issue. 

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->


### Description
In order to allow banks to invite and approve partner as a single step when additional info isn't needed, a column, `use_single_step_invite_and_approve_partner_process` is added in this PR. 

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
1. Ran specs and passed
2. Did sanity check with booting up to ensure schema changes didn't break anything

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
