### PR TITLE
feat: makes changes to accomodate removing seeding

### DIFF
--- a/app/models/base_item.rb
+++ b/app/models/base_item.rb
@@ -28,23 +28,5 @@ class BaseItem < ApplicationRecord
   def to_h
     { partner_key: partner_key, name: name }
   end
-
-  def self.seed_items
-    base_items = File.read(Rails.root.join("db", "base_items.json"))
-    items_by_category = JSON.parse(base_items)
-    base_items_data = items_by_category.map do |category, entries|
-      entries.map do |entry|
-        {
-          name: entry["name"],
-          category: category,
-          partner_key: entry["key"],
-          updated_at: Time.zone.now,
-          created_at: Time.zone.now
-        }
-      end
-    end.flatten
-
-    BaseItem.create!(base_items_data)
-  end
 end
 

--- a/app/models/base_item.rb
+++ b/app/models/base_item.rb
@@ -28,5 +28,23 @@ class BaseItem < ApplicationRecord
   def to_h
     { partner_key: partner_key, name: name }
   end
+
+  def self.seed_items
+    base_items = File.read(Rails.root.join("db", "base_items.json"))
+    items_by_category = JSON.parse(base_items)
+    base_items_data = items_by_category.map do |category, entries|
+      entries.map do |entry|
+        {
+          name: entry["name"],
+          category: category,
+          partner_key: entry["key"],
+          updated_at: Time.zone.now,
+          created_at: Time.zone.now
+        }
+      end
+    end.flatten
+
+    BaseItem.create!(base_items_data)
+  end
 end
 

--- a/app/models/kit.rb
+++ b/app/models/kit.rb
@@ -26,7 +26,7 @@ class Kit < ApplicationRecord
   scope :by_partner_key, ->(key) { joins(:items).where(items: { partner_key: key }) }
   scope :by_name, ->(name) { where("name ILIKE ?", "%#{name}%") }
 
-  validates :organization, :name, presence: true
+  validates :name, presence: true
   validates :name, uniqueness: { scope: :organization }
 
   validate :at_least_one_item

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -198,6 +198,7 @@ class Organization < ApplicationRecord
 
   def self.seed_items(organization = Organization.all)
     base_items = BaseItem.all.map(&:to_h)
+
     Array.wrap(organization).each do |org|
       Rails.logger.info "\n\nSeeding #{org.name}'s items...\n"
       org.seed_items(base_items)
@@ -211,6 +212,7 @@ class Organization < ApplicationRecord
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.info "[SEED] Duplicate item! #{e.record.name}"
       existing_item = items.find_by(name: e.record.name)
+      # TODO: should this be a proper error class? NameTakenError?
       if e.to_s.match(/been taken/).present? && existing_item.other?
         Rails.logger.info "Changing Item##{existing_item.id} from Other to #{e.record.partner_key}"
         existing_item.update(partner_key: e.record.partner_key)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -212,7 +212,6 @@ class Organization < ApplicationRecord
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.info "[SEED] Duplicate item! #{e.record.name}"
       existing_item = items.find_by(name: e.record.name)
-      # TODO: should this be a proper error class? NameTakenError?
       if e.to_s.match(/been taken/).present? && existing_item.other?
         Rails.logger.info "Changing Item##{existing_item.id} from Other to #{e.record.partner_key}"
         existing_item.update(partner_key: e.record.partner_key)

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -69,12 +69,22 @@ class ProductDrive < ApplicationRecord
     @search_date_range = { start_date: dates[0], end_date: dates[1] }
   end
 
+  # TODO: this method name was confusing to me
+  # quantities are FILTERED by date then SORTED by name
+  # method name makes it sound like it's filtering by both
+  #
+  # @param date_range [Range]
+  # @return [Array<Integer>]
   def item_quantities_by_name_and_date(date_range)
     quantities = donations.joins(:line_items)
       .during(date_range)
       .group('line_items.item_id')
       .sum('line_items.quantity')
 
+    # If an org does not have an item
+    # then it is stripped from the donation
+    # This is super unexpected behavior
+    # given the other by_ methods don't do this
     organization.items.order(:name).map do |item|
       quantities[item.id] || 0
     end

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -69,9 +69,7 @@ class ProductDrive < ApplicationRecord
     @search_date_range = { start_date: dates[0], end_date: dates[1] }
   end
 
