### PR TITLE
replace org_user deactivation with removal of org_user role

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -65,18 +65,17 @@ class OrganizationsController < ApplicationController
     end
   end
 
-  def deactivate_user
-    user = User.with_discarded.find_by!(id: params[:user_id])
+  def remove_user
+    user = User.find(params[:user_id])
     raise ActiveRecord::RecordNotFound unless user.has_role?(Role::ORG_USER, current_organization)
-    user.discard!
-    redirect_to user_update_redirect_path, notice: "User has been deactivated."
-  end
-
-  def reactivate_user
-    user = User.with_discarded.find_by!(id: params[:user_id])
-    raise ActiveRecord::RecordNotFound unless user.has_role?(Role::ORG_USER, current_organization)
-    user.undiscard!
-    redirect_to user_update_redirect_path, notice: "User has been reactivated."
+    begin
+      RemoveRoleService.call(user_id: params[:user_id],
+        resource_type: Role::ORG_USER,
+        resource_id: current_organization.id)
+      redirect_to user_update_redirect_path, notice: "User has been removed!"
+    rescue => e
+      redirect_back(fallback_location: organization_path, alert: e.message)
+    end
   end
 
   private

--- a/app/controllers/partners/users_controller.rb
+++ b/app/controllers/partners/users_controller.rb
@@ -23,6 +23,7 @@ module Partners
       end
     end
 
+    # partner user creation
     def create
       user = UserInviteService.invite(name: user_params[:name],
         email: user_params[:email],

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -1,9 +1,6 @@
 <tr>
   <td>
     <%= user.display_name %>
-    <% if user.discarded? %>
-      <span class="badge badge-danger bg-danger">Deactivated</span>
-    <% end %>
   </td>
   <td><%= user.email %></td>
   <td><%= user.kind %> </td>
@@ -18,30 +15,25 @@
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu">
-          <% if user.kept? %>
-            <li>
-              <%=
-                  edit_button_to(
-                    promote_to_org_admin_organization_path(user_id: user.id),
-                    {text: 'Make admin'},
-                    {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}}
-                  )
-              %>
-            </li>
-            <li>
-              <%= deactivate_button_to deactivate_user_organization_path(user_id: user.id),
-                  {id: dom_id(user), method: :post, class: 'deactivate', rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}} %>
-            </li>
-          <% else %>
-            <%= reactivate_button_to reactivate_user_organization_path(user_id: user.id),
-                {id: dom_id(user), method: :post, class: 'reactivate', rel: "nofollow", data: {confirm: 'This will reactivate the user. Are you sure that you want to submit this?', size: 'xs'}} %>
-          <% end %>
+          <li>
+            <%=
+              edit_button_to(
+                promote_to_org_admin_organization_path(user_id: user.id),
+                {text: 'Promote to Admin'},
+                {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}}
+              )
+            %>
+          </li>
+          <li>
+            <%= delete_button_to remove_user_organization_path(user_id: user.id),
+              {id: dom_id(user), method: :post, class: 'deactivate', text: "Remove User", rel: "nofollow", data: {confirm: 'This will revoke the user\'s organization permissions. Are you sure that you want to submit this?', size: 'xs'}} %>
+          </li>
         </ul>
       </div>
     <% end %>
     <% if current_user.has_role?(Role::ORG_ADMIN, current_organization) && user.has_role?(Role::ORG_ADMIN, current_organization) %>
       <%= edit_button_to demote_to_user_organization_path(user_id: user.id),
-                 {text: 'Make User'},
+                 {text: 'Demote to User'},
                  {method: :post, rel: "nofollow", data: {confirm: 'This will demote the admin to user status. Are you sure that you want to submit this?', size: 'xs'}} unless user.id == current_user.id %>
     <% end %>
   </td>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -326,3 +326,10 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 end
+
+Warden::Manager.after_set_user do |user, auth, opts|
+  if user.roles.empty?
+    auth.logout
+    throw(:warden)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,8 +89,7 @@ Rails.application.routes.draw do
   resource :organization, path: :manage, only: %i(edit update) do
     collection do
       post :invite_user
-      put :deactivate_user
-      put :reactivate_user
+      post :remove_user
       post :resend_user_invitation
       post :promote_to_org_admin
       post :demote_to_user

--- a/db/migrate/20240624185108_reactivate_users_and_remove_org_user_roles.rb
+++ b/db/migrate/20240624185108_reactivate_users_and_remove_org_user_roles.rb
@@ -1,10 +1,10 @@
 class ReactivateUsersAndRemoveOrgUserRoles < ActiveRecord::Migration[7.1]
   def up
-    users = User.unscoped.joins(:roles).where.not(discarded_at: nil).where("roles.name": "org_user")
+    users = User.unscoped.where.not(discarded_at: nil)
     users.each do |user|
       user.transaction do
         user.update!(discarded_at: nil)
