### PR TITLE
[4409] Only show fulfillment column if partner has default location

### DIFF
--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -65,8 +65,8 @@
               <tr>
                 <th>Item</th>
                 <th>Quantity</th>
-                <% default_storage_location = @request.organization.default_storage_location ||
-                                              @request.partner.default_storage_location_id %>
+                <% default_storage_location = @request.partner.default_storage_location_id ||
+                                              @request.organization.default_storage_location %>
                 <% if default_storage_location %>
                   <th>Default storage location inventory</th>
                 <% end %>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -65,7 +65,11 @@
               <tr>
                 <th>Item</th>
                 <th>Quantity</th>
-                <th>Fulfillment Location Inventory</th>
+                <% default_storage_location = @request.organization.default_storage_location ||
+                                              @request.partner.default_storage_location_id %>
+                <% if default_storage_location %>
+                  <th>Default storage location inventory</th>
+                <% end %>
                 <th>Total Inventory</th>
               </tr>
               </thead>
@@ -74,7 +78,9 @@
                 <tr>
                   <td><%= item.name %></td>
                   <td><%= item.quantity %></td>
-                  <td><%= item.on_hand_for_location %></td>
+                  <% if default_storage_location %>
+                    <td><%= item.on_hand_for_location %></td>
+                  <% end %>
                   <td><%= item.on_hand %></td>
                 </tr>
               <% end %>
@@ -94,6 +100,7 @@
             <%= view_button_to(distribution_path(@request.distribution), {text: "View Associated Distribution", size: "md"}) if @request.distribution %>
             <%= button_to 'Cancel', new_request_cancelation_path(request_id: @request.id),
                           method: :get, form_class: 'd-inline', class: 'btn btn-danger btn-md' %>
+          </div>
         </div>
       </div>
     </div>

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Requests', type: :request do
         end
       end
 
-      context 'When partner or organization does not have a default storage location' do
+      context 'When neither partner nor organization has a default storage location' do
         let(:request) { create(:request, organization: organization) }
         it 'does not show the column Default storage location inventory' do
           get request_path(request)

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -58,15 +58,6 @@ RSpec.describe 'Requests', type: :request do
         end
       end
 
-      context 'When organization does not have a default storage location' do
-        let(:request) { create(:request, organization: organization) }
-        it 'shows the column Default storage location inventory' do
-          get request_path(request)
-
-          expect(response.body).not_to include('Default storage location inventory')
-        end
-      end
-
       context 'When partner has a default storage location' do
         let(:storage_location) { create(:storage_location) }
         let(:request) { create(:request, partner: create(:partner, default_storage_location_id: storage_location.id)) }
@@ -77,9 +68,9 @@ RSpec.describe 'Requests', type: :request do
         end
       end
 
-      context 'When partner does not have a default storage location' do
-        let(:request) { create(:request) }
-        it 'shows the column Default storage location inventory' do
+      context 'When partner or organization does not have a default storage location' do
+        let(:request) { create(:request, organization: organization) }
+        it 'does not show the column Default storage location inventory' do
           get request_path(request)
 
           expect(response.body).not_to include('Default storage location inventory')

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -48,6 +48,43 @@ RSpec.describe 'Requests', type: :request do
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context 'When organization has a default storage location' do
+        let(:request) { create(:request, organization: create(:organization, default_storage_location: 1)) }
+        it 'shows the column Default storage location inventory' do
+          get request_path(request)
+
+          expect(response.body).to include('Default storage location inventory')
+        end
+      end
+
+      context 'When organization does not have a default storage location' do
+        let(:request) { create(:request, organization: organization) }
+        it 'shows the column Default storage location inventory' do
+          get request_path(request)
+
+          expect(response.body).not_to include('Default storage location inventory')
+        end
+      end
+
+      context 'When partner has a default storage location' do
+        let(:storage_location) { create(:storage_location) }
+        let(:request) { create(:request, partner: create(:partner, default_storage_location_id: storage_location.id)) }
+        it 'shows the column Default storage location inventory' do
+          get request_path(request)
+
+          expect(response.body).to include('Default storage location inventory')
+        end
+      end
+
+      context 'When partner does not have a default storage location' do
+        let(:request) { create(:request) }
+        it 'shows the column Default storage location inventory' do
+          get request_path(request)
+
+          expect(response.body).not_to include('Default storage location inventory')
+        end
+      end
     end
 
     describe 'POST #start' do

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Requests", type: :system, js: true do
         { item_id: item2.id, quantity: 100}
       ]
     }
-    let!(:request) { create(:request, request_items: request_items, organization: organization) }
+    let!(:request) { create(:request, request_items: request_items, organization: create(:organization, default_storage_location: 1)) }
 
     it "should show the request with a request sender if a partner user is set" do
       visit subject

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Requests", type: :system, js: true do
     it "should show the request with a request sender if a partner user is set" do
       visit subject
       expect(page).to have_content("Request from #{request.partner.name}")
-      expect(page).to have_content("Fulfillment Location Inventory")
+      expect(page).to have_content("Default storage location inventory")
       expect(page).to have_content("Request Sender:")
       partner_user = request.partner_user
       expect(page).to have_content("#{partner_user.name} <#{partner_user.email}>")
@@ -145,7 +145,7 @@ RSpec.describe "Requests", type: :system, js: true do
       request.save!
       visit subject
       expect(page).to have_content("Request from #{request.partner.name}")
-      expect(page).to have_content("Fulfillment Location Inventory")
+      expect(page).to have_content("Default storage location inventory")
       expect(page).to have_content("Request Sender:")
       expect(page).not_to have_content("#{partner_user.name} <#{partner_user.email}>")
     end

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Requests", type: :system, js: true do
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, default_storage_location: 1) }
   let(:user) { create(:user, organization: organization) }
 
   let(:item1) { create(:item, name: "Good item") }
@@ -128,7 +128,7 @@ RSpec.describe "Requests", type: :system, js: true do
         { item_id: item2.id, quantity: 100}
       ]
     }
-    let!(:request) { create(:request, request_items: request_items, organization: create(:organization, default_storage_location: 1)) }
+    let!(:request) { create(:request, request_items: request_items, organization: organization) }
 
     it "should show the request with a request sender if a partner user is set" do
       visit subject


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4409  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Specs were added for the new functionality
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

