### PR TITLE
Fix checkbox styling

### DIFF
--- a/app/views/partners/children/index.html.erb
+++ b/app/views/partners/children/index.html.erb
@@ -46,11 +46,12 @@
                           class: 'filterrific-periodically-observed form-control'
                       ) %>
                 </div>
-                <div class="col-2" align="center">
-                  <%= f.label :search_comments, "Show Active Only?" %>
+                <div class="col-2">
+                  <%= f.label :search_active, "Show Active Only?" %>
+                  <br>
                   <%= f.check_box(
                           :search_active,
-                          class: 'filterrific-periodically-observed form-control'
+                          class: 'filterrific-periodically-observed'
                       ) %>
                 </div>
                 <div class="col-3">

--- a/app/views/partners/families/index.html.erb
+++ b/app/views/partners/families/index.html.erb
@@ -49,11 +49,12 @@
                           class: 'filterrific-periodically-observed form-control'
                       ) %>
                 </div>
-                <div class="col-2" align="center">
+                <div class="col-2">
                   <%= f.label :include_archived, "Include Archived?" %>
+                  <br>
                   <%= f.check_box(
                           :include_archived,
-                          class: 'filterrific-periodically-observed form-control',
+                          class: 'filterrific-periodically-observed',
                       ) %>
                 </div>
                 <div class="col-3">

--- a/app/views/partners/profiles/edit/_media_information.html.erb
+++ b/app/views/partners/profiles/edit/_media_information.html.erb
@@ -11,7 +11,8 @@
             <%= form.input :facebook, label: "Facebook", class: "form-control", wrapper: :input_group %>
             <%= form.input :twitter, label: "Twitter", class: "form-control", wrapper: :input_group %>
             <%= form.input :instagram, label: "Instagram", class: "form-control", wrapper: :input_group %>
-            <%= form.input :no_social_media_presence, label: "No Social Media Presence", as: :boolean, class: "form-control", wrapper: :input_group %>
+            <%= form.check_box :no_social_media_presence, as: :boolean %>&nbsp;
+            <%= form.label :no_social_media_presence, "No Social Media Presence" %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fix Issue https://github.com/rubyforgood/human-essentials/issues/4286

**Description**

Previously, the checkboxes mentioned above were being rendered like inputs -- very wide. Also, the checked state was not reflected! This PR makes them render as normal checkboxes, primarily thanks to the removal of the form-control

**Screenshots**
http://localhost:3000/partners/profile/edit before
<img width="1712" alt="SCR-20240420-okjp" src="https://github.com/rubyforgood/human-essentials/assets/6815985/4272c442-305f-4dd8-8273-a6c5b767df0d">
http://localhost:3000/partners/profile/edit after
<img width="1703" alt="SCR-20240420-olor" src="https://github.com/rubyforgood/human-essentials/assets/6815985/57354e36-c09c-4536-952b-d7752a5e7e33">

http://localhost:3000/partners/families before
<img width="1221" alt="SCR-20240420-ojme" src="https://github.com/rubyforgood/human-essentials/assets/6815985/17cfaab3-d4ea-4f4c-987e-7b363df1a739">
http://localhost:3000/partners/families after
<img width="1466" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/6815985/9613773a-d801-4a92-ad44-8029a378fe86">

http://localhost:3000/partners/children before 
<img width="1064" alt="SCR-20240420-ojby" src="https://github.com/rubyforgood/human-essentials/assets/6815985/35722bda-82a3-49b4-8d24-1ac0126a973e">

http://localhost:3000/partners/children after 
<img width="1467" alt="image" src="https://github.com/rubyforgood/human-essentials/assets/6815985/8547a5be-4148-44dd-94f9-2f8ae0ffc76a">
