### PR TITLE
4204  deactivation and donation sites

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -661,6 +661,7 @@ PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/donation_sites_controller.rb
+++ b/app/controllers/donation_sites_controller.rb
@@ -71,9 +71,6 @@ class DonationSitesController < ApplicationController
     redirect_to donation_sites_path
   end
 
-
-
-
   private
 
   def donation_site_params

--- a/app/controllers/donation_sites_controller.rb
+++ b/app/controllers/donation_sites_controller.rb
@@ -4,7 +4,7 @@ class DonationSitesController < ApplicationController
   include Importable
 
   def index
-    @donation_sites = current_organization.donation_sites.all.alphabetized
+    @donation_sites = current_organization.donation_sites.active.alphabetized
     @donation_site = current_organization.donation_sites.new
     respond_to do |format|
       format.html
@@ -56,6 +56,23 @@ class DonationSitesController < ApplicationController
     current_organization.donation_sites.find(params[:id]).destroy
     redirect_to donation_sites_path
   end
+
+  def deactivate
+    donation_site = current_organization.donation_sites.find(params[:id])
+    begin
+      donation_site.deactivate!
+    rescue => e
+      flash[:error] = e.message
+      redirect_back(fallback_location: items_path)
+      return
+    end
+
+    flash[:notice] = "#{donation_site.name} has been deactivated."
+    redirect_to donation_sites_path
+  end
+
+
+
 
   private
 

--- a/app/controllers/donation_sites_controller.rb
+++ b/app/controllers/donation_sites_controller.rb
@@ -52,11 +52,6 @@ class DonationSitesController < ApplicationController
     end
   end
 
-  def destroy
-    current_organization.donation_sites.find(params[:id]).destroy
-    redirect_to donation_sites_path
-  end
-
   def deactivate
     donation_site = current_organization.donation_sites.find(params[:id])
     begin

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -104,7 +104,7 @@ class DonationsController < ApplicationController
 
   def load_form_collections
     @storage_locations = current_organization.storage_locations.active_locations.alphabetized
-    @donation_sites = current_organization.donation_sites.alphabetized
+    @donation_sites = current_organization.donation_sites.active.alphabetized
     @product_drives = current_organization.product_drives.alphabetized
     @product_drive_participants = current_organization.product_drive_participants.alphabetized
     @manufacturers = current_organization.manufacturers.alphabetized

--- a/app/models/donation_site.rb
+++ b/app/models/donation_site.rb
@@ -3,6 +3,7 @@
 # Table name: donation_sites
 #
 #  id              :integer          not null, primary key
+#  active          :boolean          default(TRUE)
 #  address         :string
 #  latitude        :float
 #  longitude       :float
@@ -29,6 +30,9 @@ class DonationSite < ApplicationRecord
     where(organization: organization)
       .order(:name)
   }
+
+  scope :active, -> { where(active: true) }
+
   scope :alphabetized, -> { order(:name) }
 
   def self.import_csv(csv, organization)
@@ -45,5 +49,9 @@ class DonationSite < ApplicationRecord
 
   def csv_export_attributes
     [name, address]
+  end
+
+  def deactivate!
+    update!(active: false)
   end
 end

--- a/app/views/donation_sites/_donation_site_row.html.erb
+++ b/app/views/donation_sites/_donation_site_row.html.erb
@@ -7,6 +7,6 @@
     <%= delete_button_to deactivate_donation_site_path(donation_site_row),
                          text: 'Deactivate',
                          enabled: true,
-                         confirm: confirm_deactivate_msg(donation_site_row.name) %> <%= delete_button_to donation_site_row, { confirm: confirm_delete_msg(donation_site_row.name) } %>
+                         confirm: confirm_deactivate_msg(donation_site_row.name) %>
   </td>
 </tr>

--- a/app/views/donation_sites/_donation_site_row.html.erb
+++ b/app/views/donation_sites/_donation_site_row.html.erb
@@ -4,6 +4,9 @@
   <td class="text-right">
     <%= view_button_to donation_site_row %>
     <%= edit_button_to edit_donation_site_path(donation_site_row) %>
