### PR TITLE
Stopgap  re  deletion of donation sites 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -661,6 +661,7 @@ PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/models/donation_site.rb
+++ b/app/models/donation_site.rb
@@ -20,7 +20,7 @@ class DonationSite < ApplicationRecord
 
   validates :name, :address, :organization, presence: true
 
-  has_many :donations, dependent: :destroy
+  has_many :donations, dependent: :restrict_with_error
 
   include Geocodable
   include Exportable

--- a/spec/models/donation_site_spec.rb
+++ b/spec/models/donation_site_spec.rb
@@ -49,4 +49,27 @@ RSpec.describe DonationSite, type: :model do
   describe "versioning" do
     it { is_expected.to be_versioned }
   end
+
+  describe "deletion" do
+    it "can be deleted if there are no donations associated with the donation site" do
+      donation_site = build(:donation_site,
+                            "address" => "1500 Remount Road, Front Royal, VA 22630")
+      donation_site.save
+      expect { donation_site.destroy! }.to change { DonationSite.count }.by(-1)
+    end
+
+    it "cannot be deleted if there is a donation associated with the donation site" do
+      donation_site = build(:donation_site,
+                            "address" => "1500 Remount Road, Front Royal, VA 22630")
+      donation_site.save
+      donation = build(:donation, source: "Donation Site", donation_site: donation_site)
+      donation.save
+      expect { donation_site.destroy! }
+        .to raise_error(/Failed to destroy DonationSite/)
+              .and not_change { DonationSite.count }
+      expect(donation_site.errors.full_messages).to eq(["Cannot delete record because dependent donations exist"])
+    end
+  end
+
+
 end

--- a/spec/models/donation_site_spec.rb
+++ b/spec/models/donation_site_spec.rb
@@ -66,10 +66,8 @@ RSpec.describe DonationSite, type: :model do
       donation.save
       expect { donation_site.destroy! }
         .to raise_error(/Failed to destroy DonationSite/)
-              .and not_change { DonationSite.count }
+        .and not_change { DonationSite.count }
       expect(donation_site.errors.full_messages).to eq(["Cannot delete record because dependent donations exist"])
     end
   end
-
-
 end


### PR DESCRIPTION
Partial  (just a stop gap) re  #4204

### Description
This PR prevents the deletion of donation sites if they have donations.  

Note that this is only preventing the deletion behind the scenes-- it is strictly  a stopgap that we can put in "immediately"  if the remainder of the work for #4204 is not yet ready.  (I think the remainder of 4204 will be independent of this)

It is  just restricting the deletion of the donation site to cases where there are no donations.  It leaves the button in place.  This is not by any means perfect, but will prevent the most egregious results.

I used restrict_with_error.  I considered restrict_with_exception, which would "blow up" iin the bank user's face so they would know something was not right -- whereas this is going to die silently.   I chose restrict_with_error because I didn't find any cases of restrict_with_exception in the codebase on search.

This is meant strictly to be a band-aid.   Hopefully I will get at least the next step completed for this week as well.
 

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 

Manual test:
-check which donation sites have donations
-then go to donation sites and try to delete one of them.   They aren't deleted.
- add a new donation site, and try to delete it.   It is deleted.

Plus model level tests.