-  # TODO: this method name was confusing to me
   # quantities are FILTERED by date then SORTED by name
-  # method name makes it sound like it's filtering by both
   #
   # @param date_range [Range]
   # @return [Array<Integer>]
@@ -81,10 +79,6 @@ class ProductDrive < ApplicationRecord
       .group('line_items.item_id')
       .sum('line_items.quantity')
 
-    # If an org does not have an item
-    # then it is stripped from the donation
-    # This is super unexpected behavior
-    # given the other by_ methods don't do this
     organization.items.order(:name).map do |item|
       quantities[item.id] || 0
     end

--- a/app/models/product_drive_participant.rb
+++ b/app/models/product_drive_participant.rb
@@ -23,7 +23,6 @@ class ProductDriveParticipant < ApplicationRecord
 
   has_many :donations, inverse_of: :product_drive_participant, dependent: :destroy
 
-  # NOTE: this is a bit hard to follow. Little hard to spot the difference between the two validations
   validates :phone, presence: { message: "Must provide a phone or an e-mail" }, if: proc { |pdp| pdp.email.blank? }
   validates :email, presence: { message: "Must provide a phone or an e-mail" }, if: proc { |pdp| pdp.phone.blank? }
 

--- a/app/models/product_drive_participant.rb
+++ b/app/models/product_drive_participant.rb
@@ -23,8 +23,9 @@ class ProductDriveParticipant < ApplicationRecord
 
   has_many :donations, inverse_of: :product_drive_participant, dependent: :destroy
 
-  validates :phone, presence: { message: "Must provide a phone or an e-mail" }, if: proc { |ddp| ddp.email.blank? }
-  validates :email, presence: { message: "Must provide a phone or an e-mail" }, if: proc { |ddp| ddp.phone.blank? }
+  # NOTE: this is a bit hard to follow. Little hard to spot the difference between the two validations
+  validates :phone, presence: { message: "Must provide a phone or an e-mail" }, if: proc { |pdp| pdp.email.blank? }
+  validates :email, presence: { message: "Must provide a phone or an e-mail" }, if: proc { |pdp| pdp.phone.blank? }
 
   scope :alphabetized, -> { order(:contact_name) }
 

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -124,7 +124,7 @@ class StorageLocation < ApplicationRecord
   end
 
   # NOTE: We should generalize this elsewhere -- Importable concern?
-  # This requires a user with the ORG_ADMIN role
+  # Requires a user with the ORG_ADMIN role, or it will fail silently
   # First user with role from org found will be used for adjustment creation
   #
   # @param filename [String]
@@ -133,7 +133,6 @@ class StorageLocation < ApplicationRecord
   # @return [void]
   def self.import_inventory(filename, org, loc)
     current_org = Organization.find(org)
-    # this silently fails without a user
     adjustment = current_org.adjustments.new(storage_location_id: loc.to_i,
                                              user_id: User.with_role(Role::ORG_ADMIN, current_org).first&.id,
                                              comment: "Starting Inventory")

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -124,8 +124,16 @@ class StorageLocation < ApplicationRecord
   end
 
   # NOTE: We should generalize this elsewhere -- Importable concern?
+  # This requires a user with the ORG_ADMIN role
+  # First user with role from org found will be used for adjustment creation
+  #
+  # @param filename [String]
+  # @param org [Integer] Organization ID
+  # @param loc [Integer] StorageLocation ID
+  # @return [void]
   def self.import_inventory(filename, org, loc)
     current_org = Organization.find(org)
+    # this silently fails without a user
     adjustment = current_org.adjustments.new(storage_location_id: loc.to_i,
                                              user_id: User.with_role(Role::ORG_ADMIN, current_org).first&.id,
                                              comment: "Starting Inventory")

--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -13,7 +13,7 @@
 
 FactoryBot.define do
   factory :adjustment do
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     storage_location
     comment { "A comment" }
     user { organization.users.try(:first) || create(:user, organization_id: organization.id) }

--- a/spec/factories/audits.rb
+++ b/spec/factories/audits.rb
@@ -14,7 +14,7 @@
 
 FactoryBot.define do
   factory :audit do
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     user { nil }
     storage_location { nil }
     adjustment { nil }

