### PR TITLE
3729 wider spread of dates in the seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -328,12 +328,18 @@ note = [
     end
   end
 
+  dates_generator = DispersedPastDatesGenerator.new
+
   Faker::Number.within(range: 32..56).times do
+    date = dates_generator.next
+
     partner_request = ::Request.new(
       partner_id: p.id,
       organization_id: p.organization_id,
       comments: Faker::Lorem.paragraph,
-      partner_user_id: p.primary_user.id
+      partner_user_id: p.primary_user.id,
+      created_at: date,
+      updated_at: date
     )
 
     item_requests = []
@@ -344,7 +350,9 @@ note = [
         quantity: Faker::Number.within(range: 10..30),
         children: [],
         name: item.name,
-        partner_key: item.partner_key
+        partner_key: item.partner_key,
+        created_at: date,
+        updated_at: date
       )
       partner_request.item_requests << new_item_request
     end
@@ -654,14 +662,12 @@ Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "new_logo")
 # ----------------------------------------------------------------------------
 # Add some Account Requests to fill up the account requests admin page
 
-dates_generator = DispersedPastDatesGenerator.new
-
 [{ organization_name: "Telluride Diaper Bank",    website: "TDB.com", confirmed_at: nil },
  { organization_name: "Ouray Diaper Bank",        website: "ODB.com",   confirmed_at: nil },
  { organization_name: "Canon City Diaper Bank",   website: "CCDB.com",  confirmed_at: nil },
- { organization_name: "Golden Diaper Bank",       website: "GDB.com",   confirmed_at: dates_generator.next },
- { organization_name: "Westminster Diaper Bank",  website: "WDB.com",   confirmed_at: dates_generator.next },
- { organization_name: "Lakewood Diaper Bank",     website: "LDB.com",   confirmed_at: dates_generator.next }].each do |account_request|
+ { organization_name: "Golden Diaper Bank",       website: "GDB.com",   confirmed_at: (Time.zone.today - rand(15).days) },
+ { organization_name: "Westminster Diaper Bank",  website: "WDB.com",   confirmed_at: (Time.zone.today - rand(15).days) },
+ { organization_name: "Lakewood Diaper Bank",     website: "LDB.com",   confirmed_at: (Time.zone.today - rand(15).days) }].each do |account_request|
   AccountRequest.create(
     name: Faker::Name.unique.name,
     email: Faker::Internet.unique.email,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -501,7 +501,7 @@ end
 # Donations
 # ----------------------------------------------------------------------------
 
-dates_generator = DispersedPastDatesGenerator.new(20)
+dates_generator = DispersedPastDatesGenerator.new
 # Make some donations of all sorts
 20.times.each do
   source = Donation::SOURCES.values.sample
@@ -529,7 +529,7 @@ end
 # ----------------------------------------------------------------------------
 # Distributions
 # ----------------------------------------------------------------------------
-dates_generator = DispersedPastDatesGenerator.new(20)
+dates_generator = DispersedPastDatesGenerator.new
 
 inventory = InventoryAggregate.inventory_for(pdx_org.id)
 # Make some distributions, but don't use up all the inventory
@@ -623,7 +623,7 @@ comments = [
   "Nullam dictum ac lectus at scelerisque. Phasellus volutpat, sem at eleifend tristique, massa mi cursus dui, eget pharetra ligula arcu sit amet nunc."
 ]
 
-dates_generator = DispersedPastDatesGenerator.new(25)
+dates_generator = DispersedPastDatesGenerator.new
 
 25.times do
   purchase_date = dates_generator.next
@@ -654,7 +654,7 @@ Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "new_logo")
 # ----------------------------------------------------------------------------
 # Add some Account Requests to fill up the account requests admin page
 
