### PR TITLE
Refactor request item javascript

### DIFF
--- a/app/helpers/partners/multi_item_form_helper.rb
+++ b/app/helpers/partners/multi_item_form_helper.rb
@@ -1,20 +1,19 @@
 module Partners
   module MultiItemFormHelper
     def remove_item_button(label, soft: false)
-      link_to label, 'javascript:void(0)', class: 'btn btn-warning', data: { remove_item: soft ? "soft" : "hard" }
+      link_to label, 'javascript:void(0)', class: 'btn btn-warning',
+        data: { action: 'click->request-item#removeItem:prevent', remove_soft: soft ? true : false}
     end
 
     def add_item_button(label, container: ".fields", &block)
       content_tag :div do
-        concat(link_to(
-          label,
-          "javascript:void(0)",
-          class: "btn btn-outline-primary",
-          data: {
-            request_item_target: 'addButton', action: "click->request-item#addItem:prevent",
-            add_target: container
-          }
-        ))
+        concat(
+          link_to(label, "javascript:void(0)", class: "btn btn-outline-primary",
+            data: {
+              request_item_target: 'addButton', add_target: container,
+              action: "click->request-item#addItem:prevent"
+            })
+        )
         concat(
           content_tag(:template, capture(&block), data: { request_item_target: 'addTemplate' })
         )

--- a/app/helpers/partners/multi_item_form_helper.rb
+++ b/app/helpers/partners/multi_item_form_helper.rb
@@ -5,11 +5,20 @@ module Partners
     end
 
     def add_item_button(label, container: ".fields", &block)
-      link_to(
-        label, "javascript:void(0)",
-        class: "btn btn-outline-primary",
-        data: { add_target: container, add_template: capture(&block) }
-      )
+      content_tag :div do
+        concat(link_to(
+          label,
+          "javascript:void(0)",
+          class: "btn btn-outline-primary",
+          data: {
+            request_item_target: 'addButton', action: "click->request-item#addItem:prevent",
+            add_target: container
+          }
+        ))
+        concat(
+          content_tag(:template, capture(&block), data: { request_item_target: 'addTemplate' })
+        )
+      end
     end
   end
 end

--- a/app/javascript/controllers/request_item_controller.js
+++ b/app/javascript/controllers/request_item_controller.js
@@ -5,28 +5,36 @@ export default class extends Controller {
   static targets = ["addButton", "addDest", "addTemplate"];
 
   addItem() {
-    const template =
-      this.addTemplateTarget.content.cloneNode(true).firstElementChild;
+    const template = this.addTemplateTarget.content.firstElementChild.innerHTML;
 
-    const templateId = new Date().getTime();
-    const rendered = template.innerHTML.replace(
-      /([\[_])([0-9]+)([\]_])/g,
-      "$1" + templateId + "$3",
-    );
+    const uniqId = new Date().getTime();
+    const rendered = this.setUniqIds(template, uniqId);
 
     this.addDestTarget.insertAdjacentHTML("beforeend", rendered);
   }
 
   removeItem(event) {
+    console.log(event.target);
     const wrapper = event.target.closest("tr");
     const removeSoft = event.target.dataset.removeSoft === "false";
 
     if (removeSoft) {
       wrapper.remove();
     } else {
-      const input = wrapper.querySelector("input[name*='_destroy']");
-      input && (input.value = 1);
+      const destroyField = wrapper.querySelector("input[name*='_destroy']");
+      if (destroyField) destroyField.value = 1;
       wrapper.style.display = "none";
     }
+  }
+
+  // This regex replaces [number] with [templateId]
+  // or _number_ with _templateId_
+  // Ex: name="request[items_attributes][0][name]" => name="request[items_attributes][897123413][name]"
+  // Ex: id="request_items_attributes_0_name" => id="request_items_attributes_9871239487_name"
+  setUniqIds(template, templateId) {
+    return template.replace(
+      /([\[_])([0-9]+)([\]_])/g,
+      "$1" + templateId + "$3",
+    );
   }
 }

--- a/app/javascript/controllers/request_item_controller.js
+++ b/app/javascript/controllers/request_item_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="request-item"
+export default class extends Controller {
+  static targets = ["addButton", "addDest", "addTemplate"];
+
+  addItem() {
+    const template =
+      this.addTemplateTarget.content.cloneNode(true).firstElementChild;
+
+    const templateId = new Date().getTime();
+    const rendered = template.innerHTML.replace(
+      /([\[_])([0-9]+)([\]_])/g,
+      "$1" + templateId + "$3",
+    );
+
+    this.addDestTarget.insertAdjacentHTML("beforeend", rendered);
+  }
+
+  removeItem(event) {
+    const wrapper = event.target.closest("tr");
+    const removeSoft = event.target.dataset.removeSoft === "false";
+
+    if (removeSoft) {
+      wrapper.remove();
+    } else {
+      const input = wrapper.querySelector("input[name*='_destroy']");
+      input && (input.value = 1);
+      wrapper.style.display = "none";
+    }
+  }
+}

