### PR TITLE
feat: improve bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -54,8 +54,11 @@ FileUtils.chdir APP_ROOT do
   system!("bundle check") || system!("bundle install")
 
   unless File.exist?('.env')
-    log "== Setup .env file from .env.example =="
+    log "== Setting up .env file from .env.example =="
     system!('cp .env.example .env')
+    puts  "Check .env to see if your database credentials are correct."
+    puts  "Press Enter to continue..."
+    gets
   end
 
   log "== Preparing database =="


### PR DESCRIPTION
I've seen in other projects people stumble on the ENV var setup. Namely they don't realize that they need to edit the generate `.env` with correct credentials.

How about we add something like this to `bin/setup` to prompt users to check the `.env` file but only when it is first generated?

![image](https://github.com/rubyforgood/human-essentials/assets/14540596/83f645b9-63a9-4eaf-966e-ba8a19eafdce)


