### PR TITLE
Fix one step invite migration to run in one line adding default false and not null instead of two

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,34 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                                                 :integer          not null, primary key
-#  city                                               :string
-#  deadline_day                                       :integer
-#  default_storage_location                           :integer
-#  distribute_monthly                                 :boolean          default(FALSE), not null
-#  email                                              :string
-#  enable_child_based_requests                        :boolean          default(TRUE), not null
-#  enable_individual_requests                         :boolean          default(TRUE), not null
-#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
-#  intake_location                                    :integer
-#  invitation_text                                    :text
-#  latitude                                           :float
-#  longitude                                          :float
-#  name                                               :string
-#  partner_form_fields                                :text             default([]), is an Array
-#  reminder_day                                       :integer
-#  repackage_essentials                               :boolean          default(FALSE), not null
-#  short_name                                         :string
-#  state                                              :string
-#  street                                             :string
-#  url                                                :string
-#  one_step_partner_invite                            :boolean          default(FALSE), not null
-#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
-#  zipcode                                            :string
-#  created_at                                         :datetime         not null
-#  updated_at                                         :datetime         not null
-#  account_request_id                                 :integer
-#  ndbn_member_id                                     :bigint
+#  id                             :integer          not null, primary key
+#  city                           :string
+#  deadline_day                   :integer
+#  default_storage_location       :integer
+#  distribute_monthly             :boolean          default(FALSE), not null
+#  email                          :string
+#  enable_child_based_requests    :boolean          default(TRUE), not null
+#  enable_individual_requests     :boolean          default(TRUE), not null
+#  enable_quantity_based_requests :boolean          default(TRUE), not null
+#  intake_location                :integer
+#  invitation_text                :text
+#  latitude                       :float
+#  longitude                      :float
+#  name                           :string
+#  one_step_partner_invite        :boolean          default(FALSE), not null
+#  partner_form_fields            :text             default([]), is an Array
+#  reminder_day                   :integer
+#  repackage_essentials           :boolean          default(FALSE), not null
+#  short_name                     :string
+#  state                          :string
+#  street                         :string
+#  url                            :string
+#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
+#  zipcode                        :string
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  account_request_id             :integer
+#  ndbn_member_id                 :bigint
 #
 
 class Organization < ApplicationRecord

--- a/db/migrate/20240131202431_add_one_step_partner_invite_to_organization.rb
+++ b/db/migrate/20240131202431_add_one_step_partner_invite_to_organization.rb
@@ -1,6 +1,0 @@
-class AddOneStepPartnerInviteToOrganization < ActiveRecord::Migration[7.0]
-  def change
-    add_column :organizations, :one_step_partner_invite, :boolean, null: false
-    change_column_default :organizations, :one_step_partner_invite, false
-  end
-end

--- a/db/migrate/20240207202431_add_one_step_partner_invite_to_organization.rb
+++ b/db/migrate/20240207202431_add_one_step_partner_invite_to_organization.rb
@@ -1,0 +1,7 @@
+class AddOneStepPartnerInviteToOrganization < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      add_column :organizations, :one_step_partner_invite, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_31_202431) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_07_202431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -2,34 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                                                 :integer          not null, primary key
-#  city                                               :string
-#  deadline_day                                       :integer
-#  default_storage_location                           :integer
-#  distribute_monthly                                 :boolean          default(FALSE), not null
-#  email                                              :string
-#  enable_child_based_requests                        :boolean          default(TRUE), not null
-#  enable_individual_requests                         :boolean          default(TRUE), not null
-#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
-#  intake_location                                    :integer
-#  invitation_text                                    :text
-#  latitude                                           :float
-#  longitude                                          :float
-#  name                                               :string
-#  partner_form_fields                                :text             default([]), is an Array
-#  reminder_day                                       :integer
-#  repackage_essentials                               :boolean          default(FALSE), not null
-#  short_name                                         :string
-#  state                                              :string
-#  street                                             :string
-#  url                                                :string
-#  one_step_partner_invite                            :boolean          default(FALSE), not null
-#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
-#  zipcode                                            :string
-#  created_at                                         :datetime         not null
-#  updated_at                                         :datetime         not null
-#  account_request_id                                 :integer
-#  ndbn_member_id                                     :bigint
+#  id                             :integer          not null, primary key
+#  city                           :string
+#  deadline_day                   :integer
+#  default_storage_location       :integer
+#  distribute_monthly             :boolean          default(FALSE), not null
+#  email                          :string
+#  enable_child_based_requests    :boolean          default(TRUE), not null
+#  enable_individual_requests     :boolean          default(TRUE), not null
+#  enable_quantity_based_requests :boolean          default(TRUE), not null
+#  intake_location                :integer
+#  invitation_text                :text
+#  latitude                       :float
+#  longitude                      :float
+#  name                           :string
+#  one_step_partner_invite        :boolean          default(FALSE), not null
+#  partner_form_fields            :text             default([]), is an Array
+#  reminder_day                   :integer
+#  repackage_essentials           :boolean          default(FALSE), not null
+#  short_name                     :string
+#  state                          :string
+#  street                         :string
+#  url                            :string
+#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
+#  zipcode                        :string
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  account_request_id             :integer
+#  ndbn_member_id                 :bigint
 #
 
 FactoryBot.define do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -2,34 +2,34 @@
 #
 # Table name: organizations
 #