-    <%= delete_button_to donation_site_row, { confirm: confirm_delete_msg(donation_site_row.name) } %>
+    <%= delete_button_to deactivate_donation_site_path(donation_site_row),
+                         text: 'Deactivate',
+                         enabled: true,
+                         confirm: confirm_deactivate_msg(donation_site_row.name) %> <%= delete_button_to donation_site_row, { confirm: confirm_delete_msg(donation_site_row.name) } %>
   </td>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
       collection do
         post :import_csv
       end
+      delete :deactivate, on: :member
     end
     resources :product_drive_participants, except: [:destroy] do
       collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,7 @@ Rails.application.routes.draw do
       get :find, on: :collection
       get :font, on: :collection
     end
-    resources :donation_sites do
+    resources :donation_sites, except: [:destroy] do
       collection do
         post :import_csv
       end

--- a/db/migrate/20240320193521_add_active_to_donation_site.rb
+++ b/db/migrate/20240320193521_add_active_to_donation_site.rb
@@ -1,0 +1,9 @@
+class AddActiveToDonationSite < ActiveRecord::Migration[7.0]
+  def up
+    add_column :donation_sites, :active, :boolean
+    change_column_default :donation_sites, :active, true
+  end
+  def down
+    remove_column :donation_sites, :active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_07_202431) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_20_193521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -250,6 +250,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_202431) do
     t.integer "organization_id"
     t.float "latitude"
     t.float "longitude"
+    t.boolean "active", default: true
     t.index ["latitude", "longitude"], name: "index_donation_sites_on_latitude_and_longitude"
     t.index ["organization_id"], name: "index_donation_sites_on_organization_id"
   end

--- a/spec/controllers/donation_sites_controller_spec.rb
+++ b/spec/controllers/donation_sites_controller_spec.rb
@@ -41,13 +41,6 @@ RSpec.describe DonationSitesController, type: :controller do
       end
     end
 
-    describe "DELETE #destroy" do
-      subject { delete :destroy, params: default_params.merge(id: create(:donation_site, organization: @organization)) }
-      it "returns http success" do
-        expect(subject).to redirect_to(donation_sites_path)
-      end
-    end
-
     context "Looking at a different organization" do
       let(:object) { create(:donation_site, organization: create(:organization)) }
       include_examples "requiring authorization"

--- a/spec/factories/donation_site.rb
+++ b/spec/factories/donation_site.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     organization { Organization.try(:first) || create(:organization) }
     name { "Smithsonian Conservation Center" }
     address { "1500 Remount Road, Front Royal, VA 22630" }
+    active { true }
   end
 end

--- a/spec/models/donation_site_spec.rb
+++ b/spec/models/donation_site_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe DonationSite, type: :model do
     it { is_expected.to be_versioned }
   end
 
-
   describe "active" do
     it "->active shows only donation sites that are still active" do
       DonationSite.delete_all
@@ -86,7 +85,8 @@ RSpec.describe DonationSite, type: :model do
       donation_site_2 = create(:donation_site, name: "site that will be active", active: true)
       donation_site_1.deactivate!
       expect(DonationSite.active.to_a).to match_array([donation_site_2])
