### PR TITLE
fix: test order and seeding dependencies

### DIFF
--- a/spec/models/broadcast_announcement_spec.rb
+++ b/spec/models/broadcast_announcement_spec.rb
@@ -47,29 +47,29 @@ RSpec.describe BroadcastAnnouncement, type: :model do
 
   context "filter_announcements" do
     it "should include only announcements from the passed organization" do
-      BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1)
-      BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1)
-      BroadcastAnnouncement.create!(message: "test", user_id: 1)
-      BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 2)
-      expect(BroadcastAnnouncement.filter_announcements(1).count).to eq(2)
+      BroadcastAnnouncement.create!(message: "test", user_id: @user.id, organization_id: @organization.id)
+      BroadcastAnnouncement.create!(message: "test", user_id: @user.id, organization_id: @organization.id)
+      BroadcastAnnouncement.create!(message: "test", user_id: @user.id)
+      BroadcastAnnouncement.create!(message: "test", user_id: @user.id, organization_id: 0)
+      expect(BroadcastAnnouncement.filter_announcements(@organization.id).count).to eq(2)
     end
 
     it "shouldn't include expired announcements" do
-      BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1)
-      BroadcastAnnouncement.create!(message: "test", user_id: 1, expiry: 2.days.ago, organization_id: 1)
-      BroadcastAnnouncement.create!(message: "test", user_id: 1, expiry: 5.days.ago, organization_id: 1)
-      BroadcastAnnouncement.create!(message: "test", user_id: 1, expiry: Time.zone.today, organization_id: 1)
-      expect(BroadcastAnnouncement.filter_announcements(1).count).to eq(2)
+      BroadcastAnnouncement.create!(message: "test", user_id: @user.id, organization_id: @organization.id)
+      BroadcastAnnouncement.create!(message: "test", user_id: @user.id, expiry: 2.days.ago, organization_id: @organization.id)
+      BroadcastAnnouncement.create!(message: "test", user_id: @user.id, expiry: 5.days.ago, organization_id: @organization.id)
+      BroadcastAnnouncement.create!(message: "test", user_id: @user.id, expiry: Time.zone.today, organization_id: @organization.id)
+      expect(BroadcastAnnouncement.filter_announcements(@organization.id).count).to eq(2)
     end
 
     it "sorts announcements from most recently created to last" do
-      announcement_1 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, created_at: Time.zone.today)
-      announcement_2 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, created_at: 2.days.ago)
-      announcement_3 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, expiry: 1.day.ago, created_at: 3.days.ago)
-      announcement_4 = BroadcastAnnouncement.create!(message: "test", user_id: 1, organization_id: 1, created_at: 4.days.ago)
+      announcement_1 = BroadcastAnnouncement.create!(message: "test", user_id: @user.id, organization_id: @organization.id, created_at: Time.zone.today)
+      announcement_2 = BroadcastAnnouncement.create!(message: "test", user_id: @user.id, organization_id: @organization.id, created_at: 2.days.ago)
+      announcement_3 = BroadcastAnnouncement.create!(message: "test", user_id: @user.id, organization_id: @organization.id, expiry: 1.day.ago, created_at: 3.days.ago)
+      announcement_4 = BroadcastAnnouncement.create!(message: "test", user_id: @user.id, organization_id: @organization.id, created_at: 4.days.ago)
 
-      expect(BroadcastAnnouncement.filter_announcements(1)).to eq([announcement_1, announcement_2, announcement_4])
-      expect(BroadcastAnnouncement.filter_announcements(1).include?(announcement_3)).to be(false)
+      expect(BroadcastAnnouncement.filter_announcements(@organization.id)).to eq([announcement_1, announcement_2, announcement_4])
+      expect(BroadcastAnnouncement.filter_announcements(@organization.id).include?(announcement_3)).to be(false)
     end
   end
 

--- a/spec/requests/admin/broadcast_announcements_spec.rb
+++ b/spec/requests/admin/broadcast_announcements_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "BroadcastAnnouncements", type: :request do
       expiry: Time.zone.today,
       link: "http://google.com",
       message: "test",
-      user_id: 1,
+      user_id: @user.id,
       organization_id: nil
     }
   }
@@ -74,8 +74,8 @@ RSpec.describe "BroadcastAnnouncements", type: :request do
           expiry: Time.zone.yesterday,
           link: "http://google.com",
           message: "new_test",
-          user_id: 1,
-          organization_id: 1
+          user_id: @user.id,
+          organization_id: @organization.id
         }
       }
 
@@ -121,7 +121,7 @@ RSpec.describe "BroadcastAnnouncements", type: :request do
 
     describe "POST /create" do
       it "redirects" do
-        post admin_broadcast_announcements_url, params: {user: 1, message: "test"}
+        post admin_broadcast_announcements_url, params: {user: @user.id, message: "test"}
         expect(response).to redirect_to(dashboard_path(organization_name: @organization_admin.organization))
       end
     end

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -124,12 +124,12 @@ RSpec.describe "Admin::UsersController", type: :request do
 
     describe "POST #create" do
       it "returns http success" do
-        post admin_users_path, params: { user: { email: 'email@email.com', organization_id: 1 } }
+        post admin_users_path, params: { user: { email: @organization.email, organization_id: @organization.id } }
         expect(response).to redirect_to(admin_users_path)
       end
 
       it "preloads organizations" do
