### PR TITLE
Product drives name filter - to list names in alphabetical order

### DIFF
--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -11,7 +11,7 @@ class ProductDrivesController < ApplicationController
                      .within_date_range(@selected_date_range)
                      .order(start_date: :desc)
     # to be used in the name filter to sort product drives in alpha order
-    @product_drives_name_filter =  @product_drives.sort_by { |pd| pd.name.downcase}
+    @product_drives_name_filter = @product_drives.sort_by { |pd| pd.name.downcase }
     @item_categories = current_organization.item_categories
     @selected_name_filter = filter_params[:by_name]
     @selected_item_category = filter_params[:by_item_category_id]

--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -10,6 +10,8 @@ class ProductDrivesController < ApplicationController
                      .class_filter(filter_params)
                      .within_date_range(@selected_date_range)
                      .order(start_date: :desc)
+    # to be used in the name filter to sort product drives in alpha order
+    @product_drives_name_filter =  @product_drives.sort_by { |pd| pd.name.downcase}
     @item_categories = current_organization.item_categories
     @selected_name_filter = filter_params[:by_name]
     @selected_item_category = filter_params[:by_item_category_id]

--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -11,7 +11,7 @@ class ProductDrivesController < ApplicationController
                      .within_date_range(@selected_date_range)
                      .order(start_date: :desc)
     # to be used in the name filter to sort product drives in alpha order
-    @product_drives_name_filter = @product_drives.sort_by { |pd| pd.name.downcase }
+    @product_drives_alphabetical = @product_drives.sort_by { |pd| pd.name.downcase }
     @item_categories = current_organization.item_categories
     @selected_name_filter = filter_params[:by_name]
     @selected_item_category = filter_params[:by_item_category_id]

--- a/app/views/product_drives/index.html.erb
+++ b/app/views/product_drives/index.html.erb
@@ -38,7 +38,7 @@
             <%= form_tag(product_drives_path, method: :get, organization_id: current_organization) do |f| %>
               <div class="row">
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_name, collection: @product_drives_name_filter, key: :name, value: :name, selected: @selected_name_filter) %>
+                  <%= filter_select(scope: :by_name, collection: @product_drives_alphabetical, key: :name, value: :name, selected: @selected_name_filter) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= filter_select(label: "Filter by item category", scope: :by_item_category_id, collection: @item_categories, selected: @selected_item_category) %>

--- a/app/views/product_drives/index.html.erb
+++ b/app/views/product_drives/index.html.erb
@@ -38,7 +38,7 @@
             <%= form_tag(product_drives_path, method: :get, organization_id: current_organization) do |f| %>
               <div class="row">
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_name, collection: @product_drives, key: :name, value: :name, selected: @selected_name_filter) %>
+                  <%= filter_select(scope: :by_name, collection: @product_drives_name_filter, key: :name, value: :name, selected: @selected_name_filter) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= filter_select(label: "Filter by item category", scope: :by_item_category_id, collection: @item_categories, selected: @selected_item_category) %>

--- a/spec/system/product_drive_system_spec.rb
+++ b/spec/system/product_drive_system_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe "Product Drives", type: :system, js: true do
     before(:each) do
       @product_drives = [
         create(:product_drive, name: "Test name 1", start_date: 3.weeks.ago, end_date: 2.weeks.ago, virtual: true),
-        create(:product_drive, name: "Test name 2", start_date: 2.weeks.ago, end_date: 1.week.ago, virtual: false)
+        create(:product_drive, name: "Test name 2", start_date: 2.weeks.ago, end_date: 1.week.ago, virtual: false),
+        create(:product_drive, name: "Alpha Test name 3", start_date: 1.week.from_now, end_date: 2.weeks.from_now, virtual: false)
       ]
       visit subject
     end
 
-    it "Shows the expected filters with the expected values" do
+    it "Shows the expected filters with the expected values and in alphabetical order for name filter" do
+      expect(page.find("select[name='filters[by_name]']").find(:xpath, 'option[2]').text).to eq "Alpha Test name 3"
       expect(page.has_select?('filters[by_name]', with_options: @product_drives.map(&:name))).to be true
       expect(page.has_field?('filters_date_range', with: this_year))
     end
@@ -35,16 +37,16 @@ RSpec.describe "Product Drives", type: :system, js: true do
       end
     end
 
-    it 'shows only one virtual product drive' do
+    it 'shows only one virtual product drives' do
       expect(page).to have_text(/Yes/, maximum: 1)
     end
 
-    it 'shows only one non-virtual product drive' do
-      expect(page).to have_text(/No/, maximum: 1)
+    it 'shows two non-virtual product drives' do
+      expect(page).to have_text(/No/, maximum: 2)
     end
 
     it 'shows in descending order of start date' do
-      expect("Test name 2").to appear_before("Test name 1")
+      expect("Alpha Test name 3").to appear_before("Test name 1")
     end
   end
 


### PR DESCRIPTION
Resolves #4119 

### Description
Name filter on Product drives list page should be in alphabetical order, this will be helpful for banks having a long list.

### Type of change

* New feature - minor enhancement (non-breaking change which adds functionality)

### How Has This Been Tested?

1. Go to All Product Drives.
2. Add product drives with different start date and end dates.
3. Filter by name should list Product Drive name alphabetically now.
4. However the list without filters should not be altered, they should be in reverse chronological order.

Browser tests have been modified to test this change.


### Screenshots

Before

![Screenshot 2024-02-29 at 11 41 57 PM](https://github.com/rubyforgood/human-essentials/assets/15196830/48536189-2c93-4df7-84ac-ef834651e332)

After

![Screenshot 2024-03-01 at 11 00 15 PM](https://github.com/rubyforgood/human-essentials/assets/15196830/67429474-7a99-4007-b3fd-59582fbf0aa4)


