### PR TITLE
Fix #4311 add comment field to product drive participant 

### DIFF
--- a/app/controllers/product_drive_participants_controller.rb
+++ b/app/controllers/product_drive_participants_controller.rb
@@ -60,7 +60,7 @@ class ProductDriveParticipantsController < ApplicationController
 
   def product_drive_participant_params
     params.require(:product_drive_participant)
-          .permit(:contact_name, :phone, :email, :business_name, :address)
+          .permit(:contact_name, :phone, :email, :business_name, :address, :comment)
   end
 
   helper_method \

--- a/app/models/product_drive_participant.rb
+++ b/app/models/product_drive_participant.rb
@@ -25,6 +25,7 @@ class ProductDriveParticipant < ApplicationRecord
 
   validates :phone, presence: { message: "Must provide a phone or an e-mail" }, if: proc { |pdp| pdp.email.blank? }
   validates :email, presence: { message: "Must provide a phone or an e-mail" }, if: proc { |pdp| pdp.phone.blank? }
+  validates :comment, length: { maximum: 500 }
 
   scope :alphabetized, -> { order(:contact_name) }
 

--- a/app/views/product_drive_participants/_form.html.erb
+++ b/app/views/product_drive_participants/_form.html.erb
@@ -34,6 +34,10 @@
                   <span class="input-group-text"><i class="fa fa-home"></i></span>
                   <%= f.input_field :address, class: "form-control" %>
                 <% end %>
+                <%= f.input :comment, label: "Comment", wrapper: :input_group do %>
+                  <span class="input-group-text"><i class="fa fa-comment"></i></span>
+                  <%= f.input_field :comment, as: :text, class: "form-control" %>
+                <% end %>
                 </div>
                 <!-- /.card-body -->
                 <div class="card-footer">

--- a/app/views/product_drive_participants/_form.html.erb
+++ b/app/views/product_drive_participants/_form.html.erb
@@ -41,7 +41,7 @@
                 </div>
                 <!-- /.card-body -->
                 <div class="card-footer">
-                  <%= submit_button({id: "diaper-drive-participant-submit"}) %>
+                  <%= submit_button({id: "product-drive-participant-submit"}) %>
                 </div>
               <% end %>
               </div>

--- a/app/views/product_drive_participants/show.html.erb
+++ b/app/views/product_drive_participants/show.html.erb
@@ -37,6 +37,7 @@
                 <th>Phone</th>
                 <th>Email</th>
                 <th>Address</th>
+                <th>Comment</th>
               </tr>
               </thead>
               <tbody>
@@ -46,6 +47,7 @@
                 <td><%= @product_drive_participant.phone %></td>
                 <td><%= @product_drive_participant.email %></td>
                 <td><%= @product_drive_participant.address %></td>
+                <td><%= @product_drive_participant.comment %></td>
               </tr>
               </tbody>
             </table>

--- a/spec/models/item_unit_spec.rb
+++ b/spec/models/item_unit_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: item_request_units
+# Table name: item_units
 #
 #  id         :bigint           not null, primary key
 #  name       :string           not null

--- a/spec/models/product_drive_participant_spec.rb
+++ b/spec/models/product_drive_participant_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe ProductDriveParticipant, type: :model do
       expect(build(:product_drive_participant, phone: nil)).to be_valid
       expect(build(:product_drive_participant, email: nil)).to be_valid
     end
+    it "is invalid if the comment field has more than 500 characters" do
+      long_comment = "a" * 501
+      expect(build(:product_drive_participant, comment: long_comment)).not_to be_valid
+    end
   end
 
   context "Methods" do

--- a/spec/requests/product_drive_participants_requests_spec.rb
+++ b/spec/requests/product_drive_participants_requests_spec.rb
@@ -97,9 +97,11 @@ RSpec.describe "ProductDriveParticipants", type: :request do
     end
 
     describe "GET #show" do
