### PR TITLE
Fixes #4425 so tests work after Docker setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,3 +3,6 @@
 # See https://github.com/devcontainers/images/blob/main/src/ruby/history/
 FROM mcr.microsoft.com/devcontainers/ruby:dev-3.2-buster
 RUN apt -y update && apt install -y vim curl gpg postgresql postgresql-contrib
+RUN cd /tmp
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 
+RUN apt install -y ./google-chrome-stable_current_amd64.deb 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,5 +16,10 @@
     }
   },
 
+  // DOCKER env variable passed to Cuprite to enable --no-sandbox so Chrome can run in Docker
+  "remoteEnv": {
+    "DOCKER": "true"
+  },
+
   "postCreateCommand": ".devcontainer/post-create.sh"
  }


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4425  <!--fill issue number-->

### Description
Fixes the Docker setup files so that tests pass out of the box, by installing latest version of Chrome and also setting the DOCKER environment variable.

Tests use Cuprite which relies on a headless Chrome browser. However, you can't run Chrome's browser sandboxed in Docker containers. There's an environment variable called DOCKER when registering Cuprite (see [rails_helper.rb](https://github.com/rubyforgood/human-essentials/blob/1f85193d36504ef02600bef035357398c7fe225c/spec/rails_helper.rb#L59)) which tells it to run browser as non-sandboxed.

### Alternative solutions
- latest version of Chromium can't run on this old-old-stable version of Debian, which means some tests fail if trying to use old-old-stable Chromium
- You could set the DOCKER environment variable in the dockerfile, but I don't think there's a big difference between that and devcontainer.json,
- Also, you could set cap_add: SYS_ADMIN in docker-compose.yml instead of setting this environment variable which grants the container root access to the parent machine and allows Chrome to run sandboxed, but I think that's overkill

### Motivation
I wanted to try out Codespaces because I have a relatively old machine and rspec locally takes about 25 minutes, rspec on Codespaces 4-core takes 10 minutes and is much faster.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Create new codespace from this branch
2. After installation, run `bundle exec rspec` in terminal. All tests pass.
3. Install Dev Container add-on in VSCode and open repo locally in Dev Container
4. After installation, run `bundle exec rspec` in terminal. All tests pass.
