### PR TITLE
fix: flaky dist by county spec

### DIFF
--- a/spec/support/distribution_by_county_shared_example.rb
+++ b/spec/support/distribution_by_county_shared_example.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples_for "distribution_by_county" do
-  let(:organization) { create(:organization, skip_items: true) }
+  let(:organization) { create(:organization, skip_items: true, name: "Some Unique Name") }
   let(:user) { create(:user, organization: organization) }
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 

--- a/spec/system/distributions_by_county_system_spec.rb
+++ b/spec/system/distributions_by_county_system_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Distributions by County", type: :system do
+RSpec.feature "Distributions by County", type: :system, skip_seed: true do
   include_examples "distribution_by_county"
 
   let(:year) { Time.current.year }


### PR DESCRIPTION
Fixes #4338 

Spec looked for a certain amount of the value '50' on the page if the bank was name Bank 50 or Bank 150 the test would fail.
For example: ![screenshot_works-for-this-year_2024-05-15-19-44-17 582](https://github.com/rubyforgood/human-essentials/assets/14540596/8535e80c-8dc4-4b59-bcb5-b79f1ad8655c)


Set a unique name to ensure failures will not occur.

