### PR TITLE
Correct word for the NDBN report

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -787,4 +787,4 @@ DEPENDENCIES
   webmock (~> 3.23)
 
 BUNDLED WITH
-   2.5.11
+   2.5.14

--- a/app/services/reports/summary_report_service.rb
+++ b/app/services/reports/summary_report_service.rb
@@ -16,7 +16,7 @@ module Reports
                     entries: {
                       '% difference in yearly donations' => percent_donations,
                       '% difference in total money donated' => percent_money,
-                      '% difference in diaper donations' => percent_diapers
+                      '% difference in disposable diaper donations' => percent_diapers
                     } }
     end
 

--- a/spec/services/reports/summary_report_service_spec.rb
+++ b/spec/services/reports/summary_report_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Reports::SummaryReportService, type: :service do
       expect(report.report).to eq({
                                     entries: { "% difference in yearly donations" => "0%",
                                                "% difference in total money donated" => "0%",
-                                               "% difference in diaper donations" => "0%" },
+                                               "% difference in disposable diaper donations" => "0%" },
                                     name: "Year End Summary"
                                   })
     end
@@ -47,7 +47,7 @@ RSpec.describe Reports::SummaryReportService, type: :service do
         expect(report.report).to eq({
           entries: { "% difference in yearly donations" => "+200%",
                      "% difference in total money donated" => "+800%",
-                     "% difference in diaper donations" => "+200%" },
+                     "% difference in disposable diaper donations" => "+200%" },
           name: "Year End Summary"
         })
       end
@@ -79,7 +79,7 @@ RSpec.describe Reports::SummaryReportService, type: :service do
         expect(report.report).to eq({
           entries: { "% difference in yearly donations" => "-67%",
                      "% difference in total money donated" => "0%",
-                     "% difference in diaper donations" => "-67%" },
+                     "% difference in disposable diaper donations" => "-67%" },
           name: "Year End Summary"
         })
       end


### PR DESCRIPTION
Resolves #4470

### Description
This pull request Fixes #4470 correcting the wording for the NDBN report , this has been tested through visual observance, running corresponding tests and checking if everything works as before.
Below you can see the screenshots what was written before and after the changes .Also  a screenshot of the corresponding tests passing


### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

- [x]  text changed

 

- [x] screenshots of changed text

 

- [x] all tests around reports pass

### Screenshots
* Before
![Στιγμιότυπο οθόνης 2024-07-02, 19 21 16](https://github.com/rubyforgood/human-essentials/assets/13764631/219a9e6a-6b52-49a8-a22f-f85b6079648d)

* After
![Στιγμιότυπο οθόνης 2024-07-02, 19 26 14](https://github.com/rubyforgood/human-essentials/assets/13764631/d23091b1-a3c9-4898-a39e-ec0a0b9dc367)

* Corresponding test passes
![Στιγμιότυπο οθόνης 2024-07-02, 19 25 34](https://github.com/rubyforgood/human-essentials/assets/13764631/7ddd3170-ab29-47b6-b0a2-1d33df1a4944)