-      it "returns http success" do
-        get product_drive_participant_path(id: create(:product_drive_participant, organization: organization))
+      it "returns http success and displays comments" do
+        @participant = create(:product_drive_participant, organization: organization)
+        get product_drive_participant_path(id: @participant)
         expect(response).to be_successful
+        expect(response.body).to include(@participant.comment)
       end
     end
 

--- a/spec/requests/product_drive_participants_requests_spec.rb
+++ b/spec/requests/product_drive_participants_requests_spec.rb
@@ -98,10 +98,11 @@ RSpec.describe "ProductDriveParticipants", type: :request do
 
     describe "GET #show" do
       it "returns http success and displays comments" do
-        @participant = create(:product_drive_participant, organization: organization)
+        comment = "Test comment about product drive participant."
+        @participant = create(:product_drive_participant, organization: organization, comment: comment)
         get product_drive_participant_path(id: @participant)
         expect(response).to be_successful
-        expect(response.body).to include(@participant.comment)
+        expect(response.body).to include(comment)
       end
     end
 

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -265,6 +265,7 @@ RSpec.describe "Donations", type: :system, js: true do
           fill_in "product_drive_participant_business_name", with: "businesstest"
           fill_in "product_drive_participant_contact_name", with: "test"
           fill_in "product_drive_participant_email", with: "123@mail.ru"
+          fill_in "product_drive_participant_comment", with: "test comment"
           click_on "diaper-drive-participant-submit"
           select "businesstest", from: "donation_product_drive_participant_id"
         end

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe "Donations", type: :system, js: true do
           fill_in "product_drive_participant_contact_name", with: "test"
           fill_in "product_drive_participant_email", with: "123@mail.ru"
           fill_in "product_drive_participant_comment", with: "test comment"
-          click_on "diaper-drive-participant-submit"
+          click_on "product-drive-participant-submit"
           select "businesstest", from: "donation_product_drive_participant_id"
         end
 

--- a/spec/system/product_drive_participant_system_spec.rb
+++ b/spec/system/product_drive_participant_system_spec.rb
@@ -25,11 +25,6 @@ RSpec.describe " Participant", type: :system, js: true do
       expect(page.find(:xpath, "//table/tbody/tr[3]/td[1]")).to have_content(@third.business_name)
     end
 
-    it "allows single participants to show comments" do
-      visit product_drive_participant_path(product_drive_participant)
-      expect(page).to have_xpath("//table/tbody/tr/td", text: @first.comment)
-    end
-
     context "When the participants have donations associated with them already" do
       before(:each) do
         create(:donation, :with_items, created_at: 1.day.ago, item_quantity: 10, source: Donation::SOURCES[:product_drive], product_drive: product_drive, product_drive_participant: product_drive_participant)

--- a/spec/system/product_drive_participant_system_spec.rb
+++ b/spec/system/product_drive_participant_system_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe " Participant", type: :system, js: true do
       expect(page.find(:xpath, "//table/tbody/tr[3]/td[1]")).to have_content(@third.business_name)
     end
 
+    it "allows single Participants to show comments" do
+      visit product_drive_participant_path(product_drive_participant)
+      expect(page).to have_xpath("//table/tbody/tr/td", text: @first.comment)
+    end
+
     context "When the s have donations associated with them already" do
       before(:each) do
         create(:donation, :with_items, created_at: 1.day.ago, item_quantity: 10, source: Donation::SOURCES[:product_drive], product_drive: product_drive, product_drive_participant: product_drive_participant)
@@ -53,6 +58,7 @@ RSpec.describe " Participant", type: :system, js: true do
       fill_in "Contact Name", with: product_drive_participant_traits[:contact_name]
       fill_in "Business Name", with: product_drive_participant_traits[:business_name]
       fill_in "Phone", with: product_drive_participant_traits[:phone]
+      fill_in "Comment", with: product_drive_participant_traits[:comment]
 
       expect do
         click_button "Save"
