### PR TITLE
feat: add FMV column to purchases

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -5,7 +5,7 @@ class PurchasesController < ApplicationController
   def index
     setup_date_range_picker
     @purchases = current_organization.purchases
-                                     .includes(:line_items, :storage_location)
+                                     .includes(:storage_location, :vendor, line_items: [:item],)
                                      .order(created_at: :desc)
                                      .class_filter(filter_params)
                                      .during(helpers.selected_range)

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -5,7 +5,7 @@ class PurchasesController < ApplicationController
   def index
     setup_date_range_picker
     @purchases = current_organization.purchases
-                                     .includes(:storage_location, :vendor, line_items: [:item],)
+                                     .includes(:storage_location, :vendor, line_items: [:item])
                                      .order(created_at: :desc)
                                      .class_filter(filter_params)
                                      .during(helpers.selected_range)

--- a/app/views/purchases/_purchase_row.html.erb
+++ b/app/views/purchases/_purchase_row.html.erb
@@ -4,6 +4,7 @@
   <td class="numeric"><%= purchase_row.line_items.total %></td>
   <td class="numeric"><%= purchase_row.line_items.size %></td>
   <td class="numeric"><%= dollar_value(purchase_row.amount_spent_in_cents) %></td>
+  <td class="numeric"><%= dollar_value(purchase_row.value_per_itemizable) %></td>
   <td class="date"><%= purchase_row.issued_at.strftime("%F") %></td>
   <td class="text-right">
     <%= view_button_to purchase_path(purchase_row) %>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -82,6 +82,7 @@
                 <th>Quantity of Items</th>
                 <th>Variety of Items</th>
                 <th>Amount spent</th>
+                <th>FMV</th>
                 <th>Purchased Date</th>
                 <th class="text-right">Actions</th>
               </tr>

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -20,15 +20,26 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
         response
       end
 
-      before { create(:purchase) }
-
       context "html" do
         let(:response_format) { 'html' }
 
-        it { is_expected.to be_successful }
+        it "returns success when a purchase exists" do
+          create(:purchase)
+          expect(subject).to be_successful
+        end
+
+        it "shows the FMV column" do
+          purchase = create(:purchase, amount_spent_in_cents: 1234, organization: organization)
+          item = create(:item, value_in_cents: 42, organization: organization)
+          create(:line_item, item: item, itemizable: purchase, quantity: 2)
+
+          expect(subject.body).to include("FMV")
+          expect(subject.body).to include("$0.84")
+        end
       end
 
       context "csv" do
+        before { create(:purchase) }
         let(:response_format) { 'csv' }
 
         it { is_expected.to be_successful }

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -47,15 +47,6 @@ RSpec.describe "Purchases", type: :system, js: true do
           expect(page).to have_text(dollar_value(purchases.sum(&:amount_spent_in_cents)))
           expect(page).to have_text(dollar_value(3579))
         end
-
-        it "user sees FMV column" do
-          purchase = create(:purchase, amount_spent_in_cents: 1234, organization: @organization)
-          item = create(:item, value_in_cents: 42, organization: @organization)
-          create(:line_item, item: item, itemizable: purchase, quantity: 2)
-          page.refresh
-          expect(page).to have_text("FMV")
-          expect(page).to have_text(dollar_value(84))
-        end
       end
 
       context "When filtering on the index page" do

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe "Purchases", type: :system, js: true do
           expect(page).to have_text(dollar_value(purchases.sum(&:amount_spent_in_cents)))
           expect(page).to have_text(dollar_value(3579))
         end
+
+        it "user sees FMV column" do
+          purchase = create(:purchase, amount_spent_in_cents: 1234, organization: @organization)
+          item = create(:item, value_in_cents: 42, organization: @organization)
+          create(:line_item, item: item, itemizable: purchase, quantity: 2)
+          page.refresh
+          expect(page).to have_text("FMV")
+          expect(page).to have_text(dollar_value(84))
+        end
       end
 
       context "When filtering on the index page" do


### PR DESCRIPTION
Resolves #4314 

### Description
- Adds the FMV Column to the purchases index page
- Updates the purchases index controller action to eager load the `item` of each `line_item` to avoid n+1 issues.
  - *Note* I also added `vendor` here to the `includes` clause as well as I noticed the n+1 in the logs. This is an unrelated change so if you'd like me to revert that I'd be happy to.    
  

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- Added a new spec to the purchases system spec
- Tested manually by viewing the page (with seeded data)

### Screenshots

Before
![Screenshot 2024-05-03 at 19-28-41 Purchases - Pawnee Diaper Bank](https://github.com/rubyforgood/human-essentials/assets/90267290/c9177840-4588-4efd-a476-43ab44455919)

After
![Screenshot 2024-05-03 at 19-26-16 Purchases - Pawnee Diaper Bank](https://github.com/rubyforgood/human-essentials/assets/90267290/45d7c029-f464-467d-9453-5efce97f1a86)