--- a/app/views/partners/individuals_requests/new.html.erb
+++ b/app/views/partners/individuals_requests/new.html.erb
@@ -30,7 +30,8 @@
               <%= render partial: 'partners/requests/error' %>
             <% end %>
 
-            <%= simple_form_for @request, url: partners_individuals_requests_path, html: {role: 'form', class: 'form-horizontal'} do |form| %>
+            <%= simple_form_for @request, url: partners_individuals_requests_path, html: {role: 'form', class: 'form-horizontal'},
+              data: {controller: 'request-item'} do |form| %>
 
               <%= form.input :comments, label: "Comments:", as: :text, class: "form-control", wrapper: :input_group %>
 
@@ -43,7 +44,7 @@
                   </tr>
                 </thead>
 
-                <tbody class='fields'>
+                <tbody class='fields' data-request-item-target="addDest">
                   <%= render 'partners/individuals_requests/item_request', form: form %>
                 </tbody>
               </table>
@@ -67,31 +68,3 @@
     </div>
   </div>
 </section>
-
-<script type="module">
-  $(document).ready(function() {
-    $(document).on('click', '[data-add-target][data-add-template]', (event) => {
-      var button = $(event.target)
-      var target = button.data('add-target');
-      var template = button.data("add-template");
-      var templateId = new Date().getTime();
-      var rendered = template.replace(/([\[_])([0-9]+)([\]_])/g, "$1" + templateId + '$3');
-
-      $(target).append(rendered);
-
-      event.preventDefault();
-    });
-
-    $(document).on('click', '[data-remove-item]', (event) => {
-      var button = $(event.target)
-      var wrapper = button.closest('tr')
-      if (button.data("remove-item") === "soft") {
-        wrapper.hide();
-        button.prev('input[type=hidden]').val('1');
-      } else {
-        wrapper.remove()
-      }
-      event.preventDefault();
-    });
-  })
-</script>

--- a/app/views/partners/requests/new.html.erb
+++ b/app/views/partners/requests/new.html.erb
@@ -31,7 +31,7 @@
             <% end %>
 
             <%= simple_form_for @partner_request, url: partners_requests_path(@partner_request, :organization_id => current_partner.organization.id),
-                                html: {role: 'form', class: 'form-horizontal'}, method: :post do |form| %>
+              html: {role: 'form', class: 'form-horizontal'}, method: :post, data: { controller: 'request-item' } do |form| %>
               <%= form.input :comments, label: "Comments:", as: :text, class: "form-control", wrapper: :input_group %>
 
               <table class='table'>
@@ -42,7 +42,7 @@
                   <th></th>
                 </tr>
                 </thead>
-                <tbody class='fields'>
+                <tbody class='fields' data-request-item-target="addDest">
                   <%= render 'item_request', form: form %>
                 </tbody>
               </table>
@@ -65,31 +65,3 @@
     </div>
   </div>
 </section>
-
-<script type="module">
-  $(document).ready(function() {
-    $(document).on('click', '[data-add-target][data-add-template]', (event) => {
-      var button = $(event.target)
-      var target = button.data('add-target');
-      var template = button.data("add-template");
-      var templateId = new Date().getTime();
-      var rendered = template.replace(/([\[_])([0-9]+)([\]_])/g, "$1" + templateId + '$3');
-
-      $(target).append(rendered);
-
-      event.preventDefault();
-    });
-
-    $(document).on('click', '[data-remove-item]', (event) => {
-      var button = $(event.target)
-      var wrapper = button.closest('tr')
-      if (button.data("remove-item") === "soft") {
-        wrapper.hide();
-        button.prev('input[type=hidden]').val('1');
-      } else {
-        wrapper.remove()
-      }
-      event.preventDefault();
-    });
-  })
-</script>


### PR DESCRIPTION
This refactors the Javascript for request buttons out of ERB templates and into a stimulus controller. Changes the button helper to pass the template block as an HTML `template` instead of a data attribute.

### Type of change
* Refactor

### How Has This Been Tested?
No new tests. Pass all old tests.