--- a/spec/factories/barcode_items.rb
+++ b/spec/factories/barcode_items.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
   end
 
   factory :barcode_item, class: "BarcodeItem" do
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     sequence(:value) { (SecureRandom.random_number * (10**12)).to_i } # 037000863427
     quantity { 50 }
     barcodeable { nil }

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
   factory :distribution do
     storage_location
     partner
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     issued_at { nil }
     delivery_method { :pick_up }
     state { :scheduled }
@@ -35,6 +35,7 @@ FactoryBot.define do
       storage_location { create :storage_location, :with_items, item: item, organization: organization }
 
       after(:build) do |instance, evaluator|
+        # NOTE: does this need to run if item is passed in?
         event_item = View::Inventory.new(instance.organization_id)
           .items_for_location(instance.storage_location_id)
           .first

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
       storage_location { create :storage_location, :with_items, item: item, organization: organization }
 
       after(:build) do |instance, evaluator|
-        # NOTE: does this need to run if item is passed in?
+        # Don't remove this. Shortcutting does not work
         event_item = View::Inventory.new(instance.organization_id)
           .items_for_location(instance.storage_location_id)
           .first

--- a/spec/factories/donation_site.rb
+++ b/spec/factories/donation_site.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :donation_site do
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     name { "Smithsonian Conservation Center" }
     address { "1500 Remount Road, Front Royal, VA 22630" }
   end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     source { Donation::SOURCES[:misc] }
     comment { "It's a fine day for diapers." }
     storage_location
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     issued_at { nil }
 
     factory :manufacturer_donation do

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -24,7 +24,7 @@
 FactoryBot.define do
   factory :item do
     sequence(:name) { |n| "#{n}T Diapers" }
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     partner_key { BaseItem.first&.partner_key || create(:base_item).partner_key }
     kit { nil }
 

--- a/spec/factories/kits.rb
+++ b/spec/factories/kits.rb
@@ -18,13 +18,13 @@ FactoryBot.define do
 
     after(:build) do |instance, _|
       if instance.line_items.blank?
-        instance.line_items << create(:line_item)
+        instance.line_items << create(:line_item, item: create(:item, organization: instance.organization))
       end
     end
 
     trait :with_item do
       after(:create) do |instance, _|
-        create(:item, kit: instance)
+        create(:item, kit: instance, organization: instance.organization)
       end
     end
   end

--- a/spec/factories/kits.rb
+++ b/spec/factories/kits.rb
@@ -17,7 +17,9 @@ FactoryBot.define do
     organization
 
     after(:build) do |instance, _|
-      instance.line_items << create(:line_item)
+      if instance.line_items.blank?
+        instance.line_items << create(:line_item)
+      end
     end
 
     trait :with_item do

--- a/spec/factories/manufacturers.rb
+++ b/spec/factories/manufacturers.rb
@@ -11,7 +11,7 @@
 
 FactoryBot.define do
   factory :manufacturer do
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     sequence(:name) { |n| "Manufacturer #{n}" }
   end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -58,14 +58,7 @@ FactoryBot.define do
 
     trait :with_items do
       after(:create) do |instance, evaluator|
-        BaseItem.seed_items if BaseItem.count.zero?
-        Organization.seed_items(instance)
-      end
-    end
-
-    trait :with_items do
-      after(:create) do |instance, evaluator|
-        BaseItem.seed_items if BaseItem.count.zero?
+        seed_base_items if BaseItem.count.zero?
         Organization.seed_items(instance)
       end
     end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -56,6 +56,20 @@ FactoryBot.define do
       deadline_day { nil }
     end
 
+    trait :with_items do
+      after(:create) do |instance, evaluator|
+        BaseItem.seed_items if BaseItem.count.zero?
+        Organization.seed_items(instance)
+      end
+    end
+
+    trait :with_items do
+      after(:create) do |instance, evaluator|
+        BaseItem.seed_items if BaseItem.count.zero?
+        Organization.seed_items(instance)
+      end
+    end
+
     after(:create) do |instance, evaluator|
       Organization.seed_items(instance) unless evaluator.skip_items
     end

