### PR TITLE
feat(tests): Add helper to await select2

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -286,6 +286,29 @@ def select2(node, select_name, value, position: nil)
   container.find(:xpath, '//li[contains(@class, "select2-results__option")][@role="option"]', text: value).click
 end
 
+# Runs the provided block of code that will change select2 dropdown. Waits until
+# select2 javascript has finished running to return
+#
+# @param select2 [String] The CSS selector for the Select2 dropdown element.
+# @param container [String, nil] The CSS selector for the container element
+# @yield Block to execute that will trigger Select2 change
+#
+# @example Usage
+#   # Wait for Select2 dropdown with CSS selector '.select2' inside container '.container'
+#   await_select2('.select2', '.container') do
+#     # Perform actions that trigger a change in the Select2 dropdown
+#   end
+def await_select2(select2, container = nil, &block)
+  page_html = Nokogiri::HTML.parse(page.body)
+  page_html = page_html.css(container).first unless container.nil?
+  select2_element = page_html.css(select2).first
+  current_id = select2_element.children.first["data-select2-id"]
+
+  yield
+
+  find("#{container} select option[data-select2-id=\"#{current_id.to_i + 1}\"]", wait: 10)
+end
+
 def seed_base_items
   base_items = File.read(Rails.root.join("db", "base_items.json"))
   items_by_category = JSON.parse(base_items)

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -88,7 +88,11 @@ RSpec.describe "Audit management", type: :system, js: true do
       it "should be able to confirm the audit from the #new page", js: true do
         visit subject
         click_link "New Audit"
-        select storage_location.name, from: "Storage location"
+
+        await_select2("#audit_line_items_attributes_0_item_id") do
+          select storage_location.name, from: "Storage location"
+        end
+
         select Item.last.name, from: "audit_line_items_attributes_0_item_id"
         fill_in "audit_line_items_attributes_0_quantity", with: quantity.to_s
 

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -118,8 +118,11 @@ RSpec.feature "Distributions", type: :system do
 
         visit @url_prefix + "/distributions/new"
         select @partner.name, from: "Partner"
-        select @storage_location.name, from: "From storage location"
-        find('select option[data-select2-id="3"]', wait: 10)
+
+        await_select2("#distribution_line_items_attributes_0_item_id") do
+          select @storage_location.name, from: "From storage location"
+        end
+
         select item.name, from: "distribution_line_items_attributes_0_item_id"
         fill_in "distribution_line_items_attributes_0_quantity", with: 18
 


### PR DESCRIPTION
Select2 uses javascript to populate dropdowns. This adds a generic helper to await the dropdown being populated.

Resolves stuff like this: https://github.com/rubyforgood/human-essentials/actions/runs/8958924985/job/24603724933

### Type of change

* New feature (non-breaking change which adds functionality)
