### PR TITLE
Show inventory history for pre-event read

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -79,7 +79,15 @@ class StorageLocationsController < ApplicationController
     @items_in = ItemsInQuery.new(organization: current_organization, storage_location: @storage_location).call
     @items_in_total = ItemsInTotalQuery.new(organization: current_organization, storage_location: @storage_location).call
     if Event.read_events?(current_organization)
-      @inventory = View::Inventory.new(current_organization.id, event_time: params[:version_date])
+      if View::Inventory.within_snapshot?(current_organization.id, params[:version_date])
+        @inventory = View::Inventory.new(current_organization.id, event_time: params[:version_date])
+      else
+        @legacy_inventory = View::Inventory.legacy_inventory_for_storage_location(
+          current_organization.id,
+          @storage_location.id,
+          params[:version_date]
+        )
+      end
     end
 
     respond_to do |format|

--- a/app/views/storage_locations/show.html.erb
+++ b/app/views/storage_locations/show.html.erb
@@ -102,6 +102,13 @@
                         <td><%= number_with_delimiter(item.quantity) %></td>
                       </tr>
                     <% end %>
+                  <% elsif @legacy_inventory %>
+                    <% @legacy_inventory.each do |item| %>
+                      <tr>
+                        <td><%= link_to item.name, item_path(item.item_id) %></td>
+                        <td><%= number_with_delimiter(item.quantity) %></td>
+                      </tr>
+                    <% end %>
                   <% else %>
                     <%= render partial: "inventory_item_row",
                                collection: @storage_location.inventory_items.joins(:item).where(items: { active: true }),

--- a/app/views/storage_locations/show.html.erb
+++ b/app/views/storage_locations/show.html.erb
@@ -118,7 +118,15 @@
                   <tfoot>
                   <tr>
                     <td>Total</td>
-                    <td><%= @inventory ? @inventory.quantity_for(storage_location: @storage_location.id) : @storage_location.size %></td>
+                    <td>
+                      <% if @inventory %>
+                        <%= number_with_delimiter(@inventory.quantity_for(storage_location: @storage_location.id)) %>
+                      <% elsif @legacy_inventory %>
+                        <%= number_with_delimiter(@legacy_inventory.map(&:quantity).sum) %>
+                      <% else %>
+                        <%= number_with_delimiter(@storage_location.size) %>
+                      <% end %>
+                    </td>
                   </tr>
                   </tfoot>
                 </table>

--- a/lib/tasks/kill_postgres_connections.rake
+++ b/lib/tasks/kill_postgres_connections.rake
@@ -1,4 +1,5 @@
 task :kill_postgres_connections => :environment do
+  puts "Killing existing Postgres connections - you may be prompted for your computer admin password"
   db_name = Rails.configuration.database_configuration[Rails.env]['database']
   sh = <<EOF
 ps xa \

--- a/spec/models/item_unit_spec.rb
+++ b/spec/models/item_unit_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: item_request_units
+# Table name: item_units
 #
 #  id         :bigint           not null, primary key
 #  name       :string           not null

--- a/spec/requests/storage_locations_requests_spec.rb
+++ b/spec/requests/storage_locations_requests_spec.rb
@@ -235,20 +235,77 @@ RSpec.describe "StorageLocations", type: :request do
           let(:inventory_item) { storage_location.inventory_items.first }
 
           context "with a version found" do
-            it "should show the version specified" do
-              travel 1.day do
-                inventory_item.update!(quantity: 100)
+            context "with events_read on" do
+              before(:each) { allow(Event).to receive(:read_events?).and_return(true) }
+              context "before active events" do
+                it "should show the version specified" do
+                  travel 1.day do
+                    inventory_item.update!(quantity: 100)
+                  end
+                  travel 1.week do
+                    inventory_item.update!(quantity: 300)
+                  end
+                  travel 8.days do
+                    SnapshotEvent.delete_all
+                    SnapshotEvent.publish(organization)
+                  end
+                  travel 2.weeks do
+                    get storage_location_path(storage_location, format: response_format,
+                      version_date: 9.days.ago.to_date.to_fs(:db))
+                    expect(response).to be_successful
+                    expect(response.body).to include("Smithsonian")
+                    expect(response.body).to include("Test Item")
+                    expect(response.body).to include("100")
+                  end
+                end
               end
-              travel 1.week do
-                inventory_item.update!(quantity: 300)
+
+              context "with active events" do
+                it 'should show the right version' do
+                  travel 1.day do
+                    TestInventory.create_inventory(organization, {
+                      storage_location.id => {
+                        item.id => 100,
+                        item2.id => 0
+                      }
+                    })
+                  end
+                  travel 1.week do
+                    TestInventory.create_inventory(organization, {
+                      storage_location.id => {
+                        item.id => 300,
+                        item2.id => 0
+                      }
+                    })
+                  end
+                  travel 2.weeks do
+                    get storage_location_path(storage_location, format: response_format,
+                      version_date: 9.days.ago.to_date.to_fs(:db))
+                    expect(response).to be_successful
+                    expect(response.body).to include("Smithsonian")
+                    expect(response.body).to include("Test Item")
+                    expect(response.body).to include("100")
+                  end
+                end
               end
-              travel 2.weeks do
-                get storage_location_path(storage_location, format: response_format,
-                  version_date: 9.days.ago.to_date.to_fs(:db))
-                expect(response).to be_successful
-                expect(response.body).to include("Smithsonian")
-                expect(response.body).to include("Test Item")
-                expect(response.body).to include("100")
+            end
+            context "with events_read off" do
+              before(:each) { allow(Event).to receive(:read_events?).and_return(false) }
+              it "should show the version specified" do
+                travel 1.day do
+                  inventory_item.update!(quantity: 100)
+                end
+                travel 1.week do
+                  inventory_item.update!(quantity: 300)
+                end
+                travel 2.weeks do
+                  get storage_location_path(storage_location, format: response_format,
+                    version_date: 9.days.ago.to_date.to_fs(:db))
+                  expect(response).to be_successful
+                  expect(response.body).to include("Smithsonian")
+                  expect(response.body).to include("Test Item")
+                  expect(response.body).to include("100")
+                end
               end
             end
           end


### PR DESCRIPTION
Fix for #4433 .

This will show inventory history regardless of whether the time selected had events active or not. If the time is before events were active, it will use inventory item versions (using paper_trail).