### PR TITLE
Restoring donation sites to being active.  Mea culpa.

### DIFF
--- a/db/migrate/20240402230156_restore_donation_sites.rb
+++ b/db/migrate/20240402230156_restore_donation_sites.rb
@@ -1,0 +1,11 @@
+class RestoreDonationSites < ActiveRecord::Migration[7.0]
+  def up
+    DonationSite.all.each do |site|
+      site.update!(active: true)
+    end
+  end
+
+  def down
+
+  end
+end


### PR DESCRIPTION
### Description
Argh!  The last release made all the donation sites inactive (Mea culpa.)

This sets them to all being active. 

There is no problem with doing this with a broad stroke, because they were all active before the release.  I'm reasonably confident that there aren't any new ones that would have been made inactive.   If there are, we'll have to deal with any fallout from that.  (there is no creation date on donation sites)

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I deactivated all the donation sites on my local before coding and running this migration.  They are now active.   
Also ran the test suite on local - all passed 
