### PR TITLE
Show units on a partner request dashboard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -787,4 +787,4 @@ DEPENDENCIES
   webmock (~> 3.23)
 
 BUNDLED WITH
-   2.5.10
+   2.5.11

--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -23,9 +23,11 @@
           <td class="p-4 d-flex flex-wrap">
             <% request.item_requests.each do |item_request| %>
               <span class="p-1 mr-1 mb-2 lg:mb-0 border border-dark rounded-1">
-                <%= item_request.quantity %>
-                <% if Flipper.enabled?(:enable_packs) %>
-                enable_packs
+                <% if Flipper.enabled?(:enable_packs) && item_request.request_unit %>
+                  <%= pluralize(item_request.quantity, item_request.request_unit) %>
+                  --
+                <% else %>
+                  <%= item_request.quantity %>
                 <% end %>
                 <%= item_request.item.name %>
               </span>

--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -25,7 +25,7 @@
               <span class="p-1 mr-1 mb-2 lg:mb-0 border border-dark rounded-1">
                 <% if Flipper.enabled?(:enable_packs) && item_request.request_unit %>
                   <%= pluralize(item_request.quantity, item_request.request_unit) %>
-                  --
+                  —
                 <% else %>
                   <%= item_request.quantity %>
                 <% end %>

--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -21,11 +21,13 @@
 
           <td class="p-4"><%= request.total_items %></td>
           <td class="p-4 d-flex flex-wrap">
-            <% request_item = request.request_items.map { |json| RequestItem.from_json(json, request, @inventory) } %>
-
-            <% request_item.map do |item| %>
+            <% request.item_requests.each do |item_request| %>
               <span class="p-1 mr-1 mb-2 lg:mb-0 border border-dark rounded-1">
-                <%= item.quantity %> <%= item.name %>
+                <%= item_request.quantity %>
+                <% if Flipper.enabled?(:enable_packs) %>
+                enable_packs
+                <% end %>
+                <%= item_request.item.name %>
               </span>
             <% end %>
           </td>

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe "/partners/dashboard", type: :request do
       create(:item_request, request: request, quantity: 7, request_unit: "Pack", item: item2)
       get partners_dashboard_path
 
-      expect(response.body).to match(/1\s+Pack\s+--\s+#{item1.name}/m)
-      expect(response.body).to match(/7\s+Packs\s+--\s+#{item2.name}/m)
+      expect(response.body).to match(/1\s+Pack\s+—\s+#{item1.name}/m)
+      expect(response.body).to match(/7\s+Packs\s+—\s+#{item2.name}/m)
     end
 
     it "skips units when are not provided" do

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -17,8 +17,11 @@ RSpec.describe "/partners/dashboard", type: :request do
 
   describe "GET #index" do
     it "displays requests that are pending" do
-      create(:request, :pending, partner: partner, request_items: [{item_id: item1.id, quantity: "16"}])
-      create(:request, :pending, partner: partner, request_items: [{item_id: item2.id, quantity: "16"}])
+      request1 = create(:request, :pending, partner: partner, request_items: [])
+      create(:item_request, request: request1, quantity: 16, item: item1)
+
+      request2 = create(:request, :pending, partner: partner, request_items: [])
+      create(:item_request, request: request2, quantity: 16, item: item2)
 
       get partners_dashboard_path
 
@@ -34,6 +37,17 @@ RSpec.describe "/partners/dashboard", type: :request do
 
       expect(response.body).to_not include(item1.name)
       expect(response.body).to_not include(item2.name)
+    end
+
+    it "shows units if needed" do
+      Flipper.enable(:enable_packs)
+      create(:item_unit, item: item1, name: "Pack")
+      request = create(:request, :pending, partner: partner, request_items: [])
+      create(:item_request, request: request, quantity: 1, request_unit: "Pack", item: item1)
+
+      get partners_dashboard_path
+
+      expect(response.body).to match(/1\s+Pack\s+--\s+#{item1.name}/m)
     end
   end
 

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -39,15 +39,27 @@ RSpec.describe "/partners/dashboard", type: :request do
       expect(response.body).to_not include(item2.name)
     end
 
-    it "shows units if needed" do
+    it "shows units" do
       Flipper.enable(:enable_packs)
       create(:item_unit, item: item1, name: "Pack")
+      create(:item_unit, item: item2, name: "Pack")
       request = create(:request, :pending, partner: partner, request_items: [])
       create(:item_request, request: request, quantity: 1, request_unit: "Pack", item: item1)
-
+      create(:item_request, request: request, quantity: 7, request_unit: "Pack", item: item2)
       get partners_dashboard_path
 
       expect(response.body).to match(/1\s+Pack\s+--\s+#{item1.name}/m)
+      expect(response.body).to match(/7\s+Packs\s+--\s+#{item2.name}/m)
+    end
+
+    it "skips units when are not provided" do
+      Flipper.enable(:enable_packs)
+      create(:item_unit, item: item1, name: "Pack")
+      request = create(:request, :pending, partner: partner, request_items: [])
+      create(:item_request, request: request, quantity: 7, item: item1)
+      get partners_dashboard_path
+
+      expect(response.body).to match(/7\s+#{item1.name}/m)
     end
   end
 


### PR DESCRIPTION
Implements #4401, including units on a partner request dashboard.
Tested locally and with unit tests.