### PR TITLE
4397 - Add Request units to item new/edit

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,7 +37,11 @@ class ItemsController < ApplicationController
   end
 
   def create
-    create = ItemCreateService.new(organization_id: current_organization.id, item_params: item_params, request_unit_ids:)
+    if Flipper.enabled?(:enable_packs)
+      create = ItemCreateService.new(organization_id: current_organization.id, item_params: item_params, request_unit_ids:)
+    else
+      create = ItemCreateService.new(organization_id: current_organization.id, item_params: item_params)
+    end
     result = create.call
 
     if result.success?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,10 +37,10 @@ class ItemsController < ApplicationController
   end
 
   def create
-    if Flipper.enabled?(:enable_packs)
-      create = ItemCreateService.new(organization_id: current_organization.id, item_params: item_params, request_unit_ids:)
+    create = if Flipper.enabled?(:enable_packs)
+      ItemCreateService.new(organization_id: current_organization.id, item_params: item_params, request_unit_ids:)
     else
-      create = ItemCreateService.new(organization_id: current_organization.id, item_params: item_params)
+      ItemCreateService.new(organization_id: current_organization.id, item_params: item_params)
     end
     result = create.call
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   def index
     @items = current_organization
       .items
-      .includes(:base_item, :kit, :line_items)
+      .includes(:base_item, :kit, :line_items, :request_units)
       .alphabetized
       .class_filter(filter_params)
       .group('items.id')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -178,7 +178,8 @@ class ItemsController < ApplicationController
       :on_hand_recommended_quantity,
       :distribution_quantity,
       :visible_to_partners,
-      :active
+      :active,
+      :request_unit_ids
     )
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -179,7 +179,7 @@ class ItemsController < ApplicationController
       :distribution_quantity,
       :visible_to_partners,
       :active,
-      :request_unit_ids
+      request_unit_ids: []
     )
   end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -14,4 +14,9 @@ module ItemsHelper
   def cents_to_dollar(value_in_cents)
     value_in_cents.to_f / 100
   end
+
+  def selected_item_request_units(item)
+    item_request_unit_names = item.persisted? ? item.request_units.pluck(:name) : []
+    current_organization.request_units.select { |unit| item_request_unit_names.include?(unit.name) }.pluck(:id)
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -235,6 +235,13 @@ class Item < ApplicationRecord
     inventory_items.find_by(storage_location_id: storage_location_id)
   end
 
+  def sync_request_units!(unit_ids)
+    request_units.clear
+    organization.request_units.where(id: unit_ids).pluck(:name).each do |name|
+      request_units.create!(name:)
+    end
+  end
+
   private
 
   def update_associated_kit_name

--- a/app/services/item_create_service.rb
+++ b/app/services/item_create_service.rb
@@ -9,8 +9,9 @@ class ItemCreateService
     new_item = organization.items.new(item_params)
     organization.transaction do
       new_item.save!
