### PR TITLE
Modify PartnerInviteService to use Partner name as name to use for invite

### DIFF
--- a/app/services/partner_invite_service.rb
+++ b/app/services/partner_invite_service.rb
@@ -14,6 +14,7 @@ class PartnerInviteService
 
     partner.update!(status: 'invited')
     UserInviteService.invite(email: partner.email,
+      name: partner.name,
       roles: [Role::PARTNER],
       resource: partner,
       force: @force)

--- a/spec/services/partner_invite_service_spec.rb
+++ b/spec/services/partner_invite_service_spec.rb
@@ -24,6 +24,7 @@ describe PartnerInviteService do
     subject
     expect(UserInviteService).to have_received(:invite).with(
       email: partner.email,
+      name: partner.name,
       roles: [Role::PARTNER],
       resource: partner,
       force: false
@@ -37,6 +38,7 @@ describe PartnerInviteService do
       subject
       expect(UserInviteService).to have_received(:invite).with(
         email: partner.email,
+        name: partner.name,
         roles: [Role::PARTNER],
         resource: partner,
         force: true


### PR DESCRIPTION
Resolves #4036.

### Description

This PR uses the Partner name given in the new partner form as the User's name during the partner invite process.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Modified `spec/services/partner_invite_service_spec.rb`.

### Screenshots

<img width="1853" alt="Screenshot" src="https://github.com/rubyforgood/human-essentials/assets/85654561/c416832a-c70c-4240-a9a5-deb4101d491b">


