### PR TITLE
Fixes #4242 so that  css file doesn't make the warning message look scary

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -188,7 +188,7 @@ select.selectpicker + .dropdown-toggle::after {
   background-color: #8282df
 }
 
-div.warning {
+div.low_priority_warning {
   margin: 5px;
   text-align: center;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -189,7 +189,6 @@ select.selectpicker + .dropdown-toggle::after {
 }
 
 div.warning {
-  color: #e15563;
   margin: 5px;
   text-align: center;
 }

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -32,6 +32,6 @@
             text: "Reclaim",
             icon: "undo", enabled: !distribution_row.has_inactive_item? } %>
     <% if distribution_row.has_inactive_item? %>
-      <div class="warning">Has Inactive Items</div>
+      <div class="low_priority_warning">Has Inactive Items</div>
     <% end %>
   </td>

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -92,7 +92,7 @@
             <%= print_button_to print_distribution_path(@distribution, format: :pdf), {size: "md"} %>
           </div>
           <% if @distribution.has_inactive_item? %>
-            <div class="warning">
+            <div class="low_prioirty_warning">
               You can only correct distributions where all the items are active.
               If you need to make a correction, please make the following items active: <%= @distribution.inactive_items.map(&:name).join(", ") %>
             </div>

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -82,7 +82,7 @@
                 confirm: "Are you sure you want to permanently remove this donation?" } %>
             <% end %>
             <% if @donation.has_inactive_item? %>
-              <div class="warning">
+              <div class="low_priority_warning">
                 You can only delete or correct donations where all the items are active.
                 If you need to delete this donation or make a correction, please make the following items active: <%= @donation.inactive_items.map(&:name).join(", ") %>
               </div>

--- a/app/views/purchases/show.html.erb
+++ b/app/views/purchases/show.html.erb
@@ -77,7 +77,7 @@
                 confirm: "Are you sure you want to permanently remove this purchase?" } %>
             <% end %>
             <% if @purchase.has_inactive_item? %>
-              <div class="warning">
+              <div class="low_priority_warning">
                 You can only delete or correct purchases where all the items are active.
                 If you need to delete this purchase or make a correction, please make the following items active: <%= @purchase.inactive_items.map(&:name).join(", ") %>
               </div>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4242

### Description
This PR updates the CSS so that they warning text appears in plaintext and not in red.
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
I tested this changes locally to ensure removing the text-colour changes the warning message to black or close to black. 

In order to test this out you will need to

- set up a new distribution (Distributions | New Distribution) , a new donation (Donation |New Donation), and a new purchase (Purchases | New Purchase) that are all using a particular item (e.g. Adult Briefs L/XL)

- then go into Inventory | Inventory Adjustments
- Enter new Inventory Adjustments to take the levels for that item for each storage location down to 0
- Go to Inventory|Items & Inventory
- Deactivate the item
- Go to Distributions
- you should see a "Has Inactive Items" message. The style of this has has be changed
- click View on that item, and scroll to the bottom
- you should see a message indicating why you can't correct this. The style of this message has be changed
- Go to Donations
- Click view on the donation you entered and scroll to the bottom
- you should see a message indicating why you can't correct this. The style of this message has be changed
- Go to Purchases
- Click view on the purchase you entered and scroll to the bottom
- you should see a message indicating why you can't correct this. The style of this message has be changed
- <!-- Please describe the tests that you ran to verify your changes. 

Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

### Before
<img width="315" alt="Screenshot 2024-06-19 at 1 12 38 PM" src="https://github.com/rubyforgood/human-essentials/assets/22033020/c5541fa7-7a0e-4d18-866f-3eba3d1d2d4f">

<img width="1183" alt="Screenshot 2024-06-23 at 4 11 42 PM" src="https://github.com/rubyforgood/human-essentials/assets/22033020/08c87fcd-b6d5-423f-9d71-2068e155ce63">

<img width="1317" alt="Screenshot 2024-06-23 at 4 15 24 PM" src="https://github.com/rubyforgood/human-essentials/assets/22033020/2d0b3b35-24c1-4e1c-b6db-f1ae8d5f9bb4">

<img width="1262" alt="Screenshot 2024-07-02 at 12 45 52 PM" src="https://github.com/rubyforgood/human-essentials/assets/22033020/164d788f-584c-454e-9969-76061333eaac">


### After
![Screenshot 2024-06-19 at 10 01 38 PM](https://github.com/rubyforgood/human-essentials/assets/22033020/996b189c-fb3a-496d-83f2-42c7f826d87f)

<img width="1175" alt="Screenshot 2024-06-23 at 4 13 55 PM" src="https://github.com/rubyforgood/human-essentials/assets/22033020/9255f8f8-3fd3-4b87-a587-c6fcad82570d">

<img width="1289" alt="Screenshot 2024-06-23 at 4 15 37 PM" src="https://github.com/rubyforgood/human-essentials/assets/22033020/b4a97358-7a79-4282-a536-7ef8713fb964">

<img width="1289" alt="Screenshot 2024-06-23 at 4 15 37 PM" src="https://github.com/rubyforgood/human-essentials/assets/22033020/448e0517-4844-42dc-9bb0-2d1abd83eb19">