-      pp new_item.errors
-      new_item.sync_request_units!(@request_unit_ids)
+      if Flipper.enabled?(:enable_packs)
+        new_item.sync_request_units!(@request_unit_ids)
+      end
 
       organization.storage_locations.each do |sl|
         InventoryItem.create!(

--- a/app/services/item_create_service.rb
+++ b/app/services/item_create_service.rb
@@ -1,8 +1,7 @@
 class ItemCreateService
-  def initialize(organization_id:, item_params:)
+  def initialize(organization_id:, item_params:, request_unit_ids: [])
     @organization_id = organization_id
-    @request_unit_ids = item_params.fetch(:request_unit_ids, [])
-    item_params.delete(:request_unit_ids)
+    @request_unit_ids = request_unit_ids
     @item_params = item_params
   end
 
@@ -10,7 +9,8 @@ class ItemCreateService
     new_item = organization.items.new(item_params)
     organization.transaction do
       new_item.save!
-      create_request_units!(new_item)
+      pp new_item.errors
+      new_item.sync_request_units!(@request_unit_ids)
 
       organization.storage_locations.each do |sl|
         InventoryItem.create!(
@@ -32,12 +32,5 @@ class ItemCreateService
 
   def organization
     @organization ||= Organization.find(organization_id)
-  end
-
-  def create_request_units!(item)
-    return if @request_unit_ids.empty?
-    organization.request_units.where(id: @request_unit_ids).pluck(:name).each do |name|
-      item.request_units.create!(name:)
-    end
   end
 end

--- a/app/services/item_create_service.rb
+++ b/app/services/item_create_service.rb
@@ -1,14 +1,16 @@
 class ItemCreateService
   def initialize(organization_id:, item_params:)
     @organization_id = organization_id
+    @request_unit_ids = item_params.fetch(:request_unit_ids, [])
+    item_params.delete(:request_unit_ids)
     @item_params = item_params
   end
 
   def call
     new_item = organization.items.new(item_params)
-
     organization.transaction do
       new_item.save!
+      create_request_units!(new_item)
 
       organization.storage_locations.each do |sl|
         InventoryItem.create!(
@@ -30,5 +32,12 @@ class ItemCreateService
 
   def organization
     @organization ||= Organization.find(organization_id)
+  end
+
+  def create_request_units!(item)
+    return if @request_unit_ids.empty?
+    organization.request_units.where(id: @request_unit_ids).pluck(:name).each do |name|
+      item.request_units.create!(name:)
+    end
   end
 end

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -45,7 +45,7 @@
 
               <% if Flipper.enabled?(:enable_packs) %>
                 <%= f.input :request_units, label: "Additional Custom Request Units" do %>
-                  <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, checked: selected_request_units(@item), label_method: :name, value_method: :id, class: "form-check-input" %>
+                  <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, checked: selected_item_request_units(@item), label_method: :name, value_method: :id, class: "form-check-input" %>
                 <% end %>
               <% end %>
 

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -45,7 +45,9 @@
 
               <% if Flipper.enabled?(:enable_packs) %>
                 <%= f.input :request_units, label: "Additional Custom Request Units" do %>
-                  <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, label_method: :name, value_method: :id, class: "form-check-input" %>
+                  <% item_request_unit_names = @item.persisted? ? @item.request_units.pluck(:name) : [] %>
+                  <% selected_request_units = current_organization.request_units.select { |unit| item_request_unit_names.include?(unit.name)}.pluck(:id) %>
+                  <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, checked: selected_request_units, label_method: :name, value_method: :id, class: "form-check-input" %>
                 <% end %>
               <% end %>
 

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -43,6 +43,12 @@
                 <%= f.input_field :package_size, class: "form-control" %>
               <% end %>
 
+              <% if Flipper.enabled?(:enable_packs) %>
+                <%= f.input :request_units, label: "Additional Custom Request Units" do %>
+                  <%= f.input_field :request_units, as: :check_boxes, collection: current_organization.request_units, label_method: :name, value_method: :id, class: "form-check-input" %>
+                <% end %>
+              <% end %>
+
               <%= f.input :visible, label: "Item is Visible to Partners?", wrapper: :input_group do %>
                 <%= f.check_box :visible_to_partners, {class: "input-group-text", id: "visible_to_partners"}, "true", "false" %>
               <% end %>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -45,9 +45,7 @@
 
               <% if Flipper.enabled?(:enable_packs) %>
                 <%= f.input :request_units, label: "Additional Custom Request Units" do %>
-                  <% item_request_unit_names = @item.persisted? ? @item.request_units.pluck(:name) : [] %>
-                  <% selected_request_units = current_organization.request_units.select { |unit| item_request_unit_names.include?(unit.name)}.pluck(:id) %>
-                  <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, checked: selected_request_units, label_method: :name, value_method: :id, class: "form-check-input" %>
+                  <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, checked: selected_request_units(@item), label_method: :name, value_method: :id, class: "form-check-input" %>
                 <% end %>
               <% end %>
 

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -45,7 +45,7 @@
 
               <% if Flipper.enabled?(:enable_packs) %>
                 <%= f.input :request_units, label: "Additional Custom Request Units" do %>
-                  <%= f.input_field :request_units, as: :check_boxes, collection: current_organization.request_units, label_method: :name, value_method: :id, class: "form-check-input" %>
+                  <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, label_method: :name, value_method: :id, class: "form-check-input" %>
                 <% end %>
               <% end %>
 

--- a/app/views/items/_item_list.html.erb
+++ b/app/views/items/_item_list.html.erb
@@ -10,6 +10,11 @@
       <th>Name</th>
       <th>Quantity Per Individual</th>
       <th>Fair Market Value (per item)</th>
+      <% if Flipper.enabled?(:enable_packs) %>
+        <% unless current_organization.request_units.empty? %>
+          <th>Custom Request Units</th>
+        <% end %>
+      <% end %>
       <th class="text-center">Actions</th>
     </tr>
     </thead>

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -3,6 +3,9 @@
   <td><%= item_row.name %></td>
   <td><%= item_row.distribution_quantity %></td>
   <td class="numeric"><%= dollar_value(item_row.value_in_cents) %></td>
+  <% if Flipper.enabled?(:enable_packs) %>
+   <td><%= item_row.request_units.pluck(:name).join(', ') %></td>
+  <% end %>
   <td class="text-right">
     <%= view_button_to item_path(item_row) %>
     <%= edit_button_to edit_item_path(item_row) %>

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -4,7 +4,9 @@
   <td><%= item_row.distribution_quantity %></td>
   <td class="numeric"><%= dollar_value(item_row.value_in_cents) %></td>
   <% if Flipper.enabled?(:enable_packs) %>
-   <td><%= item_row.request_units.pluck(:name).join(', ') %></td>
+    <% unless current_organization.request_units.empty? %>
+     <td><%= item_row.request_units.pluck(:name).join(', ') %></td>
+    <% end %>
   <% end %>
   <td class="text-right">
     <%= view_button_to item_path(item_row) %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_27_151622) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_19_201258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -484,7 +484,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_27_151622) do
     t.boolean "one_step_partner_invite", default: false, null: false
     t.boolean "hide_value_columns_on_receipt", default: false
     t.boolean "hide_package_column_on_receipt", default: false
-    t.boolean "signature_for_distribution_pdf", default: false
     t.index ["latitude", "longitude"], name: "index_organizations_on_latitude_and_longitude"
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_19_201258) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_27_151622) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -484,6 +484,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_19_201258) do
     t.boolean "one_step_partner_invite", default: false, null: false
     t.boolean "hide_value_columns_on_receipt", default: false
     t.boolean "hide_package_column_on_receipt", default: false
