### PR TITLE
Alternate approach -- Changes to address issues with fetch_latest_db after 7.1.3.2

### DIFF
--- a/lib/tasks/kill_postgres_connections.rake
+++ b/lib/tasks/kill_postgres_connections.rake
@@ -1,0 +1,15 @@
+task :kill_postgres_connections => :environment do
+  db_name = Rails.configuration.database_configuration[Rails.env]['database']
+  sh = <<EOF
+ps xa \
+  | grep postgres: \
+  | grep #{db_name} \
+  | grep -v grep \
+  | awk '{print $1}' \
+  | sudo xargs kill
+EOF
+  puts `#{sh}`
+  puts "Done killing the connections!"
+end
+
+task "db:drop" => :kill_postgres_connections


### PR DESCRIPTION

### Description
An alternate approach to fixing the current issues with fetch_latest_db
As per suggestions from @dorner on #4388 -- see that PR for details of the issue.
Approach from:  https://stackoverflow.com/questions/2369744/rails-postgres-drop-error-database-is-being-accessed-by-other-users 

This will just require that folks input their password,  rather than having to run two different tasks to get to the final result.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran it after a cold boot.  Then signed in and confirmed that the basic functionality works.
