### PR TITLE
Temporarily disable historical cache job

### DIFF
--- a/config/initializers/task_scheduler.rb
+++ b/config/initializers/task_scheduler.rb
@@ -4,7 +4,7 @@ scheduler = Rufus::Scheduler.singleton
 
 # TODO: Re-enable this on production once we figure out why it's running nonstop.
 
-unless Rails.env.production?
+if ENV['ENABLE_HISTORICAL_CACHE_JOB'] == 'true'
   scheduler.cron '0 3 * * *' do
     system('bundle exec rake cache_historical_data')
   end

--- a/config/initializers/task_scheduler.rb
+++ b/config/initializers/task_scheduler.rb
@@ -2,6 +2,10 @@ require 'rufus-scheduler'
 
 scheduler = Rufus::Scheduler.singleton
 
-scheduler.cron '0 3 * * *' do
-  system('bundle exec rake cache_historical_data')
+# TODO: Re-enable this on production once we figure out why it's running nonstop.
+
+unless Rails.env.production?
+  scheduler.cron '0 3 * * *' do
+    system('bundle exec rake cache_historical_data')
+  end
 end


### PR DESCRIPTION
See issue #4064 . This way it'll only run if the env variable is set.