### PR TITLE
Update CI workflow version

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/factory-bot-lint.yml
+++ b/.github/workflows/factory-bot-lint.yml
@@ -30,7 +30,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -6,7 +6,7 @@ jobs:
     name: plantuml
     steps:
     - name: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: plantuml

--- a/.github/workflows/rspec-events.yml
+++ b/.github/workflows/rspec-events.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
-      - '*.md'
-      - 'bin/*'
+      - "doc/**"
+      - "*.md"
+      - "bin/*"
 
 jobs:
   rspec-events:
-
     runs-on: ubuntu-latest
 
     services:
@@ -41,7 +40,7 @@ jobs:
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
         ci_node_index: [0, 1]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -85,7 +84,7 @@ jobs:
           RUBYOPT='-W:no-deprecated -W:no-experimental' bin/knapsack_pro_rspec
       - name: Upload artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: failed-browser-tests
           path: tmp/screenshots

--- a/.github/workflows/rspec-system-events.yml
+++ b/.github/workflows/rspec-system-events.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
-      - '*.md'
-      - 'bin/*'
+      - "doc/**"
+      - "*.md"
+      - "bin/*"
 
 jobs:
   rspec-system-events:
-
     runs-on: ubuntu-latest
 
     services:
@@ -41,7 +40,7 @@ jobs:
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
         ci_node_index: [0, 1, 2, 3, 4, 5]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -86,7 +85,9 @@ jobs:
           RUBYOPT='-W:no-deprecated -W:no-experimental' bin/knapsack_pro_rspec
       - name: Upload artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: failed-browser-tests
-          path: tmp/capybara
+          path: |
+            tmp/capybara
+            tmp/screenshots

--- a/.github/workflows/rspec-system.yml
+++ b/.github/workflows/rspec-system.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
-      - '*.md'
-      - 'bin/*'
+      - "doc/**"
+      - "*.md"
+      - "bin/*"
 
 jobs:
   rspec-system:
-
     runs-on: ubuntu-latest
 
     services:
@@ -41,7 +40,7 @@ jobs:
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
         ci_node_index: [0, 1, 2, 3, 4, 5]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -85,7 +84,7 @@ jobs:
           RUBYOPT='-W:no-deprecated -W:no-experimental' bin/knapsack_pro_rspec
       - name: Upload artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: failed-browser-tests
           path: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'doc/**'
-      - '*.md'
-      - 'bin/*'
+      - "doc/**"
+      - "*.md"
+      - "bin/*"
 
 jobs:
   rspec:
-
     runs-on: ubuntu-latest
 
     services:
@@ -41,7 +40,7 @@ jobs:
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
         ci_node_index: [0, 1]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -84,7 +83,7 @@ jobs:
           RUBYOPT='-W:no-deprecated -W:no-experimental' bin/knapsack_pro_rspec
       - name: Upload artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: failed-browser-tests
           path: |

--- a/.github/workflows/ruby_lint.yml
+++ b/.github/workflows/ruby_lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Github is deprecating Node16 actions, thus, workflows flows need to be updated to use Node20.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
CI Runs

Also ran with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE20=true` and worked fine.