-#  id                                                 :integer          not null, primary key
-#  city                                               :string
-#  deadline_day                                       :integer
-#  default_storage_location                           :integer
-#  distribute_monthly                                 :boolean          default(FALSE), not null
-#  email                                              :string
-#  enable_child_based_requests                        :boolean          default(TRUE), not null
-#  enable_individual_requests                         :boolean          default(TRUE), not null
-#  enable_quantity_based_requests                     :boolean          default(TRUE), not null
-#  intake_location                                    :integer
-#  invitation_text                                    :text
-#  latitude                                           :float
-#  longitude                                          :float
-#  name                                               :string
-#  partner_form_fields                                :text             default([]), is an Array
-#  reminder_day                                       :integer
-#  repackage_essentials                               :boolean          default(FALSE), not null
-#  short_name                                         :string
-#  state                                              :string
-#  street                                             :string
-#  url                                                :string
-#  one_step_partner_invite                            :boolean          default(FALSE), not null
-#  ytd_on_distribution_printout                       :boolean          default(TRUE), not null
-#  zipcode                                            :string
-#  created_at                                         :datetime         not null
-#  updated_at                                         :datetime         not null
-#  account_request_id                                 :integer
-#  ndbn_member_id                                     :bigint
+#  id                             :integer          not null, primary key
+#  city                           :string
+#  deadline_day                   :integer
+#  default_storage_location       :integer
+#  distribute_monthly             :boolean          default(FALSE), not null
+#  email                          :string
+#  enable_child_based_requests    :boolean          default(TRUE), not null
+#  enable_individual_requests     :boolean          default(TRUE), not null
+#  enable_quantity_based_requests :boolean          default(TRUE), not null
+#  intake_location                :integer
+#  invitation_text                :text
+#  latitude                       :float
+#  longitude                      :float
+#  name                           :string
+#  one_step_partner_invite        :boolean          default(FALSE), not null
+#  partner_form_fields            :text             default([]), is an Array
+#  reminder_day                   :integer
+#  repackage_essentials           :boolean          default(FALSE), not null
+#  short_name                     :string
+#  state                          :string
+#  street                         :string
+#  url                            :string
+#  ytd_on_distribution_printout   :boolean          default(TRUE), not null
+#  zipcode                        :string
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  account_request_id             :integer
+#  ndbn_member_id                 :bigint
 #
 
 RSpec.describe Organization, type: :model do


### PR DESCRIPTION
**Best reviewed with Hide Whitespace on**

### Description
While running the migration from https://github.com/rubyforgood/human-essentials/pull/4075, we encountered an issue where null values where detected. This is because the column was added in two lines, first default then setting not null. This allowed some null values to slip in.

This PR changes migration to run one on line adding both default and non null inside safety assured block.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Ran migrations locally with no error.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
