### PR TITLE
Fix Remove Item buttons on partner request pages

### DIFF
--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -49,11 +49,7 @@ module Partners
     private
 
     def partner_request_params
-      params.require(:request).permit(:comments, item_requests_attributes: [
-                                        :item_id,
-                                                 :quantity,
-                                                 :_destroy
-                                      ])
+      params.require(:request).permit(:comments, item_requests_attributes: [:item_id, :quantity])
     end
   end
 end

--- a/app/helpers/partners/multi_item_form_helper.rb
+++ b/app/helpers/partners/multi_item_form_helper.rb
@@ -1,7 +1,7 @@
 module Partners
   module MultiItemFormHelper
     def remove_item_button(label, soft: false)
-      link_to label, 'javascript:void(0)', class: 'btn btn-warning', data: { remove_item: soft ? "soft" : nil }
+      link_to label, 'javascript:void(0)', class: 'btn btn-warning', data: { remove_item: soft ? "soft" : "hard" }
     end
 
     def add_item_button(label, container: ".fields", &block)

--- a/app/views/partners/requests/_item_request.html.erb
+++ b/app/views/partners/requests/_item_request.html.erb
@@ -3,8 +3,7 @@
     <td><%= field.select :item_id, @formatted_requestable_items, {include_blank: 'Select an item'}, {class: 'form-control'} %></td>
     <td><%= field.number_field :quantity, label: false, step: 1, min: 1, class: 'form-control' %></td>
     <td>
-      <%= field.hidden_field :_destroy, as: :hidden %>
-      <%= remove_item_button "Remove", soft: true %>
+      <%= remove_item_button "Remove" %>
     </td>
   </tr>
 <% end %>

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe "Managing requests", type: :system, js: true do
             last_row.find('option', text: item[:name], exact_text: true).select_option
             last_row.find_all('.form-control').last.fill_in(with: item[:person_count])
           end
+
+          # delete an item
+          find_all('td').last.click
+
+          # BUG: Consider how to make this work. Currently
+          # partners/family_request_create_service validates that no blank values
+          # got passed in. This results in an error. partners/request_create_service filters
+          # all blank items passed in. What is correct behavior?
+          #
+          # Trigger another row but keep it empty. It should still be valid!
+          # click_link 'Add Another Item'
         end
 
         context 'THEN a request records will be created and the partner will be notified via flash message on the dashboard' do
@@ -62,9 +73,13 @@ RSpec.describe "Managing requests", type: :system, js: true do
             visit partners_request_path(id: Request.last.id)
 
             # Should have the proper quantity per each item.
+            deleted_item = item_details.pop
             item_details.each do |item|
               expect(page).to have_content("#{item[:quantity].to_i * item[:quantity_per_person]} of #{item[:name]}")
             end
+
+            # Should not have the last item: it was deleted.
+            expect(page).to_not have_content("#{deleted_item[:quantity].to_i * deleted_item[:quantity_per_person]} of #{deleted_item[:name]}")
           end
         end
       end
@@ -132,6 +147,9 @@ RSpec.describe "Managing requests", type: :system, js: true do
             last_row.find_all('.form-control').last.fill_in(with: item[:quantity])
           end
 
+          # delete an item
+          find_all('td').last.click
+
           # Trigger another row but keep it empty. It should still be valid!
           click_link 'Add Another Item'
         end
@@ -148,9 +166,13 @@ RSpec.describe "Managing requests", type: :system, js: true do
           it 'AND the partner_user can view the details of the created request in a seperate page' do
             visit partners_request_path(id: Request.last.id)
 
+            deleted_item = item_details.pop
             item_details.each do |item|
               expect(page).to have_content("#{item[:quantity]} of #{item[:name]}")
             end
+
+            # Should not have the last item: it was deleted.
+            expect(page).not_to have_content("#{deleted_item[:quantity]} of #{deleted_item[:name]}")
           end
         end
       end


### PR DESCRIPTION

### Description
Sign in as a partner. Click on "Create request" under "# of individuals. Click Remove => Button does not work
Sign in as a partner. Click on "Create request" under "Quantity". Add 2 Items. Remove 1. Submit => Request will have both

### Fix
When remove_item was not set to "soft" data-remove-item would get to nil which would not register that data attribute on the element, thus, the event listener would not work. Hidden elements also get submitted, thus, should not use soft. 

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Added systems tests.
