### PR TITLE
Improve child functionality by allowing multiple items to be requested

### DIFF
--- a/app/controllers/partners/children_controller.rb
+++ b/app/controllers/partners/children_controller.rb
@@ -82,11 +82,11 @@ module Partners
         :first_name,
         :gender,
         :health_insurance,
-        :item_needed_diaperid,
         :last_name,
         :race,
         :archived,
-        child_lives_with: []
+        child_lives_with: [],
+        requested_item_ids: []
       )
     end
 

--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -23,9 +23,9 @@ module Partners
         end
       end
 
-      children = current_partner.children.active.where(id: children_ids).where.not(item_needed_diaperid: [nil, 0])
+      children = current_partner.children.active.where(id: children_ids).joins(:requested_items).select('children.*', :item_id)
 
-      children_grouped_by_item_id = children.group_by(&:item_needed_diaperid)
+      children_grouped_by_item_id = children.group_by(&:item_id)
       family_requests_attributes = children_grouped_by_item_id.map do |item_id, item_requested_children|
         { item_id: item_id, person_count: item_requested_children.size, children: item_requested_children }
       end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -1,5 +1,12 @@
 # Encapsulates methods that need some business logic
 module PartnersHelper
+  def display_requested_items(partner, child)
+    ids = child.requested_item_ids
+    ids.map do |item_id|
+      partner.organization.item_id_to_display_string_map[item_id]
+    end.join(', ')
+  end
+
   def show_header_column_class(partner, additional_classes: "")
     if partner.quota.present?
       "col-sm-3 col-3 #{additional_classes}"

--- a/app/models/partners/child.rb
+++ b/app/models/partners/child.rb
@@ -25,6 +25,7 @@ module Partners
     serialize :child_lives_with, Array
     belongs_to :family
     has_many :child_item_requests, dependent: :destroy
+    has_and_belongs_to_many :requested_items, class_name: 'Item'
 
     include Filterable
     include Exportable
@@ -88,7 +89,7 @@ module Partners
     def self.csv_export_headers
       %w[
         id first_name last_name date_of_birth gender child_lives_with race agency_child_id
-        health_insurance comments created_at updated_at family_id item_needed_diaperid active archived
+        health_insurance comments created_at updated_at family_id requested_item_ids active archived
       ].freeze
     end
 
@@ -107,7 +108,7 @@ module Partners
         created_at,
         updated_at,
         family_id,
-        item_needed_diaperid,
+        requested_item_ids,
         active,
         archived
       ]

--- a/app/views/partners/children/_child.json.jbuilder
+++ b/app/views/partners/children/_child.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! child, :id, :first_name, :last_name, :date_of_birth, :gender, :child_lives_with, :race, :agency_child_id, :health_insurance, :item_needed_diaperid, :comments, :created_at, :updated_at
+json.extract! child, :id, :first_name, :last_name, :date_of_birth, :gender, :child_lives_with, :race, :agency_child_id, :health_insurance, :requested_item_ids, :comments, :created_at, :updated_at
 json.url child_url(child, format: :json)

--- a/app/views/partners/children/_form.html.erb
+++ b/app/views/partners/children/_form.html.erb
@@ -16,11 +16,21 @@
               <%= form.label :last_name, "Last Name" %>
               <%= form.text_field :last_name, class: "form-control" %>
 
-              <%= form.label :item_needed, "Diaper/Item Used" %>
-              <%= form.select :item_needed_diaperid, @requestable_items,
-                              {include_blank: 'Select an item'},
-                              {class: 'form-control'} %>
+              <div class="requestable-items-container">
+                <%= form.label :item_needed, "Items Requested" %>
+                <%= form.select(
+                  :requested_item_ids,
+                  @requestable_items,
+                  { include_hidden: true },
+                  {
+                    multiple: true,
+                    class: "form-control custom-select",
+                    "data-controller": "select2",
+                    "data-select2-config-value": "{}",
+                  },
+                ) %>
               <br>
+              </div>
 
               <%= form.input :date_of_birth, as: :date, start_year: 20.years.ago.year, end_year: Time.current.year, label: "Date of Birth" %>
               <%= form.input :gender, collection: ["Male", "Female"], class: "form-control" %>
