### PR TITLE
4134 fix inconsistent request behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -751,4 +751,4 @@ DEPENDENCIES
   webmock (~> 3.23)
 
 BUNDLED WITH
-   2.5.4
+   2.5.6

--- a/app/services/partners/family_request_create_service.rb
+++ b/app/services/partners/family_request_create_service.rb
@@ -54,7 +54,8 @@ module Partners
     end
 
     def item_requests_attributes
-      @item_requests_attributes ||= family_requests_attributes.map do |fr_attr|
+      @item_requests_attributes ||= family_requests_attributes.filter_map do |fr_attr|
+        next if fr_attr[:item_id].blank? && fr_attr[:person_count].blank?
         {
           item_id: fr_attr[:item_id],
           quantity: convert_person_count_to_item_quantity(item_id: fr_attr[:item_id], person_count: fr_attr[:person_count])&.to_i,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -840,8 +840,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_202431) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type"
-    t.string "{:null=>false}"
+    t.string "item_type", null: false
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -233,8 +233,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_202431) do
     t.integer "organization_id"
     t.datetime "issued_at", precision: nil
     t.string "agency_rep"
-    t.integer "state", default: 5, null: false
     t.boolean "reminder_email_enabled", default: false, null: false
+    t.integer "state", default: 5, null: false
     t.integer "delivery_method", default: 0, null: false
     t.decimal "shipping_cost", precision: 8, scale: 2
     t.index ["organization_id"], name: "index_distributions_on_organization_id"
@@ -840,7 +840,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_202431) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Managing requests", type: :system, js: true do
             expect(page.all('select[name="partners_family_request[items_attributes][0][item_id]"] option').map(&:text)).to eq(expected_items)
           end
 
-          context 'WHEN they create a request inproperly' do
+          context 'WHEN they create a request improperly' do
             before {
               click_button 'Submit Essentials Request'
               click_link 'Add Another Item'
@@ -35,7 +35,7 @@ RSpec.describe "Managing requests", type: :system, js: true do
         visit new_partners_individuals_request_path
       end
 
-      context 'WHEN they create a request inproperly by not inputting anything' do
+      context 'WHEN they create a request improperly by not inputting anything' do
         before do
           click_button 'Submit Essentials Request'
         end
@@ -173,7 +173,7 @@ RSpec.describe "Managing requests", type: :system, js: true do
             expect(page.all('select[name="request[item_requests_attributes][0][item_id]"] option').map(&:text)).to eq(expected_items)
           end
 
-          context 'WHEN they create a request inproperly' do
+          context 'WHEN they create a request improperly' do
             before {
               click_button 'Submit Essentials Request'
               click_link 'Add Another Item'

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -35,7 +35,57 @@ RSpec.describe "Managing requests", type: :system, js: true do
         visit new_partners_individuals_request_path
       end
 
-      context 'WHEN they create a request inproperly' do
+      context 'WHEN they create a request inproperly by not inputting anything' do
+        before do
+          click_button 'Submit Essentials Request'
+        end
+
+        it 'should show an error message with the instructions ' do
+          expect(page).to have_content('Oops! Something went wrong with your Request')
+          expect(page).to have_content('Ensure each line item has a item selected AND a quantity greater than 0.')
+          expect(page).to have_content('Still need help? Submit a support ticket here and we will do our best to follow up with you via email.')
+        end
+      end
+
+      context 'WHEN they create a request with only a comment' do
+        before do
+          fill_in 'Comments', with: Faker::Lorem.paragraph
+        end
+
+        it 'should be created without any issue' do
+          expect { click_button 'Submit Essentials Request' }.to change { Request.count }.by(1)
+
+          expect(current_path).to eq(partners_request_path(Request.last.id))
+          expect(page).to have_content('Request has been successfully created!')
+          expect(page).to have_content("#{partner.organization.name} should have received the request.")
+        end
+      end
+
+      context 'WHEN they create a request with blank lines' do
+        before do
+          fill_in 'Comments', with: Faker::Lorem.paragraph
+
+          # fill in an item
+          click_link 'Add Another Item'
+          item = partner_user.partner.organization.valid_items.sample
+          last_row = find_all('tr').last
+          last_row.find('option', text: item[:name], exact_text: true).select_option
+          last_row.find_all('.form-control').last.fill_in(with: 1)
+
+          # Trigger another row but keep it empty. It should still be valid!
+          click_link 'Add Another Item'
+        end
+
+        it 'should be created without any issue' do
+          expect { click_button 'Submit Essentials Request' }.to change { Request.count }.by(1)
+
+          expect(current_path).to eq(partners_request_path(Request.last.id))
+          expect(page).to have_content('Request has been successfully created!')
+          expect(page).to have_content("#{partner.organization.name} should have received the request.")
+        end
+      end
+
+      context 'WHEN they create a request completely empty request' do
         before do
           click_button 'Submit Essentials Request'
         end
@@ -142,7 +192,7 @@ RSpec.describe "Managing requests", type: :system, js: true do
         visit new_partners_request_path
       end
 
-      context 'WHEN they create a request inproperly by not inputting anything' do
+      context 'WHEN they create a request completely empty request' do
         before do
           click_button 'Submit Essentials Request'
         end
@@ -157,6 +207,30 @@ RSpec.describe "Managing requests", type: :system, js: true do
       context 'WHEN they create a request with only a comment' do
         before do
           fill_in 'Comments', with: Faker::Lorem.paragraph
+        end
+
+        it 'should be created without any issue' do
+          expect { click_button 'Submit Essentials Request' }.to change { Request.count }.by(1)
+
+          expect(current_path).to eq(partners_request_path(Request.last.id))
+          expect(page).to have_content('Request has been successfully created!')
+          expect(page).to have_content("#{partner.organization.name} should have received the request.")
+        end
+      end
+
+      context 'WHEN they create a request with blank lines' do
+        before do
+          fill_in 'Comments', with: Faker::Lorem.paragraph
+
+          # fill in an item
+          click_link 'Add Another Item'
+          item = partner_user.partner.organization.valid_items.sample
+          last_row = find_all('tr').last
+          last_row.find('option', text: item[:name], exact_text: true).select_option
+          last_row.find_all('.form-control').last.fill_in(with: 1)
+
+          # Trigger another row but keep it empty. It should still be valid!
+          click_link 'Add Another Item'
         end
 
         it 'should be created without any issue' do


### PR DESCRIPTION
Resolves #4134 

### Description
Individual requests and Quantity requests are very similar but have small differences in behavior:

Quantity:
| Comment | Item | Number | Result |
| --- | --- | --- | --- |
| Valid | Valid | Valid | Valid |
| Valid | Blank | Blank | Valid |
| Valid | 1 row Blank  | 1 row Blank | Valid (removes blank row) |
| Valid | Blank | Valid | Invalid |
| Valid | Valid | Blank | Invalid |

Individual: 
| Comment | Item | Number | Result |
| --- | --- | --- | --- |
| Valid | Valid | Valid | Valid |
| Valid | Blank | Blank | Invalid |
| Valid | 1 row Blank  | 1 row Blank | Invalid |
| Valid | Blank | Valid | Invalid |
| Valid | Valid | Blank | Invalid |


This PR makes Individual requests behave like quantity requests: 

Target => Both act like:
| Comment | Item | Number | Result |
| --- | --- | --- | --- |
| Valid | Valid | Valid | Valid |
| Valid | Blank | Blank | Valid |
| Valid | 1 row Blank  | 1 row Blank | Valid (removes blank row) |
| Valid | Blank | Valid | Invalid |
| Valid | Valid | Blank | Invalid |

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
System Tests
