### PR TITLE
Clean up incorrect request statuses that have a distribution [#4275]

### DIFF
--- a/db/migrate/20240519201258_mark_distributed_started_requests_as_fulfilled.rb
+++ b/db/migrate/20240519201258_mark_distributed_started_requests_as_fulfilled.rb
@@ -1,0 +1,14 @@
+class MarkDistributedStartedRequestsAsFulfilled < ActiveRecord::Migration[7.0]
+  def up
+    # Fix a data integrity issue; once a request has an associated
+    # distribution created the request should be marked as fulfilled
+    Request
+      .where(status: :started)
+      .where.not(distribution: nil)
+      .update_all(status: :fulfilled)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_12_140954) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_19_201258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Validated by pulling down a production snapshot and running locally.

There are only 6 records that are fixed by this data cleanup, affecting helping_moms, sweetcheeks, and franciscan.