### PR TITLE
4077 Add the partner's pickup person to the distribution notification

### DIFF
--- a/app/mailers/distribution_mailer.rb
+++ b/app/mailers/distribution_mailer.rb
@@ -26,7 +26,13 @@ class DistributionMailer < ApplicationMailer
     @distribution_changes = distribution_changes
     pdf = DistributionPdf.new(current_organization, @distribution).compute_and_render
     attachments[format("%s %s.pdf", @partner.name, @distribution.created_at.strftime("%Y-%m-%d"))] = pdf
-    mail(to: requestee_email, cc: @partner.email, subject: "#{subject} from #{current_organization.name}")
+    cc = [@partner.email]
+    if distribution.pick_up?
+      pickup_person_email = @partner.profile&.pick_up_email
+      cc.push(pickup_person_email) if pickup_person_email.present? && pickup_person_email != @partner.email
+    end
+
+    mail(to: requestee_email, cc: cc, subject: "#{subject} from #{current_organization.name}")
   end
 
   def reminder_email(distribution_id)

--- a/app/mailers/distribution_mailer.rb
+++ b/app/mailers/distribution_mailer.rb
@@ -27,10 +27,9 @@ class DistributionMailer < ApplicationMailer
     pdf = DistributionPdf.new(current_organization, @distribution).compute_and_render
     attachments[format("%s %s.pdf", @partner.name, @distribution.created_at.strftime("%Y-%m-%d"))] = pdf
     cc = [@partner.email]
-    if distribution.pick_up?
-      pickup_person_email = @partner.profile&.pick_up_email
-      cc.push(pickup_person_email) if pickup_person_email.present? && pickup_person_email != @partner.email
-    end
+    cc.push(@partner.profile&.pick_up_email) if distribution.pick_up?
+    cc.compact!
+    cc.uniq!
 
     mail(to: requestee_email, cc: cc, subject: "#{subject} from #{current_organization.name}")
   end

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe DistributionMailer, type: :mailer do
 
       it "renders the body with 'picked up' specified" do
         expect(mail.body.encoded).to match("picked up")
-        expect(mail.cc.first).to match(@partner.email)
       end
 
       context 'when parners profile pick_up_email is present' do

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DistributionMailer, type: :mailer do
         context 'when pickup person happens to be the same as the primary contact' do
           let(:pick_up_email) { @partner.email }
 
-          it 'dones not send email twice' do
+          it 'does not send email twice' do
             expect(mail.cc.count).to eq(1)
             expect(mail.cc.first).to match(@partner.email)
           end

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe DistributionMailer, type: :mailer do
         distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :delivery)
         DistributionMailer.partner_mailer(@organization, distribution, 'test subject', distribution_changes)
       }
-      
+
       it "renders the body with 'delivered' specified" do
         expect(mail.body.encoded).to match("delivered")
       end


### PR DESCRIPTION
Resolves #4077  <!--fill issue number-->

### Description
Add the partner's pickup person to the distribution notification email (if the distribution is pickup).
Note: From the stakeholder meeting 20221207. We have a pickup person email, but they aren't notified
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
tested with rspec by matching parameters of outgoing email
