### PR TITLE
Issue 4117 - Make distribution_quantity disallow 0

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -37,7 +37,8 @@ class Item < ApplicationRecord
   validates :name, uniqueness: { scope: :organization }
   validates :name, presence: true
   validates :organization, presence: true
-  validates :distribution_quantity, :on_hand_recommended_quantity, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
+  validates :distribution_quantity, numericality: { greater_than: 0 }, allow_blank: true
+  validates :on_hand_recommended_quantity, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
   validates :on_hand_minimum_quantity, numericality: { greater_than_or_equal_to: 0 }
 
   has_many :line_items, dependent: :destroy

--- a/db/migrate/20240419225137_update_distribution_qty_from_zero_to_null.rb
+++ b/db/migrate/20240419225137_update_distribution_qty_from_zero_to_null.rb
@@ -1,0 +1,8 @@
+class UpdateDistributionQtyFromZeroToNull < ActiveRecord::Migration[7.0]
+  def up
+    Item.where(distribution_quantity: 0).update_all(distribution_quantity: nil)
+  end
+
+  def down
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -37,10 +37,13 @@ RSpec.describe Item, type: :model do
       expect(build(:item, name: nil)).not_to be_valid
       expect(build(:item, name: item.name)).not_to be_valid
     end
-    it "requires that items quantity are not a negative number" do
-      expect(build(:item, distribution_quantity: -1)).not_to be_valid
+    it "requires that on hand items quantity are not a negative number" do
       expect(build(:item, on_hand_minimum_quantity: -1)).not_to be_valid
       expect(build(:item, on_hand_recommended_quantity: -1)).not_to be_valid
+    end
+
+    it "requires that item distribution quantity is greater than 0" do
+      expect(build(:item, distribution_quantity: 0)).not_to be_valid
     end
   end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4117

### Description
The item quantity is being used to make some calculations in some reports. Because there some reports that use this value in some calculations, when a `0` is entered, a divide by 0 error is displayed. 

To address this issue, a change to one of the validations in the `items` model was made to only allow for numeric value `greater_than 0`.
   


### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested manually
Added test specific to item `distribution_quantity` to check for `0`

### Screenshots
After:
<img width="1574" alt="Screenshot 2024-04-06 at 12 36 55" src="https://github.com/rubyforgood/human-essentials/assets/1057497/7d5cf95e-402a-433a-b421-9ecb34ce72cf">

