### PR TITLE
Update organizations#edit Trix style

### DIFF
--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,3 +1,22 @@
+<style>
+  trix-editor {
+    border: 1px solid #ced4da;
+    border-radius: 0.25rem;
+    margin-top: 0.5em;
+    padding: 0.5em;
+  }
+  .trix-dialog--link input[type='url'] {
+    border: 1px solid #ced4da;
+    margin: 1em 0;
+  }
+  .trix-dialog--link input[type='button'] {
+    margin-right: 1em;
+  }
+  button.trix-active {
+    background-color: #999;
+    border-color: #999;
+  }
+</style>
 <section class="content-header">
   <div class="container-fluid">
     <div class="mb-2 row">
@@ -89,7 +108,7 @@
 
                 <% default_email_text_hint = "You can use the variables <code>%{partner_name}</code>, <code>%{delivery_method}</code>, <code>%{distribution_date}</code>, and <code>%{comment}</code> to include the partner's name, delivery method, distribution date, and comments sent in the request." %>
                 <%= f.input :default_email_text, label: "Distribution Email Content", hint: default_email_text_hint.html_safe do %>
-                  <%= f.rich_text_area :default_email_text %>
+                  <%= f.rich_text_area :default_email_text, placeholder: 'Enter distribution email content...' %>
                 <% end %>
 
                 <%= f.input :logo, wrapper: :input_group do %>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4190  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Adds some styling to the Distributed Email Content rich text box:
- Active buttons (Bold, Italic, Strikethrough, and Link) are now a darker color when they're active
- The Link form is spaced out a little bit
- The `.trix-content` textarea now has a border and some padding
- The `.trix-content` textarea now has a default placeholder text

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Tested in the browser only; it's primarily a CSS change.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

#### Before
<img width="1052" alt="before 1" src="https://github.com/rubyforgood/human-essentials/assets/6723/aea598c8-a494-4259-9771-26c872e313d2">
<img width="1064" alt="before 2" src="https://github.com/rubyforgood/human-essentials/assets/6723/75779ad5-1083-4291-bf8c-3043689b678b">


#### After
<img width="1061" alt="Screenshot 2024-03-22 at 13 17 26" src="https://github.com/rubyforgood/human-essentials/assets/6723/296058a6-a262-497d-9545-6a72ec2840c4">

<img width="1056" alt="DEC style - all" src="https://github.com/rubyforgood/human-essentials/assets/6723/c476f00a-ce61-49bb-9e04-f75b191b18f5">