-        user.roles.where(name: "org_user").delete_all
+        user.roles.delete_all
       end
     end
   end

--- a/db/migrate/20240624185108_reactivate_users_and_remove_org_user_roles.rb
+++ b/db/migrate/20240624185108_reactivate_users_and_remove_org_user_roles.rb
@@ -1,0 +1,15 @@
+class ReactivateUsersAndRemoveOrgUserRoles < ActiveRecord::Migration[7.1]
+  def up
+    users = User.unscoped.joins(:roles).where.not(discarded_at: nil).where("roles.name": "org_user")
+    users.each do |user|
+      user.transaction do
+        user.update!(discarded_at: nil)
+        user.roles.where(name: "org_user").delete_all
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_01_155348) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_24_185108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -77,6 +77,10 @@ FactoryBot.define do
       end
     end
 
+    trait :no_roles do
+      organization { nil }
+    end
+
     trait :deactivated do
       discarded_at { Time.zone.now }
     end

--- a/spec/factories/users_roles.rb
+++ b/spec/factories/users_roles.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: users_roles
+#
+#  id      :bigint           not null, primary key
+#  role_id :bigint
+#  user_id :bigint
+#
+FactoryBot.define do
+  factory :users_role do
+    user
+    role
+  end
+end

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -113,19 +113,13 @@ RSpec.describe "Organizations", type: :request do
       subject { post remove_user_organization_path(user_id: user.id) }
 
       context "when user is org user" do
-        it "redirect after update" do
+        it "redirects after update" do
           subject
           expect(response).to redirect_to(organization_path)
         end
 
         it "removes the org user role" do
-          role = user.roles.find_by(resource: organization, name: Role::ORG_USER)
-          user_role = UsersRole.find_by(user: user, role: role)
-          expect(user_role).to_not be_nil
-
-          subject
-
-          expect(UsersRole.find_by(user: user, role: role)).to be_nil
+          expect { subject }.to change { user.has_role?(Role::ORG_USER, organization) }.from(true).to(false)
         end
       end
 

--- a/spec/requests/partners/user_requests_spec.rb
+++ b/spec/requests/partners/user_requests_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "/partners/users", type: :request do
   before do
     sign_in(partner_user)
   end
+
   describe "GET #edit" do
     it "successfully loads the page" do
       get edit_partners_user_path(partner_user)
@@ -26,6 +27,55 @@ RSpec.describe "/partners/users", type: :request do
       expect(response.request.flash[:success]).to eq "User information was successfully updated!"
       partner_user.reload
       expect(partner_user.name).to eq "New name"
+    end
+  end
+
+  describe "POST #create" do
+    let(:params) do
+      {user: {name: "New User", email: "new_partner_email@example.com"}}
+    end
+
+    it "creates a new user" do
+      post partners_users_path, params: params
+
+      aggregate_failures do
+        expect(response.request.flash[:success]).to eq "You have invited New User to join your organization!"
+        expect(response).to redirect_to(partners_users_path)
+      end
+    end
+
+    context "when the user already exists" do
+      let(:user) { create(:user, name: "Existing User") }
+
+      let(:params) do
+        {user: {name: user.name, email: user.email}}
+      end
+
+      it "creates a new user" do
+        post partners_users_path, params: params
+
+        aggregate_failures do
+          expect(response.request.flash[:success]).to eq "You have invited Existing User to join your organization!"
+          expect(response).to redirect_to(partners_users_path)
+          expect(user.roles.count).to eq(2)
+        end
+      end
+
+      context "when org user had role removed" do
+        before do
+          post remove_user_organization_path(user_id: user.id)
+        end
+
+        it "adds role to user" do
+          post partners_users_path, params: params
+
+          aggregate_failures do
+            expect(response.request.flash[:success]).to eq "You have invited Existing User to join your organization!"
+            expect(response).to redirect_to(partners_users_path)
+            expect(user.roles.count).to eq(2)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/partners/user_requests_spec.rb
+++ b/spec/requests/partners/user_requests_spec.rb
@@ -45,34 +45,40 @@ RSpec.describe "/partners/users", type: :request do
     end
 
     context "when the user already exists" do
-      let(:user) { create(:user, name: "Existing User") }
+      let(:organization) { create(:organization) }
+      let(:org_user) { create(:user, name: "Existing User", organization: organization) }
 
       let(:params) do
-        {user: {name: user.name, email: user.email}}
+        {user: {name: org_user.name, email: org_user.email}}
       end
 
-      it "creates a new user" do
+      it "succeeds and adds additional role to user" do
         post partners_users_path, params: params
 
         aggregate_failures do
           expect(response.request.flash[:success]).to eq "You have invited Existing User to join your organization!"
           expect(response).to redirect_to(partners_users_path)
