### PR TITLE
Add events view

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@ class EventsController < ApplicationController
 
     @events = Event.for_organization(current_organization)
       .during(helpers.selected_range)
-      .includes(:eventable)
+      .includes(:eventable, :user)
     @events = if params[:eventable_id]
       @events.where(eventable_id: params[:eventable_id],
         eventable_type: params[:eventable_type])

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,12 @@ class EventsController < ApplicationController
   def index
     setup_date_range_picker
 
-    @events = Event.for_organization(current_organization).during(helpers.selected_range)
+    @events = Event.for_organization(current_organization).
+      class_filter(filter_params).
+      includes(:eventable)
+    if params.dig(:filters, :date_range).present?
+      @events = @events.during(helpers.selected_range)
+    end
     @items = current_organization.items
     @locations = current_organization.storage_locations
 
@@ -14,7 +19,7 @@ class EventsController < ApplicationController
   end
 
   def filter_params
-    {}
+    params.require(:filters).permit(:by_type, :by_storage_location)
   end
   helper_method :filter_params
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,20 @@
+class EventsController < ApplicationController
+  def index
+    setup_date_range_picker
+
+    @events = Event.for_organization(current_organization).during(helpers.selected_range)
+    @items = current_organization.items
+    @locations = current_organization.storage_locations
+
+    respond_to do |format|
+      format.html do
+        @events = @events.page(params[:page])
+      end
+    end
+  end
+
+  def filter_params
+    {}
+  end
+  helper_method :filter_params
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,13 +2,19 @@ class EventsController < ApplicationController
   def index
     setup_date_range_picker
 
-    @events = Event.for_organization(current_organization).
-      class_filter(filter_params).
-      includes(:eventable)
+    @events = Event.for_organization(current_organization)
+      .during(helpers.selected_range)
+      .includes(:eventable)
+    @events = if params[:eventable_id]
+      @events.where(eventable_id: params[:eventable_id],
+        eventable_type: params[:eventable_type])
+    else
+      @events.class_filter(filter_params)
+    end
     if params.dig(:filters, :date_range).present?
       @events = @events.during(helpers.selected_range)
     end
-    @items = current_organization.items
+    @items = current_organization.items.sort_by(&:name)
     @locations = current_organization.storage_locations
 
     respond_to do |format|
@@ -19,7 +25,7 @@ class EventsController < ApplicationController
   end
 
   def filter_params
-    params.require(:filters).permit(:by_type, :by_storage_location)
+    params.fetch(:filters, {}).permit(:by_type, :by_storage_location, :by_item)
   end
   helper_method :filter_params
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,6 +17,7 @@
 class Event < ApplicationRecord
   scope :for_organization, ->(organization_id) { where(organization_id: organization_id).order(:event_time, :updated_at) }
   scope :without_snapshots, -> { where("type != 'SnapshotEvent'") }
+  scope :during, ->(range) { where(events: {created_at: range}) }
 
   serialize :data, EventTypes::StructCoder.new(EventTypes::InventoryPayload)
 

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -5,7 +5,7 @@
   <% to_loc = event.data.items.first&.to_storage_location %>
   <tr>
     <td>
-      <%= event.user.name %>
+      <%= event.user&.name || "No Name Provided" %>
     </td>
     <td title="Internal Event ID: <%= event.id %>"><%= event.type.sub(/Event/, '') %></td>
     <td>

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -21,7 +21,7 @@
     <td>
       <% event.data.items.each do |entry| %>
         <%= link_to items.find { |i| i.id == entry.item_id}.name, item_path(entry.item_id) %>:
-        <%= entry.from_storage_location == from_loc ? entry.quantity : -entry.quantity %><br/>
+        <%= entry.from_storage_location == from_loc ? entry.quantity : -entry.quantity %><br>
       <% end %>
     </td>
   </tr>

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -1,23 +1,28 @@
-<% from_loc = event_row.data.items.first&.from_storage_location %>
-<% to_loc = event_row.data.items.first&.to_storage_location %>
-<tr>
-  <td><%= event_row.id %></td>
-  <td><%= event_row.type.sub(/Event/, '') %></td>
-  <td><%= link_to event_row.eventable_id, event_row.eventable %></td>
-  <td>
-    <% if from_loc %>
-      <%= link_to storage_locs.find { |i| i.id == from_loc}.name, storage_location_path(from_loc) %>
-    <% end %>
-  </td>
-  <td>
-    <% if to_loc %>
-      <%= link_to storage_locs.find { |i| i.id == to_loc}.name, storage_location_path(to_loc) %>
-    <% end %>
-  </td>
-  <td>
-    <% event_row.data.items.each do |entry| %>
-      <%= link_to items.find { |i| i.id == entry.item_id}.name, item_path(entry.item_id) %>:
-      <%= entry.from_storage_location == from_loc ? entry.quantity : -entry.quantity %><br/>
-    <% end %>
-  </td>
-</tr>
+<% if event.is_a?(SnapshotEvent) %>
+  <%= render partial: "snapshot_event_row", object: event, as: :event, locals: { items: items, storage_locs: storage_locs } %>
+<% else %>
+  <% from_loc = event.data.items.first&.from_storage_location %>
+  <% to_loc = event.data.items.first&.to_storage_location %>
+  <tr>
+    <td><%= event.id %></td>
+    <td><%= event.type.sub(/Event/, '') %></td>
+    <td><%= link_to event.eventable_id, event.eventable %></td>
+    <td><%= event.event_time.to_s %></td>
+    <td>
+      <% if from_loc %>
+        <%= link_to storage_locs.find { |i| i.id == from_loc}.name, storage_location_path(from_loc) %>
+      <% end %>
+    </td>
+    <td>
+      <% if to_loc %>
+        <%= link_to storage_locs.find { |i| i.id == to_loc}.name, storage_location_path(to_loc) %>
+      <% end %>
+    </td>
+    <td>
+      <% event.data.items.each do |entry| %>
+        <%= link_to items.find { |i| i.id == entry.item_id}.name, item_path(entry.item_id) %>:
+        <%= entry.from_storage_location == from_loc ? entry.quantity : -entry.quantity %><br/>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -7,7 +7,7 @@
     <td><%= event.id %></td>
     <td><%= event.type.sub(/Event/, '') %></td>
     <td><%= link_to event.eventable_id, event.eventable %></td>
-    <td><%= event.event_time.to_s %></td>
+    <td><%= event.event_time.strftime("%Y/%m/%d %H:%M:%S %Z") %></td>
     <td>
       <% if from_loc %>
         <%= link_to storage_locs.find { |i| i.id == from_loc}.name, storage_location_path(from_loc) %>

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -6,7 +6,15 @@
   <tr>
     <td><%= event.id %></td>
     <td><%= event.type.sub(/Event/, '') %></td>
-    <td><%= link_to event.eventable_id, event.eventable %></td>
+    <td>
+      <%= link_to event.eventable_id, event.eventable %>
+      <%= link_to(
+          events_path(current_organization, eventable_type: event.eventable_type, eventable_id: event.eventable_id),
+          class: 'btn btn-md') do
+      %>
+        <i class="fa fa-filter"></i>
+      <% end %>
+    </td>
     <td><%= event.event_time.strftime("%Y/%m/%d %H:%M:%S %Z") %></td>
     <td>
       <% if from_loc %>

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -1,0 +1,23 @@
+<% from_loc = event_row.data.items.first&.from_storage_location %>
+<% to_loc = event_row.data.items.first&.to_storage_location %>
+<tr>
+  <td><%= event_row.id %></td>
+  <td><%= event_row.type.sub(/Event/, '') %></td>
+  <td><%= link_to event_row.eventable_id, event_row.eventable %></td>
+  <td>
+    <% if from_loc %>
+      <%= link_to storage_locs.find { |i| i.id == from_loc}.name, storage_location_path(from_loc) %>
+    <% end %>
+  </td>
+  <td>
+    <% if to_loc %>
+      <%= link_to storage_locs.find { |i| i.id == to_loc}.name, storage_location_path(to_loc) %>
+    <% end %>
+  </td>
+  <td>
+    <% event_row.data.items.each do |entry| %>
+      <%= link_to items.find { |i| i.id == entry.item_id}.name, item_path(entry.item_id) %>:
+      <%= entry.from_storage_location == from_loc ? entry.quantity : -entry.quantity %><br/>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -10,8 +10,7 @@
       <%= link_to event.eventable_id, event.eventable %>
       <%= link_to(
           events_path(current_organization, eventable_type: event.eventable_type, eventable_id: event.eventable_id),
-          class: 'btn btn-md') do
-      %>
+          class: 'btn btn-md') do %>
         <i class="fa fa-filter"></i>
       <% end %>
     </td>

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -4,8 +4,10 @@
   <% from_loc = event.data.items.first&.from_storage_location %>
   <% to_loc = event.data.items.first&.to_storage_location %>
   <tr>
