### PR TITLE
fix: empty item request regression

### DIFF
--- a/app/services/partners/family_request_create_service.rb
+++ b/app/services/partners/family_request_create_service.rb
@@ -8,10 +8,10 @@ module Partners
 
     attr_reader :partner_user_id, :comments, :family_requests_attributes, :partner_request
 
-    def initialize(partner_user_id:, comments: nil, for_families: false, family_requests_attributes: [])
+    def initialize(partner_user_id:, family_requests_attributes:, comments: nil, for_families: false)
       @partner_user_id = partner_user_id
       @comments = comments
-      @family_requests_attributes = family_requests_attributes
+      @family_requests_attributes = family_requests_attributes.presence || []
       @for_families = for_families
     end
 
@@ -42,10 +42,6 @@ module Partners
     private
 
     def valid?
-      if family_requests_attributes.blank?
-        errors.add(:base, 'family_requests_attributes cannot be empty')
-      end
-
       if item_requests_attributes.any? { |attr| included_items_by_id[attr[:item_id].to_i].nil? }
         errors.add(:base, 'detected a unknown item_id')
       end

--- a/spec/requests/partners/individuals_requests_controller_spec.rb
+++ b/spec/requests/partners/individuals_requests_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Partners::IndividualsRequestsController, type: :request do
         {
           partners_family_request:
           {
-            items_attributes: {"0" => {person_count: nil, item_id: nil}},
+            items_attributes: nil,
             comments: nil
           }
         }
@@ -136,9 +136,7 @@ RSpec.describe Partners::IndividualsRequestsController, type: :request do
 
     context "when a request has only a comment" do
       it "is valid" do
-        params[:partners_family_request][:items_attributes] = {
-          "0" => {person_count: nil, item_id: nil}
-        }
+        params[:partners_family_request][:items_attributes] = nil
 
         expect { post partners_individuals_requests_path, params: params }.to change { Request.count }.by(1)
         expect(response).to redirect_to(partners_request_path(Request.last.id))

--- a/spec/services/partners/family_request_create_service_spec.rb
+++ b/spec/services/partners/family_request_create_service_spec.rb
@@ -17,14 +17,15 @@ describe Partners::FamilyRequestCreateService do
     let(:for_families) { false }
 
     context 'when the arguments are incorrect' do
-      context 'because no family_requests_attributes were defined' do
+      context 'because no family_requests_attributes or comments were defined' do
         let(:family_requests_attributes) { [] }
+        let(:comments) { '' }
 
         it 'should return the Partners::FamilyRequestCreateService object with an error' do
           result = subject
 
           expect(result).to be_a_kind_of(Partners::FamilyRequestCreateService)
-          expect(result.errors[:base]).to eq(["family_requests_attributes cannot be empty"])
+          expect(result.errors[:base]).to eq(["completely empty request"])
         end
       end
 

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -456,7 +456,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 
           it 'should properly indicate the requestable items and adjust the partners requestable items' do
             assert page.has_content? item_category.name
-            expect { @partner.reload }.to change(@partner, :requestable_items).from([]).to(items_in_category)
+            expect { @partner.reload }.to change(@partner, :requestable_items).from([]).to(match_array(items_in_category))
           end
         end
 


### PR DESCRIPTION
A previous PR by me introduced a regression that made individuals requests fail with empty attributes.

The mistaken assumption I made was assuming an empty request would be: 
```rb
params[:partners_family_request][:items_attributes] = {
    "0" => {person_count: nil, item_id: nil}
}
```
should be:

```rb
params[:partners_family_request][:items_attributes] = nil
```

This causes `FamilyRequestService` to fail. This PR fixes the regression.

Also `expect { @partner.reload }.to change(@partner, :requestable_items).from([]).to(items_in_category)` created order dependent flakiness. That has been fixed.

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Request Tests