### PR TITLE
add line items to purchases in seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -516,7 +516,7 @@ dates_generator = DispersedPastDatesGenerator.new
   # Depending on which source it uses, additional data may need to be provided.
   donation = Donation.new(source: source,
                           storage_location: random_record_for_org(pdx_org, StorageLocation),
-                          organization: pdx_org, 
+                          organization: pdx_org,
                           issued_at: dates_generator.next)
   case source
   when Donation::SOURCES[:product_drive]
@@ -648,6 +648,11 @@ dates_generator = DispersedPastDatesGenerator.new
     updated_at: purchase_date,
     vendor_id: vendor.id
   )
+
+  rand(1..5).times do
+    purchase.line_items.push(LineItem.new(quantity: rand(1..1000),
+                                          item_id: pdx_org.item_ids.sample))
+  end
   PurchaseCreateService.call(purchase)
 end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4173 <!--fill issue number-->

### Description
Adds line items and randomised number for quantities on purchases in the seeds. 
This prepares more realistic purchases on using the rails db:seed, or reset command.
<img width="739" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/74938003/c6ff38a5-64b9-43a9-9c1f-321a1525543e">
  
Tradeoffs :  only one organisation (Pawnee Diaper Bank) has any purchases in seed. 

### How Has This Been Tested?

Ran specs and the bin/setup command and checked manually that all purchases had line items, and random quantities.
It didn't cross my mind to add specs specifically for seeds, happy to add some though ?