### PR TITLE
Add feature to single step invite and approve

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -97,7 +97,8 @@ class OrganizationsController < ApplicationController
       :repackage_essentials, :distribute_monthly,
       :ndbn_member_id, :enable_child_based_requests,
       :enable_individual_requests, :enable_quantity_based_requests,
-      :ytd_on_distribution_printout, partner_form_fields: []
+      :ytd_on_distribution_printout,:use_single_step_invite_and_approve_partner_process ,
+      partner_form_fields: []
     )
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,33 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                             :integer          not null, primary key
-#  city                           :string
-#  deadline_day                   :integer
-#  default_storage_location       :integer
-#  distribute_monthly             :boolean          default(FALSE), not null
-#  email                          :string
-#  enable_child_based_requests    :boolean          default(TRUE), not null
-#  enable_individual_requests     :boolean          default(TRUE), not null
-#  enable_quantity_based_requests :boolean          default(TRUE), not null
-#  intake_location                :integer
-#  invitation_text                :text
-#  latitude                       :float
-#  longitude                      :float
-#  name                           :string
-#  partner_form_fields            :text             default([]), is an Array
-#  reminder_day                   :integer
-#  repackage_essentials           :boolean          default(FALSE), not null
-#  short_name                     :string
-#  state                          :string
-#  street                         :string
-#  url                            :string
-#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
-#  zipcode                        :string
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  account_request_id             :integer
-#  ndbn_member_id                 :bigint
+#  id                                                 :integer          not null, primary key
+#  city                                               :string
+#  deadline_day                                       :integer
+#  default_storage_location                           :integer
+#  distribute_monthly                                 :boolean          default(FALSE), not null
+#  email                                              :string
+#  enable_child_based_requests                        :boolean          default(TRUE), not null
+#  enable_individual_requests                         :boolean          default(TRUE), not null
+#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
+#  intake_location                                    :integer
+#  invitation_text                                    :text
+#  latitude                                           :float
+#  longitude                                          :float
+#  name                                               :string
+#  partner_form_fields                                :text             default([]), is an Array
+#  reminder_day                                       :integer
+#  repackage_essentials                               :boolean          default(FALSE), not null
+#  short_name                                         :string
+#  state                                              :string
+#  street                                             :string
+#  url                                                :string
+#  use_single_step_invite_and_approve_partner_process :boolean          default(FALSE)
+#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
+#  zipcode                                            :string
+#  created_at                                         :datetime         not null
+#  updated_at                                         :datetime         not null
+#  account_request_id                                 :integer
+#  ndbn_member_id                                     :bigint
 #
 
 class Organization < ApplicationRecord

--- a/app/views/organizations/_details.html.erb
+++ b/app/views/organizations/_details.html.erb
@@ -152,6 +152,12 @@
                   <%= humanize_boolean(@organization.ytd_on_distribution_printout) %>
                 </p>
               </div>
+              <div class="mb-4">
+                <h3 class='font-bold'>Use Single-step Invite and Approve Partner Process?</h3>
+                <p>
+                  <%= humanize_boolean(@organization.use_single_step_invite_and_approve_partner_process) %>
+                </p>
+              </div>
               <% if @organization.logo.attached? %>
                     <div class="mb-4">
                     <h3 class='font-bold'>Logo</h3>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -86,6 +86,7 @@
                 <%= f.input :enable_individual_requests, label: 'Enable partners to make requests for individuals?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
                 <%= f.input :enable_quantity_based_requests, label: 'Enable partners to make quantity-based requests?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
                 <%= f.input :ytd_on_distribution_printout, label: 'Show Year-to-date values on distribution printout?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
+                <%= f.input :use_single_step_invite_and_approve_partner_process, label: 'Use single step invite and approve partner process?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
 
                 <% default_email_text_hint = "You can use the variables <code>%{partner_name}</code>, <code>%{delivery_method}</code>, <code>%{distribution_date}</code>, and <code>%{comment}</code> to include the partner's name, delivery method, distribution date, and comments sent in the request." %>
                 <%= f.input :default_email_text, label: "Distribution Email Content", hint: default_email_text_hint.html_safe do %>