@@ -53,16 +63,15 @@
               <%= form.label "Archived?" %>&nbsp;
               <%= form.check_box :archived %>
 
-              </div>
               <div class="card-footer">
                 <%= form.submit(class: 'btn btn-primary') %>
               </div>
-
             <% end %>
-            </div>
-        <!-- /.card -->
+          </div>
+        </div>
       </div>
-      <!-- /.row -->
-    </div><!-- /.container-fluid -->
-  </div>
+      <!-- /.card -->
+    </div>
+    <!-- /.row -->
+  </div><!-- /.container-fluid -->
 </section>

--- a/app/views/partners/children/_form.html.erb
+++ b/app/views/partners/children/_form.html.erb
@@ -16,8 +16,9 @@
               <%= form.label :last_name, "Last Name" %>
               <%= form.text_field :last_name, class: "form-control" %>
 
+              <%= @requestable_items.map(&:last).intersect?(child.requested_item_ids) %>
               <div class="requestable-items-container">
-                <%= form.label :item_needed, "Items Requested" %>
+                <%= form.label :item_needed, "Item(s) Requested" %>
                 <%= form.select(
                   :requested_item_ids,
                   @requestable_items,

--- a/app/views/partners/children/show.html.erb
+++ b/app/views/partners/children/show.html.erb
@@ -58,7 +58,7 @@
                     <dt>Health insurance:</dt>
                     <dd><%= @child.health_insurance %></dd>
 
-                    <dt>Item needed:</dt>
+                    <dt>Item(s) needed:</dt>
                     <dd><%= display_requested_items(current_partner, @child) %></dd>
 
                     <dt>Comments:</dt>

--- a/app/views/partners/children/show.html.erb
+++ b/app/views/partners/children/show.html.erb
@@ -59,7 +59,7 @@
                     <dd><%= @child.health_insurance %></dd>
 
                     <dt>Item needed:</dt>
-                    <dd><%= current_partner.organization.item_id_to_display_string_map[@child.item_needed_diaperid] %></dd>
+                    <dd><%= display_requested_items(current_partner, @child) %></dd>
 
                     <dt>Comments:</dt>
                     <dd><%= @child.comments %></dd>

--- a/app/views/partners/family_requests/_list.html.erb
+++ b/app/views/partners/family_requests/_list.html.erb
@@ -18,15 +18,15 @@
         <%= child.first_name %> <%= child.last_name %>
       </td>
       <td>
-        <% if child.item_needed_diaperid %>
-          <%= current_partner.organization.item_id_to_display_string_map[child.item_needed_diaperid] %>
+        <% if child.requested_item_ids.any? %>
+          <%= display_requested_items(current_partner, child) %>
         <% else %>
           <%= "N/A" %>
         <% end %>
       </td>
       <td>
         <div class="custom-control custom-switch form-switch">
-          <% if child.item_needed_diaperid %>
+          <% if child.requested_item_ids.any? %>
             <%= check_box_tag "child-#{child.id}", child.active, child.active,
                               class: "custom-control-input",
                               id: "child-#{child.id}" %>

--- a/db/migrate/20240703174254_create_join_table_children_items.rb
+++ b/db/migrate/20240703174254_create_join_table_children_items.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableChildrenItems < ActiveRecord::Migration[7.1]
+  def change
+    create_join_table :children, :items do |t|
+      t.index [:child_id, :item_id], unique: true
+      t.index [:item_id, :child_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20240704214509_backfill_partner_child_requested_items.rb
+++ b/db/migrate/20240704214509_backfill_partner_child_requested_items.rb
@@ -1,0 +1,7 @@
+class BackfillPartnerChildRequestedItems < ActiveRecord::Migration[7.1]
+  def change
+    Partners::Child.unscoped.where.not(item_needed_diaperid: nil).each do |child|
+      child.requested_items << Item.find_by(id: child.item_needed_diaperid)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_24_185108) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_04_214509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -186,6 +186,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_24_185108) do
     t.boolean "active", default: true
     t.boolean "archived"
     t.index ["family_id"], name: "index_children_on_family_id"
