### PR TITLE
#3990 Add csv export tests for read_events feature toggle enabled

### DIFF
--- a/spec/requests/storage_locations_requests_spec.rb
+++ b/spec/requests/storage_locations_requests_spec.rb
@@ -65,6 +65,93 @@ RSpec.describe "StorageLocations", type: :request do
 
           expect(response.body.split("\n")[0]).to eq([StorageLocation.csv_export_headers, item3.name, item2.name, item1.name].join(','))
         end
+
+        context "when read_events feature toggle is enabled" do
+          let(:storage_location_with_items) { create(:storage_location, name: "Storage Location with Items", warehouse_type: StorageLocation::WAREHOUSE_TYPES.first) }
+          let(:storage_location_with_duplicate_item) { create(:storage_location, name: "Storage Location with Duplicate Items", warehouse_type: StorageLocation::WAREHOUSE_TYPES.first) }
+          let(:storage_location_with_unique_item) { create(:storage_location, name: "Storage Location with Unique Items", warehouse_type: StorageLocation::WAREHOUSE_TYPES.first) }
+          let(:item1) { create(:item, name: 'A') }
+          let(:item2) { create(:item, name: 'B') }
+          let(:item3) { create(:item, name: 'C') }
+          let(:item4) { create(:item, name: 'D') }
+
+          before do
+            allow(Event).to receive(:read_events?).and_return(true)
+            create(:item, name: 'inactive item', active: false)
+            TestInventory.create_inventory(storage_location_with_items.organization, {
+              storage_location_with_items.id => {
+                item1.id => 1,
+                item2.id => 1,
+                item3.id => 1
+              },
+              storage_location_with_duplicate_item.id => {
+                item3.id => 1
+              },
+              storage_location_with_unique_item.id => {
+                item4.id => 5
+              }
+            })
+          end
+
+          it "generates header with Storage Location fields followed by alphabetized item names" do
+            get storage_locations_path(default_params.merge(format: response_format))
+            expect(response.body.split("\n")[0]).to eq([StorageLocation.csv_export_headers, item1.name, item2.name, item3.name, item4.name].join(','))
+          end
+
+          it "generates data row for storage location with 1 of each of 3 items, and 0 of the last item" do
+            get storage_locations_path(default_params.merge(format: response_format))
+            csv_rows = response.body.split("\n")
+            storage_location_row = csv_rows.find { |line| line.start_with?(storage_location_with_items.name) }
+
+            expect(storage_location_row).to eq([
+              storage_location_with_items.name,
+              "\"" + storage_location_with_items.address + "\"",
+              storage_location_with_items.square_footage,
+              storage_location_with_items.warehouse_type,
+              3,
+              1,
+              1,
+              1,
+              0
+            ].join(","))
+          end
+
+          it "generates data row for storage location with duplicate item" do
+            get storage_locations_path(default_params.merge(format: response_format))
+            csv_rows = response.body.split("\n")
+            storage_location_row = csv_rows.find { |line| line.start_with?(storage_location_with_duplicate_item.name) }
+
+            expect(storage_location_row).to eq([
+              storage_location_with_duplicate_item.name,
+              "\"" + storage_location_with_duplicate_item.address + "\"",
+              storage_location_with_duplicate_item.square_footage,
+              storage_location_with_duplicate_item.warehouse_type,
+              1,
+              0,
+              0,
+              1,
+              0
+            ].join(","))
+          end
+
+          it "generates data row for storage location with unique item" do
+            get storage_locations_path(default_params.merge(format: response_format))
+            csv_rows = response.body.split("\n")
+            storage_location_row = csv_rows.find { |line| line.start_with?(storage_location_with_unique_item.name) }
+
+            expect(storage_location_row).to eq([
+              storage_location_with_unique_item.name,
+              "\"" + storage_location_with_unique_item.address + "\"",
+              storage_location_with_unique_item.square_footage,
+              storage_location_with_unique_item.warehouse_type,
+              5,
+              0,
+              0,
+              0,
+              5
+            ].join(","))
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #3990 

### Description
Based on [issue discussion](https://github.com/rubyforgood/human-essentials/issues/3990#issuecomment-2041481545), it was determined that when the `read_events` feature toggle is enabled, the storage location csv export is correct. In that a storage location with an item that's not present in any of the other storage locations will have the inventory for that item located in the correct column for that item. And for cells with none of the items, a `0` is displayed.

So it's only when `read_events` feature toggle is disabled, then the code uses the `generate_csv` from the Exportable concern, with incorrect input which leads to the bug.

It was decided rather than spending time to fix the path the code takes when `read_events` is off, to just add tests to cover the csv exporting when `read_events` is on. This PR adds tests for both header, and data rows generation.

For reference these comments in the issue have further analysis details:
1. https://github.com/rubyforgood/human-essentials/issues/3990#issuecomment-2041216418
2. https://github.com/rubyforgood/human-essentials/issues/3990#issuecomment-2041247832

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix - sort of, adds tests.

### How Has This Been Tested?

* With the Rails server running `bin/start`, navigate to `http://localhost:3000/flipper` and sign in with the admin account, then add toggle `read_events` and enable for all.
* Then as an org admin, navigate to `http://localhost:3000/diaper_bank/storage_locations`, and add a new storage location
* Go to Inventory -> Items & Inventory and add a new item
* Add the new item to the new storage location by recording a new donation. At this point, you should have one storage location with an item that is not present in any of the other locations.
* Click Export Storage Locations, and inspect the downloaded csv
* There should be a column for the new item you added, and the inventory quantity should be populated in that column only for the new storage location. All the other rows should have `0` in this column.

Run the tests that verify this behaviour: `bin/rspec spec/requests/storage_locations_requests_spec.rb:69`

Note when I run the full test suite, get 3 failing system tests, but this branch doesn't have any code changes:
```
Failed examples:

rspec ./spec/system/purchase_system_spec.rb:227 # Purchases while signed in as a normal user When creating a new purchase via barcode entry a user can add items via scanning them in by barcode
rspec ./spec/system/audit_system_spec.rb:42 # Audit management while signed in as an organization admin when starting a new audit does not display quantities in line-item drop down selector
rspec ./spec/system/distributions_by_county_system_spec.rb:18 # Distributions by County handles time ranges properly works for all time
```