+    t.boolean "signature_for_distribution_pdf", default: false
     t.index ["latitude", "longitude"], name: "index_organizations_on_latitude_and_longitude"
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe ItemsController, type: :controller do
       end
 
       context "request units" do
+        before(:each) { Flipper.enable(:enable_packs) }
         let(:item) { create(:item, organization:) }
         let(:unit) { create(:unit, organization:) }
         it "should add new item's request units" do
@@ -154,6 +155,7 @@ RSpec.describe ItemsController, type: :controller do
         end
 
         it "should accept request_unit ids and create request_units" do
+          Flipper.enable(:enable_packs)
           unit = create(:unit, organization: organization)
           item_params[:item] = item_params[:item].merge({request_unit_ids: [unit.id]})
           post :create, params: item_params

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe ItemsController, type: :controller do
           expect(item.reload.visible_to_partners).to be false
         end
       end
+
+      context "request units" do
+        let(:item) { create(:item) }
+        let(:item_unit) { create(:item_unit, item: item) }
+        subject { put :update, params: { id: item.id, item: { request_unit_ids: [item_unit.id] } } }
+        it "should update the item's request units" do
+          expect(item.request_units).to be_empty
+          expect(subject).to redirect_to(items_path)
+          expect(item.reload.request_units).to eq [item_unit]
+        end
+      end
     end
 
     describe "GET #show" do

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe ItemsController, type: :controller do
 
       context "request units" do
         let(:item) { create(:item) }
-        let(:item_unit) { create(:item_unit, item: item) }
-        subject { put :update, params: { id: item.id, item: { request_unit_ids: [item_unit.id] } } }
+        let(:unit) { create(:unit, organization: organization) }
+        subject { put :update, params: { id: item.id, item: { request_unit_ids: [unit.id] } } }
         it "should update the item's request units" do
           expect(item.request_units).to be_empty
           expect(subject).to redirect_to(items_path)
-          expect(item.reload.request_units).to eq [item_unit]
+          expect(item.reload.request_units).to eq [unit.id]
         end
       end
     end