-dates_generator = DispersedPastDatesGenerator.new(3)
+dates_generator = DispersedPastDatesGenerator.new
 
 [{ organization_name: "Telluride Diaper Bank",    website: "TDB.com", confirmed_at: nil },
  { organization_name: "Ouray Diaper Bank",        website: "ODB.com",   confirmed_at: nil },

--- a/lib/dispersed_past_dates_generator.rb
+++ b/lib/dispersed_past_dates_generator.rb
@@ -1,0 +1,25 @@
+class DispersedPastDatesGenerator
+  RANGES = [0..6, 7..31, 32..300, 350..700].freeze
+
+  def initialize(dates_quantity)
+    @dates_quantity = dates_quantity
+    @current_iteration = 0.0
+    @dates_per_range = (dates_quantity.to_f / RANGES.size).ceil
+  end
+
+  def next
+    range_index = (current_iteration / dates_per_range).to_i
+
+    if dates_quantity > current_iteration
+      @current_iteration += 1
+    else
+      0.0
+    end
+
+    Time.zone.today - rand(RANGES[range_index]).days
+  end
+
+  private
+
+  attr_reader :dates_quantity, :dates_per_range, :current_iteration
+end

--- a/lib/dispersed_past_dates_generator.rb
+++ b/lib/dispersed_past_dates_generator.rb
@@ -1,25 +1,18 @@
 class DispersedPastDatesGenerator
   DAYS_RANGES = [0..6, 7..30, 31..300, 350..700].freeze
 
-  def initialize(dates_quantity)
-    @dates_quantity = dates_quantity
-    @current_iteration = 0.0
-    @dates_per_range = (dates_quantity.to_f / DAYS_RANGES.size).ceil
+  def initialize
+    @current_index = 0
   end
 
   def next
-    range_index = (current_iteration / dates_per_range).to_i
-
-    if dates_quantity > current_iteration
-      @current_iteration += 1
+    day = Time.zone.today - rand(DAYS_RANGES[@current_index]).days
+    if DAYS_RANGES.size - 1 > @current_index
+      @current_index = @current_index.next
     else
-      0.0
+      @current_index = 0
     end
 
-    Time.zone.today - rand(DAYS_RANGES[range_index]).days
+    day
   end
-
-  private
-
-  attr_reader :dates_quantity, :dates_per_range, :current_iteration
 end

--- a/lib/dispersed_past_dates_generator.rb
+++ b/lib/dispersed_past_dates_generator.rb
@@ -1,10 +1,10 @@
 class DispersedPastDatesGenerator
-  RANGES = [0..6, 7..31, 32..300, 350..700].freeze
+  DAYS_RANGES = [0..6, 7..30, 31..300, 350..700].freeze
 
   def initialize(dates_quantity)
     @dates_quantity = dates_quantity
     @current_iteration = 0.0
-    @dates_per_range = (dates_quantity.to_f / RANGES.size).ceil
+    @dates_per_range = (dates_quantity.to_f / DAYS_RANGES.size).ceil
   end
 
   def next
@@ -16,7 +16,7 @@ class DispersedPastDatesGenerator
       0.0
     end
 
-    Time.zone.today - rand(RANGES[range_index]).days
+    Time.zone.today - rand(DAYS_RANGES[range_index]).days
   end
 
   private

--- a/lib/dispersed_past_dates_generator.rb
+++ b/lib/dispersed_past_dates_generator.rb
@@ -7,10 +7,10 @@ class DispersedPastDatesGenerator
 
   def next
     day = Time.zone.today - rand(DAYS_RANGES[@current_index]).days
-    if DAYS_RANGES.size - 1 > @current_index
-      @current_index = @current_index.next
+    @current_index = if DAYS_RANGES.size - 1 > @current_index
+      @current_index.next
     else
-      @current_index = 0
+      0
     end
 
     day

--- a/spec/lib/dispersed_past_dates_generator_spec.rb
+++ b/spec/lib/dispersed_past_dates_generator_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe DispersedPastDatesGenerator do
 
     it "returns equally dispersed dates between all time ranges" do
       expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
-      expect(dates_generator.next).to be_between(Time.zone.today - 31.days, Time.zone.today - 7.days)
-      expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 32.days)
+      expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
+      expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
       expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
     end
 