-          expect(user.roles.count).to eq(2)
+          expect(org_user.has_role?(Role::PARTNER, partner)).to be true
+          expect(org_user.has_role?(Role::ORG_USER, organization)).to be true
         end
       end
 
       context "when org user had role removed" do
         before do
-          post remove_user_organization_path(user_id: user.id)
+          sign_in create(:organization_admin, organization: organization)
+          post remove_user_organization_path(user_id: org_user.id)
+          sign_in(partner_user)
         end
 
         it "adds role to user" do
+          expect(org_user.has_role?(Role::ORG_USER, organization)).to be false
+
           post partners_users_path, params: params
 
           aggregate_failures do
             expect(response.request.flash[:success]).to eq "You have invited Existing User to join your organization!"
             expect(response).to redirect_to(partners_users_path)
-            expect(user.roles.count).to eq(2)
+            expect(org_user.has_role?(Role::PARTNER, partner)).to be true
           end
         end
       end

--- a/spec/system/log_in_system_spec.rb
+++ b/spec/system/log_in_system_spec.rb
@@ -10,9 +10,23 @@ RSpec.describe "Authentication", type: :system, js: true do
     end
   end
 
+  describe "User with no roles" do
+    before do
+      create(:user, :no_roles, email: "no_role_user@example.com")
+    end
+
+    it "should not allow the user to log in" do
+      visit "/users/sign_in"
+      fill_in "user_email", with: "no_role_user@example.com"
+      fill_in "user_password", with: DEFAULT_USER_PASSWORD
+      find('input[name="commit"]').click
+      expect(page).to have_content("You need to sign in before continuing.")
+    end
+  end
+
   describe "Deactivated user" do
     before do
-      create(:user, :deactivated, email: "deactivated@exmaple.com")
+      create(:user, :deactivated, email: "deactivated@example.com")
     end
 
     it "should not allow the user to log in" do

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -158,31 +158,19 @@ RSpec.describe "Organization management", type: :system, js: true do
     it "can see 'Make user' button for admins" do
       create(:organization_admin)
       visit organization_path
-      expect(page.find(".table.border")).to have_content "Make User"
+      expect(page.find(".table.border")).to have_content "Demote to User"
     end
 
-    it "can deactivate a user in the organization" do
-      user = create(:user, name: "User to be deactivated")
+    it "can remove a user from the organization" do
+      user = create(:user, name: "User to be deactivated", organization: organization)
       visit organization_path
       accept_confirm do
         click_button dom_id(user, "dropdownMenu")
-        click_link dom_id(user)
+        click_link "Remove User"
       end
 
-      expect(page).to have_content("User has been deactivated")
-      expect(user.reload.discarded_at).to be_present
-    end
-
-    it "can re-activate a user in the organization" do
-      user = create(:user, :deactivated)
-      visit organization_path
-      accept_confirm do
-        click_button dom_id(user, "dropdownMenu")
-        click_link dom_id(user)
-      end
-
-      expect(page).to have_content("User has been reactivated")
-      expect(user.reload.discarded_at).to be_nil
+      expect(page).to have_content("User has been removed!")
+      expect(user.has_role?(Role::ORG_USER)).to be false
     end
   end
 end


### PR DESCRIPTION
Resolves #3587

## Description

### Problem

The issue was that banks could "deactivate" a user (which is essentially a soft delete of the whole `User` record). However, if that user then went to a `Partner` they would not be able to invite that user because that user would exist (new User cannot be created) but be soft deleted (existing User is treated like they didn't have permissions).

### Solution

Roles got added in https://github.com/rubyforgood/human-essentials/pull/3117. Therefore, the logic around deactivation should address the role not the user. 

**However,** there is a caveat. I attempted to implement logic around deactivating roles themselves in https://github.com/rubyforgood/human-essentials/pull/4392, https://github.com/rubyforgood/human-essentials/pull/4382. But the logic became very complex. We decided (https://github.com/rubyforgood/human-essentials/issues/3587#issuecomment-2138464940) to go for a more architerurally simple solution of removing the deactivation functionality and just deleting the roles.

### Drawbacks
There are two main drawbacks with this approach.

#### Existing Data

What do we do with existing discarded users? Discarded == soft deleted. I can imagine a world where a user was discarded without that meaning to be a "deactivation". 

My current idea is that any User that is discarded and only had the `org_user` role was probably a deactivation and we can reactivate them and remove the `org_user` role from them. But this requires some more information.

#### Loss of Granularity

Previously we had 3 states for `org_user`s: active, not an `org_user` and deactivated (meaning they were a user at one point but not any more).

Now there are only 2 states: user or not. This means we have a bit less information, we can no longer track if someone was _once_ a user but not anymore. Does this matter? Probably not.  


### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Request + System specs

### Screenshots
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/9f78b405-9a2d-44a8-b0bf-5788f76567d2)

