### PR TITLE
Eagerly de-duplicating items when submitting request

### DIFF
--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -10,6 +10,11 @@ class RequestsConfirmationMailer < ApplicationMailer
 
   private
 
+  # fetch_items
+  #
+  # Fetches sorted items associated with the current Request object.
+  #
+  # @return Array of request_items with item names
   def fetch_items(request)
     items_sorted = request.request_items.sort_by { |k| k['item_id'] }
     item_ids = items_sorted&.map { |item| item['item_id'] }

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -10,17 +10,22 @@ class RequestsConfirmationMailer < ApplicationMailer
 
   private
 
-  # fetch_items
-  #
-  # Fetches sorted items associated with the current Request object.
-  #
-  # @return Array of request_items with item names
+  # TODO: remove the need to de-duplicate items in the request
   def fetch_items(request)
-    items_sorted = request.request_items.sort_by { |k| k['item_id'] }
-    item_ids = items_sorted&.map { |item| item['item_id'] }
-    items_names = Item.where(id: item_ids).order(:id).pluck(:name)
-    names_hash = items_names.map { |name| { 'name' => name } }
+    combined = combined_items(request)
+    item_ids = combined&.map { |item| item['item_id'] }
+    db_items = Item.where(id: item_ids).select(:id, :name)
+    combined.each { |i| i['name'] = db_items.find { |db_item| i["item_id"] == db_item.id }.name }
+    combined.sort_by { |i| i['name'] }
+  end
 
-    items_sorted.zip(names_hash).map { |items, names| items.merge(names) }
+  def combined_items(request)
+    return [] if request.request_items.size == 0
+    # convert items into a hash of (id => list of items with that ID)
+    grouped = request.request_items.group_by { |i| i['item_id'] }
+    # convert hash into an array of items with combined quantities
+    grouped.map do |id, items|
+      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum }
+    end
   end
 end

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -11,20 +11,11 @@ class RequestsConfirmationMailer < ApplicationMailer
   private
 
   def fetch_items(request)
-    combined = combined_items(request)
-    item_ids = combined&.map { |item| item['item_id'] }
-    db_items = Item.where(id: item_ids).select(:id, :name)
-    combined.each { |i| i['name'] = db_items.find { |db_item| i["item_id"] == db_item.id }.name }
-    combined.sort_by { |i| i['name'] }
-  end
+    items_sorted = request.request_items.sort_by { |k| k['item_id'] }
+    item_ids = items_sorted&.map { |item| item['item_id'] }
+    items_names = Item.where(id: item_ids).order(:id).pluck(:name)
+    names_hash = items_names.map { |name| { 'name' => name } }
 
-  def combined_items(request)
-    return [] if request.request_items.size == 0
-    # convert items into a hash of (id => list of items with that ID)
-    grouped = request.request_items.group_by { |i| i['item_id'] }
-    # convert hash into an array of items with combined quantities
-    grouped.map do |id, items|
-      { 'item_id' => id, 'quantity' => items.map { |i| i['quantity'] }.sum }
-    end
+    items_sorted.zip(names_hash).map { |items, names| items.merge(names) }
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -33,6 +33,7 @@ class Request < ApplicationRecord
   enum status: { pending: 0, started: 1, fulfilled: 2, discarded: 3 }, _prefix: true
 
   validates :distribution_id, uniqueness: true, allow_nil: true
+  validate :item_requests_uniqueness_by_item_id
   before_save :sanitize_items_data
 
   include Filterable
@@ -58,6 +59,13 @@ class Request < ApplicationRecord
   end
 
   private
+
+  def item_requests_uniqueness_by_item_id
+    item_ids = request_items.map { |item| item["item_id"] }
+    if item_ids.uniq.length != item_ids.length
+      errors.add(:request_items, "should have unique item_ids")
+    end
+  end
 
   def sanitize_items_data
     return unless request_items && request_items_changed?

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -61,9 +61,9 @@ class Request < ApplicationRecord
   private
 
   def item_requests_uniqueness_by_item_id
-    item_ids = request_items.map { |item| item["item_id"] }
+    item_ids = item_requests.map(&:item_id)
     if item_ids.uniq.length != item_ids.length
