### PR TITLE
Prevent flaky test by sorting report values [#4066]

### DIFF
--- a/app/services/reports/partner_info_report_service.rb
+++ b/app/services/reports/partner_info_report_service.rb
@@ -37,7 +37,7 @@ module Reports
     end
 
     def partner_zipcodes_serviced
-      partner_agency_profiles.map(&:zips_served).uniq.join(', ')
+      partner_agency_profiles.map(&:zips_served).uniq.sort.join(', ')
     end
   end
 end

--- a/spec/services/reports/partner_info_report_service_spec.rb
+++ b/spec/services/reports/partner_info_report_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Reports::PartnerInfoReportService, type: :service do
                                     entries: { "Agency Type: Career technical training" => 2,
                                                "Agency Type: Education program" => 1,
                                                "Number of Partner Agencies" => 3,
-                                               "Zip Codes Served" => "90210-1234, 12345, 09876-3564" },
+                                               "Zip Codes Served" => "09876-3564, 12345, 90210-1234" },
                                     name: "Partner Agencies and Service Area"
                                   })
     end


### PR DESCRIPTION
While reviewing #4072 I noticed this flaky test; I think sorting the zips in the report output will fix it.