### PR TITLE
Changes to fetch_latest_db process to address issues after 7.1.3.2

### DIFF
--- a/lib/tasks/reset_passwords.rake
+++ b/lib/tasks/reset_passwords.rake
@@ -1,0 +1,23 @@
+desc "reset passwords"
+PASSWORD_REPLACEMENT = 'password'
+
+task :reset_passwords => :environment do
+
+  puts "Replacing all the passwords with the replacement for ease of use: '#{PASSWORD_REPLACEMENT}'"
+  replace_user_passwords
+
+  puts "DONE!"
+end
+
+private
+
+def replace_user_passwords
+  # Generate the encrypted password so that we can quickly update
+  # all users with `update_all`
+
+  u = User.new(password: PASSWORD_REPLACEMENT)
+  u.save
+  encrypted_password = u.encrypted_password
+
+  User.all.update_all(encrypted_password: encrypted_password)
+end


### PR DESCRIPTION
### Description

fetch_latest_db started failing on the drop database after a recent upgrade,  or possibly as a result of changes that were made to fix bin/setup after that upgrade -- though it is not failing for everyone,  it is failing for the person who uses it the most!  

Here is what was happening:  
...
Recreating databases...
PG::ObjectInUse: ERROR:  database "diaper_dev" is being accessed by other users
DETAIL:  There is 1 other session using the database.
Couldn't drop database 'diaper_dev'
bin/rails aborted!
ActiveRecord::StatementInvalid: PG::ObjectInUse: ERROR:  database "diaper_dev" is being accessed by other users (ActiveRecord::StatementInvalid)
DETAIL:  There is 1 other session using the database.


Caused by:
PG::ObjectInUse: ERROR:  database "diaper_dev" is being accessed by other users (PG::ObjectInUse)
DETAIL:  There is 1 other session using the database.

Tasks: TOP => db:drop:_unsafe
(See full trace by running task with --trace)





We worked through the issue in the Sunday office hours.  Removing the => :environment got by the initial issue, but we also had to split the password setup into its own rake.   If there is a way to keep them in one task, that would be grand - but this at least allows it to be used.


A quick check of the project does not indicate any mention of fetch_latest_db,   but we should check any external docs.


### Type of change

<!-- Please delete options that are not relevant. -->


* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change may requires a documentation update

### How Has This Been Tested?

ran fetch_latest_db and rest_passwords on my local, then signed in.   Seems ok.