--- a/spec/factories/partner_groups.rb
+++ b/spec/factories/partner_groups.rb
@@ -15,7 +15,7 @@
 FactoryBot.define do
   factory :partner_group do
     sequence(:name) { |n| "Group #{n}" }
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     reminder_day { 14 }
     deadline_day { 28 }
 

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     sequence(:email) { |n| "leslie#{n}@gmail.com" }
     notes { "Lorem ipsum" }
     send_reminders { true }
-    organization_id { Organization.try(:first).try(:id) || create(:organization).id }
+    organization_id { Organization.try(:first).try(:id) || create(:organization, skip_items: true).id }
 
     trait :approved do
       status { :approved }

--- a/spec/factories/partners/child.rb
+++ b/spec/factories/partners/child.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     first_name           { Faker::Name.first_name }
     last_name            { Faker::Name.last_name }
     gender               { Faker::Gender.binary_type }
-    item_needed_diaperid { Item.all.sample&.id || create(:item).id }
+    # TODO: change when closing #4199
+    item_needed_diaperid { Item.all.sample&.id || create(:item, organization: family.partner.organization).id }
   end
 end

--- a/spec/factories/partners/child.rb
+++ b/spec/factories/partners/child.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
     first_name           { Faker::Name.first_name }
     last_name            { Faker::Name.last_name }
     gender               { Faker::Gender.binary_type }
-    item_needed_diaperid { Item.all.sample.id }
+    item_needed_diaperid { Item.all.sample&.id || create(:item).id }
   end
 end

--- a/spec/factories/product_drive.rb
+++ b/spec/factories/product_drive.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     start_date { Time.current }
     end_date { Time.current }
     virtual { [true, false].sample }
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
   end
 end

--- a/spec/factories/product_drive_participants.rb
+++ b/spec/factories/product_drive_participants.rb
@@ -18,7 +18,7 @@
 
 FactoryBot.define do
   factory :product_drive_participant do
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     contact_name { "Don Draper" }
     business_name { "Awesome Business" }
     sequence(:email) { |n| "don#{n}@scdp.com" }

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     comment { "It's a fine day for diapers." }
     purchased_from { "Google" }
     storage_location
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     issued_at { nil }
     amount_spent_in_cents { 10_00 }
     vendor { Vendor.try(:first) || create(:vendor) }

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -24,7 +24,7 @@ end
 FactoryBot.define do
   factory :request do
     partner { Partner.try(:first) || create(:partner) }
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     request_items { random_request_items }
     comments { "Urgent" }
     partner_user { ::User.partner_users.first || create(:partners_user) }

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
   factory :storage_location do
     name { "Smithsonian Conservation Center" }
     address { "1500 Remount Road, Front Royal, VA 22630" }
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     square_footage { 100 }
     warehouse_type { StorageLocation::WAREHOUSE_TYPES.sample }
     transient do

