### PR TITLE
Fix fetch_latest_db rake command

### DIFF
--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -30,6 +30,8 @@ task :fetch_latest_db => :environment do
   # environment.
   system("bin/rails jobs:clear")
 
+  ActiveRecord::Base.connection.reconnect!
+
   puts "Replacing all the passwords with the replacement for ease of use: '#{PASSWORD_REPLACEMENT}'"
   replace_user_passwords
 


### PR DESCRIPTION
This command was crashing on my local with 

```
rake aborted!
ActiveRecord::StatementInvalid: PG::ConnectionBad: PQconsumeInput() FATAL:  terminating connection due to administrator command (ActiveRecord::StatementInvalid)
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

With this change, it no longer crashes.