### PR TITLE
add role deactivation model attributes, methods and services

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,6 +140,28 @@ class User < ApplicationRecord
     false
   end
 
+  def self.with_active_role(role_name, resource = nil)
+    roles = {name: role_name}.merge((resource == :any) ? {} : {resource: resource})
+
+    User.joins(:roles)
+      .where(
+        roles: roles,
+        "users_roles.deactivated": [false, nil]
+      )
+  end
+
+  def has_active_role?(role_name, resource = nil)
+    roles = {name: role_name}.merge((resource == :any) ? {} : {resource: resource})
+
+    UsersRole.joins(:role)
+      .where(
+        user: self,
+        roles: roles,
+        deactivated: [false, nil]
+      )
+      .exists?
+  end
+
   def self.from_omniauth(access_token)
     data = access_token.info
     User.find_by(email: data["email"])

--- a/app/models/users_role.rb
+++ b/app/models/users_role.rb
@@ -2,9 +2,10 @@
 #
 # Table name: users_roles
 #
-#  id      :bigint           not null, primary key
-#  role_id :bigint
-#  user_id :bigint
+#  id          :bigint           not null, primary key
+#  deactivated :boolean          default(FALSE)
+#  role_id     :bigint
+#  user_id     :bigint
 #
 class UsersRole < ApplicationRecord
   has_paper_trail

--- a/app/services/activate_role_service.rb
+++ b/app/services/activate_role_service.rb
@@ -1,0 +1,29 @@
+class ActivateRoleService
+  # @param user_id [Integer]
+  # @param role_id [Integer]
+  # @param resource_type [String]
+  # @param resource_id [Integer]
+  def self.call(user_id:, role_id: nil, resource_type: nil, resource_id: nil)
+    if role_id.nil? && resource_id.nil?
+      raise "Must provide either a role ID or resource ID!"
+    end
+    if role_id.nil?
+      role_id = Role.find_by(name: resource_type, resource_id: resource_id).id
+    end
+    user_role = UsersRole.find_by(user_id: user_id, role_id: role_id)
+    unless user_role
+      user = User.find(user_id)
+      role = Role.find(role_id)
+      raise "User #{user.display_name} does not have role for #{role.resource.name}!"
+    end
+
+    user_role.update(deactivated: false)
+
+    if user_role.role.name.to_sym == Role::ORG_ADMIN
+      org_user_role = Role.find_by(resource_id: user_role.role.resource_id, name: Role::ORG_USER)
+      if org_user_role
+        UsersRole.find_by(user_id: user_id, role_id: org_user_role.id)&.update(deactivated: false)
+      end
+    end
+  end
+end

--- a/app/services/deactivate_role_service.rb
+++ b/app/services/deactivate_role_service.rb
@@ -1,0 +1,29 @@
+class DeactivateRoleService
+  # @param user_id [Integer]
+  # @param role_id [Integer]
+  # @param resource_type [String]
+  # @param resource_id [Integer]
+  def self.call(user_id:, role_id: nil, resource_type: nil, resource_id: nil)
+    if role_id.nil? && resource_id.nil?
+      raise "Must provide either a role ID or resource ID!"
+    end
+    if role_id.nil?
+      role_id = Role.find_by(name: resource_type, resource_id: resource_id).id
+    end
+    user_role = UsersRole.find_by(user_id: user_id, role_id: role_id)
+    unless user_role
+      user = User.find(user_id)
+      role = Role.find(role_id)
+      raise "User #{user.display_name} does not have role for #{role.resource.name}!"
+    end
+
+    user_role.update(deactivated: true)
+
+    if user_role.role.name.to_sym == Role::ORG_USER # they can't be an admin if they're not a user
+      admin_role = Role.find_by(resource_id: user_role.role.resource_id, name: Role::ORG_ADMIN)
+      if admin_role
+        UsersRole.find_by(user_id: user_id, role_id: admin_role.id)&.update(deactivated: true)
+      end
+    end
+  end
+end

--- a/db/migrate/20240525212223_add_deactivated_to_users_role.rb
+++ b/db/migrate/20240525212223_add_deactivated_to_users_role.rb
@@ -1,0 +1,10 @@
+class AddDeactivatedToUsersRole < ActiveRecord::Migration[7.1]
+  def up
+    add_column :users_roles, :deactivated, :boolean
+    change_column_default :users_roles, :deactivated, false
+  end
+
+  def down
+    remove_column :users_roles, :deactivated
+  end
+end

