### PR TITLE
4434 remove superuser delete functionality

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -49,16 +49,6 @@ class Admin::UsersController < AdminController
     render "admin/users/new"
   end
 
-  def destroy
-    @user = User.find_by(id: params[:id])
-    if @user.present?
-      @user.destroy
-      redirect_to admin_users_path, notice: "Deleted that user"
-    else
-      redirect_to admin_users_path, flash: { error: "Couldn't find that user, sorry" }
-    end
-  end
-
   def resource_ids
     klass = case params[:resource_type]
     when "org_admin", "org_user"

--- a/app/views/admin/users/_list.html.erb
+++ b/app/views/admin/users/_list.html.erb
@@ -15,7 +15,6 @@
         <td><%= user.email %></td>
         <td class="text-right">
           <%= edit_button_to edit_admin_user_path(user) %>
-          <%= delete_button_to(admin_user_path(user), {confirm: "Are you sure you want to permanently remove this user?"}) unless user == current_user %>
         </td>
       </tr>
     <% end %>

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -56,18 +56,6 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       expect(page.find('.alert')).to have_content('Role added')
     end
 
-    it "deletes an existing user" do
-      create(:user, organization: organization, name: "AAlphabetically First User")
-
-      visit admin_users_path
-
-      page.accept_confirm do
-        click_link "Delete", match: :first
-      end
-
-      expect(page.find(".alert")).to have_content "Deleted that user"
-    end
-
     it "filters users by name" do
       create(:user, name: "UserA", organization: organization)
       create(:user, name: "UserB", organization: organization)


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4434 

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Based on the description in [this issue](https://github.com/rubyforgood/human-essentials/issues/4434), I have removed the button for deleting users from the admin's user list. 

While the issue description said only to remove the button, I have included a commit removing the functionality from the controller as well, which I am not certain is strictly necessary and would appreciate any feedback available. 

### Type of change

<!-- Please delete options that are not relevant. -->

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

I removed the [delete button from the view](https://github.com/rubyforgood/human-essentials/blob/main/app/views/admin/users/_list.html.erb#L18), then locally ran the site and saw the button no longer rendered. I then added the button back and removed the [controller logic to destroy a user](https://github.com/rubyforgood/human-essentials/blob/main/app/controllers/admin/users_controller.rb#L52-L60), ran the site locally and clicked the delete button, which produced a `The action 'destroy' could not be found for Admin::UsersController` and did not delete the user. 

I removed the test that asserted functionality in that controller, ran the full test suite, and all tests passed. 


### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
Before button removal:
![Screenshot 2024-06-19 at 9 10 00 AM](https://github.com/rubyforgood/human-essentials/assets/44882074/b7da55ea-beb4-40d9-857c-c96290f51e67)
After button removal:
![Screenshot 2024-06-26 at 10 20 14 AM](https://github.com/rubyforgood/human-essentials/assets/44882074/d2c628b8-590e-4ef7-9779-d7f5338ff7c0)
