### PR TITLE
issue addressed: 4274

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -222,7 +222,8 @@ class Item < ApplicationRecord
   end
 
   def self.existing_item_with_same_name?(organization_id, name)
-    where(organization_id: organization_id, name: name).exists?
+    where(organization_id: organization_id).where("LOWER(name) = ?", name.downcase)
+      .exists?
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -221,6 +221,10 @@ class Item < ApplicationRecord
     inventory_items.find_by(storage_location_id: storage_location_id)
   end
 
+  def self.existing_item_with_same_name?(organization_id, name)
+    where(organization_id: organization_id, name: name).exists?
+  end
+
   private
 
   def update_associated_kit_name

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -128,20 +128,39 @@ RSpec.describe ItemsController, type: :controller do
       end
 
       context "with an already existing item name" do
-        let(:item_params) do
-          {
-            item: {
-              name: "Really Good Item",
-              partner_key: create(:base_item).partner_key,
-              value_in_cents: 1001,
-              package_size: 5,
-              distribution_quantity: 30
-            }
-          }
-        end
         it "shouldn't create an item with the same name" do
-          create(:item, name: "Really Good Item", organization: @organization)
           post :create, params: default_params.merge(item_params)
+
+          item_params_with_same_name =
+            {
+              item: {
+                name: "Really Good Item",
+                partner_key: create(:base_item).partner_key,
+                value_in_cents: 1001,
+                package_size: 5,
+                distribution_quantity: 30
+              }
+            }
+          post :create, params: default_params.merge(item_params_with_same_name)
+
+          expect(flash[:error]).to eq("An item with that name already exists (could be an inactive item).")
+          expect(response).to render_template(:new)
+        end
+
+        it "shouldn't create an item with the same name, case-insensitively" do
+          post :create, params: default_params.merge(item_params)
+
+          item_params_with_same_name_lower_case =
+            {
+              item: {
+                name: "really good item",
+                partner_key: create(:base_item).partner_key,
+                value_in_cents: 1001,
+                package_size: 5,
+                distribution_quantity: 30
+              }
+            }
+          post :create, params: default_params.merge(item_params_with_same_name_lower_case)
 
           expect(flash[:error]).to eq("An item with that name already exists (could be an inactive item).")
           expect(response).to render_template(:new)

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe ItemsController, type: :controller do
             post :create, params: default_params.merge(item_params)
           end.to change { Item.count }.by(1)
         end
-
         it "should accept params with dollar signs, periods, and commas" do
           item_params["value_in_cents"] = "$5,432.10"
           post :create, params: default_params.merge(item_params)
@@ -125,6 +124,27 @@ RSpec.describe ItemsController, type: :controller do
 
           expect(response).to redirect_to items_path
           expect(response).to have_notice
+        end
+      end
+
+      context "with an already existing item name" do
+        let(:item_params) do
+          {
+            item: {
+              name: "Really Good Item",
+              partner_key: create(:base_item).partner_key,
+              value_in_cents: 1001,
+              package_size: 5,
+              distribution_quantity: 30
+            }
+          }
+        end
+        it "shouldn't create an item with the same name" do
+          create(:item, name: "Really Good Item", organization: @organization)
+          post :create, params: default_params.merge(item_params)
+
+          expect(flash[:error]).to eq("An item with that name already exists (could be an inactive item).")
+          expect(response).to render_template(:new)
         end
       end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -204,6 +204,23 @@ RSpec.describe Item, type: :model do
           expect(item.can_deactivate_or_delete?).to eq(false)
         end
       end
+
+      context ".existing_item_with_same_name?" do
+        it "should return true if the item name exist in the same organization" do
+          create(:item, name: "Item 1", organization: organization)
+          expect(Item.existing_item_with_same_name?(organization, "Item 1")).to eq(true)
+        end
+        it "should return false if the item name doesn't exist in the same organization" do
+          create(:item, name: "Item 1", organization: organization)
+          expect(Item.existing_item_with_same_name?(organization, "New Item")).to eq(false)
+        end
+        it "should return false if the item name exist in a different organization" do
+          organization = create(:organization)
+          different_organization = create(:organization)
+          create(:item, name: "Item 1", organization: different_organization)
+          expect(Item.existing_item_with_same_name?(organization, "Item 1")).to eq(false)
+        end
+      end
     end
 
     describe '#can_delete?' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -204,23 +204,6 @@ RSpec.describe Item, type: :model do
           expect(item.can_deactivate_or_delete?).to eq(false)
         end
       end
-
-      context ".existing_item_with_same_name?" do
-        it "should return true if the item name exist in the same organization" do
-          create(:item, name: "Item 1", organization: organization)
-          expect(Item.existing_item_with_same_name?(organization, "Item 1")).to eq(true)
-        end
-        it "should return false if the item name doesn't exist in the same organization" do
-          create(:item, name: "Item 1", organization: organization)
-          expect(Item.existing_item_with_same_name?(organization, "New Item")).to eq(false)
-        end
-        it "should return false if the item name exist in a different organization" do
-          organization = create(:organization)
-          different_organization = create(:organization)
-          create(:item, name: "Item 1", organization: different_organization)
-          expect(Item.existing_item_with_same_name?(organization, "Item 1")).to eq(false)
-        end
-      end
     end
 
     describe '#can_delete?' do
