### PR TITLE
Fix crash on adjustment error

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -88,7 +88,7 @@ class Event < ApplicationRecord
     e.message << " for #{item} in #{loc}"
     if e.event != self
       e.message.prepend("Error occurred when re-running events: #{e.event.type} on #{e.event.created_at.to_date}: ")
-      e.message += " Please contact the Human Essentials admin staff for assistance."
+      e.message << " Please contact the Human Essentials admin staff for assistance."
     end
     raise e
   end

--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -19,17 +19,19 @@ class AdjustmentCreateService
 
     if @adjustment.valid? && enough_inventory_for_decreases?
       ActiveRecord::Base.transaction do
-        # Make the necessary changes in the db
-        @adjustment.save
-        AdjustmentEvent.publish(adjustment)
-        # Split into positive and negative portions.
-        # N.B. -- THIS CHANGES THE ORIGINAL LINE ITEMS ON @adjustment DO **NOT** RESAVE AS THAT WILL CHANGE ANY NEGATIVE LINE ITEMS ON THE ADJUSTMENT TO POSITIVES
-        increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
-        @adjustment.storage_location.increase_inventory(increasing_adjustment.line_item_values)
-        @adjustment.storage_location.decrease_inventory(decreasing_adjustment.line_item_values)
-      rescue InsufficientAllotment, InventoryError => e
-        @adjustment.errors.add(:base, e.message)
-        raise e
+        begin
+          # Make the necessary changes in the db
+          @adjustment.save
+          AdjustmentEvent.publish(adjustment)
+          # Split into positive and negative portions.
+          # N.B. -- THIS CHANGES THE ORIGINAL LINE ITEMS ON @adjustment DO **NOT** RESAVE AS THAT WILL CHANGE ANY NEGATIVE LINE ITEMS ON THE ADJUSTMENT TO POSITIVES
+          increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
+          @adjustment.storage_location.increase_inventory(increasing_adjustment.line_item_values)
+          @adjustment.storage_location.decrease_inventory(decreasing_adjustment.line_item_values)
+        rescue Errors::InsufficientAllotment, InventoryError => e
+          @adjustment.errors.add(:base, e.message)
+          raise ActiveRecord::Rollback
+        end
       end
     end
     self

--- a/app/services/adjustment_create_service.rb
+++ b/app/services/adjustment_create_service.rb
@@ -19,19 +19,17 @@ class AdjustmentCreateService
 
     if @adjustment.valid? && enough_inventory_for_decreases?
       ActiveRecord::Base.transaction do
-        begin
-          # Make the necessary changes in the db
-          @adjustment.save
-          AdjustmentEvent.publish(adjustment)
-          # Split into positive and negative portions.
-          # N.B. -- THIS CHANGES THE ORIGINAL LINE ITEMS ON @adjustment DO **NOT** RESAVE AS THAT WILL CHANGE ANY NEGATIVE LINE ITEMS ON THE ADJUSTMENT TO POSITIVES
-          increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
-          @adjustment.storage_location.increase_inventory(increasing_adjustment.line_item_values)
-          @adjustment.storage_location.decrease_inventory(decreasing_adjustment.line_item_values)
-        rescue Errors::InsufficientAllotment, InventoryError => e
-          @adjustment.errors.add(:base, e.message)
-          raise ActiveRecord::Rollback
-        end
+        # Make the necessary changes in the db
+        @adjustment.save
+        AdjustmentEvent.publish(adjustment)
+        # Split into positive and negative portions.
+        # N.B. -- THIS CHANGES THE ORIGINAL LINE ITEMS ON @adjustment DO **NOT** RESAVE AS THAT WILL CHANGE ANY NEGATIVE LINE ITEMS ON THE ADJUSTMENT TO POSITIVES
+        increasing_adjustment, decreasing_adjustment = @adjustment.split_difference
+        @adjustment.storage_location.increase_inventory(increasing_adjustment.line_item_values)
+        @adjustment.storage_location.decrease_inventory(decreasing_adjustment.line_item_values)
+      rescue Errors::InsufficientAllotment, InventoryError => e
+        @adjustment.errors.add(:base, e.message)
+        raise ActiveRecord::Rollback
       end
     end
     self


### PR DESCRIPTION
There were 4 separate issues here:

* Invalid name for InventoryError - this has been around for ages.
* Error message was being appended incorrectly.
* Error was being raised instead of just added as an error - no calling code is set up to catch errors from this service. Ideally we'd change the flow so it *does* raise an error and calling code catches it, but that's a bigger change than I have time to do right now.
* When the error was raised, it wouldn't roll back the transaction - so it would still do the adjustment. Again, this has been around for a long time. :(

The original error seemed to have been caused by issues with re-running events (meaning there was a bad event that got in somehow which indicates that any further actions would all fail).