-      errors.add(:request_items, "should have unique item_ids")
+      errors.add(:item_requests, "should have unique item_ids")
     end
   end
 

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -60,8 +60,14 @@ module Partners
         pre_existing_entry = items[input_item['item_id']]
         if pre_existing_entry
           pre_existing_entry.quantity = (pre_existing_entry.quantity.to_i + input_item['quantity'].to_i).to_s
-          # TODO: Is the following the correct way to merge?
-          pre_existing_entry.children += input_item['children'] || []
+          # NOTE: When this code was written (and maybe it's still the
+          # case as you read it!), the FamilyRequestsController does a
+          # ton of calculation to translate children to item quantities.
+          # If that logic is incorrect, there's not much we can do here
+          # to fix things. Could make sense to move more of that logic
+          # into one of the service objects that instantiate the Request
+          # object (either this one or the FamilyRequestCreateService).
+          pre_existing_entry.children = (pre_existing_entry.children + input_item['children'] || []).uniq
         else
           items[input_item['item_id']] = Partners::ItemRequest.new(
             item_id: input_item['item_id'],

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -67,7 +67,7 @@ module Partners
           # to fix things. Could make sense to move more of that logic
           # into one of the service objects that instantiate the Request
           # object (either this one or the FamilyRequestCreateService).
-          pre_existing_entry.children = (pre_existing_entry.children + input_item['children'] || []).uniq
+          pre_existing_entry.children = (pre_existing_entry.children + (input_item['children'] || [])).uniq
         else
           items[input_item['item_id']] = Partners::ItemRequest.new(
             item_id: input_item['item_id'],

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -353,7 +353,6 @@ note = [
       updated_at: date
     )
 
-    item_requests = []
     pads = p.organization.items.find_by(name: 'Pads')
     new_item_request = Partners::ItemRequest.new(
       item_id: pads.id,
@@ -367,9 +366,10 @@ note = [
     )
     partner_request.item_requests << new_item_request
 
-    Array.new(Faker::Number.within(range: 4..14)) do
-      item = p.organization.items.sample
-      new_item_request = Partners::ItemRequest.new(
+    items = p.organization.items.sample(Faker::Number.within(range: 4..14)) - [pads]
+
+    partner_request.item_requests += items.map do |item|
+      Partners::ItemRequest.new(
         item_id: item.id,
         quantity: Faker::Number.within(range: 10..30),
         children: [],
@@ -378,7 +378,6 @@ note = [
         created_at: date,
         updated_at: date
       )
-      partner_request.item_requests << new_item_request
     end
 
     partner_request.request_items = partner_request.item_requests.map do |ir|

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -42,17 +42,6 @@ FactoryBot.define do
     status { 'pending' }
   end
 
-  trait :with_duplicates do
-    request_items {
-      # get 3 unique item ids
-      keys = Item.active.pluck(:id).sample(3)
-      # add an extra of the first key, so we have one duplicated item
-      keys.push(keys[0])
-      # give each item a quantity of 50
-      keys.map { |k| { "item_id" => k, "quantity" => 50 } }
-    }
-  end
-
   trait :with_varied_quantities do
     request_items {
       # get 10 unique item ids

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -3,9 +3,7 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
   let(:request) { create(:request, organization: organization) }
   let(:mail) { RequestsConfirmationMailer.confirmation_email(request) }
 
-  let(:request_w_duplicates) { create(:request, :with_duplicates, organization: organization) }
   let(:request_w_varied_quantities) { create(:request, :with_varied_quantities, organization: organization) }
-  let(:mail_w_duplicates) { RequestsConfirmationMailer.confirmation_email(request_w_duplicates) }
   let(:mail_w_varied_quantities) { RequestsConfirmationMailer.confirmation_email(request_w_varied_quantities) }
 
   describe "#confirmation_email" do
@@ -21,12 +19,6 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
       expect(mail.body.encoded).to match('This is an email confirmation')
       expect(mail.body.encoded).to match('For more info, please e-mail me@org.com')
     end
-  end
-
-  it 'handles duplicates' do
-    organization.update!(email: "me@org.com")
-    expect(mail_w_duplicates.body.encoded).to match('This is an email confirmation')
-    expect(mail_w_duplicates.body.encoded).to match(' - 100')
   end
 
   it 'pairs the right quantities with the right item names' do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -56,6 +56,39 @@ RSpec.describe Request, type: :model do
     end
   end
 
+  describe "validations" do
+    let(:item_one) { create(:item) }
+    let(:item_two) { create(:item) }
+    subject { build(:request, request_items: request_items) }
+
+    context "when request_items have unique item_ids" do
+      let(:request_items) do
+        [
+          { "item_id" => item_one.id, "quantity" => 5 },
+          { "item_id" => item_two.id, "quantity" => 3 }
+        ]
+      end
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when request_items do not have unique item_ids" do
+      let(:request_items) do
+        [
+          { "item_id" => item_one.id, "quantity" => 5 },
+          { "item_id" => item_one.id, "quantity" => 3 }
+        ]
+      end
+
+      it "is not valid" do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:request_items]).to include("should have unique item_ids")
+      end
+    end
+  end
+
   describe "versioning" do
     it { is_expected.to be_versioned }
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Request, type: :model do
   describe "validations" do
     let(:item_one) { create(:item) }
     let(:item_two) { create(:item) }
-    subject { build(:request, request_items: request_items) }
+    subject { build(:request, item_requests: item_requests) }
 
-    context "when request_items have unique item_ids" do
-      let(:request_items) do
+    context "when item_requests have unique item_ids" do
+      let(:item_requests) do
         [
-          { "item_id" => item_one.id, "quantity" => 5 },
-          { "item_id" => item_two.id, "quantity" => 3 }
+          create(:item_request, item: item_one, quantity: 5),
+          create(:item_request, item: item_two, quantity: 3)
         ]
       end
 
@@ -74,17 +74,17 @@ RSpec.describe Request, type: :model do
       end
     end
 
-    context "when request_items do not have unique item_ids" do
-      let(:request_items) do
+    context "when item_requests do not have unique item_ids" do
+      let(:item_requests) do
         [
-          { "item_id" => item_one.id, "quantity" => 5 },
-          { "item_id" => item_one.id, "quantity" => 3 }
+          create(:item_request, item: item_one, quantity: 5),
+          create(:item_request, item: item_one, quantity: 3)
         ]
       end
 
       it "is not valid" do
         expect(subject).to_not be_valid
-        expect(subject.errors[:request_items]).to include("should have unique item_ids")
+        expect(subject.errors[:item_requests]).to include("should have unique item_ids")
       end
     end
   end

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -25,26 +25,25 @@ RSpec.describe Exports::ExportRequestService do
            request_items: [{ item_id: 0, quantity: 200 }, { item_id: -1, quantity: 200 }])
   end
 
-  let!(:duplicate_items) do
+  let!(:unique_items) do
     [
       {item_id: item_3t.id, quantity: 2},
-      {item_id: item_2t.id, quantity: 3},
-      {item_id: item_3t.id, quantity: 5}
+      {item_id: item_2t.id, quantity: 3}
     ]
   end
 
-  let!(:duplicate_item_quantities) do
-    duplicate_items.each_with_object(Hash.new(0)) do |item, hsh|
+  let!(:item_quantities) do
+    unique_items.each_with_object(Hash.new(0)) do |item, hsh|
       hsh[item[:item_id]] += item[:quantity]
     end
   end
 
-  let!(:request_with_duplicate_items) do
+  let!(:request_with_items) do
     create(
       :request,
       :started,
       organization: org,
-      request_items: duplicate_items
+      request_items: unique_items
     )
   end
 
@@ -78,8 +77,8 @@ RSpec.describe Exports::ExportRequestService do
       item_column_idx = expected_headers.each_with_index.to_h[Exports::ExportRequestService::DELETED_ITEMS_COLUMN_HEADER]
       expect(subject.fourth[item_column_idx]).to eq(400)
 
-      expect(subject.fifth[item_2t_column_idx]).to eq(duplicate_item_quantities[item_2t.id])
-      expect(subject.fifth[item_3t_column_idx]).to eq(duplicate_item_quantities[item_3t.id])
+      expect(subject.fifth[item_2t_column_idx]).to eq(item_quantities[item_2t.id])
+      expect(subject.fifth[item_3t_column_idx]).to eq(item_quantities[item_3t.id])
     end
   end
 end

--- a/spec/services/partners/family_request_create_service_spec.rb
+++ b/spec/services/partners/family_request_create_service_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Partners::FamilyRequestCreateService do
         let(:second_item_id) { items_to_request.second.id.to_i }
         let(:child1) { create(:partners_child) }
         let(:child2) { create(:partners_child) }
+        let(:child3) { create(:partners_child) }
         let(:family_requests_attributes) do
           [
             {
@@ -66,6 +67,11 @@ RSpec.describe Partners::FamilyRequestCreateService do
               item_id: second_item_id,
               person_count: 2,
               children: [child1, child2]
+            },
+            {
+              item_id: second_item_id,
+              person_count: 2,
+              children: [child1, child3]
             }
           ]
         end
@@ -85,7 +91,12 @@ RSpec.describe Partners::FamilyRequestCreateService do
           expect(first_item_request.children).to contain_exactly(child1)
 
           second_item_request = partner_request.item_requests.find_by(item_id: second_item_id)
-          expect(second_item_request.children).to contain_exactly(child1, child2)
+          # testing the de-duping logic of request create service
+          expect(second_item_request.children).to contain_exactly(child1, child2, child3)
+          expect(second_item_request.children.count).to eq(3)
+
+          expect(first_item_request.quantity.to_i).to eq(first_item_request.item.default_quantity)
+          expect(second_item_request.quantity.to_i).to eq(second_item_request.item.default_quantity * 4)
         end
       end
 

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -86,6 +86,41 @@ RSpec.describe Partners::RequestCreateService do
         expect(NotifyPartnerJob).to have_received(:perform_now).with(Request.last.id)
       end
 
+      it 'should have created item requests' do
+        subject
+        expect(Partners::ItemRequest.count).to eq(item_requests_attributes.count)
+      end
+
+      context 'when we have duplicate item as part of request' do
+        let(:duplicate_item) { FactoryBot.create(:item) }
+        let(:unique_item) { FactoryBot.create(:item) }
+        let(:item_requests_attributes) do
+          [
+            ActionController::Parameters.new(
+              item_id: duplicate_item.id,
+              quantity: 3
+            ),
+            ActionController::Parameters.new(
+              item_id: unique_item.id,
+              quantity: 7
+            ),
+            ActionController::Parameters.new(
+              item_id: duplicate_item.id,
+              quantity: 5
+            )
+          ]
+        end
+        it 'should add the quantity of the duplicate item' do
+          subject
+          aggregate_failures {
+            expect(Partners::ItemRequest.count).to eq(2)
+            expect(Partners::ItemRequest.find_by(item_id: duplicate_item.id).quantity).to eq("8")
+            expect(Partners::ItemRequest.find_by(item_id: unique_item.id).quantity).to eq("7")
+            expect(Partners::ItemRequest.first.item_id).to eq(duplicate_item.id)
+          }
+        end
+      end
+
       context 'but a unexpected error occured during the save' do
         let(:error_message) { 'boom' }
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4394 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

In order to support the packs, we want the request items to be collapsed at save, so the banks only see one line per item in the request.

On save, the request items should be collapsed so that there is only one request item per item.
### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

We have added unit tests to cover all the scenario and verified manually by going through the flow on local machine.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
<img width="1660" alt="Screenshot 2024-05-31 at 4 45 19 PM" src="https://github.com/rubyforgood/human-essentials/assets/92335682/04247c6b-0a14-480f-b52e-4d1a136baf51">
<img width="774" alt="Screenshot 2024-05-31 at 4 46 01 PM" src="https://github.com/rubyforgood/human-essentials/assets/92335682/6e0298e9-4e91-4714-bddb-fde0a68e5684">
<img width="566" alt="Screenshot 2024-05-31 at 4 46 17 PM" src="https://github.com/rubyforgood/human-essentials/assets/92335682/6fbf4211-e89b-42cd-adfe-123abf964599">
<img width="849" alt="Screenshot 2024-05-31 at 4 46 36 PM" src="https://github.com/rubyforgood/human-essentials/assets/92335682/0092bc10-3870-43dd-ab4c-76d0f0a5f14a">
<img width="1409" alt="Screenshot 2024-05-31 at 4 47 44 PM" src="https://github.com/rubyforgood/human-essentials/assets/92335682/912cefaf-bfac-4692-8711-314fd2ce63ed">