+  end
+
+  create_table "children_items", id: false, force: :cascade do |t|
+    t.bigint "child_id", null: false
+    t.bigint "item_id", null: false
+    t.index ["child_id", "item_id"], name: "index_children_items_on_child_id_and_item_id", unique: true
+    t.index ["item_id", "child_id"], name: "index_children_items_on_item_id_and_child_id", unique: true
   end
 
   create_table "counties", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -292,6 +292,8 @@ note = [
     )
   end
 
+  requestable_items = PartnerFetchRequestableItemsService.new(partner_id: p.id).call.map(&:last)
+
   families.each do |family|
     Partners::AuthorizedFamilyMember.create!(
       first_name: Faker::Name.first_name,
@@ -316,7 +318,7 @@ note = [
         comments: Faker::Lorem.paragraph,
         active: Faker::Boolean.boolean,
         archived: false,
-        requested_item_ids: [p.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)]
+        requested_item_ids: requestable_items.sample(rand(4))
       )
     end
 
@@ -334,7 +336,7 @@ note = [
         comments: Faker::Lorem.paragraph,
         active: Faker::Boolean.boolean,
         archived: false,
-        requested_item_ids: [p.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)]
+        requested_item_ids: requestable_items.sample(rand(4))
       )
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -316,7 +316,7 @@ note = [
         comments: Faker::Lorem.paragraph,
         active: Faker::Boolean.boolean,
         archived: false,
-        item_needed_diaperid: p.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)
+        requested_item_ids: [p.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)]
       )
     end
 
@@ -334,7 +334,7 @@ note = [
         comments: Faker::Lorem.paragraph,
         active: Faker::Boolean.boolean,
         archived: false,
-        item_needed_diaperid: p.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)
+        requested_item_ids: [p.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)]
       )
     end
   end

--- a/spec/factories/partners/child.rb
+++ b/spec/factories/partners/child.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     first_name           { Faker::Name.first_name }
     last_name            { Faker::Name.last_name }
     gender               { Faker::Gender.binary_type }
-    # TODO: change when closing #4199
-    item_needed_diaperid { Item.all.sample&.id || create(:item, organization: family.partner.organization).id }
+    requested_item_ids { [create(:item, organization: family.partner.organization).id] }
   end
 end

--- a/spec/models/partners/child_spec.rb
+++ b/spec/models/partners/child_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Partners::Child, type: :model do
   describe 'associations' do
     it { should belong_to(:family) }
     it { should have_many(:child_item_requests).dependent(:destroy) }
+    it { should have_and_belong_to_many(:requested_items).class_name('Item') }
   end
 
   describe "#display_name" do

--- a/spec/requests/partners/children_requests_spec.rb
+++ b/spec/requests/partners/children_requests_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "/partners/children", type: :request do
   let(:partner_user) { partner.primary_user }
   let(:partner) { create(:partner) }
   let(:family) { create(:partners_family, partner: partner) }
+  let(:item1) { create(:item, organization: partner.organization) }
+  let(:item2) { create(:item, organization: partner.organization) }
   let!(:child1) do
     create(:partners_child,
       first_name: "John",
@@ -15,7 +17,7 @@ RSpec.describe "/partners/children", type: :request do
       agency_child_id: "Agency McAgence",
       health_insurance: "Private insurance",
       comments: "Some comment",
-      item_needed_diaperid: nil,
+      requested_item_ids: nil,
       active: true,
       archived: false,
       family: family)
@@ -31,9 +33,9 @@ RSpec.describe "/partners/children", type: :request do
       agency_child_id: "Agency McAgence",
       health_insurance: "Private insurance",
       comments: "Some comment",
-      item_needed_diaperid: nil,
       active: true,
       archived: false,
+      requested_item_ids: [item1.id, item2.id],
       family: family)
   end
 
@@ -51,9 +53,9 @@ RSpec.describe "/partners/children", type: :request do
       headers = {"Accept" => "text/csv", "Content-Type" => "text/csv"}
       get partners_children_path, headers: headers
       csv = <<~CSV
