### PR TITLE
Fix Partner Profile edit checkboxes, and new child filter checkbox

### DIFF
--- a/app/views/partners/family_requests/new.html.erb
+++ b/app/views/partners/family_requests/new.html.erb
@@ -40,11 +40,10 @@
                 </div>
                 <div class="col-3">
                   <%= f.label :search_active, "Show Active Only?" %>
-                  <%# TODO: This checkbox needs styling fixes  %>
-
+                  <br>
                   <%= f.check_box(
                           :search_active,
-                          class: 'filterrific-periodically-observed form-control'
+                          class: 'filterrific-periodically-observed'
                       ) %>
                 </div>
                 <div class="col-3">

--- a/app/views/partners/profiles/edit/_partner_settings.html.erb
+++ b/app/views/partners/profiles/edit/_partner_settings.html.erb
@@ -7,23 +7,21 @@
             <h3 class="card-title"><strong>Settings</strong></h3>
           </div>
           <div class="card-body">
-            <% if form.object.organization.enable_child_based_requests? %>
-              <%= form.input :enable_child_based_requests, label: "Enable Child-based Requests (unclick if you only do bulk requests)",
-                             as: :boolean,
-                             class: "form-control", wrapper: :input_group %>
-            <% end %>
-
-            <% if form.object.organization.enable_individual_requests? %>
-              <%= form.input :enable_individual_requests, label: "Enable Requests for Individuals",
-                             as: :boolean,
-                             class: "form-control", wrapper: :input_group %>
-            <% end %>
-
             <% if form.object.organization.enable_quantity_based_requests? %>
-              <%= form.input :enable_quantity_based_requests, label: "Enable Quantity-based Requests",
-                             as: :boolean,
-                             class: "form-control", wrapper: :input_group %>
+              <%= form.check_box :enable_quantity_based_requests, as: :boolean %>&nbsp;
+              <%= form.label :enable_quantity_based_requests, "Enable Quantity-based Requests" %>
             <% end %>
+            <br>
+            <% if form.object.organization.enable_child_based_requests? %>
+              <%= form.check_box :enable_child_based_requests, as: :boolean %>&nbsp;
+              <%= form.label :enable_child_based_requests, "Enable Child-based Requests (unclick if you only do bulk requests)" %>
+            <% end %>
+            <br>
+            <% if form.object.organization.enable_individual_requests? %>
+              <%= form.check_box :enable_individual_requests, as: :boolean %>&nbsp;
+              <%= form.label :enable_individual_requests, "Enable Requests for Individuals" %>
+            <% end %>
+            <br>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4276

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Previously, the checkboxes mentioned above were being rendered like inputs -- very wide. Also, the checked state was not reflected! This PR makes them render as normal checkboxes, primarily thanks to the removal of the `form-control` class (but with additional style tweaks too).

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

- Manual browser-based testing, and
- `bundle exec rspec`

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

#### `http://127.0.0.1:3000/partners/profile/edit` before:

![the checkboxes look like text fields and cannot be checked](https://github.com/rubyforgood/human-essentials/assets/1507328/572d2243-9abb-4839-88ce-fb20972c7113)

Note that the ticks represent "valid input" not checked-state. Checked state is not reflected visually prior to this PR.

#### `http://127.0.0.1:3000/partners/profile/edit` after

<img width="748" alt="the checkboxes are rendered as normal checkboxes" src="https://github.com/rubyforgood/human-essentials/assets/1507328/01e8f126-868e-4c5e-9b52-cc2e95b6a70c">

#### `http://127.0.0.1:3000/partners/family_requests/new` before:

![checking the box filters the list, but has no visual checked indication](https://github.com/rubyforgood/human-essentials/assets/1507328/c9589071-f788-442c-8298-8cb6528608fb)

#### `http://127.0.0.1:3000/partners/family_requests/new` after:

![rendered as a normal checkbox" src="https://github.com/rubyforgood/human-essentials/assets/1507328/19d36c6e-68e2-430d-88eb-f48a38bf79a3](https://github.com/rubyforgood/human-essentials/assets/1507328/88a3464c-3e8e-45f0-8be8-3ff689382f0c)