--- a/db/migrate/20240525215030_backfill_add_deactivated_to_users_role.rb
+++ b/db/migrate/20240525215030_backfill_add_deactivated_to_users_role.rb
@@ -1,0 +1,16 @@
+class BackfillAddDeactivatedToUsersRole < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    UsersRole.unscoped.joins(:user).where("users.discarded_at": nil).in_batches do |relation|
+      relation.update_all(deactivated: false)
+      sleep(0.01)
+    end
+
+    UsersRole.unscoped.joins(:user).where.not("users.discarded_at": nil).in_batches do |relation|
+      relation.update_all(deactivated: true)
+      sleep(0.01)
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_19_201258) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_25_215030) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -233,8 +233,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_19_201258) do
     t.integer "organization_id"
     t.datetime "issued_at", precision: nil
     t.string "agency_rep"
-    t.integer "state", default: 5, null: false
     t.boolean "reminder_email_enabled", default: false, null: false
+    t.integer "state", default: 5, null: false
     t.integer "delivery_method", default: 0, null: false
     t.decimal "shipping_cost", precision: 8, scale: 2
     t.index ["organization_id"], name: "index_distributions_on_organization_id"
@@ -833,6 +833,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_19_201258) do
   create_table "users_roles", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "role_id"
+    t.boolean "deactivated", default: false
     t.index ["role_id"], name: "index_users_roles_on_role_id"
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
     t.index ["user_id"], name: "index_users_roles_on_user_id"

--- a/spec/factories/users_roles.rb
+++ b/spec/factories/users_roles.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :users_role do
+    user
+    role
+  end
+end

--- a/spec/models/item_unit_spec.rb
+++ b/spec/models/item_unit_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: item_request_units
+# Table name: item_units
 #
 #  id         :bigint           not null, primary key
 #  name       :string           not null

--- a/spec/models/users_role_spec.rb
+++ b/spec/models/users_role_spec.rb
@@ -2,9 +2,10 @@
 #
 # Table name: users_roles
 #
-#  id      :bigint           not null, primary key
-#  role_id :bigint
-#  user_id :bigint
+#  id          :bigint           not null, primary key
+#  deactivated :boolean          default(FALSE)
+#  role_id     :bigint
+#  user_id     :bigint
 #
 RSpec.describe UsersRole, type: :model do
   describe "#current_role_for" do

--- a/spec/services/activate_role_service_spec.rb
+++ b/spec/services/activate_role_service_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe ActivateRoleService, type: :service do
+  let(:org) { create(:organization, name: "Org ABC") }
+  let(:user) { create(:user, name: "User XYZ", organization: nil) }
+  let!(:user_role) { Role.create!(resource_type: "Organization", name: "org_user", resource_id: org.id) }
+  let!(:admin_role) { Role.create!(resource_type: "Organization", name: "org_admin", resource_id: org.id) }
+
+  describe "#call" do
+    context "when the user role exists" do
+      it "should activate the role" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+        UsersRole.find_by(user_id: user.id, role_id: user_role.id).update(deactivated: true)
+
+        described_class.call(user_id: user.id, role_id: user_role.id)
+
+        expect(user.reload.has_active_role?(:org_user, org)).to be true
+      end
+
+      it "should not activate the admin role when activating user role" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_admin", resource_id: org.id)
+        role_user = UsersRole.find_by(user_id: user.id, role_id: user_role.id)
+        role_user.update(deactivated: true)
+        role_admin = UsersRole.find_by(user_id: user.id, role_id: admin_role.id)
+        role_admin.update(deactivated: true)
+
+        described_class.call(user_id: user.id, role_id: user_role.id)
+
+        expect(user.reload.has_active_role?(:org_user, org)).to be true
+        expect(user.reload.has_active_role?(:org_admin, org)).to be false
+      end
+
+      it "should activate the user role when activating admin role" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_admin", resource_id: org.id)
+
+        described_class.call(user_id: user.id, role_id: user_role.id)
+
+        expect(user.reload.has_active_role?(:org_user, org)).to be true
+        expect(user.reload.has_active_role?(:org_admin, org)).to be true
+      end
+
+      it "should work with a type and ID instead of role ID" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+
+        described_class.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+
+        expect(user.reload.has_active_role?(:org_user, org)).to be true
+      end
+    end
+
+    context "when not enough information provided" do
+      it "should raise an error" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+
+        expect { described_class.call(user_id: user.id) }
+          .to raise_error("Must provide either a role ID or resource ID!")
+      end
+    end
+
+    context "when the user role does not exist" do
+      it "should raise an error" do
+        expect {
+          described_class.call(user_id: user.id, role_id: user_role.id)
+        }.to raise_error("User User XYZ does not have role for Org ABC!")
+
+        expect(user.reload.has_role?(:org_user, org)).to be false
+      end
+    end
+  end
+end

