### PR TITLE
Adds delivery address to distribution printout/receipt

### DIFF
--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -40,10 +40,28 @@ class DistributionPdf
     text @distribution.partner.profile.primary_contact_phone, align: :right
     move_down 10
 
-    text "Issued on:", style: :bold
-    font_size 12
-    text @distribution.distributed_at
-    font_size 10
+    if %w(shipped delivered).include? (@distribution.delivery_method)
+      move_up 10
+      text "Delivery address:", style: :bold
+      font_size 10
+      text @distribution.partner.profile.address1
+      text @distribution.partner.profile.address2
+      text @distribution.partner.profile.city
+      text @distribution.partner.profile.state
+      text @distribution.partner.profile.zip_code
+      move_up 40
+
+      text "Issued on:", style: :bold, align: :right
+      font_size 12
+      text @distribution.distributed_at, align: :right
+      font_size 10
+      move_down 30
+    else
+      text "Issued on:", style: :bold
+      font_size 12
+      text @distribution.distributed_at
+      font_size 10
+    end
 
     if @organization.ytd_on_distribution_printout
       move_up 22

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -40,7 +40,7 @@ class DistributionPdf
     text @distribution.partner.profile.primary_contact_phone, align: :right
     move_down 10
 
-    if %w(shipped delivered).include? (@distribution.delivery_method)
+    if %w(shipped delivered).include?(@distribution.delivery_method)
       move_up 10
       text "Delivery address:", style: :bold
       font_size 10

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -47,7 +47,7 @@
       <div class="col-md-12">
         <div class="card">
           <div class="bg-white card-header">
-            <h3 class="card-title"><strong>Program Address (if different)</strong></h3>
+            <h3 class="card-title"><strong>Program / Delivery Address (if different)</strong></h3>
           </div>
           <div class="card-body">
             <%= form.input :program_address1, label: "Address (line 1)", class: "form-control", wrapper: :input_group %>

--- a/app/views/partners/profiles/show/_agency_stability.html.erb
+++ b/app/views/partners/profiles/show/_agency_stability.html.erb
@@ -41,7 +41,7 @@
       <dd><%= humanize_boolean_3state(profile.currently_provide_diapers) %></dd>
 
       <address>
-        <strong>Program Address (if different)</strong> <br>
+        <strong>Program / Delivery Address (if different)</strong> <br>
         <%= profile.program_address1 %> <br>
         <% unless profile.program_address2.blank? %>
           <%= profile.program_address2 %> <br>

--- a/app/views/profiles/_show.html.erb
+++ b/app/views/profiles/_show.html.erb
@@ -51,7 +51,7 @@
       <p>Do You Receive Essentials from Other Sources? <%= partner_profile.receives_essentials_from_other %></p>
       <p>Currently Providing Diapers: <%= humanize_boolean_3state(partner_profile.currently_provide_diapers) %></p>
       <br>
-      <h3>Program Address (if different)</h3>
+      <h3>Program / Delivery Address (if different)</h3>
       <p>Program Address: <%= partner_profile.program_address1 %></p>
       <p>Program Address: <%= partner_profile.program_address2 %></p>
       <p>Program City: <%= partner_profile.program_city %></p>


### PR DESCRIPTION

Resolves #4138 
### Description

Adds delivery address to distribution printout/receipt 

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

1. Login in as user_1@example.com.
2. Go to distributions
3. Print any distribution
4. The pdf should have `Delivery address:` added to the left. (if delivery method is shipped or delivered)

Note: I did not find any existing unit test or browser test related to distribution pdf. If someone could point me to the relevant tests, I am happy to cover this scenario.

### Screenshots

If the distribution delivery method is either shipped or delivered, the print will look like this

![Screenshot 2024-03-05 at 10 26 02 PM](https://github.com/rubyforgood/human-essentials/assets/15196830/62c69504-ddbc-46de-880f-a65fa9b8097f)

If not no change in the receipt.

![Screenshot 2024-03-02 at 10 28 46 PM](https://github.com/rubyforgood/human-essentials/assets/15196830/30162700-10af-4fa5-a2eb-8bf1f4e17e06)