@@ -72,16 +78,21 @@ RSpec.describe " Participant", type: :system, js: true do
   context "when editing an existing product drive participant" do
     subject { edit_product_drive_participant_path(product_drive_participant.id) }
 
-    it "allows a user to update the contact info for a product drive participant" do
+    it "allows a user to update the contact info and comments for a product drive participant" do
       new_email = "foo@bar.com"
+      new_comment = "test comment"
       visit subject
       fill_in "Phone", with: ""
       fill_in "E-mail", with: new_email
+      fill_in "Comment", with: new_comment
       click_button "Save"
 
       expect(page.find(".alert")).to have_content "updated"
       expect(page).to have_content(product_drive_participant.contact_name)
       expect(page).to have_content(new_email)
+
+      visit product_drive_participant_path(product_drive_participant)
+      expect(page).to have_content(new_comment)
     end
 
     it "does not allow a user to update a product drive participant with empty attributes" do

--- a/spec/system/product_drive_participant_system_spec.rb
+++ b/spec/system/product_drive_participant_system_spec.rb
@@ -25,24 +25,24 @@ RSpec.describe " Participant", type: :system, js: true do
       expect(page.find(:xpath, "//table/tbody/tr[3]/td[1]")).to have_content(@third.business_name)
     end
 
-    it "allows single Participants to show comments" do
+    it "allows single participants to show comments" do
       visit product_drive_participant_path(product_drive_participant)
       expect(page).to have_xpath("//table/tbody/tr/td", text: @first.comment)
     end
 
-    context "When the s have donations associated with them already" do
+    context "When the participants have donations associated with them already" do
       before(:each) do
         create(:donation, :with_items, created_at: 1.day.ago, item_quantity: 10, source: Donation::SOURCES[:product_drive], product_drive: product_drive, product_drive_participant: product_drive_participant)
         create(:donation, :with_items, created_at: 1.week.ago, item_quantity: 15, source: Donation::SOURCES[:product_drive], product_drive: product_drive, product_drive_participant: product_drive_participant)
       end
 
-      it "shows existing  Participants in the #index with some summary stats" do
+      it "shows existing participants in the #index with some summary stats" do
         visit subject
         expect(page).to have_xpath("//table/tbody/tr/td", text: product_drive_participant.business_name)
         expect(page).to have_xpath("//table/tbody/tr/td", text: "25")
       end
 
-      it "allows single  Participants to show semi-detailed stats about donations from that product drive" do
+      it "allows single participants to show semi-detailed stats about donations from that product drive" do
         visit product_drive_participant_path(product_drive_participant)
         expect(page).to have_xpath("//table/tbody/tr", count: 3)
       end
@@ -52,7 +52,7 @@ RSpec.describe " Participant", type: :system, js: true do
   context "when creating new product drive participants" do
     subject { new_product_drive_participant_path }
 
-    it "allows a user to create a new product drive instance" do
+    it "allows a user to create a new product drive participant" do
       visit subject
       product_drive_participant_traits = attributes_for(:product_drive_participant)
       fill_in "Contact Name", with: product_drive_participant_traits[:contact_name]
@@ -67,7 +67,7 @@ RSpec.describe " Participant", type: :system, js: true do
       expect(page.find(".alert")).to have_content "added"
     end
 
-    it "does not allow a user to add a new product drive instance with empty attributes" do
+    it "does not allow a user to add a new product drive participant with empty attributes" do
       visit subject
       click_button "Save"
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4311 <!--fill issue number-->

### Description
* Can add comments when creating new participant under Community
* Can add comments when creating new participant under Donation
* Can edit comments when editing participant under Community
* Can view comments on single participant page after clicking "View"
  action on Product Drive Participants index
* Validates comment to be less than 501 characters
* RSpec tests written for all above changes
* Refactor old documentation and CSS ID

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
1) bundle exec rspec
2) adding comment in browser using all above methods
