### PR TITLE
refactor: remove item seeding (models easy)

### DIFF
--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -17,8 +17,8 @@
 #
 require 'rails_helper'
 
-RSpec.describe AccountRequest, type: :model do
-  let(:account_request) { FactoryBot.create(:account_request) }
+RSpec.describe AccountRequest, type: :model, skip_seed: true do
+  let(:account_request) { create(:account_request) }
 
   describe 'associations' do
     it { should have_one(:organization).class_name('Organization') }
@@ -41,7 +41,7 @@ RSpec.describe AccountRequest, type: :model do
 
     context 'when the email provided is already used by an existing organization' do
       before do
-        FactoryBot.create(:organization, email: account_request.email)
+        create(:organization, skip_items: true, email: account_request.email)
       end
 
       it 'should not allow the email' do
@@ -118,7 +118,7 @@ RSpec.describe AccountRequest, type: :model do
 
     context 'when the account request has a associated organization' do
       before do
-        FactoryBot.create(:organization, account_request_id: account_request.id)
+        create(:organization, skip_items: true, account_request_id: account_request.id)
       end
 
       it 'should return true' do
@@ -130,9 +130,12 @@ RSpec.describe AccountRequest, type: :model do
   specify '#confirm!' do
     mail_double = instance_double(ActionMailer::MessageDelivery, deliver_later: nil)
     allow(AccountRequestMailer).to receive(:approval_request).and_return(mail_double)
+
     freeze_time do
       expect(account_request.confirmed_at).to be_nil
+
       account_request.confirm!
+
       expect(account_request.reload.confirmed_at).to eq(Time.zone.now)
       expect(account_request).to be_user_confirmed
       expect(AccountRequestMailer).to have_received(:approval_request)
@@ -144,7 +147,9 @@ RSpec.describe AccountRequest, type: :model do
   specify '#reject!' do
     mail_double = instance_double(ActionMailer::MessageDelivery, deliver_later: nil)
     allow(AccountRequestMailer).to receive(:rejection).and_return(mail_double)
+
     account_request.reject!('because I said so')
+
     expect(account_request.reload.rejection_reason).to eq('because I said so')
     expect(account_request).to be_rejected
     expect(AccountRequestMailer).to have_received(:rejection)

--- a/spec/models/concerns/deadlinable_spec.rb
+++ b/spec/models/concerns/deadlinable_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Deadlinable, type: :model do
+RSpec.describe Deadlinable, type: :model, skip_seed: true do
   let(:dummy_class) do
     Class.new do
       def self.name

--- a/spec/models/county_spec.rb
+++ b/spec/models/county_spec.rb
@@ -11,7 +11,7 @@
 #
 require "rails_helper"
 
-RSpec.describe County, type: :model do
+RSpec.describe County, type: :model, skip_seed: true do
   it { should have_many(:served_areas) }
 
   describe "versioning" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -14,8 +14,9 @@
 #  organization_id :bigint
 #  user_id         :bigint
 #
-RSpec.describe Event, type: :model do
-  let(:organization) { FactoryBot.create(:organization) }
+RSpec.describe Event, type: :model, skip_seed: true do
+  let(:organization) { create(:organization, skip_items: true) }
+
   describe "#most_recent_snapshot" do
     let(:eventable) { FactoryBot.create(:distribution, organization_id: organization.id) }
     let(:data) { EventTypes::Inventory.new(storage_locations: {}, organization_id: organization.id) }

--- a/spec/models/item_category_spec.rb
+++ b/spec/models/item_category_spec.rb
@@ -11,7 +11,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe ItemCategory, type: :model do
+RSpec.describe ItemCategory, type: :model, skip_seed: true do
   describe 'validations' do
     subject { build(:item_category) }
 

--- a/spec/models/kit_allocation_spec.rb
+++ b/spec/models/kit_allocation_spec.rb
@@ -12,9 +12,7 @@
 #
 require "rails_helper"
 
-RSpec.describe KitAllocation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-
+RSpec.describe KitAllocation, type: :model, skip_seed: true do
   describe "versioning" do
     it { is_expected.to be_versioned }
   end

--- a/spec/models/ndbn_member_spec.rb
+++ b/spec/models/ndbn_member_spec.rb
@@ -9,7 +9,7 @@
 #
 require "rails_helper"
 
-RSpec.describe NDBNMember, type: :model do
+RSpec.describe NDBNMember, type: :model, skip_seed: true do
   describe "validations" do
     subject { build(:ndbn_member) }
     it { should validate_presence_of(:ndbn_member_id) }

--- a/spec/models/organization_stats_spec.rb
+++ b/spec/models/organization_stats_spec.rb
@@ -1,7 +1,6 @@
 # == No Schema Information
 #
-
-RSpec.describe OrganizationStats, type: :model do
+RSpec.describe OrganizationStats, type: :model, skip_seed: true do
   let(:partners) { [] }
   let(:storage_locations) { [] }
   let(:donation_sites) { [] }

