### PR TITLE
[#3090] Introduce distribution confirmation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,7 @@
 @import 'modal-dialog';
 @import 'expandable_table';
 @import 'custom';
+@import 'confirm';
 
 .modal-dialog {
   display: flex;
@@ -193,4 +194,3 @@ div.warning {
   margin: 5px;
   text-align: center;
 }
-

--- a/app/assets/stylesheets/confirm.scss
+++ b/app/assets/stylesheets/confirm.scss
@@ -1,0 +1,8 @@
+.confirm {
+  padding: 20px 7.5px;
+
+  .message {
+    margin-top: 30px;
+    margin-bottom: 50px;
+  }
+}

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -10,7 +10,10 @@ class DashboardController < ApplicationController
     @purchases = current_organization.purchases.during(helpers.selected_range)
     @recent_purchases = @purchases.recent.includes(:vendor)
 
-    distributions = current_organization.distributions.includes(:partner).during(helpers.selected_range)
+    distributions = current_organization.distributions
+      .not_pending
+      .includes(:partner)
+      .during(helpers.selected_range)
     @recent_distributions = distributions.recent
 
     @itemized_donation_data = DonationItemizedBreakdownService.new(organization: current_organization, donation_ids: @donations.pluck(:id)).fetch

--- a/app/controllers/distributions_by_county_controller.rb
+++ b/app/controllers/distributions_by_county_controller.rb
@@ -4,7 +4,10 @@ class DistributionsByCountyController < ApplicationController
 
   def report
     setup_date_range_picker
-    distributions = current_organization.distributions.includes(:partner).during(helpers.selected_range)
+    distributions = current_organization.distributions
+      .not_pending
+      .includes(:partner)
+      .during(helpers.selected_range)
     @breakdown = DistributionByCountyReportService.new.get_breakdown(distributions)
   end
 end

--- a/app/controllers/partners/dashboards_controller.rb
+++ b/app/controllers/partners/dashboards_controller.rb
@@ -9,10 +9,14 @@ module Partners
     def show
       @partner = current_partner
       @partner_requests = @partner.requests.order(created_at: :desc).limit(10)
-      @upcoming_distributions = @partner.distributions.order(issued_at: :desc)
+      @upcoming_distributions = @partner.distributions
+                                        .not_pending
                                         .where('issued_at >= ?', Time.zone.today)
-      @distributions = @partner.distributions.order(issued_at: :desc)
+                                        .order(issued_at: :desc)
+      @distributions = @partner.distributions
+                               .not_pending
                                .where('issued_at < ?', Time.zone.today)
+                               .order(issued_at: :desc)
                                .limit(5)
 
       @parent_org = Organization.find(@partner.organization_id)

--- a/app/controllers/partners/distributions_controller.rb
+++ b/app/controllers/partners/distributions_controller.rb
@@ -7,7 +7,9 @@ module Partners
 
     def index
       @partner = current_partner
-      @distributions = @partner.distributions.order(issued_at: :desc)
+      @distributions = @partner.distributions
+        .not_pending
+        .order(issued_at: :desc)
 
       @parent_org = Organization.find(@partner.organization_id)
     end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -74,7 +74,10 @@ class PartnersController < ApplicationController
   def show
     @partner = current_organization.partners.find(params[:id])
     @impact_metrics = @partner.impact_metrics unless @partner.uninvited?
-    @partner_distributions = @partner.distributions.includes(:partner, :storage_location, line_items: [:item]).order("issued_at DESC")
+    @partner_distributions = @partner.distributions
+      .not_pending
+      .includes(:partner, :storage_location, line_items: [:item])
+      .order("issued_at DESC")
     @partner_profile_fields = current_organization.partner_form_fields
     @partner_users = @partner.users.order(name: :asc)
 

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -56,6 +56,28 @@ module Itemizable
         end
       end
 
+      def replace!
+        # Bail if there's nothing
+        return if size.zero?
+
+        # First we'll collect all the line_items that are used
+        combined = {}
+        parent_id = first.itemizable_id
+        each do |line_item|
+          next unless line_item.valid?
+          next unless line_item.quantity != 0
+
+          combined[line_item.item_id] = line_item.quantity
+        end
+        # Delete all the existing ones in this association -- this
+        # method aliases to `delete_all`
+        clear
+        # And now recreate a new array of line_items using the replaced quantity
+        combined.each do |item_id, qty|
+          build(quantity: qty, item_id: item_id, itemizable_id: parent_id)
+        end
+      end
+
       def quantities_by_category
         results = {}
 

--- a/app/services/calendar_service.rb
+++ b/app/services/calendar_service.rb
@@ -8,6 +8,7 @@ module CalendarService
   def self.calendar(organization_id)
     distributions = Organization.find(organization_id)
       .distributions
+      .not_pending
       .includes(:storage_location, :partner)
       .where("issued_at > ?", 1.year.ago)
 

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -10,6 +10,7 @@ class DistributionCreateService < DistributionService
     perform_distribution_service do
       validate_request_not_yet_processed! if @request.present?
 
+      distribution.state = "scheduled"
       distribution.save!
 
       DistributionEvent.publish(distribution)
@@ -29,7 +30,7 @@ class DistributionCreateService < DistributionService
 
   def validate_request_not_yet_processed!
     existing_distribution = @request.distribution
-    if existing_distribution.present?
+    if existing_distribution.present? && !existing_distribution.pending?
       raise "Request has already been fulfilled by Distribution #{existing_distribution.id}"
     end
   end

--- a/app/services/distribution_itemized_breakdown_service.rb
+++ b/app/services/distribution_itemized_breakdown_service.rb
@@ -58,7 +58,10 @@ class DistributionItemizedBreakdownService
   attr_reader :organization, :distribution_ids
 
   def distributions
-    @distributions ||= organization.distributions.where(id: distribution_ids).includes(line_items: :item)
+    @distributions ||= organization.distributions
+      .not_pending
+      .where(id: distribution_ids)
+      .includes(line_items: :item)
   end
 
   def current_onhand_quantities(inventory)

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -10,15 +10,21 @@ class DistributionUpdateService < DistributionService
       @old_issued_at = distribution.issued_at
       @old_delivery_method = distribution.delivery_method
 
-      ItemizableUpdateService.call(
-        itemizable: distribution,
-        params: @params,
-        type: :decrease,
-        event_class: DistributionEvent
-      )
+      if distribution.pending?
+        # Pending means user might still be working on it
+        # so we don't want to affect inventory at this point
+        @distribution.update!(@params)
+      else
+        ItemizableUpdateService.call(
+          itemizable: distribution,
+          params: @params,
+          type: :decrease,
+          event_class: DistributionEvent
+        )
 
-      @new_issued_at = distribution.issued_at
-      @new_delivery_method = distribution.delivery_method
+        @new_issued_at = distribution.issued_at
+        @new_delivery_method = distribution.delivery_method
+      end
     end
   end
 

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -1,4 +1,8 @@
-<%= simple_form_for distribution, data: { controller: "form-input" }, html: {class: "storage-location-required"}, wrapper_mappings: { datetime: :custom_multi_select } do |f| %>
+<%= simple_form_for distribution,
+  url: (distribution.id.present? ? distribution_path(distribution) : create_pending_distributions_path),
+  data: { controller: "form-input" },
+  html: {class: "storage-location-required"},
+  wrapper_mappings: { datetime: :custom_multi_select } do |f| %>
 
   <div class="box-body">
     <%= f.simple_fields_for :request do |r| %>

--- a/app/views/distributions/confirm.html.erb
+++ b/app/views/distributions/confirm.html.erb
@@ -1,0 +1,48 @@
+<div class="confirm w-50">
+  <div class="card card-primary">
+    <div class="card-header">
+      <h3 class="card-title">Distribution Confirmation</h3>
+    </div>
+
+    <div class="card-body table-responsive">
+      <p class="lead">You are about to create a distribution for <span class="fw-bolder fst-italic"><%= @dist.partner.name %></span>.</p>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Item Name</th>
+            <th>Quantity</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @dist.line_items.each do |item| %>
+            <tr>
+              <td><%= item.item.name %></td>
+              <td><%= item.quantity %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <div class="message fs-5">
+        <p>Please confirm that the above list is what you meant to request.</p>
+      </div>
+
+      <div class="row">
+        <div class="col">
+          <%= form_with(model: @dist, url: update_from_confirm_distribution_path) do |f| %>
+            <%= f.hidden_field :from_confirm %>
+            <%= button_tag "Yes, it's right", type: "submit", class: "btn btn-success btn-block" %>
+          <% end %>
+        </div>
+        <div class="col">
+          <%= edit_button_to edit_distribution_path(@dist), {
+            text: "No, I need to change something.",
+            enabled: !@dist.has_inactive_item?,
+            type: "block",
+            size: "secondary"} %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,12 +126,15 @@ Rails.application.routes.draw do
 
     resources :distributions do
       get :print, on: :member
+      get :confirm, on: :member
       collection do
         get :schedule
         get :pickup_day
         get :itemized_breakdown
+        post :create_pending
       end
       patch :picked_up, on: :member
+      patch :update_from_confirm, on: :member
     end
 
     resources :barcode_items do

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -180,6 +180,16 @@ RSpec.describe Distribution, type: :model, skip_seed: true do
         expect(Distribution.by_location(location_1.id)).not_to include(dist2)
       end
     end
+
+    describe "not_pending" do
+      it "only returns distributions that are not pending" do
+        dist1 = create(:distribution, state: "pending")
+        dist2 = create(:distribution, state: "scheduled")
+
+        expect(Distribution.not_pending).to include(dist2)
+        expect(Distribution.not_pending).not_to include(dist1)
+      end
+    end
   end
 
   context "Callbacks >" do


### PR DESCRIPTION
Resolves #3090 

### Description

This modifies the flow of how new distributions are created as per the motivation explained in the ticket #3090.

The overall approach is to save these "intermediate" distributions in a new `pending` state in the database, rather than relying on request and/or session as a means of maintaining data across requests. This is because of some text fields on the distribution and many items can get added, that might exceed the max cookie or url size. There was some discussion about this on a previous PR.

After a user clicks Save from the New Distribution view, it will call a new `create_pending` action on the Distributions controller, which will create the distribution in a `pending` state (new enum value added), and then redirect to a new Confirmation view for this pending distribution.

Note that at this point, the `DistributionCreateService` has not yet been called because this would affect inventory and potentially send out notifications, which is not wanted at this point because the distribution hasn't yet been confirmed.

The confirmation view displays the partner the distribution is for, and lists the items/quantities and asks the user if they're sure this is what they want. 

If user clicks Yes, then a new action `update_from_confirm` on the Distributions controller is called, which will now call the `DistributionCreateService`, which has been modified to update the state to `scheduled` (as part of the existing transaction so it should get rolled back to pending if anything goes wrong such as insufficient inventory).

If user clicks No, then the existing `edit` action on the Distributions controller is called. This is because at this point, the distribution has already been created and has an ID, so it's no longer the "new" view. Some existing update logic was modified to handle the `pending` state differently:
* Do not update inventory yet
* Replace rather than combine line_items (re: handling of accepts_nested_attributes_for in a one to many)

Note that when user clicks Save from Updating a pending distribution, they will still get the Confirmation view, they can go through this update/confirm/no loop as many times as they like.

Also all queries/views that show lists of distributions were modified to filter out `pending`.

A follow-on task will be needed to implement a scheduled clean-up job that removes old `pending` distributions. This is because it's possible for a user to "abandon" a distribution at the confirmation view.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Many of the distribution system tests were modified to expect the new confirmation view. A new one was added to ensure that an abandoned pending distribution does not show up in the distribution index listing.

### Screenshots
Here is the new confirmation view shown after user clicks Save for a new distribution. Notice the url here has the distribution id - because it has been created and saved to the database already:
![image](https://github.com/rubyforgood/human-essentials/assets/2428282/d30e98b6-8716-4569-bbe6-4da1f2205dd9)