--- a/spec/services/deactivate_role_service_spec.rb
+++ b/spec/services/deactivate_role_service_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe DeactivateRoleService, type: :service do
+  let(:org) { create(:organization, name: "Org ABC") }
+  let(:user) { create(:user, name: "User XYZ", organization: nil) }
+  let!(:user_role) { Role.create!(resource_type: "Organization", name: "org_user", resource_id: org.id) }
+  let!(:admin_role) { Role.create!(resource_type: "Organization", name: "org_admin", resource_id: org.id) }
+
+  describe "#call" do
+    context "when the role exists" do
+      it "should deactivate the role" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+
+        described_class.call(user_id: user.id, role_id: user_role.id)
+
+        expect(user.reload.has_active_role?(:org_user, org)).to be false
+        expect(user.reload.has_role?(:org_user, org)).to be true
+      end
+
+      it "should deactivate the admin role when deactivating user role" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_admin", resource_id: org.id)
+
+        described_class.call(user_id: user.id, role_id: user_role.id)
+
+        expect(user.reload.has_role?(:org_user, org)).to be true
+        expect(user.reload.has_role?(:org_admin, org)).to be true
+
+        expect(user.reload.has_active_role?(:org_user, org)).to eq(false)
+        expect(user.reload.has_active_role?(:org_admin, org)).to eq(false)
+      end
+
+      it "should not deactivate the user role when deactivating admin role" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_admin", resource_id: org.id)
+
+        described_class.call(user_id: user.id, role_id: admin_role.id)
+
+        expect(user.reload.has_role?(:org_user, org)).to be true
+        expect(user.reload.has_role?(:org_admin, org)).to be true
+
+        expect(user.reload.has_active_role?(:org_user, org)).to be true
+        expect(user.reload.has_active_role?(:org_admin, org)).to be false
+      end
+
+      it "should work with a type and ID instead of role ID" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+
+        described_class.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+
+        expect(user.reload.has_active_role?(:org_user, org)).to be false
+        expect(user.reload.has_role?(:org_user, org)).to be true
+      end
+    end
+
+    context "when not enough information provided" do
+      it "should raise an error" do
+        AddRoleService.call(user_id: user.id, resource_type: "org_user", resource_id: org.id)
+
+        expect { described_class.call(user_id: user.id) }
+          .to raise_error("Must provide either a role ID or resource ID!")
+      end
+    end
+
+    context "when the role does not exist" do
+      it "should raise an error" do
+        expect {
+          described_class.call(user_id: user.id, role_id: user_role.id)
+        }.to raise_error("User User XYZ does not have role for Org ABC!")
+
+        expect(user.reload.has_active_role?(:org_user, org)).to be false
+        expect(user.reload.has_role?(:org_user, org)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Issue #3587 

Addressing this issue seems like it will take multiple PRs.
1. a PR to add backend methods to activate and deactivate roles and query for those roles #4382
2. another PR to replaces usage of has_role with has_active_role, etc. #4392
3. another PR to change controllers and views to work with deactivation logic

This first PR adds the back-end changes needed to handle role deactivation:
- Adds boolean `deactivated` to `UsersRole`
- Adds method `user.has_active_role?` which works like `user.has_role?` but only returns true if the role is exists and deactivated is nil or false
- Adds method `User.with_active_role` which works like `User.with_role`  but only returners users with active instances of that role
- Creates services to activate and deactivate roles