### PR TITLE
3373 numeric input safari

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -85,7 +85,7 @@
 }
 
 .numeric,
-[data-quantity] {
+.quantity {
   text-align: right;
 }
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -84,7 +84,8 @@
   color: #ee5034
 }
 
-.numeric {
+.numeric,
+[data-quantity] {
   text-align: right;
 }
 

--- a/app/javascript/utils/barcode_items.js
+++ b/app/javascript/utils/barcode_items.js
@@ -57,7 +57,7 @@ $(document).ready(function() {
           if (data['src'] != this && data['value'] == this.value) {
               line_item = this.closest('.nested-fields');
               if ($(line_item).attr('scanned_more_than_two_times') != undefined) {
-                  let current_total = parseInt($(line_item).find('input[type=number]').val());
+                  let current_total = parseInt($(line_item).find('[data-quantity]').val());
                   let current_boops = (current_total / line_item_quantity) + 1;
                   let total_boops = prompt('Enter total number of packages for this item', current_boops);
                   if (total_boops != null) {
@@ -69,12 +69,12 @@ $(document).ready(function() {
                   }
               }
               if ($(line_item).attr('scanned_more_than_two_times') != "true") {
-                line_item_quantity = Number(line_item_quantity) + Number($(line_item).find('input[type=number]').val());
+                line_item_quantity = Number(line_item_quantity) + Number($(line_item).find('[data-quantity]').val());
               }
               $(line_item).attr('scanned_more_than_two_times', true);
           }
       })
-      $(line_item).find('input[type=number]').val(line_item_quantity);
+      $(line_item).find('[data-quantity]').val(line_item_quantity);
       $(line_item).find('select').val(data['item_id']);
       $(line_item).find('select').trigger('change');
 

--- a/app/javascript/utils/donations.js
+++ b/app/javascript/utils/donations.js
@@ -107,9 +107,6 @@ $(function() {
     }
   )
 
-  // As of #3373, item quantity field is a string rather than numeric input type
-  // (due to cross browser inconsistencies). Therefore it needs to be converted
-  // to a number for the large donation check.
   const large_donation_boundary = 100000;
   $(document).on("submit", "form#new_donation", (e, _) =>
     $(".quantity").each(function(_, q) {

--- a/app/javascript/utils/donations.js
+++ b/app/javascript/utils/donations.js
@@ -107,10 +107,13 @@ $(function() {
     }
   )
 
+  // As of #3373, item quantity field is a string rather than numeric input type
+  // (due to cross browser inconsistencies). Therefore it needs to be converted
+  // to a number for the large donation check.
   const large_donation_boundary = 100000;
   $(document).on("submit", "form#new_donation", (e, _) =>
     $(".quantity").each(function(_, q) {
-      const quantity = q.valueAsNumber;
+      const quantity = parseInt(q.value, 10);
       if (quantity > large_donation_boundary) {
         confirm(
           `${quantity} items is a large donation! Are you sure you want to submit?`

--- a/app/views/barcode_items/create.js.erb
+++ b/app/views/barcode_items/create.js.erb
@@ -15,7 +15,7 @@ toastr.success("Barcode Added to Inventory");
 // Locate the row where the barcode was entered from
 line_item = $('#' + source_field).closest('.nested-fields');
 // Set the values in the form. This is replicating some logic from barcode_items.js.erb
-$(line_item).find('input[type=number]').val(quantity);
+$(line_item).find('[data-quantity]').val(quantity);
 $(line_item).find('[value="' + item_id + '"]').attr("selected", true);
 $('#__add_line_item').trigger('click');
 $("input.__barcode_item_lookup").last().focus();

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -13,7 +13,6 @@
             <%= field.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false, input_html: { class: "my-0 line_item_name", "data-controller": "select2" } %>
           </span>
           <div class="li-quantity mx-2">
-            <%# Numeric input types behave differently across browsers so make this a text input for consistency %>
             <%= field.input :quantity,
               as: :string,
               placeholder: "Quantity",

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -18,13 +18,7 @@
               as: :string,
               placeholder: "Quantity",
               label: false,
-              input_html: {
-                class: "quantity my-0",
-                data: {
-                  quantity: ""
-                }
-              }
-            %>
+              input_html: { class: "quantity my-0", data: { quantity: "" } } %>
           </div>
         </div>
       </div>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -13,7 +13,18 @@
             <%= field.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false, input_html: { class: "my-0 line_item_name", "data-controller": "select2" } %>
           </span>
           <div class="li-quantity mx-2">
-            <%= field.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity my-0"} %>
+            <%# Numeric input types behave differently across browsers so make this a text input for consistency %>
+            <%= field.input :quantity,
+              as: :string,
+              placeholder: "Quantity",
+              label: false,
+              input_html: {
+                class: "quantity my-0",
+                data: {
+                  quantity: ""
+                }
+              }
+            %>
           </div>
         </div>
       </div>

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -397,7 +397,7 @@ RSpec.feature "Distributions", type: :system do
 
       it "User creates a distribution from a donation then edits it" do
         within ".distribution_line_items_quantity" do
-          first(".numeric").set 13
+          first("[data-quantity]").set 13
         end
         click_on "Save"
         expect(page).to have_content "Distribution updated!"
@@ -406,7 +406,7 @@ RSpec.feature "Distributions", type: :system do
 
       it "User creates a distribution from a donation then tries to make the quantity too big", js: true do
         within ".distribution_line_items_quantity" do
-          first(".numeric").set 999_999
+          first("[data-quantity]").set 999_999
         end
         click_on "Save"
         expect(page).to have_no_content "Distribution updated!"
@@ -427,14 +427,14 @@ RSpec.feature "Distributions", type: :system do
       it "User creates duplicate line items" do
         item = @distribution.line_items.first.item
         select2(page, 'distribution_line_items_item_id', item.name, position: 1)
-        find_all(".numeric")[0].set 1
+        find_all("[data-quantity]")[0].set 1
 
         click_on "Add Another Item"
 
         select2(page, 'distribution_line_items_item_id', item.name, position: 2)
-        new_select = find_all(".numeric")[1]
+        new_select = find_all("[data-quantity]")[1]
         expect(new_select.value).to eq("")
-        find_all(".numeric")[1].set 3
+        find_all("[data-quantity]")[1].set 3
 
         first("button", text: "Save").click
 
@@ -483,7 +483,7 @@ RSpec.feature "Distributions", type: :system do
       end
 
       expect(page).to have_content("Sorry, we weren't able to save")
-      find_all(".numeric")[0].set 1
+      find_all("[data-quantity]")[0].set 1
 
       click_on "Save"
 

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -396,6 +396,15 @@ RSpec.describe "Donations", type: :system, js: true do
           end.to change { Donation.count }.by(1)
         end
 
+        it "Requires quantity to be numeric" do
+          select Donation::SOURCES[:misc], from: "donation_source"
+          select StorageLocation.first.name, from: "donation_storage_location_id"
+          select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+          fill_in "donation_line_items_attributes_0_quantity", with: "1,000"
+          click_button "Save"
+          expect(page).to have_content("Quantity is not a number")
+        end
+
         it "Displays nested errors" do
           select Donation::SOURCES[:misc], from: "donation_source"
           select StorageLocation.first.name, from: "donation_storage_location_id"

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -230,11 +230,7 @@ RSpec.describe "Purchases", type: :system, js: true do
             expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
             Barcode.boop(@existing_barcode.value)
           end
-          # the form should update
-          expect(page).to have_xpath('//input[@id="purchase_line_items_attributes_0_quantity"]')
-          qty = page.find(:xpath, '//input[@id="purchase_line_items_attributes_0_quantity"]').value
-
-          expect(qty).to eq(@existing_barcode.quantity.to_s)
+          expect(page).to have_field "purchase_line_items_attributes_0_quantity", with: @existing_barcode.quantity.to_s
         end
 
         it "User scan same barcode 2 times" do


### PR DESCRIPTION
Resolves #3373

### Description

This changes the item quantity field to be text rather than numeric. Safari allows entry of non-numeric characters, but then submits a blank value. When combined with the feature that the system doesn't associate items when either the name or quantity is left blank (due to use of custom `reject_if` proc option on `accepts_nested_attributes_for` in `Itemizable` concern ), this creates confusion for Safari users because their donation will be saved without the item they added. (the server gets a blank quantity field and assumes they didn't want to add an item).

It was [decided](https://github.com/rubyforgood/human-essentials/issues/3373#issuecomment-2054079188) to resolve this by converting the item field to text. This ensures that for all browsers, whatever value the user types in gets submitted, and then the Item numeric validation runs server side, which will report back to the user if the value they entered isn't numeric. 

Note that other [options were considered](https://github.com/rubyforgood/human-essentials/issues/3373#issuecomment-2053764549) including modifying the Itemizable concern, this may become future work.

Changing the input type had some knock-on effects that were fixed:
1. Barcode javascript (that updates quantity field based on xhr lookup results) was using `input[type=number]` as selector, this was modified to use a data dash attribute.
2. Large donation check javascript was using `valueAsNumber` which only works when the field is numeric, for text this returns `NaN`. Fixed to use `parseInt`.
3. `create.js.erb` also uses `input[type=number]` selector, was fixed in the same way as barcode js.
4. Some system tests were using `.numeric` as a selector, which is. a class added by `simple_form` on numeric inputs. As this class is no longer added, these tests started breaking, fixed to use the data dash selector.
5. The `numeric` css class is also used for styling, added the data dash attribute to have the same style. Intentionally did not remove the existing `numeric` from css because there are other uses of it.
6. Tiny scope creep: System test `spec/system/purchase_system_spec.rb` was failing even before my changes - because it expects a quantity field to be updated, but that happens via JS and the existing way the test was written wasn't waiting for that, fixed.

### Type of change
Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Maintained existing system tests, and added new system test to verify entering a non numeric value in quantity field will error.

Can also exercise this manually - try in Safari:
- Create new donation
- Fill out the form with all valid values except for quantity - enter something like `1,000`
- Submit
- The donation is not saved, and the quantity field should show an error.

### Screenshots
From Safari:
![image](https://github.com/rubyforgood/human-essentials/assets/2428282/a0c17366-d872-4f70-bc04-cf15496f5159)
