### PR TITLE
feat: Add CSV upload to NDBN role

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ You can sign up [here](https://join.slack.com/t/rubyforgood/shared_invite/zt-21p
   ```
 </details>
 
+<details>
+  <summary> Other 👥 </summary>
+
+  ```
+    NDBN User (also Org Admin)
+    Email: ndbn_admin@example.com
+    Password: password!
+
+    NDBN User (also Super Admin)
+    Email: ndbn_super_admin@example.com
+    Password: password!
+
+    NDBN User (also Partner)
+    Email: ndbn_partner@example.com
+    Password: password!
+  ```
+</details>
+
 ## Troubleshooting 👷🏼‍♀️
 
 Please let us know by opening up an issue! We have many new contributors come through and it is likely what you experienced will happen to them as well.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,6 +86,10 @@ class ApplicationController < ActionController::Base
       current_user.has_role?(Role::PARTNER, current_partner)
   end
 
+  def authorize_ndbn
+    verboten! unless current_user.has_role?(Role::NDBN)
+  end
+
   def authorize_admin
     verboten! unless current_user.has_role?(Role::SUPER_ADMIN) ||
       current_user.has_role?(Role::ORG_ADMIN, current_organization)

--- a/app/controllers/ndbn_members_controller.rb
+++ b/app/controllers/ndbn_members_controller.rb
@@ -1,0 +1,34 @@
+class NDBNMembersController < ApplicationController
+  before_action :authorize_ndbn
+
+  layout :set_layout
+
+  def index
+  end
+
+  def create
+    service = SyncNDBNMembers.new(file_params)
+    service.call
+
+    if service.errors.none?
+      redirect_to ndbn_members_path, notice: "NDBN Members have been updated!"
+    else
+      redirect_to ndbn_members_path, error: service.errors.full_messages
+    end
+  end
+
+  private
+
+  def file_params
+    params[:member_file]&.tempfile
+  end
+
+  def set_layout
+    current_partner ? "partners/application" : "application"
+  end
+
+  def ndbn_members
+    @ndbn_members ||= NDBNMember.all
+  end
+  helper_method :ndbn_members
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,6 +75,15 @@ module ApplicationHelper
     request.path_info.include?('admin')
   end
 
+  def super_admin_ndbn_namespace?
+    return false unless current_user
+
+    has_role = current_user.has_role?(Role::SUPER_ADMIN) && current_user.has_role?(Role::NDBN)
+    ndbn_namespace = request.path_info.include?('ndbn_members')
+
+    has_role && ndbn_namespace
+  end
+
   def fullstory_script(current_user: nil)
     base_script = <<-HTML
       window['_fs_debug'] = false;

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -30,12 +30,14 @@ class Role < ApplicationRecord
   ORG_ADMIN = :org_admin
   SUPER_ADMIN = :super_admin
   PARTNER = :partner
+  NDBN = :ndbn
 
   TITLES = {
     org_user: "Organization",
     org_admin: "Organization Admin",
     partner: "Partner",
-    super_admin: "Super admin"
+    super_admin: "Super admin",
+    ndbn: "NDBN"
   }.freeze
 
   TITLE_TO_RESOURCE = {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,6 +118,7 @@ class User < ApplicationRecord
   def switchable_roles
     all_roles = roles.to_a.group_by(&:resource_id)
     all_roles.values.each do |role_list|
+      role_list.delete_if { |r| r.name == Role::NDBN.to_s }
       if role_list.any? { |r| r.name == Role::ORG_ADMIN.to_s }
         role_list.delete_if { |r| r.name == Role::ORG_USER.to_s }
       end

--- a/app/services/add_role_service.rb
+++ b/app/services/add_role_service.rb
@@ -8,11 +8,13 @@ class AddRoleService
       add_super_admin(user)
       return
     end
+
     klass = Role::TITLE_TO_RESOURCE[resource_type.to_sym]
-    resource = klass.find(resource_id)
+    resource = klass&.find(resource_id)
     if user.has_role?(resource_type, resource)
       raise "User #{user.display_name} already has role for #{resource.name}"
     end
+
     user.add_role(resource_type, resource)
     if resource_type.to_sym == Role::ORG_ADMIN
       user.add_role(:org_user, resource)

--- a/app/services/sync_ndbn_members.rb
+++ b/app/services/sync_ndbn_members.rb
@@ -1,69 +1,45 @@
 class SyncNDBNMembers
-  include HTTParty
+  include ServiceObjectErrorsMixin
 
-  NDBN_MEMBERS_PAGE = "https://ndbn.memberclicks.net/member-ids".freeze
+  def initialize(member_file)
+    @member_file = member_file
+  end
+  attr_reader :member_file
 
-  class << self
-    def sync
-      Rails.logger.info("Syncing NDBNMember started.")
+  def call
+    member_entries = parse_csv
 
-      members_page = fetch_members_page
-      member_entries = extract_member_entries(members_page)
+    return if errors.any?
 
-      member_entries.each do |member|
-        ndbn_member = NDBNMember.find_or_initialize_by(ndbn_member_id: member[:ndbn_member_id])
-        ndbn_member.account_name = member[:account_name]
+    member_entries.each do |member_id, account_name|
+      ndbn_member = NDBNMember.find_or_initialize_by(ndbn_member_id: member_id.to_i)
+      ndbn_member.account_name = account_name
 
-        # Skip if nothing has changed!
-        if ndbn_member.persisted? && !ndbn_member.changed?
-          next
-        elsif ndbn_member.persisted? && ndbn_member.changed?
-          Rails.logger.info("#{ndbn_member.id} changed their account name from #{ndbn_member.account_name_was} to #{ndbn_member.account_name}.")
-        elsif ndbn_member.new_record?
-          Rails.logger.info("New record found! #{ndbn_member.id} - #{ndbn_member.account_name} has been added!")
-        end
+      # Skip if nothing has changed!
+      if ndbn_member.persisted? && !ndbn_member.changed?
+        next
+      end
 
-        Rails.logger.info("Updating....")
-        if ndbn_member.save
-          Rails.logger.info("Done!")
-        else
-          error_msg = "Failed to update #{ndbn_member_id} due to #{e.errors.full_messages}"
-          Rails.logger.info(error_msg)
-          Bugsnag.notify(error_msg)
+      unless ndbn_member.save
+        ndbn_member.errors.full_messages.each do |msg|
+          error = "Issue with #{member_id}: #{account_name} -> #{msg}"
+          errors.add(:base, error)
         end
       end
-
-      Rails.logger.info("Syncing NDBNMember finished.")
     end
+  end
 
-    private
+  private
 
-    def fetch_members_page
-      res = get(NDBN_MEMBERS_PAGE)
+  def parse_csv
+    return @_parsed if defined?(@_parsed)
 
-      if res.code != 200
-        raise "SyncNDBNMembers.sync failed due to getting a status code of #{res.code}"
-      end
+    return errors.add(:base, "CSV upload is required") if member_file.nil?
 
-      res.body
-    end
+    raw = CSV.parse(member_file)
 
-    def extract_member_entries(html_body)
-      doc = Nokogiri::HTML(html_body)
-      entries = doc.css(".contentpaneopen p").map { |t| t.text }
-
-      # Removes the column header that only has the labels
-      entries[1..].map do |entry|
-        split = entry.split(/\s/)
-
-        member_id = split[0].squish
-        account_name = split[1..].join(" ")
-
-        {
-          ndbn_member_id: member_id,
-          account_name: account_name
-        }
-      end
+    @_parsed = raw.select do |member_id, member_name|
+      member_id.match(/^\d+$/) && member_name.present?
     end
   end
 end

--- a/app/views/admin/users/_roles.html.erb
+++ b/app/views/admin/users/_roles.html.erb
@@ -24,7 +24,7 @@
                 <% user.roles.each do |role| %>
                   <tr>
                     <td><%= role.title %></td>
-                    <td><%= link_to role.resource.name, role.resource %></td>
+                    <td><%= link_to role.resource.name, role.resource if role.resource.present? %></td>
                     <td class="text-right">
                       <%= delete_button_to admin_user_remove_role_path(user, role_id: role.id),
                                            confirm: "Are you sure you want to remove this role?" %>

--- a/app/views/layouts/_lte_admin_sidebar.html.erb
+++ b/app/views/layouts/_lte_admin_sidebar.html.erb
@@ -64,6 +64,14 @@
           <i class="nav-icon fa fa-plus-circle"></i> New Organization
         <% end %>
       </li>
+      <% if current_user.has_role?(Role::NDBN) %>
+        <li class="nav-item <%= active_class(['ndbm_members']) %>">
+          <%= link_to(ndbn_members_path(organization_id: current_user.organization_id), class: "nav-link #{active_class(['ndbn_members'])}") do %>
+            <i class="nav-icon fa fa-cloud-upload"></i>
+            NDBN Member Upload
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </li>
 

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -168,6 +168,13 @@
           <i class="nav-icon fa fa-circle-o"></i> Vendors
         <% end %>
       </li>
+      <% if current_user.has_role?(Role::NDBN) %>
+        <li class="nav-item <%= active_class(['ndbm_members']) %>">
+          <%= link_to(ndbn_members_path(organization_id: current_user.organization), class: "nav-link #{active_class(['ndbn_members'])}") do %>
+            <i class="nav-icon fa fa-circle-o"></i> NDBN Member Upload
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </li>
   <% if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,7 +76,7 @@
     <div class="sidebar">
       <nav class="mt-2">
         <% if user_signed_in? %>
-          <% if admin_namespace? %>
+          <% if admin_namespace? || super_admin_ndbn_namespace? %>
             <%= render partial: "layouts/lte_admin_sidebar" %>
           <% else %>
             <%= render partial: "layouts/lte_sidebar" %>

--- a/app/views/layouts/application_old.html.erb
+++ b/app/views/layouts/application_old.html.erb
@@ -63,7 +63,7 @@
   <!-- =============================================== -->
   <%# If there's no organization set, most of these routes won't work. %>
   <% if user_signed_in? %>
-    <% if admin_namespace? %>
+    <% if admin_namespace? || super_admin_ndbn_namespace? %>
       <%= render partial: "layouts/lte_admin_sidebar" %>
     <% else %>
       <%= render partial: "layouts/lte_sidebar" %>

--- a/app/views/layouts/partners/navigation/_sidebar.html.erb
+++ b/app/views/layouts/partners/navigation/_sidebar.html.erb
@@ -50,4 +50,12 @@
       <% end %>
     </li>
   <% end %>
+  <% if current_user.has_role?(Role::NDBN) %>
+    <li class="nav-item <%= active_class(['ndbm_members']) %>">
+      <%= link_to(ndbn_members_path(organization_id: current_user.organization_id), class: "nav-link #{active_class(['ndbn_members'])}") do %>
+        <i class="nav-icon fa fa-cloud-upload"></i>
+        NDBN Member Upload
+      <% end %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/ndbn_members/index.html.erb
+++ b/app/views/ndbn_members/index.html.erb
@@ -1,0 +1,79 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Community - NDBN Member Upload" %>
+        <h1>NDBN Member Upload</h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><%= link_to(ndbn_members_path) do %>
+              <i class="fa fa-dashboard"></i>
+              Home
+            <% end %>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <!-- left column -->
+      <div class="col-md-12">
+        <!-- jquery validation -->
+        <div class="card card-primary">
+          <div class="card-header">
+            <h3 class="card-title">Upload NDBN Members</h3>
+          </div>
+          <!-- /.card-header --> <!-- form start -->
+          <div class="card-body">
+            <div class="row">
+              <p>Update the current NDBN members by uploading a CSV file of the
+                current members.</p>
+            </div>
+            <%= form_with(url: ndbn_members_path) do |form| %>
+              <div class="row">
+                <%= form.label :member_file, "Select CSV File to Upload" %>
+              </div>
+              <%= form.file_field :member_file, required: true %>
+              <%= submit_button({ text: "Upload" }) %>
+            <% end %>
+          </div>
+        </div>
+        <!-- /.card -->
+      </div>
+    </div>
+    <!-- /.row -->
+  </div>
+  <!-- /.container-fluid -->
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12">
+        <!-- Default box -->
+        <div class="card">
+          <div class="card-body p-0">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>NDBN Member Number</th>
+                  <th>NDBN Member Name</th>
+                </tr>
+              </thead>
+              <tbody>
+                <%- ndbn_members.each do |member| %>
+                  <tr>
+                    <td><%= member.ndbn_member_id %></td>
+                    <td><%= member.account_name %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section><!-- /.content -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,6 +223,8 @@ Rails.application.routes.draw do
     get "historical_trends/donations", to: "historical_trends/donations#index"
   end
 
+  resources :ndbn_members, only: %i(index create)
+
   resources :attachments, only: %i(destroy)
   get "distributions/calendar", to: "distributions#calendar"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_20_193521) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_31_141135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/tasks/sync_ndbn_members.rake
+++ b/lib/tasks/sync_ndbn_members.rake
@@ -1,5 +1,0 @@
-desc "This task is called by the Heroku scheduler add-on to sync up NDBNMember records"
-task :sync_ndbn_members => :environment do
-  SyncNDBNMembers.sync
-end
-

--- a/spec/factories/ndbn_members.rb
+++ b/spec/factories/ndbn_members.rb
@@ -10,6 +10,6 @@
 FactoryBot.define do
   factory :ndbn_member, class: NDBNMember do
     sequence(:ndbn_member_id) { |n| n }
-    account_name { "MyString" }
+    account_name { Faker::Lorem.sentence(word_count: 2) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -68,6 +68,13 @@ FactoryBot.define do
       end
     end
 
+    factory :ndbn_user do
+      name { "NDBN User" }
+      after(:create) do |user|
+        user.add_role(Role::NDBN)
+      end
+    end
+
     factory :super_admin_no_org do
       name { "Administrative User No Org" }
       after(:create) do |user, evaluator|

--- a/spec/fixtures/ndbn-large-import.csv
+++ b/spec/fixtures/ndbn-large-import.csv
@@ -1,0 +1,91 @@
+Updated: 1/10/2024,
+NDBN Member Number,Member Name
+20040,(914) Cares
+12001,A Baby Center
+22022,Access Period
+21047,AIO Food & Energy Assistance
+22007,Alaska Adoption Services - Community Diaper Pantry
+23012,Alliance for Community Transformations
+19010,Alliance for Period Supplies of SWFL
+15027,All-Options Pregnancy Resource Center
+19017,Aloha Diaper Bank
+21056,Amenity Aid
+19003,A Precious Child
+13006,Arizona Diaper Bank
+13004,A Small Hand a Program of Shenandoah Valley Lutheran Ministries
+18005,Athens Area Diaper Bank
+21006,"Atlanta Growing Leadership of Women (GLOW), Inc"
+14001,Austin Diaper Bank
+13009,"Babies & Beyond of WI, Inc"
+20011,"Babies Need Bottoms, Inc."
+20050,Babies of Homelessness
+14112,Baby's Bounty
+13024,"Baby Basics, Inc."
+14011,Baby Basics of Collier County Inc
+14059,Baby Booties Diaper Bank
+13025,"BabyCare, Sheboygan Evangelical Free Church"
+13026,Babycycle
+22023,Baby Hope
+16025,Baby Steps Baby Pantry at Christ Lutheran Church
+23023,Bambino Basket
+20024,Banco de Alimentos Puerto Rico Inc
+16003,"Bare Necessities, Inc."
+21003,Basic Necessities
+20009,Basics4Babies Emergency Pantry for Infants
+20020,Battle Creek Diaper Initiative
+19005,Battle Ground Adventist Community Services
+20022,Beantown Baby Diaper Bank
+23015,Bellingham Food Bank
+16004,Berkshire Community Diaper Project Inc
+21055,Beyond the Pantry
+22042,Black Mustard Seed Community Group
+21013,Bottoms Up Diaper Drive
+13046,Bundled Blessings Diaper Bank
+15032,Bundles of Hope Diaper Bank
+17015,Bundles of Joy - Diaper Bank of the Low Country
+23021,Care Collective of Southwest Michigan
+20014,CarrollBaby
+14075,Catholic Charities Archdiocese of Denver
+13035,Catholic Charities Bayard House
+12032,Catholic Charities Diaper Depot
+21011,Catholic Charities of Northern Kansas
+14058,"Center for Leadership, Development and Advocacy"
+18024,Central California Food Bank
+14100,Central Florida Diaper Bank
+14010,"Central Jersey Diaper Bank of AECDC, Inc."
+16027,Central New York Diaper Bank Inc.
+20053,"Change Today, Change Tomorrow Inc."
+19013,Charitable Union
+21034,Chhaupadi
+13048,Childrens Aid and Family Services Inc
+19023,Childrens Clothes Closet at Mission Central
+23014,Columbia Community Care
+15003,Columbus Diaper Bank
+23005,Communities in Schools of Tennessee
+13050,"Community Action, Inc."
+23017,Community Action Center of Northfield
+20004,Community Action Partnership of Orange County
+20008,Community Diaper Bank
+13038,Community Diaper Bank of Southwest Wyoming
+14034,Community FoodBank of New Jersey
+22035,Community Foundation of Lorain County - Change the Cycle an initiative of The Women's Fund
+22030,Community Resource Center
+16011,Covered Bottoms Diaper Bank
+17009,"Covered with Love, Inc"
+20047,Covering Weld; United Way of Weld County
+18008,Walworth County Diaper Bank
+15033,WeeCycle
+13044,Western Pennsylvania Diaper Bank
+12017,WestSide Baby
+22038,Williamsburg House of Mercy
+19016,"Women4Women Tempe, Inc."
+23007,Women Empowering Each Other Inc
+18008,Walworth County Diaper Bank
+16018,We Care Community Baby Center
+15033,WeeCycle
+13044,Western Pennsylvania Diaper Bank
+12017,WestSide Baby
+22038,Williamsburg House of Mercy
+19016,"Women4Women Tempe, Inc."
+20035,Womens Fund of Greater Chattanooga
+20052,Yolo Diaper Bank

--- a/spec/fixtures/ndbn-small-import.csv
+++ b/spec/fixtures/ndbn-small-import.csv
@@ -1,0 +1,7 @@
+Updated: 1/10/2024,
+NDBN Member Number,Member Name
+10000,Homeless Shelter
+20000,Other Spot
+20000,
+30000,Amazing Place
+10000,Pawnee

--- a/spec/models/users_role_spec.rb
+++ b/spec/models/users_role_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe UsersRole, type: :model do
       end
     end
 
+    context "for ndbn member" do
+      it "should return still return org user role" do
+        user = FactoryBot.create(:ndbn_user)
+        expect(described_class.current_role_for(user).name).to eq("org_user")
+      end
+    end
+
     context "for org admin" do
       it "should return org admin" do
         user = FactoryBot.create(:organization_admin)

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe "Admin::UsersController", type: :request do
         expect(response.body).to include('Org ABC')
         expect(response.body).to include('Partner XYZ')
       end
+
+      it 'renders a role that has no resource' do
+        AddRoleService.call(user_id: user.id, resource_type: Role::NDBN)
+        get edit_admin_user_path(user)
+        expect(response.body).to include('NDBN')
+      end
     end
 
     describe "PATCH #update" do

--- a/spec/requests/ndbn_members_spec.rb
+++ b/spec/requests/ndbn_members_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe "NDBNMembers", type: :request do
+  describe "GET /index" do
+    context "when user does not have role 'NDBN'" do
+      it "redirects to the root path" do
+        user = create(:user)
+        sign_in user
+        get ndbn_members_path
+
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+
+    context "when user has role 'NDBN'" do
+      let(:user) { create(:ndbn_user) }
+
+      it "renders the index page" do
+        sign_in user
+        get ndbn_members_path
+
+        expect(response).to be_successful
+      end
+
+      it "displays the NDBN members and csv upload" do
+        sign_in user
+        get ndbn_members_path
+
+        create(:ndbn_member, ndbn_member_id: "123", account_name: "A Baby Center")
+
+        get ndbn_members_path
+        html = Nokogiri::HTML(response.body)
+
+        expect(html.css("h1").text).to eq("NDBN Member Upload")
+        expect(html.css("input[type=file]").count).to eq(1)
+        expect(html.css("button[type=submit]").count).to eq(1)
+
+        expect(html.css("th").map(&:text)).to match_array(["NDBN Member Number", "NDBN Member Name"])
+        expect(html.css("tbody tr td").map(&:text)).to match_array(["123", "A Baby Center"])
+      end
+
+      context "when user is also an organization admin" do
+        it "is successful" do
+          user.add_role(Role::ORG_ADMIN, user.organization)
+          sign_in user
+
+          get ndbn_members_path
+
+          expect(response).to be_successful
+        end
+      end
+
+      context "when user is also a super admin" do
+        it "is successful" do
+          user.add_role(Role::SUPER_ADMIN)
+          sign_in user
+
+          get ndbn_members_path
+
+          expect(response).to be_successful
+        end
+      end
+
+      context "when user is also partner" do
+        it "is successful" do
+          user.add_role(Role::PARTNER, user.organization)
+          sign_in user
+
+          get ndbn_members_path
+
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
+
+  describe "POST /create" do
+    context "when user has role 'NDBN'" do
+      let(:user) { create(:ndbn_user) }
+
+      before do
+        sign_in user
+      end
+
+      it "updates the index contents" do
+        params = {member_file: fixture_file_upload("spec/fixtures/ndbn-large-import.csv", "text/csv")}
+
+        post ndbn_members_path, params: params
+        expected_url = ndbn_members_path(organization_name: user.organization.short_name)
+
+        expect(response).to redirect_to(expected_url)
+        expect(flash[:notice]).to eq("NDBN Members have been updated!")
+
+        get ndbn_members_path
+        body = response.body
+
+        expect(body).to include("A Baby Center")
+        expect(body).to include("Covering Weld; United Way of Weld County")
+      end
+
+      it "shows flash error if nil file provided" do
+        params = {member_file: nil}
+
+        post ndbn_members_path, params: params
+
+        expect(response).to be_redirect
+        expect(flash[:error]).to include("CSV upload is required")
+      end
+    end
+  end
+end

--- a/spec/services/add_role_service_spec.rb
+++ b/spec/services/add_role_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe AddRoleService, type: :service do
         expect(user.has_role?(:org_admin)).to eq(false)
         expect(user.has_role?(:partner)).to eq(false)
         expect(user.has_role?(:super_admin)).to eq(false)
+        expect(user.has_role?(:ndbn)).to eq(false)
       end
 
       it "should add the user role when asked to add admin" do
@@ -19,22 +20,33 @@ RSpec.describe AddRoleService, type: :service do
         expect(user.reload.has_role?(:org_admin, org)).to eq(true)
         expect(user.has_role?(:partner)).to eq(false)
         expect(user.has_role?(:super_admin)).to eq(false)
+        expect(user.has_role?(:ndbn)).to eq(false)
       end
 
       it "works with a partner" do
         described_class.call(user_id: user.id, resource_type: "partner", resource_id: partner.id)
-        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+        expect(user.reload.has_role?(:partner, partner)).to eq(true)
+        expect(user.has_role?(:org_user, org)).to eq(false)
         expect(user.has_role?(:org_admin)).to eq(false)
-        expect(user.has_role?(:partner, partner)).to eq(true)
+        expect(user.has_role?(:super_admin)).to eq(false)
+        expect(user.has_role?(:ndbn)).to eq(false)
+      end
+
+      it "works with a ndbn" do
+        described_class.call(user_id: user.id, resource_type: "ndbn")
+        expect(user.reload.has_role?(:ndbn)).to eq(true)
+        expect(user.has_role?(:org_user, org)).to eq(false)
+        expect(user.has_role?(:org_admin)).to eq(false)
         expect(user.has_role?(:super_admin)).to eq(false)
       end
 
       it "works with super admin" do
         described_class.call(user_id: user.id, resource_type: "super_admin")
-        expect(user.reload.has_role?(:org_user, org)).to eq(false)
+        expect(user.reload.has_role?(:super_admin)).to eq(true)
+        expect(user.has_role?(:org_user, org)).to eq(false)
         expect(user.has_role?(:org_admin)).to eq(false)
         expect(user.has_role?(:partner)).to eq(false)
-        expect(user.has_role?(:super_admin)).to eq(true)
+        expect(user.has_role?(:ndbn)).to eq(false)
       end
     end
 
@@ -45,9 +57,10 @@ RSpec.describe AddRoleService, type: :service do
           described_class.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
         }.to raise_error("User User XYZ already has role for Org ABC")
         expect(user.reload.has_role?(:org_user, org)).to eq(true)
-        expect(user.reload.has_role?(:org_admin)).to eq(false)
-        expect(user.reload.has_role?(:partner)).to eq(false)
-        expect(user.reload.has_role?(:super_admin)).to eq(false)
+        expect(user.has_role?(:org_admin)).to eq(false)
+        expect(user.has_role?(:partner)).to eq(false)
+        expect(user.has_role?(:super_admin)).to eq(false)
+        expect(user.has_role?(:ndbn)).to eq(false)
       end
 
       it "should raise an error for super admin" do
@@ -56,9 +69,10 @@ RSpec.describe AddRoleService, type: :service do
           described_class.call(user_id: user.id, resource_type: "super_admin")
         }.to raise_error("User User XYZ already has super admin role!")
         expect(user.reload.has_role?(:org_user, org)).to eq(false)
-        expect(user.reload.has_role?(:org_admin)).to eq(false)
-        expect(user.reload.has_role?(:partner)).to eq(false)
-        expect(user.reload.has_role?(:super_admin)).to eq(true)
+        expect(user.has_role?(:org_admin)).to eq(false)
+        expect(user.has_role?(:partner)).to eq(false)
+        expect(user.has_role?(:super_admin)).to eq(true)
+        expect(user.has_role?(:ndbn)).to eq(false)
       end
     end
   end

--- a/spec/system/navigation_system_spec.rb
+++ b/spec/system/navigation_system_spec.rb
@@ -12,8 +12,23 @@ RSpec.describe "Navigation", type: :system, js: true do
 
       it "shows navigation options" do
         sidebar = page.find(".sidebar")
+        expect(sidebar).to_not have_link("NDBN Member Upload")
         links.each do |title|
           expect(sidebar).to have_link(title)
+        end
+      end
+
+      context "user has NDBN role" do
+        let(:user) do
+          user = create(:organization_admin)
+          user.add_role(:ndbn)
+          user
+        end
+
+        it "shows NDBN Member Upload" do
+          sidebar = page.find(".sidebar")
+          click_link("Community")
+          expect(sidebar).to have_link("NDBN Member Upload")
         end
       end
 
@@ -43,6 +58,7 @@ RSpec.describe "Navigation", type: :system, js: true do
 
       it "shows navigation options" do
         sidebar = page.find(".sidebar")
+        expect(sidebar).to_not have_link("NDBN Member Upload")
         links.each do |title|
           expect(sidebar).to have_link(title)
         end
@@ -57,6 +73,20 @@ RSpec.describe "Navigation", type: :system, js: true do
             expect(label).to match_style(width: "0px")
             expect(links).to include(label.text(:all))
           end
+        end
+      end
+
+      context "user has NDBN role" do
+        let(:user) do
+          user = create(:super_admin)
+          user.add_role(:ndbn)
+          user
+        end
+
+        it "shows NDBN Member Upload" do
+          sidebar = page.find(".sidebar")
+          click_link("Organizations")
+          expect(sidebar).to have_link("NDBN Member Upload")
         end
       end
     end

--- a/spec/system/ndbn_members_system_spec.rb
+++ b/spec/system/ndbn_members_system_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Kit management", type: :system do
+  # TODO: This test crashes right after the upload
+  xit "CSV upload flow functions without error" do
+    user = create(:ndbn_user)
+    sign_in(user)
+    visit ndbn_members_path
+
+    attach_file("member_file", "spec/fixtures/ndbn-large-import.csv")
+    click_button "Upload"
+
+    expect(page).to have_content("NDBN Members have been updated!")
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/rubyforgood/human-essentials/issues/3323
Blocked by https://github.com/rubyforgood/human-essentials/pull/4249

NDBN members  need to sync based on this google sheet:  https://docs.google.com/spreadsheets/d/1DRXeG206M0kgtUYT9lpD8fyEWRO7-a6m/edit?usp=sharing&ouid=107461548380845807455&rtpof=true&sd=true

We don't have an API to do that, instead we will create a page where users can upload a CSV of the member data.

### `/ndbn_members`

Added a new page that shows the current list and allows input of members from a CSV.

![image](https://github.com/rubyforgood/human-essentials/assets/14540596/7611dc5a-32c5-436d-8f9a-f7b5006a98b7)


There a links to this page in the sidebar.
Partner:
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/4c66d071-c17a-4730-8486-63203fe75015)
Admin:
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/6ed226fe-00ad-406f-8e30-cd002d6c4489)
Super Admin:
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/1dfcd52d-92d7-43ca-b10a-de0b876094cc)


## Remaining Concerns

### Index page errors

Currently errors look like this:

![image](https://github.com/rubyforgood/human-essentials/assets/14540596/0b6c5cc9-b43d-4fa6-b8b8-4a99bf33ff3a)

It is ugly otherwise it is hard to tell apart where one error starts and the next end. 
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/2474f0a3-27f2-4a2a-8067-ac89a34874ab)

I could not figure out how to make them be on separate lines without changing the error partial. I will also note, I am not sure how an error can even occur unless a user purposefully circumvents client side validations.