-    <td><%= event.id %></td>
-    <td><%= event.type.sub(/Event/, '') %></td>
+    <td>
+      <%= event.user.name %>
+    </td>
+    <td title="Internal Event ID: <%= event.id %>"><%= event.type.sub(/Event/, '') %></td>
     <td>
       <%= link_to event.eventable_id, event.eventable %>
       <%= link_to(

--- a/app/views/events/_snapshot_event_row.html.erb
+++ b/app/views/events/_snapshot_event_row.html.erb
@@ -1,0 +1,19 @@
+<% num_locations = event.data.storage_locations.length %>
+<% event.data.storage_locations.values.each_with_index do |loc, loc_index| %>
+  <tr>
+    <% if loc_index == 0 %>
+      <td rowspan="<%= num_locations %>"><%= event.id %></td>
+      <td rowspan="<%= num_locations %>">Snapshot</td>
+      <td rowspan="<%= num_locations %>"></td>
+      <td rowspan="<%= num_locations %>"><%= event.event_time.to_s %></td>
+    <% end %>
+    <td colspan="2">
+      <%= link_to storage_locs.find { |i| i.id == loc.id}.name, storage_location_path(loc.id) %>
+    <td>
+      <% loc.items.values.each do |entry| %>
+        <%= link_to items.find { |i| i.id == entry.item_id}.name, item_path(entry.item_id) %>:
+        <%= entry.quantity %><br/>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/events/_snapshot_event_row.html.erb
+++ b/app/views/events/_snapshot_event_row.html.erb
@@ -1,6 +1,6 @@
 <% num_locations = event.data.storage_locations.length %>
 <% event.data.storage_locations.values.each_with_index do |loc, loc_index| %>
-  <tr>
+  <tr style="background-color: #e9e4f3;">
     <% if loc_index == 0 %>
       <td rowspan="<%= num_locations %>"><%= event.id %></td>
       <td rowspan="<%= num_locations %>">Snapshot</td>

--- a/app/views/events/_snapshot_event_row.html.erb
+++ b/app/views/events/_snapshot_event_row.html.erb
@@ -12,7 +12,7 @@
     <td>
       <% loc.items.values.each do |entry| %>
         <%= link_to items.find { |i| i.id == entry.item_id}.name, item_path(entry.item_id) %>:
-        <%= entry.quantity %><br/>
+        <%= entry.quantity %><br>
       <% end %>
     </td>
   </tr>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -41,12 +41,20 @@
                   <%= label_tag "Date Range" %>
                   <%= render partial: "shared/date_range_picker", locals: {css_class: "form-control"} %>
                 </div>
+                <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                  <%= filter_select(scope: :by_type, collection: Event.types_for_select, key: :value, value: :name,
+                                    selected: params.dig(:filters, :by_type)) %>
+                </div>
+                <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                  <%= filter_select(scope: :by_storage_location, collection: current_organization.storage_locations,
+                                    selected:params.dig(:filters, :by_storage_location)) %>
+                </div>
               </div>
-              </div>
-              <div class="card-footer">
-                <%= filter_button %>
-                <%= clear_filter_button %>
-              </div>
+            </div>
+            <div class="card-footer">
+              <%= filter_button %>
+              <%= clear_filter_button %>
+            </div>
             <% end # form %>
             </div>
         <!-- /.card -->

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -49,6 +49,10 @@
                   <%= filter_select(scope: :by_storage_location, collection: current_organization.storage_locations,
                                     selected:params.dig(:filters, :by_storage_location)) %>
                 </div>
+                <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                  <%= filter_select(scope: :by_item, collection: @items,
+                                    selected:params.dig(:filters, :by_item)) %>
+                </div>
               </div>
             </div>
             <div class="card-footer">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -46,9 +46,6 @@
               <div class="card-footer">
                 <%= filter_button %>
                 <%= clear_filter_button %>
-                <span class="float-right">
-                  <%= download_button_to(events_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Events", size: "md"}) if @events.any? %>
-                </span>
               </div>
             <% end # form %>
             </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,99 @@
+<!-- Content Header (Page header) -->
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Events - #{current_organization.name}" %>
+        <h1>
+          Events
+          <small>for <%= current_organization.name %></small>
+        </h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><%= link_to(dashboard_path) do %>
+              <i class="fa fa-dashboard"></i> Home
+            <% end %>
+          </li>
+          <li class="breadcrumb-item"><a href="#">Events</a></li>
+        </ol>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+<!-- Main content -->
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <!-- left column -->
+      <div class="col-md-12">
+        <!-- jquery validation -->
+        <div class="card card-primary">
+          <div class="card-header">
+            <h3 class="card-title">Event Filter</h3>
+          </div>
+          <!-- /.card-header -->
+          <!-- form start -->
+          <div class="card-body">
+            <%= form_tag(events_path, method: :get) do |f| %>
+              <div class="row">
+                <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
+                  <%= label_tag "Date Range" %>
+                  <%= render partial: "shared/date_range_picker", locals: {css_class: "form-control"} %>
+                </div>
+              </div>
+              </div>
+              <div class="card-footer">
+                <%= filter_button %>
+                <%= clear_filter_button %>
+                <span class="float-right">
+                  <%= download_button_to(events_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Events", size: "md"}) if @events.any? %>
+                </span>
+              </div>
+            <% end # form %>
+            </div>
+        <!-- /.card -->
+      </div>
+      <!--/.col (left) -->
+      <!-- right column -->
+      <div class="col-md-6">
+
+      </div>
+      <!--/.col (right) -->
+    </div>
+    <!-- /.row -->
+  </div><!-- /.container-fluid -->
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12">
+        <!-- Default box -->
+        <div class="card">
+          <div class="card-body p-0">
+            <table class="table">
+              <thead>
+              <tr>
+                <th>Event ID</th>
+                <th>Type</th>
+                <th>Resource</th>
+                <th>From Location</th>
+                <th>To Location</th>
+                <th>Items</th>
+              </tr>
+              </thead>
+              <tbody>
+                <%= render partial: "event_row", collection: @events, locals: { items: @items, storage_locs: @locations} %>
+              </tbody>
+            </table>
+          </div>
+          <!-- /.card-body -->
+          <div class="card-footer clearfix">
+            <%= paginate @events %>
+          </div>
+          <!-- /.card-footer-->
+        </div>
+        <!-- /.card -->
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -3,9 +3,9 @@
   <div class="container-fluid">
     <div class="row mb-2">
       <div class="col-sm-6">
-        <% content_for :title, "Events - #{current_organization.name}" %>
+        <% content_for :title, "History - #{current_organization.name}" %>
         <h1>
-          Events
+          History
           <small>for <%= current_organization.name %></small>
         </h1>
       </div>
@@ -15,7 +15,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><a href="#">Events</a></li>
+          <li class="breadcrumb-item"><a href="#">History</a></li>
         </ol>
       </div>
     </div>
@@ -30,7 +30,7 @@
         <!-- jquery validation -->
         <div class="card card-primary">
           <div class="card-header">
-            <h3 class="card-title">Event Filter</h3>
+            <h3 class="card-title">History Filter</h3>
           </div>
           <!-- /.card-header -->
           <!-- form start -->
@@ -70,16 +70,17 @@
             <table class="table">
               <thead>
               <tr>
-                <th>Event ID</th>
+                <th>Internal ID</th>
                 <th>Type</th>
-                <th>Resource</th>
+                <th>Refers To</th>
+                <th>Date/Time</th>
                 <th>From Location</th>
                 <th>To Location</th>
                 <th>Items</th>
               </tr>
               </thead>
               <tbody>
-                <%= render partial: "event_row", collection: @events, locals: { items: @items, storage_locs: @locations} %>
+                <%= render partial: "event_row", collection: @events, as: :event, locals: { items: @items, storage_locs: @locations} %>
               </tbody>
             </table>
           </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -82,7 +82,7 @@
             <table class="table">
               <thead>
               <tr>
-                <th>Internal ID</th>
+                <th>User</th>
                 <th>Type</th>
                 <th>Refers To</th>
                 <th>Date/Time</th>

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -189,6 +189,11 @@
             <i class="nav-icon fa fa-circle-o"></i> Annual Survey
           <% end %>
         </li>
+        <li class="nav-item <%= active_class(['events']) %>">
+          <%= link_to(events_path(organization_id: current_user.organization), class: "nav-link #{active_class(['events'])}") do %>
+            <i class="nav-icon fa fa-circle-o"></i> Events
+          <% end %>
+        </li>
       </ul>
     </li>
   <% end %>

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -191,7 +191,7 @@
         </li>
         <li class="nav-item <%= active_class(['events']) %>">
           <%= link_to(events_path(organization_id: current_user.organization), class: "nav-link #{active_class(['events'])}") do %>
-            <i class="nav-icon fa fa-circle-o"></i> Events
+            <i class="nav-icon fa fa-circle-o"></i> History
           <% end %>
         </li>
       </ul>

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -189,11 +189,13 @@
             <i class="nav-icon fa fa-circle-o"></i> Annual Survey
           <% end %>
         </li>
-        <li class="nav-item <%= active_class(['events']) %>">
-          <%= link_to(events_path(organization_id: current_user.organization), class: "nav-link #{active_class(['events'])}") do %>
-            <i class="nav-icon fa fa-circle-o"></i> History
-          <% end %>
-        </li>
+        <% if Event.read_events?(current_user.organization) %>
+          <li class="nav-item <%= active_class(['events']) %>">
+            <%= link_to(events_path(organization_id: current_user.organization), class: "nav-link #{active_class(['events'])}") do %>
+              <i class="nav-icon fa fa-circle-o"></i> History
+            <% end %>
+          </li>
+        <% end %>
       </ul>
     </li>
   <% end %>

--- a/config/initializers/event_types.rb
+++ b/config/initializers/event_types.rb
@@ -1,0 +1,5 @@
+# load all event types so we can use it in e.g. drop-downs.
+
+Rails.application.reloader.to_prepare do
+  Dir["#{Rails.root}/app/events/*_event.rb"].each { |f| require f }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :events, only: %i(index)
+
     resources :adjustments, except: %i(edit update)
     resources :audits do
       post :finalize

--- a/spec/requests/events_requests_spec.rb
+++ b/spec/requests/events_requests_spec.rb
@@ -6,42 +6,153 @@ RSpec.describe "Events", type: :request do
   let(:default_params) do
     {organization_id: organization.to_param}
   end
+  let(:storage_location) { create(:storage_location, organization: organization) }
+  let(:storage_location2) { create(:storage_location, organization: organization) }
+  let(:item) { create(:item, organization: organization, name: "Item1") }
+  let(:item2) { create(:item, organization: organization, name: "Item2") }
 
   context "When signed in" do
     before { sign_in(user) }
 
     describe "GET #index" do
+      let(:params) { default_params.merge(format: "html") }
+
       subject do
-        get events_path(default_params.merge(format: response_format))
+        get events_path(params)
         response
       end
 
       before do
-        item = create(:item, organization: organization, name: "Item1")
-        donation = create(:donation, :with_items, organization: organization, item: item, item_quantity: 66)
+        donation = create(:donation, :with_items, storage_location: storage_location,
+          organization: organization, item: item, item_quantity: 66)
         DonationEvent.publish(donation)
-
-        # too old
+        donation2 = create(:donation, :with_items, storage_location: storage_location2,
+          organization: organization, item: item, item_quantity: 77)
+        DonationEvent.publish(donation2)
+        donation3 = create(:donation, :with_items, storage_location: storage_location,
+          organization: organization, item: item2, item_quantity: 55)
+        DonationEvent.publish(donation3)
+        adjustment = create(:adjustment, :with_items, storage_location: storage_location,
+          organization: organization, item: item, item_quantity: 88)
+        AdjustmentEvent.publish(adjustment)
         travel(-1.year) do
-          donation = create(:donation, :with_items, organization: organization, item: item, item_quantity: 4954)
+          donation = create(:donation, :with_items, item: item, organization: organization, item_quantity: 99)
           DonationEvent.publish(donation)
         end
       end
 
-      context "html" do
-        let(:response_format) { "html" }
+      it "should be successful" do
+        subject
+        expect(response.body).to include("Item1")
+        expect(response.body).to include("Item2")
+        expect(response.body).to include("55<br>")
+        expect(response.body).to include("66<br>")
+        expect(response.body).to include("77<br>")
+        expect(response.body).to include("88<br>")
+        expect(response.body).not_to include("99<br>")
+      end
 
-        it "should be successful" do
+      context "with type filter" do
+        let(:params) do
+          default_params.merge(format: "html", filters: {by_type: "DonationEvent"})
+        end
+
+        it "should not include the adjustment" do
           subject
           expect(response.body).to include("Item1")
-          expect(response.body).to include("66")
-          expect(response.body).not_to include("4954")
+          expect(response.body).to include("Item2")
+          expect(response.body).to include("55<br>")
+          expect(response.body).to include("66<br>")
+          expect(response.body).to include("77<br>")
+          expect(response.body).not_to include("88<br>")
+          expect(response.body).not_to include("99<br>")
+        end
+      end
+
+      context "with item filter" do
+        let(:params) do
+          default_params.merge(format: "html", filters: {by_item: item.id})
+        end
+
+        it "should not include the other item" do
+          subject
+          expect(response.body).to include("Item1")
+          expect(response.body).not_to include("Item2")
+          expect(response.body).not_to include("55<br>")
+          expect(response.body).to include("66<br>")
+          expect(response.body).to include("77<br>")
+          expect(response.body).to include("88<br>")
+          expect(response.body).not_to include("99<br>")
+        end
+      end
+
+      context "with storage location filter" do
+        let(:params) do
+          default_params.merge(format: "html", filters: {by_storage_location: storage_location.id})
+        end
+
+        it "should not include the other storage location" do
+          subject
+          expect(response.body).to include("Item1")
+          expect(response.body).to include("Item2")
+          expect(response.body).to include("55<br>")
+          expect(response.body).to include("66<br>")
+          expect(response.body).not_to include("77<br>")
+          expect(response.body).to include("88<br>")
+          expect(response.body).not_to include("99<br>")
+        end
+      end
+
+      context "with date filter" do
+        let(:params) {
+          default_params.merge(format: "html",
+            filters: {filters: {
+              date_range: date_range_picker_params(3.days.ago, Time.zone.tomorrow)
+            }})
+        }
+
+        it "should not include the old donation" do
+          subject
+          expect(response.body).to include("Item1")
+          expect(response.body).to include("Item2")
+          expect(response.body).to include("55<br>")
+          expect(response.body).to include("66<br>")
+          expect(response.body).to include("77<br>")
+          expect(response.body).to include("88<br>")
+          expect(response.body).not_to include("99<br>")
+        end
+      end
+
+      context "with eventable_id" do
+        let(:donation) do
+          create(:donation, :with_items, item: item, organization: organization, item_quantity: 44)
+        end
+        let(:params) do
+          default_params.merge(format: "html", eventable_id: donation.id, eventable_type: "Donation")
+        end
+        before do
+          DonationEvent.publish(donation)
+          donation.line_items.first.quantity = 33
+          DonationEvent.publish(donation) # an update
+        end
+
+        it "should only show events from that eventable" do
+          subject
+          expect(response.body).to include("Item1")
+          expect(response.body).to include("44<br>")
+          expect(response.body).to include("33<br>")
+          expect(response.body).not_to include("Item2")
+          expect(response.body).not_to include("55<br>")
+          expect(response.body).not_to include("66<br>")
+          expect(response.body).not_to include("77<br>")
+          expect(response.body).not_to include("88<br>")
+          expect(response.body).not_to include("99<br>")
         end
       end
     end
   end
 
-  context "When not signed" do
+  context "When not signed in" do
     let(:object) do
       donation = create(:donation)
       DonationEvent.publish(donation)

--- a/spec/requests/events_requests_spec.rb
+++ b/spec/requests/events_requests_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe "Events", type: :request do
 
       it "should be successful" do
         subject
-        expect(response.body).to include("Item1")
-        expect(response.body).to include("Item2")
+        expect(response.body).to include("Item1</a>")
+        expect(response.body).to include("Item2</a>")
         expect(response.body).to include("55<br>")
         expect(response.body).to include("66<br>")
         expect(response.body).to include("77<br>")
@@ -59,8 +59,8 @@ RSpec.describe "Events", type: :request do
 
         it "should not include the adjustment" do
           subject
-          expect(response.body).to include("Item1")
-          expect(response.body).to include("Item2")
+          expect(response.body).to include("Item1</a>")
+          expect(response.body).to include("Item2</a>")
           expect(response.body).to include("55<br>")
           expect(response.body).to include("66<br>")
           expect(response.body).to include("77<br>")
@@ -76,8 +76,8 @@ RSpec.describe "Events", type: :request do
 
         it "should not include the other item" do
           subject
-          expect(response.body).to include("Item1")
-          expect(response.body).not_to include("Item2")
+          expect(response.body).to include("Item1</a>")
+          expect(response.body).not_to include("Item2</a>")
           expect(response.body).not_to include("55<br>")
           expect(response.body).to include("66<br>")
           expect(response.body).to include("77<br>")
@@ -93,8 +93,8 @@ RSpec.describe "Events", type: :request do
 
         it "should not include the other storage location" do
           subject
-          expect(response.body).to include("Item1")
-          expect(response.body).to include("Item2")
+          expect(response.body).to include("Item1</a>")
+          expect(response.body).to include("Item2</a>")
           expect(response.body).to include("55<br>")
           expect(response.body).to include("66<br>")
           expect(response.body).not_to include("77<br>")
@@ -113,8 +113,8 @@ RSpec.describe "Events", type: :request do
 
         it "should not include the old donation" do
           subject
-          expect(response.body).to include("Item1")
-          expect(response.body).to include("Item2")
+          expect(response.body).to include("Item1</a>")
+          expect(response.body).to include("Item2</a>")
           expect(response.body).to include("55<br>")
           expect(response.body).to include("66<br>")
           expect(response.body).to include("77<br>")
@@ -138,10 +138,10 @@ RSpec.describe "Events", type: :request do
 
         it "should only show events from that eventable" do
           subject
-          expect(response.body).to include("Item1")
+          expect(response.body).to include("Item1</a>")
           expect(response.body).to include("44<br>")
           expect(response.body).to include("33<br>")
-          expect(response.body).not_to include("Item2")
+          expect(response.body).not_to include("Item2</a>")
           expect(response.body).not_to include("55<br>")
           expect(response.body).not_to include("66<br>")
           expect(response.body).not_to include("77<br>")

--- a/spec/requests/events_requests_spec.rb
+++ b/spec/requests/events_requests_spec.rb
@@ -42,7 +42,10 @@ RSpec.describe "Events", type: :request do
   end
 
   context "When not signed" do
-    let(:object) { create(:event) }
+    let(:object) do
+      donation = create(:donation)
+      DonationEvent.publish(donation)
+    end
 
     include_examples "requiring authorization"
   end

--- a/spec/requests/events_requests_spec.rb
+++ b/spec/requests/events_requests_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Events", type: :request do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:organization_admin, organization: organization) }
+  let(:default_params) do
+    {organization_id: organization.to_param}
+  end
+
+  context "When signed in" do
+    before { sign_in(user) }
+
+    describe "GET #index" do
+      subject do
+        get events_path(default_params.merge(format: response_format))
+        response
+      end
+
+      before do
+        item = create(:item, organization: organization, name: "Item1")
+        donation = create(:donation, :with_items, organization: organization, item: item, item_quantity: 66)
+        DonationEvent.publish(donation)
+
+        # too old
+        travel(-1.year) do
+          donation = create(:donation, :with_items, organization: organization, item: item, item_quantity: 4954)
+          DonationEvent.publish(donation)
+        end
+      end
+
+      context "html" do
+        let(:response_format) { "html" }
+
+        it "should be successful" do
+          subject
+          expect(response.body).to include("Item1")
+          expect(response.body).to include("66")
+          expect(response.body).not_to include("4954")
+        end
+      end
+    end
+  end
+
+  context "When not signed" do
+    let(:object) { create(:event) }
+
+    include_examples "requiring authorization"
+  end
+end

--- a/spec/services/distribution_itemized_breakdown_service_spec.rb
+++ b/spec/services/distribution_itemized_breakdown_service_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe DistributionItemizedBreakdownService, type: :service do
     it "should output the expected output but in CSV format" do
       expected_output_csv = <<~CSV
         Item,Total Distribution,Total On Hand
-        Item 1,500,100
-        Item 2,200,200
+        A Diapers,500,100
+        B Diapers,200,200
       CSV
 
       expect(subject).to eq(expected_output_csv)

--- a/spec/services/distribution_itemized_breakdown_service_spec.rb
+++ b/spec/services/distribution_itemized_breakdown_service_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe DistributionItemizedBreakdownService, type: :service do
   let(:organization) { create(:organization) }
   let(:distribution_ids) { [distribution_1, distribution_2, distribution_3].map(&:id) }
   let(:item_a) do
-    create(:item, organization: organization, on_hand_minimum_quantity: 9999)
+    create(:item, organization: organization, on_hand_minimum_quantity: 9999, name: "Item 1")
   end
   let(:item_b) do
-    create(:item, organization: organization, on_hand_minimum_quantity: 5)
+    create(:item, organization: organization, on_hand_minimum_quantity: 5, name: "Item 2")
   end
   let(:distribution_1) { create(:distribution, :with_items, item: item_a, item_quantity: 500, organization: organization) }
   let(:distribution_2) { create(:distribution, :with_items, item: item_b, item_quantity: 100, organization: organization) }
@@ -33,13 +33,11 @@ RSpec.describe DistributionItemizedBreakdownService, type: :service do
     let(:service) { described_class.new(organization: organization, distribution_ids: distribution_ids) }
 
     it "should output the expected output but in CSV format" do
-      expected_output_csv = CSV.generate do |csv|
-        csv << ["Item", "Total Distribution", "Total On Hand"]
-
-        expected_output.each do |row|
-          csv << [row[:name], row[:distributed], row[:current_onhand]]
-        end
-      end
+      expected_output_csv = <<-CSV
+Item,Total Distribution,Total On Hand
+Item 1,500,100
+Item 2,200,200
+      CSV
 
       expect(subject).to eq(expected_output_csv)
     end

--- a/spec/services/distribution_itemized_breakdown_service_spec.rb
+++ b/spec/services/distribution_itemized_breakdown_service_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe DistributionItemizedBreakdownService, type: :service do
     let(:service) { described_class.new(organization: organization, distribution_ids: distribution_ids) }
 
     it "should output the expected output but in CSV format" do
-      expected_output_csv = <<-CSV
-Item,Total Distribution,Total On Hand
-Item 1,500,100
-Item 2,200,200
+      expected_output_csv = <<~CSV
+        Item,Total Distribution,Total On Hand
+        Item 1,500,100
+        Item 2,200,200
       CSV
 
       expect(subject).to eq(expected_output_csv)


### PR DESCRIPTION
Fixes #4079.

This adds a simple events view for org admins:
<img width="1332" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/1986893/cec48f87-2b9f-424b-9a40-cb955675a980">

Missing some features:
* CSV export
* Filter by storage location and item

We can do that as a fast follow.