### PR TITLE
refactor: change item seeding removal strategy

### DIFF
--- a/spec/mailers/account_request_mailer_spec.rb
+++ b/spec/mailers/account_request_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AccountRequestMailer, type: :mailer, seed_items: false do
+RSpec.describe AccountRequestMailer, type: :mailer, skip_seed: true do
   describe '#confirmation' do
     let(:mail) { AccountRequestMailer.confirmation(account_request_id: account_request_id) }
     let(:account_request_id) { account_request.id }

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe CustomDeviseMailer, type: :mailer, seed_items: false do
+RSpec.describe CustomDeviseMailer, type: :mailer, skip_seed: true do
   describe "#invitation_instructions" do
     let(:user) { create(:partner_user) }
     let(:mail) { described_class.invitation_instructions(user, SecureRandom.uuid) }

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DistributionMailer, type: :mailer, seed_items: false do
+RSpec.describe DistributionMailer, type: :mailer, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true, name: "TEST ORG") }
   let(:user) { create(:user, organization: organization) }
   let(:partner) { create(:partner, name: 'PARTNER', organization_id: organization.id) }

--- a/spec/mailers/organization_mailer_spec.rb
+++ b/spec/mailers/organization_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe OrganizationMailer, type: :mailer, seed_items: false do
+RSpec.describe OrganizationMailer, type: :mailer, skip_seed: true do
   describe "#partner_approval_request" do
     subject { described_class.partner_approval_request(organization: organization, partner: partner) }
     let(:organization) { create(:organization, skip_items: true) }

--- a/spec/mailers/partner_mailer_spec.rb
+++ b/spec/mailers/partner_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PartnerMailer, type: :mailer, seed_items: false do
+RSpec.describe PartnerMailer, type: :mailer, skip_seed: true do
   describe "#recertification_request" do
     subject { PartnerMailer.recertification_request(partner: partner) }
     let(:partner) { create(:partner) }

--- a/spec/mailers/reminder_deadline_mailer_spec.rb
+++ b/spec/mailers/reminder_deadline_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ReminderDeadlineMailer, type: :job, seed_items: false do
+RSpec.describe ReminderDeadlineMailer, type: :job do
   let(:organization) { create(:organization, skip_items: true) }
 
   describe 'notify deadline' do

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RequestMailer, type: :mailer, seed_items: false do
+RSpec.describe RequestMailer, type: :mailer, skip_seed: true do
   describe "#request_cancel_partner_notification" do
     subject { described_class.request_cancel_partner_notification(request_id: request.id) }
     let(:request) { create(:request) }

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RequestsConfirmationMailer, type: :mailer, seed_items: false do
+RSpec.describe RequestsConfirmationMailer, type: :mailer, skip_seed: true do
   let(:organization) { create(:organization, :with_items) }
   let(:request) { create(:request, organization: organization) }
   let(:mail) { RequestsConfirmationMailer.confirmation_email(request) }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe User, type: :mailer, seed_items: false do
+RSpec.describe User, type: :mailer, skip_seed: true do
   describe "#role_added" do
     let(:user) { create(:user, email: "me@me.com") }
     let(:partner) { create(:partner, name: "Partner 1") }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -204,8 +204,6 @@ RSpec.configure do |config|
         ]
       )
     end
-
-    seed_base_data_for_tests if !ENV["SKIP_SEED"]
   end
 
   config.before(:each, type: :system) do
@@ -214,10 +212,20 @@ RSpec.configure do |config|
     Capybara.server = :puma, { Silent: true }
   end
 
-  config.before(:each) do
-    # Defined shared @ global variables used throughout the test suite.
-    define_global_variables if RSpec.current_example.metadata[:seed_items] != false
+  config.before(:all) do
+    unless Thread.current[:skipped_last_seeding]
+      DatabaseCleaner.clean_with(:truncation)
+    end
 
+    Thread.current[:skipped_last_seeding] = true
+    unless self.class.metadata[:skip_seed]
+      seed_base_data_for_tests
+      define_global_variables
+      Thread.current[:skipped_last_seeding] = false
+    end
+  end
+
+  config.before(:each) do
     if ENV['EVENTS_READ'] == 'true'
       allow(Event).to receive(:read_events?).and_return(true)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -213,16 +213,25 @@ RSpec.configure do |config|
   end
 
   config.before(:all) do
-    unless Thread.current[:skipped_last_seeding]
+    seed_current = self.class.metadata[:skip_seed].nil? || self.class.metadata[:skip_seed] == false
+    seeded_last = Thread.current[:seeded_last]
+
+    if seeded_last && !seed_current
       DatabaseCleaner.clean_with(:truncation)
     end
 
-    Thread.current[:skipped_last_seeding] = true
-    unless self.class.metadata[:skip_seed]
+    if seeded_last && seed_current
+      define_global_variables
+    end
+
+    if !seeded_last && seed_current
       seed_base_data_for_tests
       define_global_variables
-      Thread.current[:skipped_last_seeding] = false
     end
+
+    # if !seeded_last && !seed_current do nothing
+
+    Thread.current[:seeded_last] = seed_current
   end
 
   config.before(:each) do

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "ProductDrives", type: :request, skip_seed: true do
+RSpec.describe "ProductDrives", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }
   let(:default_params) { { organization_name: organization.to_param } }

--- a/spec/services/organization_update_service_spec.rb
+++ b/spec/services/organization_update_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe OrganizationUpdateService, skip_seed: true do
+RSpec.describe OrganizationUpdateService do
   let(:organization) { create(:organization) }
 
   describe "#update" do

--- a/spec/services/partner_profile_update_service_spec.rb
+++ b/spec/services/partner_profile_update_service_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe PartnerProfileUpdateService do
           expect(result.error.to_s).to include("Validation failed: Total client share must be 0 or 100")
 
           profile.reload
-          puts profile.served_areas.size
           expect(profile.served_areas.size).to eq(0)
         end
       end

--- a/spec/services/user_invite_service_spec.rb
+++ b/spec/services/user_invite_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe UserInviteService, type: :service, skip_seed: true do
+RSpec.describe UserInviteService, type: :service do
   let(:organization) { FactoryBot.create(:organization) }
   before(:each) do
     allow(UserMailer).to receive(:role_added).and_return(double(:mail, deliver_later: nil))


### PR DESCRIPTION
New change in item seeding strategy:

![](https://i.imgur.com/K0egUTF.png)

All specs are seeded by default except specs tagged with `skip_seed: true`. `Thread.current[:seeded_last]` stores if the last run seeded data or not.

### Cost of the Change (based on how long it takes me to run the full specs)
- old strategy with pre-seeded data: 9:16
- `before(:all)` with lots of `seed_db: true`: 12:56
- `before(:all)` with a few `skip_seed: true`: 12:36