--- a/spec/factories/transfers.rb
+++ b/spec/factories/transfers.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     transient do
       storage_location { nil }
     end
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     from { nil }
     to { nil }
     comment { "A comment" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -41,7 +41,7 @@ FactoryBot.define do
     password { "password!" }
     password_confirmation { "password!" }
     transient do
-      organization { Organization.try(:first) || create(:organization) }
+      organization { Organization.try(:first) || create(:organization, skip_items: true) }
     end
 
     after(:create) do |user, evaluator|

--- a/spec/factories/vendor.rb
+++ b/spec/factories/vendor.rb
@@ -18,7 +18,7 @@
 
 FactoryBot.define do
   factory :vendor do
-    organization { Organization.try(:first) || create(:organization) }
+    organization { Organization.try(:first) || create(:organization, skip_items: true) }
     contact_name { "Don Draper" }
     business_name { "Awesome Business" }
     sequence(:email) { |n| "don#{n}@scdp.com" }

--- a/spec/models/kit_spec.rb
+++ b/spec/models/kit_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Kit, type: :model do
   describe '#can_deactivate?' do
     context 'with inventory' do
       it 'should return false' do
-        kit = create(:kit, :with_item)
+        kit = create(:kit, :with_item, organization: @organization)
         TestInventory.create_inventory(@organization, {
           @organization.storage_locations.first.id => {
             kit.item.id => 10

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -162,7 +162,7 @@ RSpec.configure do |config|
 
   def seed_base_data_for_tests
     # Create base items that are used to handle seeding Organization with items
-    BaseItem.seed_items
+    seed_base_items
     # Create default organization
     organization = FactoryBot.create(:organization, name: DEFAULT_TEST_ORGANIZATION_NAME)
 
@@ -267,4 +267,22 @@ def select2(node, select_name, value, position: nil)
   container = node.find(:xpath, xpath)
   container.click
   container.find(:xpath, '//li[contains(@class, "select2-results__option")][@role="option"]', text: value).click
+end
+
+def seed_base_items
+  base_items = File.read(Rails.root.join("db", "base_items.json"))
+  items_by_category = JSON.parse(base_items)
+  base_items_data = items_by_category.map do |category, entries|
+    entries.map do |entry|
+      {
+        name: entry["name"],
+        category: category,
+        partner_key: entry["key"],
+        updated_at: Time.zone.now,
+        created_at: Time.zone.now
+      }
+    end
+  end.flatten
+
+  BaseItem.create!(base_items_data)
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -120,7 +120,7 @@ RSpec.configure do |config|
     config.use_transactional_fixtures = true
 
     DatabaseCleaner.clean_with(:truncation)
-    seed_base_data_for_tests
+    seed_base_data_for_tests if RSpec.current_example.metadata[:seed_items] != false
   end
 
   #
@@ -162,22 +162,7 @@ RSpec.configure do |config|
 
   def seed_base_data_for_tests
     # Create base items that are used to handle seeding Organization with items
-    base_items = File.read(Rails.root.join("db", "base_items.json"))
-    items_by_category = JSON.parse(base_items)
-    base_items_data = items_by_category.map do |category, entries|
-      entries.map do |entry|
-        {
-          name: entry["name"],
-          category: category,
-          partner_key: entry["key"],
-          updated_at: Time.zone.now,
-          created_at: Time.zone.now
-        }
-      end
-    end.flatten
-
-    BaseItem.create!(base_items_data)
-
+    BaseItem.seed_items
     # Create default organization
     organization = FactoryBot.create(:organization, name: DEFAULT_TEST_ORGANIZATION_NAME)
 
@@ -203,24 +188,24 @@ RSpec.configure do |config|
     Geocoder.configure(lookup: :test)
 
     ["1500 Remount Road, Front Royal, VA 22630",
-     "123 Donation Site Way",
-     "Smithsonian Conservation Center new"].each do |address|
-       Geocoder::Lookup::Test.add_stub(
-         address, [
-           {
-             "latitude" => 40.7143528,
-             "longitude" => -74.0059731,
-             "address" => "1500 Remount Road, Front Royal, VA",
-             "state" => "Virginia",
-             "state_code" => "VA",
-             "country" => "United States",
-             "country_code" => "US"
-           }
-         ]
-       )
-     end
+       "123 Donation Site Way",
+       "Smithsonian Conservation Center new"].each do |address|
+         Geocoder::Lookup::Test.add_stub(
+           address, [
+             {
+               "latitude" => 40.7143528,
+               "longitude" => -74.0059731,
+               "address" => "1500 Remount Road, Front Royal, VA",
+               "state" => "Virginia",
+               "state_code" => "VA",
+               "country" => "United States",
+               "country_code" => "US"
+             }
+           ]
+         )
+       end
 
-    seed_base_data_for_tests
+    seed_base_data_for_tests if !ENV["SKIP_SEED"]
   end
 
   config.before(:each, type: :system) do
@@ -231,7 +216,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     # Defined shared @ global variables used throughout the test suite.
-    define_global_variables
+    define_global_variables if RSpec.current_example.metadata[:seed_items] != false
 
     if ENV['EVENTS_READ'] == 'true'
       allow(Event).to receive(:read_events?).and_return(true)


### PR DESCRIPTION
Related to #4199

Makes changes to factories, models, and rails helper needed to allow removal of seeding.
Adds RSpec meta tag `seed_items` when set to `false` will disable seeding of items on a per test basis.
`ENV` flag `SKIP_SEED=true` will prevent rspec seeding before the suite runs.

### Note
I added some comments in places because I found stuff confusing. Those can be removed in the final PR but most of them felt like stuff worth bringing up.

Additional note: the speedup was actually much less than I expected, across all the models I saw only a 5s speedup, from 29s to 25s


### Type of change

* Refactor

### How Has This Been Tested?
Passes all tests
