### PR TITLE
Ensure random record for organization in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ def random_record(klass)
 end
 
 def random_record_for_org(org, klass)
-  klass.where(organization: org).limit(1).order(Arel.sql('random()')).first
+  klass.where(organization: org).all.sample
 end
 
 # ----------------------------------------------------------------------------

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,10 +14,6 @@ Flipper.enable(:onebase)
 # ----------------------------------------------------------------------------
 load "lib/dispersed_past_dates_generator.rb"
 
-def random_record(klass)
-  klass.limit(1).order(Arel.sql('random()')).first
-end
-
 def random_record_for_org(org, klass)
   klass.where(organization: org).all.sample
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4211.

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

When seeding donations, we expect between one and five items attached to each donation (each with several hundred quantity). For some reason, the `random_record_for_org` method was caching, resulting up to five line items with the same item.

This PR just ensures that a fresh record is returned for each line item. 

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

I've run and re-run the `bin/setup` process multiple times and ensured the data generated looks correct.

### Screenshots

#### Before

<img width="888" alt="Donations without modification" src="https://github.com/rubyforgood/human-essentials/assets/6723/4046a7a7-900e-4caa-8806-58d7be7cb2b0">

#### After

<img width="895" alt="Donations with modification" src="https://github.com/rubyforgood/human-essentials/assets/6723/938e807e-43bd-49b4-81d3-ff706d5337fc">
