### PR TITLE
fix: remove bugsnag api key message

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,3 +1,7 @@
-Bugsnag.configure do |config|
-  config.api_key = ENV["BUGSNAG_API_KEY"]
+if ENV["BUGSNAG_API_KEY"].present?
+  Bugsnag.configure do |config|
+    config.api_key = ENV["BUGSNAG_API_KEY"]
+  end
+else
+  Bugsnag.configuration.logger = ::Logger.new("/dev/null")
 end


### PR DESCRIPTION
Without an API key bugsnag displays the following warning: 
```sh
Not delivering sessions due to an invalid api_key
```

It is something that new people often get worried about and is very annoying when using irb for debugging. This PR sends that warning to `dev/null` if an API key is not provided.

Solution take from [here](https://github.com/chaskiq/chaskiq/issues/251#issuecomment-1813804184)




### Type of change

* Bug fix (non-breaking change which fixes an issue)