@@ -350,6 +333,31 @@ RSpec.describe Item, type: :model do
           expect do
             Item.reactivate(item_id)
           end.to change { Item.active.size }.by(1)
+        end
+      end
+    end
+
+    describe ".existing_item_with_same_name?" do
+      let!(:organization) { create(:organization) }
+
+      context "when the item name exist in the same organization" do
+        before do
+          create(:item, organization: organization, name: 'Item 1')
+        end
+
+        it "should return true if the item name exist in the same organization" do
+          expect(Item.existing_item_with_same_name?(organization.id, "item 1")).to eq(true)
+        end
+        it "should return false if the item name doesn't exist in the same organization" do
+          expect(Item.existing_item_with_same_name?(organization.id, "New Item")).to eq(false)
+        end
+      end
+
+      context "when the item name exist but in a different organization" do
+        it "should return false if the item name exist in a different organization" do
+          different_organization = create(:organization)
+          create(:item, name: "Cool Item", organization: different_organization)
+          expect(Item.existing_item_with_same_name?(organization.id, "cool item")).to eq(false)
         end
       end
     end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code, ✅ 
- I have commented my code, particularly in hard-to-understand areas, ✅ 
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works, ✅ 
- New and existing unit tests pass locally with my changes ("bundle exec rake"), ✅ 
- Title include "WIP" if work is in progress. ✅ 

-->

Resolves #4274 

### Description
This PR implements changes to the `ItemsController` and adds an instance method to the `Item` model to query an organization for existing item names. These changes allow banks to receive a clear message, “An item with that name already exists (could be an inactive item),” when attempting to enter a new item name that already exists.
Please also include relevant motivation and context.
Main changes:

1. ItemsController

- Slightly restructured the create method to use abstraction for error handling and added a custom method while using `rescue_from` with `ActiveRecord::RecordInvalid`

2. Item Model

- Added a method to query for existing item names within an organization.


Guide questions:
  - What motivated this change (if not already described in an issue)?
  -- Banks should have a clear message explaining why an item couldn’t be created in the case of creating an item with the same name as another.
  - What alternative solutions did you consider?
  -- I considered using `ActiveRecord` to handle the case without the new model method but wanted clean code with the desired message. 
  - What are the tradeoffs for your solution?
  -- Using the model method allowed for easier readability and control over error messages. This allowed to keep the other error message in the case of the error not being matching item names.
-- Using `ActiveRecord` could be a more useful route since it is built in and would reduce the amount of logic in the controller and model.
  
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 

I created two additional tests. In the `Item_controller_spec` and the `item_spec` for testing the model method.
The controller test creates an item, and then tries to create a 2nd item but with the same name name. Triggering an error.
The model test queries an organization for already existing item names. It is thoroughly tested and ensures that items with different names do not match and different organizations can have the same item names. Though I am not 100% sure this is what was wanted. This is my first issue, so please let me know if there is anything I should change or if I over thought the logic! 😄 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
I added WIP in the title since I got a couple of failing tests.
`Ferrum:: JavaScriptError:
TypeError: Cannot read properties of null (reading 'dispatchEvent')
at Cuprite,trigger (<anonymous>: 412:10) at Cuprite.select (<anonymous>: 359:12)
at HTMLOptionElement. <anonymous> (<anonymous>: 1:31)`
 I believe others have been having similar issues when running the test suite and this is being figured out currently. The two failing test do pass if I run the test separately.
![Screenshot 2024-05-16 at 11 46 18 PM](https://github.com/rubyforgood/human-essentials/assets/127896538/0bbe516d-0253-49da-8005-ca443203e169)

Include screenshots (before / after) for style changes, highlight edited element.-->
<h1>Before<h1/>

![Screenshot 2024-05-17 at 1 29 09 AM](https://github.com/rubyforgood/human-essentials/assets/127896538/748f2b05-c2c9-4767-a1e0-783220d10391)

<h1>After<h1/>

![Screenshot 2024-05-17 at 1 24 42 AM](https://github.com/rubyforgood/human-essentials/assets/127896538/4f1b8b61-2e38-49af-ad47-45935b01bbd6)

![Screenshot 2024-05-17 at 1 24 34 AM](https://github.com/rubyforgood/human-essentials/assets/127896538/6ad4b9ea-4f3c-4007-9624-b7b65d8ef6e0)

![Screenshot 2024-05-17 at 1 24 18 AM](https://github.com/rubyforgood/human-essentials/assets/127896538/ffa024f6-7360-4b67-8479-1bfe75a78dd0)

![Screenshot 2024-05-17 at 1 25 37 AM](https://github.com/rubyforgood/human-essentials/assets/127896538/8d601ccb-d6ff-46d7-874e-e9c0a52e17ee)

![Screenshot 2024-05-17 at 1 23 22 AM](https://github.com/rubyforgood/human-essentials/assets/127896538/cb38e7a0-8b81-493b-ad34-627dab1ab1bf)

![Screenshot 2024-05-17 at 1 25 11 AM](https://github.com/rubyforgood/human-essentials/assets/127896538/118f4496-6acf-45d0-b211-696fa020b734)