### PR TITLE
fix: Capybara Screenshoots not Uploading in CI

### DIFF
--- a/.github/workflows/rspec-events.yml
+++ b/.github/workflows/rspec-events.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
-      - '*.md'
-      - 'bin/*'
+      - "doc/**"
+      - "*.md"
+      - "bin/*"
 
 jobs:
   rspec-events:
-
     runs-on: ubuntu-latest
 
     services:
@@ -88,4 +87,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: failed-browser-tests
-          path: tmp/screenshots
+          path: |
+            ${{ github.workspace }}/tmp/screenshots/*.png
+            ${{ github.workspace }}/tmp/screenshots/*.html

--- a/.github/workflows/rspec-system-events.yml
+++ b/.github/workflows/rspec-system-events.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
-      - '*.md'
-      - 'bin/*'
+      - "doc/**"
+      - "*.md"
+      - "bin/*"
 
 jobs:
   rspec-system-events:
-
     runs-on: ubuntu-latest
 
     services:
@@ -89,4 +88,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: failed-browser-tests
-          path: tmp/capybara
+          path: |
+            ${{ github.workspace }}/tmp/screenshots/*.png
+            ${{ github.workspace }}/tmp/screenshots/*.html

--- a/.github/workflows/rspec-system.yml
+++ b/.github/workflows/rspec-system.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
-      - '*.md'
-      - 'bin/*'
+      - "doc/**"
+      - "*.md"
+      - "bin/*"
 
 jobs:
   rspec-system:
-
     runs-on: ubuntu-latest
 
     services:
@@ -89,5 +88,5 @@ jobs:
         with:
           name: failed-browser-tests
           path: |
-            tmp/screenshots
-            tmp/capybara
+            ${{ github.workspace }}/tmp/screenshots/*.png
+            ${{ github.workspace }}/tmp/screenshots/*.html

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
-      - '*.md'
-      - 'bin/*'
+      - "doc/**"
+      - "*.md"
+      - "bin/*"
 
 jobs:
   rspec:
-
     runs-on: ubuntu-latest
 
     services:
@@ -88,5 +87,5 @@ jobs:
         with:
           name: failed-browser-tests
           path: |
-            tmp/screenshots
-            tmp/capybara
+            ${{ github.workspace }}/tmp/screenshots/*.png
+            ${{ github.workspace }}/tmp/screenshots/*.html


### PR DESCRIPTION
Capybara screenshots are not uploading in CI. 

This is because the path was incorrect it was looking for files in `tmp/capybara` but they were getting saved to `tmp/screenshots`. This fixes the issue.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### Tests

Sample failed job with artifacts. https://github.com/rubyforgood/human-essentials/actions/runs/8256286176

