### PR TITLE
fix: remove mini_racer to prevent segfaults (and because we don't use it)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ gem "clockwork"
 # These are gems that aren't used directly, only as dependencies for other gems.
 # Technically they don't need to be in this Gemfile at all, but we are pinning them to
 # specific versions for compatibility reasons.
-gem "mini_racer", "~> 0.12.0"
+gem "mini_racer", "~> 0.9.0"
 gem "nokogiri", ">= 1.10.4"
 gem "image_processing"
 gem "sprockets", "~> 4.2.1"

--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,6 @@ gem "clockwork"
 # These are gems that aren't used directly, only as dependencies for other gems.
 # Technically they don't need to be in this Gemfile at all, but we are pinning them to
 # specific versions for compatibility reasons.
-gem "mini_racer", "~> 0.9.0"
 gem "nokogiri", ">= 1.10.4"
 gem "image_processing"
 gem "sprockets", "~> 4.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,9 +336,6 @@ GEM
       childprocess (~> 5.0)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    libv8-node (18.19.0.0-arm64-darwin)
-    libv8-node (18.19.0.0-x86_64-darwin)
-    libv8-node (18.19.0.0-x86_64-linux)
     lint_roller (1.1.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -367,8 +364,6 @@ GEM
     method_source (1.1.0)
     mini_magick (4.11.0)
     mini_mime (1.1.5)
-    mini_racer (0.9.0)
-      libv8-node (~> 18.19.0.0)
     minitest (5.24.0)
     monetize (1.12.0)
       money (~> 6.12)
@@ -747,7 +742,6 @@ DEPENDENCIES
   lograge
   magic_test
   matrix
-  mini_racer (~> 0.9.0)
   money-rails
   newrelic_rpm
   nokogiri (>= 1.10.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,9 +336,9 @@ GEM
       childprocess (~> 5.0)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    libv8-node (21.7.2.0-arm64-darwin)
-    libv8-node (21.7.2.0-x86_64-darwin)
-    libv8-node (21.7.2.0-x86_64-linux)
+    libv8-node (18.19.0.0-arm64-darwin)
+    libv8-node (18.19.0.0-x86_64-darwin)
+    libv8-node (18.19.0.0-x86_64-linux)
     lint_roller (1.1.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -367,8 +367,8 @@ GEM
     method_source (1.1.0)
     mini_magick (4.11.0)
     mini_mime (1.1.5)
-    mini_racer (0.12.0)
-      libv8-node (~> 21.7.2.0)
+    mini_racer (0.9.0)
+      libv8-node (~> 18.19.0.0)
     minitest (5.24.0)
     monetize (1.12.0)
       money (~> 6.12)
@@ -747,7 +747,7 @@ DEPENDENCIES
   lograge
   magic_test
   matrix
-  mini_racer (~> 0.12.0)
+  mini_racer (~> 0.9.0)
   money-rails
   newrelic_rpm
   nokogiri (>= 1.10.4)


### PR DESCRIPTION
Currently when I run `rails assets:precompile` the application segfaults. 
```plaintext
$ > rails assets:precompile
/home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/mini_racer-0.12.0/lib/mini_racer.rb:228: [BUG] Segmentation fault at 0x00007ff911d85008
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0064 p:---- s:0428 e:000427 CFUNC  :eval_unsafe
c:0063 p:0009 s:0422 e:000421 BLOCK  /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/mini_racer-0.12.0/lib/mini_racer.rb:228
c:0062 p:0010 s:0419 e:000418 METHOD /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/mini_racer-0.12.0/lib/mini_racer.rb:348
c:0061 p:0008 s:0408 e:000407 BLOCK  /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/mini_racer-0.12.0/lib/mini_racer.rb:227 [FINISH]
c:0060 p:---- s:0405 e:000404 CFUNC  :synchronize
c:0059 p:0045 s:0401 e:000400 METHOD /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/mini_racer-0.12.0/lib/mini_racer.rb:225
c:0058 p:0007 s:0394 e:000393 BLOCK  /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/execjs-2.9.1/lib/execjs/mini_racer_runtime.rb:11
c:0057 p:0003 s:0391 e:000389 METHOD /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/execjs-2.9.1/lib/execjs/mini_racer_runtime.rb:67
c:0056 p:0035 s:0383 e:000382 METHOD /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/execjs-2.9.1/lib/execjs/mini_racer_runtime.rb:10 [FINISH]
c:0055 p:---- s:0376 e:000375 CFUNC  :new
c:0054 p:0038 s:0369 e:000368 METHOD /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/execjs-2.9.1/lib/execjs/runtime.rb:68
c:0053 p:0013 s:0363 e:000362 METHOD /home/bandito/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/execjs-2.9.1/lib/execjs/module.rb:27

```

This seems to be related to `mini_racer`. ~~The easiest solution is to downgrade to a version of `mini_racer` without these issues.~~ Just kidding, we aren't using it so we might as well remove it!

See https://github.com/rubyjs/mini_racer/issues/300 for more info.
