### PR TITLE
4294 Disable deleting purchases and donations with inactive items

### DIFF
--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -75,7 +75,10 @@
               enabled: !@donation.has_inactive_item?,
               size: "md" } %>
             <%= new_button_to new_distribution_path(donation_id: @donation.id, storage_location_id: @donation.storage_location_id), { text: "Start a new Distribution" } %>
-            <%= delete_button_to donation_path(@donation), { size: "md", confirm: "Are you sure you want to permanently remove this donation?" } if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
+            <%= delete_button_to donation_path(@donation), { 
+              size: "md", 
+              enabled: !@donation.has_inactive_item?,
+              confirm: "Are you sure you want to permanently remove this donation?" } if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
             <% if @donation.has_inactive_item? %>
               <div class="warning">
                 You can only correct donations where all the items are active.

--- a/app/views/purchases/show.html.erb
+++ b/app/views/purchases/show.html.erb
@@ -70,7 +70,10 @@
             <%= edit_button_to edit_purchase_path(@purchase), { text: "Make a correction",
                                                                 enabled: !@purchase.has_inactive_item?,
                                                                 size: "md" } %>
-            <%= delete_button_to purchase_path(@purchase), { size: "md", confirm: "Are you sure you want to permanently remove this purchase?" } if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
+            <%= delete_button_to purchase_path(@purchase), { 
+              size: "md", 
+              enabled: !@purchase.has_inactive_item?,
+              confirm: "Are you sure you want to permanently remove this purchase?" } if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
             <% if @purchase.has_inactive_item? %>
               <div class="warning">
                 You can only correct purchases where all the items are active.

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Donations", type: :request do
         expect(response.body).not_to match(/please make the following items active:/)
       end
 
-      context "with an inactive item" do
+      context "with an inactive item - non organization admin user" do
         before do
           item.update(active: false)
         end
@@ -105,6 +105,23 @@ RSpec.describe "Donations", type: :request do
           page = Nokogiri::HTML(response.body)
           edit = page.at_css("a[href='#{edit_donation_path(default_params.merge(id: donation.id))}']")
           expect(edit.attr("class")).to match(/disabled/)
+          expect(response.body).to match(/please make the following items active: #{item.name}/)
+        end
+      end
+
+      context "with an inactive item - organization admin user" do
+        before do
+          sign_in(@organization_admin)
+          item.update(active: false)
+        end
+
+        it "shows a disabled edit and delete buttons" do
+          get donation_path(default_params.merge(id: donation.id))
+          page = Nokogiri::HTML(response.body)
+          edit = page.at_css("a[href='#{edit_donation_path(default_params.merge(id: donation.id))}']")
+          delete = page.at_css("a.btn-danger[href='#{donation_path(default_params.merge(id: donation.id))}']")
+          expect(edit.attr("class")).to match(/disabled/)
+          expect(delete.attr("class")).to match(/disabled/)
           expect(response.body).to match(/please make the following items active: #{item.name}/)
         end
       end

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe "Purchases", type: :request do
         expect(response.body).not_to match(/please make the following items active:/)
       end
 
-      context "with an inactive item" do
+      context "with an inactive item - non-organization admin user" do
         before do
           item.update(active: false)
         end
@@ -270,6 +270,23 @@ RSpec.describe "Purchases", type: :request do
           page = Nokogiri::HTML(response.body)
           edit = page.at_css("a[href='#{edit_purchase_path(default_params.merge(id: purchase.id))}']")
           expect(edit.attr("class")).to match(/disabled/)
+          expect(response.body).to match(/please make the following items active: #{item.name}/)
+        end
+      end
+
+      context "with an inactive item - organization admin user" do
+        before do
+          sign_in(@organization_admin)
+          item.update(active: false)
+        end
+
+        it "shows a disabled edit and delete buttons" do
+          get purchase_path(default_params.merge(id: purchase.id))
+          page = Nokogiri::HTML(response.body)
+          edit = page.at_css("a[href='#{edit_purchase_path(default_params.merge(id: purchase.id))}']")
+          delete = page.at_css("a.btn-danger[href='#{purchase_path(default_params.merge(id: purchase.id))}']")
+          expect(edit.attr("class")).to match(/disabled/)
+          expect(delete.attr("class")).to match(/disabled/)
           expect(response.body).to match(/please make the following items active: #{item.name}/)
         end
       end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4294 

### Description
If a donation or a purchase contains an inactive item, the system is likely to return an error. 
Currently, when trying to delete a purchase with inactive items in Production, it is returning an inventory error. 

To mitigate this, we should just not allow for deleting a purchase or donation if there are inactive items and display a message instructing the user to make the inactive item active.

### Type of change
New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested manually
Updated `donations_request_spec.rb` and `purchases_request_spec.rb` to verify that the `Delete` button is `disabled` for the `organization admin` user.

### Screenshots
**Purchases**
Before:
<img width="1580" alt="purchases_before" src="https://github.com/rubyforgood/human-essentials/assets/1057497/aa434aab-d22a-414f-afa7-50e7bbbe5777">

After:
<img width="1577" alt="purchases_after" src="https://github.com/rubyforgood/human-essentials/assets/1057497/46300666-7d06-4eeb-a710-c82057abb4f9">


**Donations**
Before:
<img width="1583" alt="donations_before" src="https://github.com/rubyforgood/human-essentials/assets/1057497/8c302723-8af1-4dce-bf39-c78d608f333b">

After:
<img width="1581" alt="donations_after" src="https://github.com/rubyforgood/human-essentials/assets/1057497/edbb7373-b422-4cd9-99e6-07af1f49e2f3">