--- a/spec/models/partner_group_spec.rb
+++ b/spec/models/partner_group_spec.rb
@@ -11,7 +11,7 @@
 #  updated_at      :datetime         not null
 #  organization_id :bigint
 #
-RSpec.describe PartnerGroup, type: :model do
+RSpec.describe PartnerGroup, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:organization) }
     it { should have_many(:partners) }
@@ -43,10 +43,6 @@ RSpec.describe PartnerGroup, type: :model do
   # rubocop:enable Rails/SkipsModelValidations
 
   context "Validations >" do
-    it "must belong to an organization" do
-      expect(build(:partner_group, organization_id: nil)).not_to be_valid
-    end
-
     it "requires a unique name within an organization" do
       expect(build(:partner_group, name: nil)).not_to be_valid
       create(:partner_group, name: "Foo")

--- a/spec/models/partners/authorized_family_member_spec.rb
+++ b/spec/models/partners/authorized_family_member_spec.rb
@@ -14,14 +14,14 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::AuthorizedFamilyMember, type: :model do
+RSpec.describe Partners::AuthorizedFamilyMember, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:family) }
     it { should have_many(:child_item_requests).dependent(:nullify) }
   end
 
   describe "#display_name" do
-    let(:partners_family) { FactoryBot.create(:partners_family) }
+    let(:partners_family) { create(:partners_family) }
     let(:authorized_family_member) { partners_family.create_authorized }
 
     it "should return the family member's first and last name" do

--- a/spec/models/partners/child_item_request_spec.rb
+++ b/spec/models/partners/child_item_request_spec.rb
@@ -14,7 +14,7 @@
 #
 require 'rails_helper'
 
-RSpec.describe Partners::ChildItemRequest, type: :model do
+RSpec.describe Partners::ChildItemRequest, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:item_request) }
     it { should belong_to(:child) }

--- a/spec/models/partners/child_spec.rb
+++ b/spec/models/partners/child_spec.rb
@@ -21,7 +21,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::Child, type: :model do
+RSpec.describe Partners::Child, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:family) }
     it { should have_many(:child_item_requests).dependent(:destroy) }
@@ -29,7 +29,7 @@ RSpec.describe Partners::Child, type: :model do
 
   describe "#display_name" do
     subject { partners_child }
-    let(:partners_child) { FactoryBot.create(:partners_child) }
+    let(:partners_child) { create(:partners_child) }
 
     it "should return a child's first and last name" do
       expect(subject.display_name).to eq("#{subject.first_name} #{subject.last_name}")

--- a/spec/models/partners/family_request_spec.rb
+++ b/spec/models/partners/family_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Partners::FamilyRequest do
+RSpec.describe Partners::FamilyRequest, skip_seed: true do
   describe "Partners::FamilyRequest.new_with_attrs" do
     it "creates a new FamilyRequest with attributes" do
       attributes = [{item_id: 1, person_count: 3}]

--- a/spec/models/partners/family_spec.rb
+++ b/spec/models/partners/family_spec.rb
@@ -28,7 +28,7 @@
 
 require "rails_helper"
 
-RSpec.describe Partners::Family, type: :model do
+RSpec.describe Partners::Family, type: :model, skip_seed: true do
   describe "associations" do
     it { should belong_to(:partner) }
     it { should have_many(:children).dependent(:destroy) }

--- a/spec/models/partners/item_request_spec.rb
+++ b/spec/models/partners/item_request_spec.rb
@@ -14,7 +14,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::ItemRequest, type: :model do
+RSpec.describe Partners::ItemRequest, type: :model, skip_seed: true do
   describe 'associations' do
     it { should belong_to(:request).class_name('::Request').with_foreign_key(:partner_request_id) }
     it { should have_many(:child_item_requests).dependent(:destroy) }

--- a/spec/models/partners/profile_spec.rb
+++ b/spec/models/partners/profile_spec.rb
@@ -81,7 +81,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::Profile, type: :model do
+RSpec.describe Partners::Profile, type: :model, skip_seed: true do
   describe "associations" do
     it { should have_one_attached(:proof_of_partner_status) }
     it { should have_one_attached(:proof_of_form_990) }
@@ -95,7 +95,7 @@ RSpec.describe Partners::Profile, type: :model do
   end
 
   describe "request settings validation for profile" do
-    subject { FactoryBot.build(:partner_profile, enable_child_based_requests: false, enable_individual_requests: false, enable_quantity_based_requests: false) }
+    subject { build(:partner_profile, enable_child_based_requests: false, enable_individual_requests: false, enable_quantity_based_requests: false) }
 
     context "no settings are set to true" do
       it "should not be valid" do
@@ -117,7 +117,7 @@ RSpec.describe Partners::Profile, type: :model do
 
   describe "social media info validation for profile" do
     context "no social media presence and the checkbox isn't checked" do
