### PR TITLE
Add initial allocation column to distributions index

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -759,4 +759,4 @@ DEPENDENCIES
   webmock (~> 3.23)
 
 BUNDLED WITH
-   2.5.7
+   2.5.9

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -63,8 +63,11 @@ module Exports
         "Partner" => ->(distribution) {
           distribution.partner.name
         },
-        "Date of Distribution" => ->(distribution) {
-          distribution.issued_at.strftime("%m/%d/%Y")
+        "Initial Allocation" => ->(distribution) {
+          distribution.created_at.strftime("%m/%d/%Y")
+        },
+        "Scheduled for" => ->(distribution) {
+          (distribution.issued_at.presence || distribution.created_at).strftime("%m/%d/%Y")
         },
         "Source Inventory" => ->(distribution) {
           distribution.storage_location.name

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -1,7 +1,8 @@
 <tr <%= 'class="highlight"' if distribution_row.id == @highlight_id %>>
   <td><%= distribution_row.id %></td>
   <td><%= distribution_row.partner.name %></td>
-  <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %> </td>
+  <td class="date"><%= distribution_row.created_at.strftime("%m/%d/%Y") %></td>
+  <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %></td>
   <td><%= distribution_row.storage_location.name %></td>
 
   <!-- Quantity -->

--- a/app/views/distributions/_distribution_total.html.erb
+++ b/app/views/distributions/_distribution_total.html.erb
@@ -2,6 +2,8 @@
   <td><strong>Total:</strong></td>
   <td></td>
   <td></td>
+  <td></td>
+  <td></td>
   <td class="overall-total-items text-right">
     <%= number_with_delimiter(@total_items_all_distributions, :delimiter => ',') %> (Total)
   <br>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -99,6 +99,7 @@
               <tr>
                 <th>ID</th>
                 <th>Partner</th>
+                <th class="date">Inital Allocation</th>
                 <th class="date">Date of Distribution</th>
                 <th>Source Inventory</th>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -536,6 +536,8 @@ dates_generator = DispersedPastDatesGenerator.new
 inventory = InventoryAggregate.inventory_for(pdx_org.id)
 # Make some distributions, but don't use up all the inventory
 20.times.each do
+  issued_at = dates_generator.next
+
   storage_location = random_record_for_org(pdx_org, StorageLocation)
   stored_inventory_items_sample = inventory.storage_locations[storage_location.id].items.values.sample(20)
   delivery_method = Distribution.delivery_methods.keys.sample
@@ -544,7 +546,8 @@ inventory = InventoryAggregate.inventory_for(pdx_org.id)
     storage_location: storage_location,
     partner: random_record_for_org(pdx_org, Partner),
     organization: pdx_org,
-    issued_at: dates_generator.next,
+    issued_at: issued_at,
+    created_at: 3.days.ago(issued_at),
     delivery_method: delivery_method,
     shipping_cost: shipping_cost,
     comment: 'Urgent'

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
 
     trait :past do
       issued_at { 1.week.ago }
+      created_at { 10.days.ago }
     end
 
     trait :with_items do

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe Exports::ExportDistributionsCSVService do
     let(:non_item_headers) do
       [
         "Partner",
-        "Date of Distribution",
+        "Initial Allocation",
+        "Scheduled for",
         "Source Inventory",
         "Total Number of #{item_name}",
         "Total Value",
@@ -90,6 +91,7 @@ RSpec.describe Exports::ExportDistributionsCSVService do
       distributions.zip(total_item_quantities).each_with_index do |(distribution, total_item_quantity), idx|
         row = [
           distribution.partner.name,
+          distribution.created_at.strftime("%m/%d/%Y"),
           distribution.issued_at.strftime("%m/%d/%Y"),
           distribution.storage_location.name,
           distribution.line_items.where(item_id: item_id).total,
@@ -124,6 +126,7 @@ RSpec.describe Exports::ExportDistributionsCSVService do
         distributions.zip(total_item_quantities).each_with_index do |(distribution, total_item_quantity), idx|
           row = [
             distribution.partner.name,
+            distribution.created_at.strftime("%m/%d/%Y"),
             distribution.issued_at.strftime("%m/%d/%Y"),
             distribution.storage_location.name,
             distribution.line_items.where(item_id: item_id).total,


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #3591 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Displays `created_at` as "Initial Allocation" for distributions in the web and the CSV export.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Existing specs pass + manual testing.

### Screenshots

<img width="1090" alt="date-fulfilled" src="https://github.com/rubyforgood/human-essentials/assets/6723/2916d5f2-e488-4288-a9be-5ca51573826c">

### Notes

There was some inconsistency in information displayed between the web page and the CSV export. On the web page if the was no initial allocation it would default back to `created_at` whereas the export would default back to nil. 

The new behavior is to always default back to `created_at`.