@@ -24,10 +24,10 @@ RSpec.describe DispersedPastDatesGenerator do
       it "fits few dates in one time period" do
         expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
         expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
-        expect(dates_generator.next).to be_between(Time.zone.today - 31.days, Time.zone.today - 7.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 31.days, Time.zone.today - 7.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 32.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 32.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
         expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
         expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
       end
@@ -36,8 +36,8 @@ RSpec.describe DispersedPastDatesGenerator do
     context "when #next is called more times than declared number of dates" do
       it "starts cycle from beginning" do
         expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
-        expect(dates_generator.next).to be_between(Time.zone.today - 31.days, Time.zone.today - 7.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 32.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
         expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
         expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
       end

--- a/spec/lib/dispersed_past_dates_generator_spec.rb
+++ b/spec/lib/dispersed_past_dates_generator_spec.rb
@@ -1,0 +1,44 @@
+load "lib/dispersed_past_dates_generator.rb"
+
+RSpec.describe DispersedPastDatesGenerator do
+  describe "constants" do
+    it { expect(described_class::RANGES).to eq([0..6, 7..31, 32..300, 350..700]) }
+  end
+
+  describe "#next" do
+    let(:number_of_dates_to_disperse) { 4 }
+    let(:dates_generator) { described_class.new(number_of_dates_to_disperse) }
+
+    it "returns equally dispersed dates between all time ranges" do
+      expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
+      expect(dates_generator.next).to be_between(Time.zone.today - 31.days, Time.zone.today - 7.days)
+      expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 32.days)
+      expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
+    end
+
+    context "when number of dates is higher than number time ranges" do
+      let(:number_of_dates_to_disperse) { 8 }
+
+      it "fits few dates in one time period" do
+        expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
+        expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
+        expect(dates_generator.next).to be_between(Time.zone.today - 31.days, Time.zone.today - 7.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 31.days, Time.zone.today - 7.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 32.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 32.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
+      end
+    end
+
+    context "when #next is called more times than declared number of dates" do
+      it "starts cycle from beginning" do
+        expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
+        expect(dates_generator.next).to be_between(Time.zone.today - 31.days, Time.zone.today - 7.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 32.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
+        expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
+      end
+    end
+  end
+end

--- a/spec/lib/dispersed_past_dates_generator_spec.rb
+++ b/spec/lib/dispersed_past_dates_generator_spec.rb
@@ -8,39 +8,17 @@ RSpec.describe DispersedPastDatesGenerator do
   end
 
   describe "#next" do
-    let(:number_of_dates_to_disperse) { 4 }
-    let(:dates_generator) { described_class.new(number_of_dates_to_disperse) }
+    let(:dates_generator) { described_class.new }
 
     it "returns equally dispersed dates between all time ranges" do
       expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
       expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
       expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
       expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
-    end
-
-    context "when number of dates is higher than number time ranges" do
-      let(:number_of_dates_to_disperse) { 8 }
-
-      it "fits few dates in one time period" do
-        expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
-        expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
-        expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
-      end
-    end
-
-    context "when #next is called more times than declared number of dates" do
-      it "starts cycle from beginning" do
-        expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
-        expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
-        expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
-      end
+      expect(dates_generator.next).to be_between(Time.zone.today - 6.days, Time.zone.today)
+      expect(dates_generator.next).to be_between(Time.zone.today - 30.days, Time.zone.today - 7.days)
+      expect(dates_generator.next).to be_between(Time.zone.today - 300.days, Time.zone.today - 31.days)
+      expect(dates_generator.next).to be_between(Time.zone.today - 700.days, Time.zone.today - 350.days)
     end
   end
 end

--- a/spec/lib/dispersed_past_dates_generator_spec.rb
+++ b/spec/lib/dispersed_past_dates_generator_spec.rb
@@ -2,7 +2,9 @@ load "lib/dispersed_past_dates_generator.rb"
 
 RSpec.describe DispersedPastDatesGenerator do
   describe "constants" do
-    it { expect(described_class::RANGES).to eq([0..6, 7..31, 32..300, 350..700]) }
+    it "has 4 day ranges for generation of past dates" do
+      expect(described_class::DAYS_RANGES).to eq([0..6, 7..30, 31..300, 350..700])
+    end
   end
 
   describe "#next" do

--- a/spec/services/distribution_itemized_breakdown_service_spec.rb
+++ b/spec/services/distribution_itemized_breakdown_service_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe DistributionItemizedBreakdownService, type: :service do
   let(:organization) { create(:organization) }
   let(:distribution_ids) { [distribution_1, distribution_2, distribution_3].map(&:id) }
   let(:item_a) do
-    create(:item, organization: organization, on_hand_minimum_quantity: 9999)
+    create(:item, organization: organization, on_hand_minimum_quantity: 9999, name: "A Diapers")
   end
   let(:item_b) do
-    create(:item, organization: organization, on_hand_minimum_quantity: 5)
+    create(:item, organization: organization, on_hand_minimum_quantity: 5, name: "B Diapers")
   end
   let(:distribution_1) { create(:distribution, :with_items, item: item_a, item_quantity: 500, organization: organization) }
   let(:distribution_2) { create(:distribution, :with_items, item: item_b, item_quantity: 100, organization: organization) }


### PR DESCRIPTION
Resolves #3729

### Description
Wider spread of dates on requests, distributions, purchases, donations in the seed, including some more than 1 week ago.

An initial suggestion to use date ranges from the past (days ago):
 - 0 - 6
 - 7 - 30
 - 31 - 300
 - 350 - 700

Generated dates will look like:
```
"donations"."issued_at"
Sat, 10 Feb 2024
Tue, 13 Feb 2024
Sun, 11 Feb 2024
Fri, 09 Feb 2024
Wed, 14 Feb 2024
Mon, 15 Jan 2024
Sat, 27 Jan 2024
Wed, 31 Jan 2024
Mon, 15 Jan 2024
Sat, 27 Jan 2024
Tue, 14 Nov 2023
Fri, 13 Oct 2023
Fri, 19 May 2023
Mon, 19 Jun 2023
Fri, 09 Jun 2023
Wed, 02 Nov 2022
Fri, 12 Aug 2022
Thu, 24 Nov 2022
Sun, 22 May 2022
Tue, 26 Apr 2022

"purchases"."issued_at"
Wed, 14 Feb 2024
Mon, 12 Feb 2024
Mon, 12 Feb 2024
Fri, 09 Feb 2024
Mon, 12 Feb 2024
Tue, 13 Feb 2024
Wed, 14 Feb 2024
Tue, 23 Jan 2024
Tue, 23 Jan 2024
Mon, 22 Jan 2024
Sat, 27 Jan 2024
Mon, 05 Feb 2024
Fri, 02 Feb 2024
Tue, 06 Feb 2024
Fri, 17 Nov 2023
Fri, 28 Jul 2023
Fri, 04 Aug 2023
Sat, 03 Jun 2023
Tue, 03 Oct 2023
Sun, 06 Aug 2023
Fri, 20 Oct 2023
Wed, 14 Sep 2022
Mon, 31 Oct 2022
Sat, 23 Apr 2022
Sat, 16 Jul 2022

"distributions"."issued_at"
Thu, 15 Feb 2024
Tue, 13 Feb 2024
Thu, 15 Feb 2024
Fri, 02 Feb 2024
Tue, 30 Jan 2024
Mon, 05 Feb 2024
Mon, 18 Jul 2022

"account_requests"."confirmed_at"
nil, 
nil, 
nil, 
Wed, 14 Feb 2024
Wed, 07 Feb 2024
Mon, 17 Jul 2023
```

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- all automated tests should pass
- truncate database (`rails db:truncate_all`)
- call `rails db:seed`
- make sure all required tables are populated

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
