### PR TITLE
Fix spelling and make Oxford comma usage consistent

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -106,7 +106,7 @@
           </div>
           <div class="text-center">
             <h3 class="text-3xl">Barcode Scanning</h3>
-            <p class="text-gray-400 mt-2">Quickly add or remove inventory with the scan of a barcode. The adjustment and transfer of inventory is also supported as well as creating your own barcodes.</p>
+            <p class="text-gray-400 mt-2">Quickly add or remove inventory with the scan of a barcode. Creating your own barcodes is also supported.</p>
           </div>
         </div>
       </div>
@@ -118,7 +118,7 @@
           </div>
           <div class="text-center">
             <h3 class="text-3xl">Inventory Management</h3>
-            <p class="text-gray-400 mt-2">Easily keep track of the items in your inventory regardless of their storage location.</p>
+            <p class="text-gray-400 mt-2">Easily keep track of the items in your inventory regardless of their storage location. Adjust and transfer your inventory between locations as needed.</p>
           </div>
         </div>
 

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -96,7 +96,7 @@
           </div>
           <div class="text-center">
             <h3 class="text-3xl">Report Generation</h3>
-            <p class="text-gray-400 mt-2">Generate pdfs of partner distribution invoices for easy printing and sending.</p>
+            <p class="text-gray-400 mt-2">Generate PDFs of partner distribution invoices for easy printing and sending.</p>
           </div>
         </div>
 
@@ -106,7 +106,7 @@
           </div>
           <div class="text-center">
             <h3 class="text-3xl">Barcode Scanning</h3>
-            <p class="text-gray-400 mt-2">Quickly add or remove inventory with the scan of a barcode. The adjusting and transfering of inventory is also supported as well as creating your own barcodes.</p>
+            <p class="text-gray-400 mt-2">Quickly add or remove inventory with the scan of a barcode. The adjustment and transfer of inventory is also supported as well as creating your own barcodes.</p>
           </div>
         </div>
       </div>
@@ -127,8 +127,8 @@
             <%= image_tag("dashboard-image.svg", class: "app-images") %>
           </div>
           <div class="text-center">
-            <h3 class="text-3xl">Dashboard Vizualization</h3>
-            <p class="text-gray-400 mt-2">Quickly view your inventory, donations, purchases and distributions on a single page.</p>
+            <h3 class="text-3xl">Dashboard Visualization</h3>
+            <p class="text-gray-400 mt-2">Quickly view your inventory, donations, purchases, and distributions on a single page.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fix spelling and make Oxford comma usage consistent on app homepage

### Description
I found a typo in one of the headers on the homepage so I did a thorough review of the page and put the edits in this PR. I'm a fan of Oxford comma usage and saw it's used for most of the page so I opted to make it consistent.

### Type of change
Non-breaking change not tied to any issue

### How Has This Been Tested?
I viewed the changes on the front end of the app in development to make sure they look good.
