### PR TITLE
Add tests for `partner_settings` partials

### DIFF
--- a/spec/requests/partners/profiles_requests_spec.rb
+++ b/spec/requests/partners/profiles_requests_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe "/partners/profiles", type: :request, skip_seed: true do
       expect(response.body).to include("<dt>Form 990 Filed</dt>\n      <dd>No</dd>")
       expect(response.body).to include("<dt>Do You Verify The Income Of Your Clients</dt>\n      <dd>Yes</dd>")
     end
+
+    it "renders show partner settings partial with enabled request types only" do
+      partner.profile.organization.update!(enable_quantity_based_requests: true, enable_child_based_requests: false)
+      get partners_profile_path(partner)
+      expect(response).to render_template(partial: "partners/profiles/show/_partner_settings")
+      expect(response.body).to include("<dt>Uses Quantity Based Requests</dt>")
+      expect(response.body).not_to include("<dt>Uses Child Based Requests</dt>")
+    end
   end
 
   describe "GET #edit" do
@@ -48,6 +56,14 @@ RSpec.describe "/partners/profiles", type: :request, skip_seed: true do
       get edit_partners_profile_path(partner)
       expect(response.body).not_to include("type=\"radio\" value=\"true\" checked=\"checked\" name=\"partner[profile][storage_space]\" id=\"partner_profile_storage_space_true\" />")
       expect(response.body).to include("type=\"radio\" value=\"false\" checked=\"checked\" name=\"partner[profile][storage_space]\" id=\"partner_profile_storage_space_false\"")
+    end
+
+    it "renders edit partner settings partial with enabled request types only" do
+      partner.profile.organization.update!(enable_quantity_based_requests: true, enable_child_based_requests: false)
+      get edit_partners_profile_path(partner)
+      expect(response).to render_template(partial: "partners/profiles/edit/_partner_settings")
+      expect(response.body).to include("Enable Quantity-based Requests")
+      expect(response.body).not_to include("Enable Child-based Requests")
     end
   end
 

--- a/spec/requests/profiles_requests_spec.rb
+++ b/spec/requests/profiles_requests_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe "Profiles", type: :request, skip_seed: true do
       get edit_profile_path(default_params)
       expect(response).to be_successful
     end
+
+    it "renders edit partner settings partial with enabled request types only" do
+      partner.profile.organization.update!(enable_quantity_based_requests: true, enable_child_based_requests: false)
+      get edit_profile_path(default_params)
+      expect(response).to render_template(partial: "partners/profiles/edit/_partner_settings")
+      expect(response.body).to include("Enable Quantity-based Requests")
+      expect(response.body).not_to include("Enable Child-based Requests")
+    end
   end
 
   describe "POST #update" do


### PR DESCRIPTION
Resolves #4309 <!--fill issue number-->

### Description
The `partner_settings` partial was previously inadvertently deleted from the Partner Profile Edit view because there are no tests asserting for its presence. This PR adds a test for the presence of the partial when a Partner or Bank edits the Partner Profile and the presence of the show `partner_settings` partial when a Partner views its profile. To test that the correct request types are displaying in the partial, I assert for the presence of an enabled request type and assert for the exclusion of a disabled request type.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
The tests all pass as expected. I tested each expectation in isolation by making each fail with the following changes:
- `render_template` fails when I remove the code that renders the partial in the show/edit profile views.
- `expect(response.body).to include(...)` fails when I remove the corresponding conditional and HTML from the partial for a request type that is enabled
- `expect(response.body).not_to include(...)` fails when I remove the conditional to ensure the HTML appears in the partial for a request type that is disabled
