### PR TITLE
Replace support link for partners with a message to contact their bank

### DIFF
--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -30,7 +30,6 @@ module Partners
         flash[:success] = 'Request was successfully created.'
         redirect_to partners_request_path(create_service.partner_request.id)
       else
-
         @partner_request = create_service.partner_request
         @errors = create_service.errors
 

--- a/app/views/partners/requests/_error.html.erb
+++ b/app/views/partners/requests/_error.html.erb
@@ -10,7 +10,8 @@
       Ensure each line item has a item selected AND a quantity greater than 0.
     </p>
     <p class='text-md'>
-      Still need help? Submit a support ticket <%= link_to 'here', support_ticket_form_url, target: '_blank' %> and we will do our best to follow up with you via email.
+    Still need help? Please contact your essentials bank, <%= current_partner.organization.name %>, if you need further assistance.<br/>
+    Our email on record for them is: <%= mail_to current_partner.organization.email %>
     </p>
   </div>
 </div>

--- a/app/views/partners/requests/_error.html.erb
+++ b/app/views/partners/requests/_error.html.erb
@@ -10,7 +10,7 @@
       Ensure each line item has a item selected AND a quantity greater than 0.
     </p>
     <p class='text-md'>
-    Still need help? Please contact your essentials bank, <%= current_partner.organization.name %>, if you need further assistance.<br/>
+    Still need help? Please contact your essentials bank, <%= current_partner.organization.name %>, if you need further assistance.<br>
     Our email on record for them is: <%= mail_to current_partner.organization.email %>
     </p>
   </div>

--- a/spec/requests/partners/individuals_requests_controller_spec.rb
+++ b/spec/requests/partners/individuals_requests_controller_spec.rb
@@ -90,8 +90,9 @@ RSpec.describe Partners::IndividualsRequestsController, type: :request do
         expect(response).to be_unprocessable
         expect(response.body).to include("Oops! Something went wrong with your Request")
         expect(response.body).to include("Ensure each line item has a item selected AND a quantity greater than 0.")
-        expect(response.body).to include("Still need help? Submit a support ticket")
-        expect(response.body).to include("and we will do our best to follow up with you via email.")
+        expect(response.body).to include("Still need help? Please contact your essentials bank, #{partner.organization.name}")
+        expect(response.body).to include("Our email on record for them is:")
+        expect(response.body).to include(partner.organization.email)
       end
     end
 
@@ -129,8 +130,9 @@ RSpec.describe Partners::IndividualsRequestsController, type: :request do
         expect(response).to be_unprocessable
         expect(response.body).to include("Oops! Something went wrong with your Request")
         expect(response.body).to include("Ensure each line item has a item selected AND a quantity greater than 0.")
-        expect(response.body).to include("Still need help? Submit a support ticket")
-        expect(response.body).to include("and we will do our best to follow up with you via email.")
+        expect(response.body).to include("Still need help? Please contact your essentials bank, #{partner.organization.name}")
+        expect(response.body).to include("Our email on record for them is:")
+        expect(response.body).to include(partner.organization.email)
       end
     end
 

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -129,8 +129,9 @@ RSpec.describe "/partners/requests", type: :request do
         expect(response).to be_unprocessable
         expect(response.body).to include("Oops! Something went wrong with your Request")
         expect(response.body).to include("Ensure each line item has a item selected AND a quantity greater than 0.")
-        expect(response.body).to include("Still need help? Submit a support ticket")
-        expect(response.body).to include("and we will do our best to follow up with you via email.")
+        expect(response.body).to include("Still need help? Please contact your essentials bank, #{partner.organization.name}")
+        expect(response.body).to include("Our email on record for them is:")
+        expect(response.body).to include(partner.organization.email)
       end
     end
 
@@ -172,8 +173,9 @@ RSpec.describe "/partners/requests", type: :request do
         expect(response).to be_unprocessable
         expect(response.body).to include("Oops! Something went wrong with your Request")
         expect(response.body).to include("Ensure each line item has a item selected AND a quantity greater than 0.")
-        expect(response.body).to include("Still need help? Submit a support ticket")
-        expect(response.body).to include("and we will do our best to follow up with you via email.")
+        expect(response.body).to include("Still need help? Please contact your essentials bank, #{partner.organization.name}")
+        expect(response.body).to include("Our email on record for them is:")
+        expect(response.body).to include(partner.organization.email)
       end
     end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4186<!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

As described in #4186, this PR makes a change to the error message displayed to partners. It removes the support link and replaces it with the name of the Partner's Bank and the email address of that bank.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

The existing tests have been modified to reflect the changes in the error message. They now ensure that the name of the Bank and the email address exist in the error message

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
#### Before

![Screenshot 2024-04-16 at 11 34 01](https://github.com/rubyforgood/human-essentials/assets/17725/7361d31c-c48f-4561-a9bb-6f9c1075ba58)

#### After
![Screenshot 2024-04-16 at 11 20 34](https://github.com/rubyforgood/human-essentials/assets/17725/9aac58d5-6b95-489a-bd45-e1d0950c0c64)

/cc @sampart @kurgol @hharen