@@ -128,6 +128,15 @@ RSpec.describe ItemsController, type: :controller do
           post :create, params: item_params
 
           expect(response).not_to have_error
+        end
+
+        it "should accept request_unit ids and create request_units" do
+          unit = create(:unit, organization: organization)
+          item_params[:item] = item_params[:item].merge({request_unit_ids: [unit.id]})
+          post :create, params: item_params
+          expect(response).not_to have_error
+          newly_created_item = Item.last
+          expect(newly_created_item.request_units.pluck(:name)).to match_array [unit.name]
         end
 
         it "should redirect to the item page" do

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe "Items", type: :request do
       end
     end
 
+    describe "GET #new" do
+      it "shows the organization request_units options if they exist" do
+        Flipper.enable(:enable_packs)
+        organization_units = create_list(:unit, 3, organization: organization)
+        get new_item_path
+        organization_units.each do |unit|
+          expect(response.body).to include unit.name
+        end
+      end
+    end
+
     describe 'DELETE #deactivate' do
       let(:item) { create(:item, organization: organization, active: true) }
       let(:storage_location) { create(:storage_location, organization: organization) }

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -144,6 +144,26 @@ RSpec.describe "Items", type: :request do
         expect(button3.text.strip).to eq("Deactivate")
         expect(button3.attr('class')).to match(/disabled/)
       end
+
+      context "custom request items" do
+        before(:each) { Flipper.enable(:enable_packs) }
+
+        it "does not show the column if the organization does not use custom request units" do
+          get items_path
+          expect(response.body).not_to include("Custom Request Units")
+        end
+
+        it "shows the column if there are custom request units defined" do
+          units = create_list(:unit, 3, organization:)
+          units.each do |unit|
+            create(:item_unit, item:, name: unit.name)
+          end
+          expect(item.request_units).not_to be_empty
+          get items_path
+          expect(response.body).to include("Custom Request Units")
+          expect(response.body).to include(item.request_units.pluck(:name).join(', '))
+        end
+      end
     end
   end
 end

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -43,6 +43,29 @@ RSpec.describe "Items", type: :request do
       end
     end
 
+    describe "GET #edit" do
+      it "shows the selected request_units" do
+        Flipper.enable(:enable_packs)
+        organization_units = create_list(:unit, 3, organization: organization)
+        selected_unit = organization_units.first
+        item = create(:item, organization: organization)
+        create(:item_unit, item: item, name: selected_unit.name)
+
+        get edit_item_path(item)
+
+        parsed_body = Nokogiri::HTML(response.body)
+        checkboxes = parsed_body.css("input[type='checkbox'][name='item[request_unit_ids][]']")
+        expect(checkboxes.length).to eq organization_units.length
+        checkboxes.each do |checkbox|
+          if checkbox['value'] == selected_unit.id.to_s
+            expect(checkbox['checked']).to eq('checked')
+          else
+            expect(checkbox['checked']).to be_nil
+          end
+        end
+      end
+    end
+
     describe 'DELETE #deactivate' do
       let(:item) { create(:item, organization: organization, active: true) }
       let(:storage_location) { create(:storage_location, organization: organization) }


### PR DESCRIPTION
Resolves #4397

### Description
- Adds the ability to assign request units to an item when creating and editing the item
- Adds the custom request units column on the items list, only for organizations that have custom units defined 
- Currently if you edit an item we are clearing out the list of units and the recreating the join records from the updated selection. However there is the potential for this to make the de-normalization on the `ItemUnit` model less useful. If we need to keep units around that the organization has deleted or changed, we may need to reconsider this approach as I'm currently relying on the unit id's and just copying over the name based on the ids that are selected from the form. 
- I maybe could have considered using `accepts_nested_attributes` for, but given the "syncing" that I needed to do I decided to use a more explicit path initially.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- I've added tests for this functionality in the controller and request files and have tested it locally to ensure it is working correctly. Note that everything is behind the feature flag `:enable_packs`

### Screenshots

<img width="1556" alt="Screenshot 2024-06-01 at 12 41 19 PM" src="https://github.com/rubyforgood/human-essentials/assets/90267290/c722e60c-6cc3-4850-9af1-dca29cc003c1">

