### PR TITLE
restoring settings partial in partner profile edit

### DIFF
--- a/app/views/partners/profiles/edit.html.erb
+++ b/app/views/partners/profiles/edit.html.erb
@@ -39,6 +39,9 @@
                     <%= render partial: "partners/profiles/edit/#{partial}", locals: {form: profile_form, f: profile_form, profile: current_partner.profile} %>
                   </div>
                 <% end %>
+                <div class="col-6">
+                  <%= render partial: "partners/profiles/edit/partner_settings", locals: {form: profile_form, profile: current_partner.profile} %>
+                </div>
               </div>
               <div class="card-footer">
                 <%= form.submit("Update Information", class: "btn btn-primary") %>


### PR DESCRIPTION




### Description
I found an issue on staging where the settings had disappeared from the partner profile edit (from the partner pov)., it appears from #4051.    This restores it.

Noting, though,  that we should also have a test that this partial is appearing -- since we didn't catch it disappearing through either our functional or technical reviews -- and most partners  won't notice that it's gone.

I'm also getting a lot of unrelated failures on my local (11).

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
manual check  -- went in as verified@example.com and checked that the fields appeared.