-      let(:profile) { FactoryBot.build(:partner_profile, website: "", twitter: "", facebook: "", instagram: "", no_social_media_presence: false) }
+      let(:profile) { build(:partner_profile, website: "", twitter: "", facebook: "", instagram: "", no_social_media_presence: false) }
 
       it "should not be valid" do
         expect(profile.valid?(:edit)).to eq(false)
@@ -131,7 +131,7 @@ RSpec.describe Partners::Profile, type: :model do
     end
 
     context "no social media presence and the checkbox is checked" do
-      let(:profile) { FactoryBot.build(:partner_profile, website: "", twitter: "", facebook: "", instagram: "", no_social_media_presence: true) }
+      let(:profile) { build(:partner_profile, website: "", twitter: "", facebook: "", instagram: "", no_social_media_presence: true) }
 
       it "should be valid" do
         expect(profile.valid?(:edit)).to eq(true)
@@ -139,7 +139,7 @@ RSpec.describe Partners::Profile, type: :model do
     end
 
     context "has social media presence and the checkbox is unchecked" do
-      let(:profile) { FactoryBot.build(:partner_profile, no_social_media_presence: false) }
+      let(:profile) { build(:partner_profile, no_social_media_presence: false) }
 
       it "with just a website it should be valid" do
         profile.update(website: "some website URL", twitter: "", facebook: "", instagram: "")
@@ -170,7 +170,7 @@ RSpec.describe Partners::Profile, type: :model do
 
   describe "client share behaviour" do
     context "no served areas" do
-      let(:profile) { FactoryBot.build(:partner_profile) }
+      let(:profile) { build(:partner_profile) }
       it "has 0 client share" do
         expect(profile.client_share_total).to eq(0)
         expect(profile.valid?).to eq(true)

--- a/spec/models/partners/served_area_spec.rb
+++ b/spec/models/partners/served_area_spec.rb
@@ -11,7 +11,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Partners::ServedArea, type: :model do
+RSpec.describe Partners::ServedArea, type: :model, skip_seed: true do
   it { should belong_to(:partner_profile) }
   it { should belong_to(:county) }
 

--- a/spec/models/product_drive_participant_spec.rb
+++ b/spec/models/product_drive_participant_spec.rb
@@ -18,7 +18,7 @@
 
 require "rails_helper"
 
-RSpec.describe ProductDriveParticipant, type: :model do
+RSpec.describe ProductDriveParticipant, type: :model, skip_seed: true do
   it_behaves_like "provideable"
 
   context "Validations" do
@@ -26,10 +26,6 @@ RSpec.describe ProductDriveParticipant, type: :model do
       expect(build(:product_drive_participant, phone: nil, email: nil)).not_to be_valid
       expect(build(:product_drive_participant, phone: nil)).to be_valid
       expect(build(:product_drive_participant, email: nil)).to be_valid
-    end
-
-    it "is invalid without an organization" do
-      expect(build(:product_drive_participant, organization: nil)).not_to be_valid
     end
   end
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -11,7 +11,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Question, type: :model do
+RSpec.describe Question, type: :model, skip_seed: true do
   describe "scope for_partners" do
     it "should filter out questions that aren't meant for partners" do
       question_1 = build(:question)

--- a/spec/models/request_item_spec.rb
+++ b/spec/models/request_item_spec.rb
@@ -1,10 +1,10 @@
 # == No Schema Information
 #
 
-RSpec.describe RequestItem, type: :model do
+RSpec.describe RequestItem, type: :model, skip_seed: true do
   context "Methods >" do
     describe "#from_json" do
-      let(:organization) { create :organization }
+      let(:organization) { create(:organization, skip_items: true) }
       let(:inventory) { View::Inventory.new(organization.id) }
       let(:location) { create :storage_location, organization: organization }
       let(:other_location) { create :storage_location, organization: organization }

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -12,7 +12,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Role, type: :model do
+RSpec.describe Role, type: :model, skip_seed: true do
   describe "Validations" do
     it { should validate_inclusion_of(:resource_type).in_array(Rolify.resource_types) }
   end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -18,7 +18,7 @@
 
 require "rails_helper"
 
-RSpec.describe Vendor, type: :model do
+RSpec.describe Vendor, type: :model, skip_seed: true do
   it_behaves_like "provideable"
 
   context "Methods" do

--- a/spec/models/view/inventory_spec.rb
+++ b/spec/models/view/inventory_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe View::Inventory do
+RSpec.describe View::Inventory, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let!(:storage_location1) { create(:storage_location, name: "SL1", organization: organization) }
   let!(:storage_location2) { create(:storage_location, name: "SL2", organization: organization) }


### PR DESCRIPTION
Related to https://github.com/rubyforgood/human-essentials/issues/4199

This is the model changes that require minimal work. Their behavior does not depend on item seeding.

Lemme know how you feel about the sizes of these PRs. Its not that many lines of code and basically all find and replaces but its a lot of files.

### Type of change

* Refactor

### How Has This Been Tested?

Passes current suite