### PR TITLE
[4171] Fix issue with storage location resetting on error.

### DIFF
--- a/app/helpers/purchases_helper.rb
+++ b/app/helpers/purchases_helper.rb
@@ -5,6 +5,6 @@ module PurchasesHelper
   end
 
   def new_purchase_default_location(purchase)
-    purchase.new_record? ? current_organization.intake_location : purchase.storage_location_id
+    purchase.storage_location_id.presence || current_organization.intake_location
   end
 end

--- a/spec/helpers/purchases_helper_spec.rb
+++ b/spec/helpers/purchases_helper_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe PurchasesHelper, type: :helper do
+  describe '#new_purchase_default_location' do
+    helper do
+      def current_organization; end
+    end
+
+    context 'returns purchase storage_location_id if present' do
+      let(:purchase) { build(:purchase, storage_location_id: 2) }
+      subject { helper.new_purchase_default_location(purchase) }
+
+      it { is_expected.to eq(2) }
+    end
+
+    context 'returns current_organization intake_location if purchase storage_location_id is not present' do
+      let(:organization) { build(:organization, intake_location: 1) }
+      let(:purchase) { build(:purchase, storage_location_id: nil) }
+
+      before do
+        allow(helper).to receive(:current_organization).and_return(organization)
+      end
+
+      subject { helper.new_purchase_default_location(purchase) }
+
+      it { is_expected.to eq(1) }
+    end
+  end
+end

--- a/spec/helpers/purchases_helper_spec.rb
+++ b/spec/helpers/purchases_helper_spec.rb
@@ -1,19 +1,20 @@
 require "rails_helper"
 
 RSpec.describe PurchasesHelper, type: :helper do
-  describe '#new_purchase_default_location' do
+  describe "#new_purchase_default_location" do
     helper do
-      def current_organization; end
+      def current_organization
+      end
     end
 
-    context 'returns purchase storage_location_id if present' do
+    context "returns purchase storage_location_id if present" do
       let(:purchase) { build(:purchase, storage_location_id: 2) }
       subject { helper.new_purchase_default_location(purchase) }
 
       it { is_expected.to eq(2) }
     end
 
-    context 'returns current_organization intake_location if purchase storage_location_id is not present' do
+    context "returns current_organization intake_location if purchase storage_location_id is not present" do
       let(:organization) { build(:organization, intake_location: 1) }
       let(:purchase) { build(:purchase, storage_location_id: nil) }
 


### PR DESCRIPTION
Resolves #4171 

### Description
When creating a new purchase, if a storage location is selected and there's an error during submission, the storage location resets to the first one in the list. This PR addresses this issue by ensuring that the selected storage location remains unchanged in case of an error.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This change has been tested by creating a new purchase, selecting a storage location, and intentionally causing an error during submission. Upon encountering the error, it was verified that the selected storage location remained unchanged.

### Screencast
[Screencast from 23-03-24 11:44:13 PM IST.webm](https://github.com/rubyforgood/human-essentials/assets/67000557/445e0bff-a7d9-4111-8084-89c307e281ed)
