### PR TITLE
Fix for copy calendar url button ui on pick ups and deliverables page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -151,6 +151,7 @@ body a {
 
 #copy-calendar-button {
   margin-left: 10px;
+  height: fit-content;
 }
 
 select.selectpicker + .dropdown-toggle::after {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -16,7 +16,8 @@
 
 #calendar {
     background-color: #ffffff;
-    width: 100%
+    width: 100%;
+    height: 80%
 }
 
 #csvImportModal .modal-dialog.onboarding_steps .modal-body li {


### PR DESCRIPTION
Resolves #4014 

### Description

Fixes the copy calendar url button ui on pick ups and deliverables page.

### Type of change

Non breaking UI change.

### How Has This Been Tested?

Go to Pick ups and deliverables page (distributions/schedule) the copy calendar url button should look normal.

### Screenshots

Before

![Screenshot 2024-03-01 at 11 23 40 PM](https://github.com/rubyforgood/human-essentials/assets/15196830/8ac76c1b-76b5-4ca5-bf2c-2bad2443df92)

After
![Screenshot 2024-03-01 at 11 18 39 PM](https://github.com/rubyforgood/human-essentials/assets/15196830/038b7f66-6bd8-4bcb-8461-dc23410f7129)