-        id,first_name,last_name,date_of_birth,gender,child_lives_with,race,agency_child_id,health_insurance,comments,created_at,updated_at,family_id,item_needed_diaperid,active,archived
+        id,first_name,last_name,date_of_birth,gender,child_lives_with,race,agency_child_id,health_insurance,comments,created_at,updated_at,family_id,requested_item_ids,active,archived
         #{child1.id},John,Smith,2019-01-01,Male,"mother,grandfather",Other,Agency McAgence,Private insurance,Some comment,#{child1.created_at},#{child1.updated_at},#{family.id},"",true,false
-        #{child2.id},Jane,Smith,2018-01-01,Female,father,Hispanic,Agency McAgence,Private insurance,Some comment,#{child2.created_at},#{child2.updated_at},#{family.id},"",true,false
+        #{child2.id},Jane,Smith,2018-01-01,Female,father,Hispanic,Agency McAgence,Private insurance,Some comment,#{child2.created_at},#{child2.updated_at},#{family.id},"#{item1.id},#{item2.id}",true,false
       CSV
       expect(response.body).to eq(csv)
     end

--- a/spec/requests/partners/family_requests_controller_spec.rb
+++ b/spec/requests/partners/family_requests_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Partners::FamilyRequestsController, type: :request do
       # Set one child as deactivated and the other as active but
       # without a item_needed_diaperid
       children[0].update(active: false)
-      children[1].update(item_needed_diaperid: nil)
+      children[1].update(requested_item_ids: [])
     end
     subject { post partners_family_requests_path, params: params }
 

--- a/spec/system/partners/children_system_spec.rb
+++ b/spec/system/partners/children_system_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe "Creating a parner child", type: :system, js: true do
+  let(:organization) { create(:organization) }
+  let(:partner) { FactoryBot.create(:partner, organization: organization) }
+  let(:partner_user) { partner.primary_user }
+  let(:family) { create(:partners_family, guardian_first_name: "Main", guardian_last_name: "Family", partner: partner) }
+
+  before do
+    partner.update(status: :approved)
+    login_as(partner_user)
+    create(:item, name: "Item 1", organization: organization)
+    create(:item, name: "Item 2", organization: organization)
+  end
+
+  describe "creating a child for a family" do
+    it "creates a child with correct info" do
+      visit new_partners_child_path(family_id: family.id)
+      fill_in "First Name", with: "Child First Name"
+      fill_in "Last Name", with: "Child Last Name"
+      select "Other", from: "Race"
+      fill_in "Agency Child ID", with: "01234"
+      fill_in "Comments", with: "Some Comment"
+
+      select2(page, "requestable-items-container", "Item 2")
+      select2(page, "requestable-items-container", "Item 1")
+
+      click_button "Create Child"
+
+      expect(page).to have_text("Child was successfully created.")
+      expect(page).to have_text("Child First Name")
+      expect(page).to have_text("Child Last Name")
+      expect(page).to have_text("01234")
+      expect(page).to have_text("Some Comment")
+      expect(page).to have_text("Item 1, Item 2")
+    end
+  end
+end


### PR DESCRIPTION
Resolves #3797

### Description

Most of the work for this PR was already done in https://github.com/rubyforgood/human-essentials/pull/4126. But essentially we create a HABTM relationship between children and items.

I changed the front end selection behavior to use a `select2` dropdown.
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/3f2c4f12-625a-458b-901d-6b543a053e4e)

Added an additional system test to ensure that we can create a child with multiple requested items correctly.

#### Future PRs

- add inline editing of requestable items
- drop the `item_needed_diaperid` column

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

- New system spec added
- modified existing system, model and request specs

### Screenshots

![image](https://github.com/rubyforgood/human-essentials/assets/14540596/33fbae3b-d8ab-49ca-a96c-082976f70b78)
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/cb7aebd5-911b-428a-a18f-9b6a995a4649)
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/4fe5a5cd-4d02-47f0-9415-d41a7ab4fdf7)
![image](https://github.com/rubyforgood/human-essentials/assets/14540596/92ff2b52-3e5e-463e-843a-ad02369ebbdb)


