### PR TITLE
4174 Add Last Distribution Date column on the Organization view for Super Admin user.

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -266,7 +266,7 @@ class Organization < ApplicationRecord
 
   def last_distribution_date
     distribution = distributions.order(issued_at: :desc).first
-    distribution == nil ? "No distributions" : distribution[:issued_at].strftime("%F")
+    distribution.nil? ? "No distributions" : distribution[:issued_at].strftime("%F")
   end
 
   private

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -264,6 +264,11 @@ class Organization < ApplicationRecord
     year
   end
 
+  def last_distributed_at
+    distribution = distributions.order(issued_at: :desc).first
+    distribution == nil ? "No distributions" : distribution[:issued_at].strftime("%F")
+  end
+
   private
 
   def correct_logo_mime_type

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -264,7 +264,7 @@ class Organization < ApplicationRecord
     year
   end
 
-  def last_distributed_at
+  def last_distribution_date
     distribution = distributions.order(issued_at: :desc).first
     distribution == nil ? "No distributions" : distribution[:issued_at].strftime("%F")
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -264,7 +264,7 @@ class Organization < ApplicationRecord
     year
   end
 
-  def last_distribution_date
+  def display_last_distribution_date
     distribution = distributions.order(issued_at: :desc).first
     distribution.nil? ? "No distributions" : distribution[:issued_at].strftime("%F")
   end

--- a/app/views/admin/organizations/_list.html.erb
+++ b/app/views/admin/organizations/_list.html.erb
@@ -15,7 +15,7 @@
         <td><%= organization.name %></td>
         <td><%= link_to organization.email, "mailto:#{organization.email}" %></td>
         <td class="date"><%= organization.created_at.strftime("%F") %></td>
-        <td class="date"><%= organization.last_distributed_at %></td>
+        <td class="date"><%= organization.last_distribution_date %></td>
         <td class="text-right">
           <%= view_button_to admin_organization_path(organization.id) %>
           <%= edit_button_to edit_admin_organization_path(organization.id) %>

--- a/app/views/admin/organizations/_list.html.erb
+++ b/app/views/admin/organizations/_list.html.erb
@@ -15,7 +15,7 @@
         <td><%= organization.name %></td>
         <td><%= link_to organization.email, "mailto:#{organization.email}" %></td>
         <td class="date"><%= organization.created_at.strftime("%F") %></td>
-        <td class="date"><%= organization.last_distribution_date %></td>
+        <td class="date"><%= organization.display_last_distribution_date %></td>
         <td class="text-right">
           <%= view_button_to admin_organization_path(organization.id) %>
           <%= edit_button_to edit_admin_organization_path(organization.id) %>

--- a/app/views/admin/organizations/_list.html.erb
+++ b/app/views/admin/organizations/_list.html.erb
@@ -4,6 +4,7 @@
       <th>Organization</th>
       <th>Contact E-mail</th>
       <th class="date">Added On</th>
+      <th class="date">Last Distribution Date</th>
       <th class="text-right">Actions</th>
     </tr>
   </thead>
@@ -14,6 +15,7 @@
         <td><%= organization.name %></td>
         <td><%= link_to organization.email, "mailto:#{organization.email}" %></td>
         <td class="date"><%= organization.created_at.strftime("%F") %></td>
+        <td class="date"><%= organization.last_distributed_at %></td>
         <td class="text-right">
           <%= view_button_to admin_organization_path(organization.id) %>
           <%= edit_button_to edit_admin_organization_path(organization.id) %>

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -184,6 +184,22 @@ RSpec.describe "Organizations", type: :request do
       sign_in(@super_admin)
     end
 
+    describe "GET #show" do
+      before { get organization_path(default_params) }
+
+      it { expect(response).to be_successful }
+
+      it 'organization details' do
+        expect(assigns(:organization)).to have_attributes(
+          name: @organization.name,
+          email: @organization.email,
+          url: @organization.url,
+          created_at: @organization.created_at,
+          last_distributed_at: @organization.last_distributed_at
+        )
+      end
+    end
+
     describe "POST #promote_to_org_admin" do
       subject { post promote_to_org_admin_organization_path(default_params.merge(user_id: @user.id)) }
 

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe "Organizations", type: :request do
           email: @organization.email,
           url: @organization.url,
           created_at: @organization.created_at,
-          last_distribution_datet: @organization.last_distribution_date
+          last_distribution_date: @organization.last_distribution_date
         )
       end
     end

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe "Organizations", type: :request do
           email: @organization.email,
           url: @organization.url,
           created_at: @organization.created_at,
-          last_distributed_at: @organization.last_distributed_at
+          last_distribution_datet: @organization.last_distribution_date
         )
       end
     end

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -185,18 +185,15 @@ RSpec.describe "Organizations", type: :request do
     end
 
     describe "GET #show" do
-      before { get organization_path(default_params) }
+      before { get admin_organizations_path({ id: @organization.id }) }
 
       it { expect(response).to be_successful }
 
       it 'organization details' do
-        expect(assigns(:organization)).to have_attributes(
-          name: @organization.name,
-          email: @organization.email,
-          url: @organization.url,
-          created_at: @organization.created_at,
-          display_last_distribution_date: @organization.display_last_distribution_date
-        )
+        expect(response.body).to include(@organization.name)
+        expect(response.body).to include(@organization.email)
+        expect(response.body).to include(@organization.created_at.strftime("%Y-%m-%d"))
+        expect(response.body).to include(@organization.display_last_distribution_date)
       end
     end
 

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe "Organizations", type: :request do
           email: @organization.email,
           url: @organization.url,
           created_at: @organization.created_at,
-          last_distribution_date: @organization.last_distribution_date
+          display_last_distribution_date: @organization.display_last_distribution_date
         )
       end
     end


### PR DESCRIPTION
Resolves #[4174](https://github.com/rubyforgood/human-essentials/issues/4174)

### Description
This change adds the `Last Distribution Date` to the Organization view for the Super Admin user.


### Type of change
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
* Test manually visually.
* Added a test in the `organization_requests_spec.rb` file to verify all the data returned for an organization, including the `last_distribution_date`


### Screenshots
**Before:**
<img width="1476" alt="Screenshot 2024-03-20 at 11 50 08" src="https://github.com/rubyforgood/human-essentials/assets/1057497/1a7a8a7e-0fe1-4806-afef-8c6fc58eb711">

**After:**
<img width="1476" alt="Screenshot 2024-03-20 at 11 45 28" src="https://github.com/rubyforgood/human-essentials/assets/1057497/9c93b263-1874-423d-bb68-24644e12b207">

