### PR TITLE
Fix flaky tests

### DIFF
--- a/app/javascript/controllers/turbo_controller.js
+++ b/app/javascript/controllers/turbo_controller.js
@@ -7,16 +7,14 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
 
   connect() {
-    
+
     /**
-     * Scrolls to the top after turbo:submit-end event if the 
+     * Scrolls to the top after turbo:submit-end event if the
      * request was unsuccessful with status code of 4xx or 5xx.
      */
     document.addEventListener("turbo:submit-end", (event) => {
-      let status = event.detail.fetchResponse.response.status
-
-      if (status >= 400) {
-        scrollTo(0, 0)
+      if (!event.detail.success) {
+        scrollTo(0, 0);
       }
     })
   }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -275,3 +275,11 @@ end
 def text_body(mail)
   mail.body.parts.find { |p| p.content_type =~ /text/ }.body.encoded
 end
+
+def select2(node, select_name, value, position: nil)
+  position_str = position ? "[#{position}]" : ""
+  xpath = %((//div[contains(@class, "#{select_name}")]//span[contains(@class, "select2-container")])#{position_str})
+  container = node.find(:xpath, xpath)
+  container.click
+  container.find(:xpath, '//li[contains(@class, "select2-results__option")][@role="option"]', text: value).click
+end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Distributions", type: :system do
         visit @url_prefix + "/distributions/new"
         select @partner.name, from: "Partner"
         select @storage_location.name, from: "From storage location"
-        select item.name, from: "distribution_line_items_attributes_0_item_id"
+        select2(page, 'distribution_line_items_item_id', item.name, position: 1)
         select @storage_location.name, from: "distribution_storage_location_id"
         fill_in "distribution_line_items_attributes_0_quantity", with: 18
 
@@ -426,14 +426,12 @@ RSpec.feature "Distributions", type: :system do
 
       it "User creates duplicate line items" do
         item = @distribution.line_items.first.item
-        first_field = page.find_all('select', class: 'line_item_name').first
-        first_field.find("option[value='#{item.id}']").select_option
+        select2(page, 'distribution_line_items_item_id', item.name, position: 1)
         find_all(".numeric")[0].set 1
 
         click_on "Add another item"
 
-        last_field = page.find_all('.line_item_name').last
-        last_field.find("option[value='#{item.id}']").select_option
+        select2(page, 'distribution_line_items_item_id', item.name, position: 2)
         find_all(".numeric")[1].set 3
 
         first("button", text: "Save").click


### PR DESCRIPTION
The main reason for the flaky tests seems to have been our use of select2. During initialization, select2 creates options and appends them to the select div. However, there is a point where the option exists but isn't appended. This causes Cuprite not to be able to select it because it has no parent node.

I added a `select2` helper which should ease us in selecting these in the future. We can make use of it for any other flaky tests that crop up.

I also fixed an issue with the `turbo_controller` where it would crash on error because it's trying to access a property of something that doesn't exist.