### PR TITLE
Disable editing/reclaiming itemizables with inactive items

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -187,3 +187,10 @@ select.selectpicker + .dropdown-toggle::after {
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
   background-color: #8282df
 }
+
+div.warning {
+  color: #e15563;
+  margin: 5px;
+  text-align: center;
+}
+

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -13,6 +13,16 @@ module Itemizable
       line_items.each(&:destroy)
     end
 
+    # @return [Boolean]
+    def has_inactive_item?
+      inactive_items.any?
+    end
+
+    # @return [Array<Item>]
+    def inactive_items
+      line_items.map(&:item).select { |i| !i.active? }
+    end
+
     has_many :line_items, as: :itemizable, inverse_of: :itemizable do
       def assign_insufficiency_errors(insufficiency_hash)
         insufficiency_hash = insufficiency_hash.index_by { |i| i[:item_id] }

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -23,12 +23,14 @@
   <td class="text-right">
     <%= view_button_to distribution_path(distribution_row) %>
     <% if (!distribution_row.complete? && !distribution_row.future?) || current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
-      <%= edit_button_to edit_distribution_path(distribution_row) %>
+      <%= edit_button_to edit_distribution_path(distribution_row), enabled: !distribution_row.has_inactive_item? %>
     <% end %>
     <%= print_button_to print_distribution_path(distribution_row, format: :pdf) %>
     <%= delete_button_to distribution_path(distribution_row),
           { confirm: "Are you sure you want to reclaim this distribution to #{distribution_row.partner.name}?",
             text: "Reclaim",
-            icon: "undo" } %>
+            icon: "undo", enabled: !distribution_row.has_inactive_item? } %>
+    <% if distribution_row.has_inactive_item? %>
+      <div class="warning">Has Inactive Items</div>
+    <% end %>
   </td>
-</tr>

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -84,9 +84,19 @@
           <div class="card-footer">
             <%= update_button_to picked_up_distribution_path(@distribution), {text: "Distribution Complete", size: "md"} if @distribution.scheduled? %>
             <% if @distribution.future? || current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
-              <%= edit_button_to edit_distribution_path(@distribution), {text: "Make a Correction", size: "md"} %>
+              <%= edit_button_to edit_distribution_path(@distribution), {
+                text: "Make a Correction",
+                enabled: !@distribution.has_inactive_item?,
+                size: "md"} %>
             <% end %>
-            <%= print_button_to print_distribution_path(@distribution, format: :pdf), {size: "md"} %>                        </div>
+            <%= print_button_to print_distribution_path(@distribution, format: :pdf), {size: "md"} %>
+          </div>
+          <% if @distribution.has_inactive_item? %>
+            <div class="warning">
+              You can only correct distributions where all the items are active.
+              If you need to make a correction, please make the following items active: <%= @distribution.inactive_items.map(&:name).join(", ") %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -70,9 +70,18 @@
             </table>
           </div>
           <div class="card-footer">
-            <%= edit_button_to edit_donation_path(@donation), { text: "Make a correction", size: "md" } %>
+            <%= edit_button_to edit_donation_path(@donation), {
+              text: "Make a correction",
+              enabled: !@donation.has_inactive_item?,
+              size: "md" } %>
             <%= new_button_to new_distribution_path(donation_id: @donation.id, storage_location_id: @donation.storage_location_id), { text: "Start a new Distribution" } %>
             <%= delete_button_to donation_path(@donation), { size: "md", confirm: "Are you sure you want to permanently remove this donation?" } if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
+            <% if @donation.has_inactive_item? %>
+              <div class="warning">
+                You can only correct donations where all the items are active.
+                If you need to make a correction, please make the following items active: <%= @donation.inactive_items.map(&:name).join(", ") %>
+              </div>
+            <% end %>
           </div>
           </div>
       </div>

--- a/app/views/purchases/show.html.erb
+++ b/app/views/purchases/show.html.erb
@@ -67,8 +67,16 @@
             </table>
           </div>
           <div class="card-footer">