-        post admin_users_path, params: { user: { organization_id: 1 } }
+        post admin_users_path, params: { user: { organization_id: @organization.id } }
         expect(assigns(:organizations)).to eq(Organization.all.alphabetized)
       end
     end
@@ -150,7 +150,7 @@ RSpec.describe "Admin::UsersController", type: :request do
 
     describe "POST #create" do
       it "redirects" do
-        post admin_users_path, params: { user: { organization_id: 1 } }
+        post admin_users_path, params: { user: { organization_id: @organization.id } }
         expect(response).to redirect_to(dashboard_path(organization_name: @organization_admin.organization))
       end
     end
@@ -171,7 +171,7 @@ RSpec.describe "Admin::UsersController", type: :request do
 
     describe "POST #create" do
       it "redirects" do
-        post admin_users_path, params: { user: { organization_id: 1 } }
+        post admin_users_path, params: { user: { organization_id: @organization.id } }
         expect(response).to redirect_to(dashboard_path(organization_name: @user.organization))
       end
     end

--- a/spec/requests/broadcast_announcements_spec.rb
+++ b/spec/requests/broadcast_announcements_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "BroadcastAnnouncements", type: :request do
       expiry: Time.zone.today,
       link: "http://google.com",
       message: "test",
-      user_id: 1,
-      organization_id: 1
+      user_id: @user.id,
+      organization_id: @organization.id
     }
   }
 
@@ -74,8 +74,8 @@ RSpec.describe "BroadcastAnnouncements", type: :request do
           expiry: Time.zone.yesterday,
           link: "http://google.com",
           message: "new_test",
-          user_id: 1,
-          organization_id: 1
+          user_id: @user.id,
+          organization_id: @organization.id
         }
       }
 

--- a/spec/requests/dashboard_requests_spec.rb
+++ b/spec/requests/dashboard_requests_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe "Dashboard", type: :request do
 
     context "BroadcastAnnouncement card" do
       it "displays announcements if there are valid ones" do
-        BroadcastAnnouncement.create(message: "test announcement", user_id: 1, organization_id: nil)
+        BroadcastAnnouncement.create(message: "test announcement", user_id: @user.id, organization_id: nil)
         get dashboard_path(default_params)
         expect(response.body).to include("test announcement")
       end
 
       it "doesn't display announcements if they are not from super admins" do
-        BroadcastAnnouncement.create(message: "test announcement", user_id: 1, organization_id: 1)
+        BroadcastAnnouncement.create(message: "test announcement", user_id: @user.id, organization_id: @organization.id)
         get dashboard_path(default_params)
         expect(response.body).not_to include("test announcement")
       end

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -59,19 +59,19 @@ RSpec.describe "/partners/dashboard", type: :request do
 
   context "BroadcastAnnouncement card" do
     it "displays announcements if there are valid ones" do
-      BroadcastAnnouncement.create(message: "test announcement", user_id: 1, organization_id: 1)
+      BroadcastAnnouncement.create(message: "test announcement", user_id: @user.id, organization_id: @organization.id)
       get partners_dashboard_path
       expect(response.body).to include("test announcement")
     end
 
     it "doesn't display announcements if there are not valid ones" do
-      BroadcastAnnouncement.create(expiry: 5.days.ago, message: "test announcement", user_id: 1, organization_id: 1)
+      BroadcastAnnouncement.create(expiry: 5.days.ago, message: "test announcement", user_id: @user.id, organization_id: @organization.id)
       get partners_dashboard_path
       expect(response.body).not_to include("test announcement")
     end
 
     it "doesn't display announcements from super admins" do
-      BroadcastAnnouncement.create(message: "test announcement", user_id: 1, organization_id: nil)
+      BroadcastAnnouncement.create(message: "test announcement", user_id: @user.id, organization_id: nil)
       get partners_dashboard_path
       expect(response.body).not_to include("test announcement")
     end

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -56,14 +56,6 @@ describe Partners::RequestCreateService do
 
     context 'when the arguments are correct' do
       let(:items_to_request) { BaseItem.all.sample(3) }
-      let(:item_requests_attributes) do
-        items_to_request.map do |item|
-          ActionController::Parameters.new(
-            item_id: item.id,
-            quantity: Faker::Number.within(range: 1..10)
-          )
-        end
-      end
       let(:fake_organization_valid_items) do
         items_to_request.map do |item|
           {

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -72,11 +72,11 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
     end
 
     it "filters users by email" do
-      user_email = "person100@example.com"
+      user_email = @organization_admin.email
 
       visit admin_users_path
       fill_in "filterrific_search_email", with: user_email
-      expect(page.find("table")).to have_content(user_email)
+      expect(page).to have_element("table", text: user_email)
     end
   end
 end

--- a/spec/system/item_system_spec.rb
+++ b/spec/system/item_system_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe "Item management", type: :system do
         let(:item) { Item.first }
 
         before do
-          find('tr', text: item.name).find('a', text: 'Edit').click
+          find("tr[data-item-id=\"#{item.id}\"]").find('a', text: 'Edit').click
           select new_item_category, from: 'Category'
           click_on 'Save'
         end


### PR DESCRIPTION
These tests depend on assumptions about database state or have hard coded values. 

Changes the tests to be more flexible.

Using `@user` and `@organization` ain't optimal but I'm gonna refactor those later anyways.