### PR TITLE
fix(4129): flaky event differ test

### DIFF
--- a/spec/events/event_differ_spec.rb
+++ b/spec/events/event_differ_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe EventDiffer do
         ),
         # missing storage_location3
         # added storage location that doesn't exist
-        StorageLocation.count + 1 => EventTypes::EventStorageLocation.new(
-          id: StorageLocation.count + 1,
+        0 => EventTypes::EventStorageLocation.new(
+          id: 0,
           items: {}
         )
       }
@@ -48,7 +48,7 @@ RSpec.describe EventDiffer do
        :type => "location"},
       {"aggregate" => true,
        "database" => false,
-       "storage_location_id" => StorageLocation.count + 1,
+       "storage_location_id" => 0,
        :type => "location"},
       {"aggregate" => 0,
        "database" => 50,


### PR DESCRIPTION
Resolves #4129

Minimal reproduction command:
`rspec ./spec/events/event_differ_spec.rb[1:1] ./spec/models/inventory_item_spec.rb[1:1:1:3] --seed 32476`

Crux of the matter is:
```rb
StorageLocation.count + 1 => EventTypes::EventStorageLocation.new(
    id: StorageLocation.count + 1,
    items: {}
    )
```
assumes that there will be 3 storage locations 1, 2, 3. If `inventory_item_spec` runs before, it creates a storage location. Thus, count will still be 3 but `storage_location3` will have id 4.

Thus, `storage_location3.id => stuff` gets overridden by `StorageLocation.count + 1 => stuff`.

By changing the id of the nonexistent location to 0 we achieve the same test without a dependency on not having storage locations created before this test runs.


### Type of change

* Bug fix (non-breaking change which fixes an issue)