-            <%= edit_button_to edit_purchase_path(@purchase), { text: "Make a correction", size: "md" } %>
+            <%= edit_button_to edit_purchase_path(@purchase), { text: "Make a correction",
+                                                                enabled: !@purchase.has_inactive_item?,
+                                                                size: "md" } %>
             <%= delete_button_to purchase_path(@purchase), { size: "md", confirm: "Are you sure you want to permanently remove this purchase?" } if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
+            <% if @purchase.has_inactive_item? %>
+              <div class="warning">
+                You can only correct purchases where all the items are active.
+                If you need to make a correction, please make the following items active: <%= @purchase.inactive_items.map(&:name).join(", ") %>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
     delivery_method { :pick_up }
     state { :scheduled }
 
+    trait :past do
+      issued_at { 1.week.ago }
+    end
+
     trait :with_items do
       transient do
         item_quantity { 100 }

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -81,7 +81,34 @@ RSpec.describe "Donations", type: :request do
       end
     end
 
-    context "GET #edit" do
+    describe "GET #show" do
+      let(:item) { create(:item) }
+      let!(:donation) { create(:donation, :with_items, item: item) }
+
+      it "shows an enabled edit button" do
+        get donation_path(default_params.merge(id: donation.id))
+        page = Nokogiri::HTML(response.body)
+        edit = page.at_css("a[href='#{edit_donation_path(default_params.merge(id: donation.id))}']")
+        expect(edit.attr("class")).not_to match(/disabled/)
+        expect(response.body).not_to match(/please make the following items active:/)
+      end
+
+      context "with an inactive item" do
+        before do
+          item.update(active: false)
+        end
+
+        it "shows a disabled edit button" do
+          get donation_path(default_params.merge(id: donation.id))
+          page = Nokogiri::HTML(response.body)
+          edit = page.at_css("a[href='#{edit_donation_path(default_params.merge(id: donation.id))}']")
+          expect(edit.attr("class")).to match(/disabled/)
+          expect(response.body).to match(/please make the following items active: #{item.name}/)
+        end
+      end
+    end
+
+    describe "GET #edit" do
       context "when an finalized audit has been performed on the donated items" do
         it "shows a warning" do
           item = create(:item, organization: @organization, name: "Brightbloom Seed")

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -248,9 +248,30 @@ RSpec.describe "Purchases", type: :request do
     end
 
     describe "GET #show" do
-      it "returns http success" do
-        get purchase_path(default_params.merge(id: create(:purchase, organization: @organization)))
+      let(:item) { create(:item) }
+      let!(:purchase) { create(:purchase, :with_items, item: item) }
+
+      it "shows an enabled edit button" do
+        get purchase_path(default_params.merge(id: purchase.id))
         expect(response).to be_successful
+        page = Nokogiri::HTML(response.body)
+        edit = page.at_css("a[href='#{edit_purchase_path(default_params.merge(id: purchase.id))}']")
+        expect(edit.attr("class")).not_to match(/disabled/)
+        expect(response.body).not_to match(/please make the following items active:/)
+      end
+
+      context "with an inactive item" do
+        before do
+          item.update(active: false)
+        end
+
+        it "shows a disabled edit button" do
+          get purchase_path(default_params.merge(id: purchase.id))
+          page = Nokogiri::HTML(response.body)
+          edit = page.at_css("a[href='#{edit_purchase_path(default_params.merge(id: purchase.id))}']")
+          expect(edit.attr("class")).to match(/disabled/)
+          expect(response.body).to match(/please make the following items active: #{item.name}/)
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #4226 

### Description

This disables editing of distributions, purchases and donations that have an inactive item.

<img width="1221" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/1986893/0bde309c-fca3-4497-9898-653384d3f95f">

<img width="1215" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/1986893/d96db172-c2b2-4888-b06e-38bd69f36820">
