### PR TITLE
4157 donation site visible after error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -752,4 +752,4 @@ DEPENDENCIES
   webmock (~> 3.23)
 
 BUNDLED WITH
-   2.5.6
+   2.5.7

--- a/app/javascript/utils/donations.js
+++ b/app/javascript/utils/donations.js
@@ -20,15 +20,6 @@ $(function() {
 
   const create_new_manufacturer_text = "---Create new Manufacturer---";
 
-  const fields_to_hide = [
-    product_drive_container_id,
-    product_drive_participant_container_id,
-    manufacturer_container_id,
-    donation_site_container_id
-  ]
-
-  hide_fields_with_no_value(fields_to_hide);
-
   $(product_drive_id).append(
 
     `<option value="">${create_new_product_drive_text}</option>`
@@ -70,7 +61,7 @@ $(function() {
     }
   });
 
-  $(document).on("change", control_id, function(evt) {
+  function handleSourceSelection() {
     const selection = $(control_id + " option")
       .filter(":selected")
       .text();
@@ -99,7 +90,13 @@ $(function() {
       $(donation_site_container_id).hide();
       $(manufacturer_container_id).hide();
     }
+  };
+
+  $(function() {
+    handleSourceSelection();
   });
+
+  $(document).on("change", control_id, handleSourceSelection);
 
   $(document).on(
     "form-input-after-insert",
@@ -124,12 +121,3 @@ $(function() {
     })
   );
 });
-
-function hide_fields_with_no_value(field_selectors) {
-  $.each(field_selectors, function(index, selector) {
-    let selected_value_text = $(selector + " select option").filter(":selected").text()
-    if (selected_value_text == "" || selected_value_text == "Choose one...") {
-      $(selector).hide();
-    }
-  });
-}

--- a/app/javascript/utils/donations.js
+++ b/app/javascript/utils/donations.js
@@ -92,9 +92,7 @@ $(function() {
     }
   };
 
-  $(function() {
-    handleSourceSelection();
-  });
+  $(control_id).each(handleSourceSelection);
 
   $(document).on("change", control_id, handleSourceSelection);
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_20_193521) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_02_230156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -411,6 +411,17 @@ RSpec.describe "Donations", type: :system, js: true do
           expect(page).to have_content("Start a new donation")
           expect(page).to have_content("must be less than")
         end
+
+        # Bug fix -- Issue #4157
+        context "when user selects Donation Site but does not enter a Site before saving" do
+          it 'displays the Donation Site field' do
+            select Donation::SOURCES[:donation_site], from: "donation_source"
+            select StorageLocation.first.name, from: "donation_storage_location_id"
+            click_button "Save"
+            expect(page).to have_css('div.donation_donation_site', visible: true)
+            expect(page).to have_content("Where was this donation dropped off?")
+          end
+        end
       end
 
       context "Via barcode entry" do


### PR DESCRIPTION
Resolves #4157

- The issue affected the creation of a new donation. If a user selected Donation Site in Source, but didn't select a value for Donation Site and saved, the page re-rendered with an error but the Donation Site field was not be visible. 
- I modified app/javascript/utils/donations.js
- The issue originated with the hide_fields_with_no_value function. The function checked if certain fields (among which Donation Site) had a value selected, and hid them if they did not. This worked on page load, but created the issue when re-rendering the form.
- I deleted hide_fields_with_no_value.
- I noticed that the function on line 73, which ran on a 'change' event, checked the value of the Donation Source field and toggled the relevant fields, so I decided to use it on page load as well. 
- I named it 'handleSourceSelection' and made it run both on page load and on a 'change' event. Now if there is no value selected in the source field, the optional fields are hidden. If a value is selected, the relevant fields appear. 
- The issue is solved. If a user selects Donation Site in Source, does not select a value for Donation Site and saves, the page re-renders with an error and the Donation Site field is visible. 
- I added a test in donation_system_spec.rb (line 415), which selects Donation Site from Source, selects a Storage Location (but does not select a Donation Site) and attempts to save. The test checks the page for a visible div with class "donation_donation_site" and for the error message "Where was this donation dropped off?"