--- a/db/migrate/20240131202431_add_use_single_step_invite_and_approve_partner_process_to_organization.rb
+++ b/db/migrate/20240131202431_add_use_single_step_invite_and_approve_partner_process_to_organization.rb
@@ -1,0 +1,6 @@
+class AddUseSingleStepInviteAndApprovePartnerProcessToOrganization < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :use_single_step_invite_and_approve_partner_process, :boolean
+    change_column_default :organizations, :use_single_step_invite_and_approve_partner_process, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_29_200106) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_31_202431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -478,6 +478,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_29_200106) do
     t.boolean "enable_individual_requests", default: true, null: false
     t.boolean "enable_quantity_based_requests", default: true, null: false
     t.boolean "ytd_on_distribution_printout", default: true, null: false
+    t.boolean "use_single_step_invite_and_approve_partner_process", default: false
     t.index ["latitude", "longitude"], name: "index_organizations_on_latitude_and_longitude"
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -2,33 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                             :integer          not null, primary key
-#  city                           :string
-#  deadline_day                   :integer
-#  default_storage_location       :integer
-#  distribute_monthly             :boolean          default(FALSE), not null
-#  email                          :string
-#  enable_child_based_requests    :boolean          default(TRUE), not null
-#  enable_individual_requests     :boolean          default(TRUE), not null
-#  enable_quantity_based_requests :boolean          default(TRUE), not null
-#  intake_location                :integer
-#  invitation_text                :text
-#  latitude                       :float
-#  longitude                      :float
-#  name                           :string
-#  partner_form_fields            :text             default([]), is an Array
-#  reminder_day                   :integer
-#  repackage_essentials           :boolean          default(FALSE), not null
-#  short_name                     :string
-#  state                          :string
-#  street                         :string
-#  url                            :string
-#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
-#  zipcode                        :string
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  account_request_id             :integer
-#  ndbn_member_id                 :bigint
+#  id                                                 :integer          not null, primary key
+#  city                                               :string
+#  deadline_day                                       :integer
+#  default_storage_location                           :integer
+#  distribute_monthly                                 :boolean          default(FALSE), not null
+#  email                                              :string
+#  enable_child_based_requests                        :boolean          default(TRUE), not null
+#  enable_individual_requests                         :boolean          default(TRUE), not null
+#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
+#  intake_location                                    :integer
+#  invitation_text                                    :text
+#  latitude                                           :float
+#  longitude                                          :float
+#  name                                               :string
+#  partner_form_fields                                :text             default([]), is an Array
+#  reminder_day                                       :integer
+#  repackage_essentials                               :boolean          default(FALSE), not null
+#  short_name                                         :string
+#  state                                              :string
+#  street                                             :string
+#  url                                                :string
+#  use_single_step_invite_and_approve_partner_process :boolean          default(FALSE)
+#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
+#  zipcode                                            :string
+#  created_at                                         :datetime         not null
+#  updated_at                                         :datetime         not null
+#  account_request_id                                 :integer
+#  ndbn_member_id                                     :bigint
 #
 
 FactoryBot.define do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id              :bigint           not null, primary key
+#  data            :jsonb
+#  event_time      :datetime         not null
+#  eventable_type  :string
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  eventable_id    :bigint
+#  organization_id :bigint
+#  user_id         :bigint
+#
 RSpec.describe Event, type: :model do
   let(:organization) { FactoryBot.create(:organization) }
   describe "#most_recent_snapshot" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -2,33 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                             :integer          not null, primary key
