### PR TITLE
Address expired slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Thanks for checking us out! If you're new here, here are some things you should 
 - This project relies entirely on volunteers, so please be patient with communication
 
 ### Join us on slack 💬
-You can sign up [here](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) and find us in #human-essentials. Many helpful members are available to answer your questions. Just ask, and someone will be there to help you!
+You can sign up [here](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) and find us in #human-essentials. Many helpful members are available to answer your questions. Just ask, and someone will be there to help you!
 
 ##  Getting Started (Local Environment) 🛠️
 


### PR DESCRIPTION
Resolves #4410 

### Description
The slack link on the readme had expired.  This adds the fresh one.
   
### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
### How Has This Been Tested?
Clicked on the link in the preview of the readme in my IDE.  It worked.