-
+    end
+  end
   describe "deletion" do
     it "can be deleted if there are no donations associated with the donation site" do
       donation_site = build(:donation_site,
@@ -105,7 +105,6 @@ RSpec.describe DonationSite, type: :model do
         .to raise_error(/Failed to destroy DonationSite/)
         .and not_change { DonationSite.count }
       expect(donation_site.errors.full_messages).to eq(["Cannot delete record because dependent donations exist"])
-
     end
   end
 end

--- a/spec/models/donation_site_spec.rb
+++ b/spec/models/donation_site_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DonationSite, type: :model do
   end
 
   describe "active" do
-    it "->active shows only items that are still active" do
+    it "->active shows only donation sites that are still active" do
       DonationSite.delete_all
       donation_site_1 = create(:donation_site, name: "site that will be deactivated", active: true)
       donation_site_2 = create(:donation_site, name: "site that will be active", active: true)

--- a/spec/models/donation_site_spec.rb
+++ b/spec/models/donation_site_spec.rb
@@ -3,6 +3,7 @@
 # Table name: donation_sites
 #
 #  id              :integer          not null, primary key
+#  active          :boolean          default(TRUE)
 #  address         :string
 #  latitude        :float
 #  longitude       :float
@@ -48,5 +49,15 @@ RSpec.describe DonationSite, type: :model do
 
   describe "versioning" do
     it { is_expected.to be_versioned }
+  end
+
+  describe "active" do
+    it "->active shows only items that are still active" do
+      DonationSite.delete_all
+      donation_site_1 = create(:donation_site, name: "site that will be deactivated", active: true)
+      donation_site_2 = create(:donation_site, name: "site that will be active", active: true)
+      donation_site_1.deactivate!
+      expect(DonationSite.active.to_a).to match_array([donation_site_2])
+    end
   end
 end

--- a/spec/requests/donation_sites_requests_spec.rb
+++ b/spec/requests/donation_sites_requests_spec.rb
@@ -32,5 +32,31 @@ RSpec.describe "DonationSites", type: :request do
         it { is_expected.to be_successful }
       end
     end
+    describe 'GET #index' do
+      let!(:active_donation_site) { create(:donation_site, organization: @organization, name: "An Active Site") }
+      let!(:inactive_donation_site) { create(:donation_site, organization: @organization, active: false, name: "An Inactive Site") }
+
+      it "should show all/only active donation sites with deactivate buttons" do
+        get donation_sites_path(default_params)
+        page = Nokogiri::HTML(response.body)
+        expect(response.body).to include("An Active Site")
+        expect(response.body).not_to include("An Inactive Site")
+        button1 = page.css(".btn[href='/#{@organization.short_name}/donation_sites/#{active_donation_site.id}/deactivate']")
+        expect(button1.text.strip).to eq("Deactivate")
+        expect(button1.attr('class')).not_to match(/disabled/)
+      end
+    end
+
+    describe 'DELETE #deactivate' do
+      it 'should be able to deactivate an item' do
+        donation_site = create(:donation_site, organization: @organization, active: true, name: "to be deactivated")
+        donation_site_2 = create(:donation_site, organization: @organization, active: true, name: "active one")
+        params =  default_params.merge(id: donation_site.id)
+
+        expect { delete deactivate_donation_site_path(params) }.to change { donation_site.reload.active }.from(true).to(false)
+          .and change { DonationSite.active.count }.by(-1)
+        expect(response).to redirect_to(donation_sites_path)
+      end
+    end
   end
 end

--- a/spec/requests/donation_sites_requests_spec.rb
+++ b/spec/requests/donation_sites_requests_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe "DonationSites", type: :request do
         params = default_params.merge(id: donation_site.id)
 
         expect { delete deactivate_donation_site_path(params) }.to change { donation_site.reload.active }.from(true).to(false)
-          .and change { DonationSite.active.count }.by(-1)
         expect(response).to redirect_to(donation_sites_path)
       end
     end

--- a/spec/requests/donation_sites_requests_spec.rb
+++ b/spec/requests/donation_sites_requests_spec.rb
@@ -50,8 +50,7 @@ RSpec.describe "DonationSites", type: :request do
     describe 'DELETE #deactivate' do
       it 'should be able to deactivate an item' do
         donation_site = create(:donation_site, organization: @organization, active: true, name: "to be deactivated")
-        donation_site_2 = create(:donation_site, organization: @organization, active: true, name: "active one")
-        params =  default_params.merge(id: donation_site.id)
+        params = default_params.merge(id: donation_site.id)
 
         expect { delete deactivate_donation_site_path(params) }.to change { donation_site.reload.active }.from(true).to(false)
           .and change { DonationSite.active.count }.by(-1)


### PR DESCRIPTION
Partial  #4204 -- excludes most of bonus round

### Description
We found that deleting donation sites also deleted donations,  so we're reworking that.
#4208 is a stopgap that should go in as well as this.

This removes the buttons that allow the banks to delete donation sites, and adds the ability to deactivate them
It also only shows the active donation sites when picking one for a donation

This gives an improved ability to the banks -- to remove the donation sites from their lists, but without destroying their donations. 

It does not:  implement the  filter on the donation sites to allow seeing the inactive donation sites, or allow restoration of them.  Those capabilities are planned as a relatively fast follow.   

Note - there is currently an outstanding issue around donation sites on donation  edit.   This may need to be revisited when that is resolved -- in light of what happens if a donation that has an inactive donation site is edited.


### Type of change

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
### How Has This Been Tested?

Manual tests --  deactivating donation sites that have donations.  Observing that the donations still exist, and that the donation sites disappear from the index and the list in the new donation.
Automated tests -- except for the donation site list in new donations.  
Current automated tests run ok