-#  city                           :string
-#  deadline_day                   :integer
-#  default_storage_location       :integer
-#  distribute_monthly             :boolean          default(FALSE), not null
-#  email                          :string
-#  enable_child_based_requests    :boolean          default(TRUE), not null
-#  enable_individual_requests     :boolean          default(TRUE), not null
-#  enable_quantity_based_requests :boolean          default(TRUE), not null
-#  intake_location                :integer
-#  invitation_text                :text
-#  latitude                       :float
-#  longitude                      :float
-#  name                           :string
-#  partner_form_fields            :text             default([]), is an Array
-#  reminder_day                   :integer
-#  repackage_essentials           :boolean          default(FALSE), not null
-#  short_name                     :string
-#  state                          :string
-#  street                         :string
-#  url                            :string
-#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
-#  zipcode                        :string
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  account_request_id             :integer
-#  ndbn_member_id                 :bigint
+#  id                                                 :integer          not null, primary key
+#  city                                               :string
+#  deadline_day                                       :integer
+#  default_storage_location                           :integer
+#  distribute_monthly                                 :boolean          default(FALSE), not null
+#  email                                              :string
+#  enable_child_based_requests                        :boolean          default(TRUE), not null
+#  enable_individual_requests                         :boolean          default(TRUE), not null
+#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
+#  intake_location                                    :integer
+#  invitation_text                                    :text
+#  latitude                                           :float
+#  longitude                                          :float
+#  name                                               :string
+#  partner_form_fields                                :text             default([]), is an Array
+#  reminder_day                                       :integer
+#  repackage_essentials                               :boolean          default(FALSE), not null
+#  short_name                                         :string
+#  state                                              :string
+#  street                                             :string
+#  url                                                :string
+#  use_single_step_invite_and_approve_partner_process :boolean          default(FALSE)
+#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
+#  zipcode                                            :string
+#  created_at                                         :datetime         not null
+#  updated_at                                         :datetime         not null
+#  account_request_id                                 :integer
+#  ndbn_member_id                                     :bigint
 #
 
 RSpec.describe Organization, type: :model do

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "Organization management", type: :system, js: true do
         expect(page).to have_content("Quantity Based Requests?")
         expect(page).to have_content("Show Year-to-date values on distribution printout?")
         expect(page).to have_content("Logo")
+        expect(page).to have_content("Use Single-step Invite and Approve Partner Process?")
       end
     end
 
@@ -115,6 +116,20 @@ RSpec.describe "Organization management", type: :system, js: true do
         click_on "Save"
         expect(page).to_not have_content('Media Information')
         expect(@organization.reload.partner_form_fields).to eq([])
+      end
+
+      it "can disable if the org does NOT use single step invite and approve partner process" do
+        choose("organization[use_single_step_invite_and_approve_partner_process]", option: false)
+
+        click_on "Save"
+        expect(page).to have_content("No")
+      end
+
+      it "can enable if the org uses single step invite and approve partner process" do
+        choose("organization[use_single_step_invite_and_approve_partner_process]", option: true)
+
+        click_on "Save"
+        expect(page).to have_content("Yes")
       end
     end
 


### PR DESCRIPTION
https://github.com/rubyforgood/human-essentials/issues/3432

Part 1: add column this PR uses: https://github.com/rubyforgood/human-essentials/pull/4071

Part 2 of 4 PRs for this issue. 
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

### Description
Edits the organization show and edit page to set new setting "Single step invite and approve partner process"

### Type of change
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

Ran specs 

QA Test

1. Login as super admin 
```
username: superadmin@example.com
  password: password!
```
2. Navigate to `http://localhost:3000/diaper_bank/organization`
3. Click Edit
4. Check `Use single step invite and approve partner process` to yes if no, or no if yes.
5. Refresh screen see that it is set to yes if no, and no if yes.

### Screenshots
<img width="1680" alt="Screenshot 2024-02-01 at 2 31 45 PM" src="https://github.com/rubyforgood/human-essentials/assets/131324731/afeb6554-a90e-4776-9345-dcca92cdb51b">
<img width="1680" alt="Screenshot 2024-02-01 at 2 31 39 PM" src="https://github.com/rubyforgood/human-essentials/assets/131324731/f12c6223-0c43-42ae-bf80-9fd5bf0168b6">
