### PR TITLE
Autoscrolling when adding new items in donations/distributions/purchases/partner requests

### DIFF
--- a/app/javascript/controllers/form_input_controller.js
+++ b/app/javascript/controllers/form_input_controller.js
@@ -27,6 +27,7 @@ export default class extends Controller {
       detail: dest.lastElementChild,
     });
 
+    dest.lastElementChild.scrollIntoView();
     dest.dispatchEvent(afterInsert);
   }
 


### PR DESCRIPTION
Resolves #4440.

### Description
Per issue description, when adding a new item to a donation, distribution, purchase or partner request the screen would stay in place. The users would have to scroll down to see the new item added.

This change introduces a simple fix in the Stimulus controller that adds new items.

- [x] The "add an item" behaviour described above works on new distributions, purchases, and donations
- [x] This behaviour also works when editing distributions, purchases, and donations
- [x] Same thing for requests

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I did some manual testing in my local development environment. Please refer to video recording below.

### Screenshots

**Before**
https://github.com/rubyforgood/human-essentials/assets/85654561/a87c0fc3-412b-4ea6-acd9-aae89bc966fb

**After**
https://github.com/rubyforgood/human-essentials/assets/85654561/214360d3-0ced-4054-9ba8-ca0fb6b9f994

