### PR TITLE
Enhancing Seed Script with Minimum and Recommended Quantities

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -77,12 +77,6 @@ Organization.all.each do |org|
   end
 end
 
-# Set minimum and recomended inventory levels for items at the Pawnee Diaper Bank Organization
-half_items_count = (pdx_org.items.count/2).to_i
-min_value = 1500
-recomended_value = 2000
-pdx_org.items.limit(half_items_count).update_all(on_hand_minimum_quantity: min_value, on_hand_recommended_quantity: recomended_value)
-
 # ----------------------------------------------------------------------------
 # Request Units
 # ----------------------------------------------------------------------------
@@ -427,6 +421,23 @@ StorageLocation.all.each do |sl|
   end
 end
 Organization.all.each { |org| SnapshotEvent.publish(org) }
+
+# Set minimum and recomended inventory levels for items at the Pawnee Diaper Bank Organization
+half_items_count = (pdx_org.items.count/2).to_i
+low_items = pdx_org.items.left_joins(:inventory_items)
+  .select('items.*, SUM(inventory_items.quantity) AS total_quantity')
+  .group('items.id')
+  .order('total_quantity')
+  .limit(half_items_count)
+
+min_qty = low_items.first.total_quantity
+max_qty = low_items.last.total_quantity
+
+low_items.each do |item|
+  min_value = rand((min_qty / 10).floor..(max_qty/10).ceil) * 10
+  recomended_value = rand((min_value/10).ceil..1000) * 10
+  item.update(on_hand_minimum_quantity: min_value, on_hand_recommended_quantity: recomended_value)
+end
 
 # ----------------------------------------------------------------------------
 # Product Drives

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -77,6 +77,12 @@ Organization.all.each do |org|
   end
 end
 
+# Set minimum and recomended inventory levels for items at the Pawnee Diaper Bank Organization
+half_items_count = (pdx_org.items.count/2).to_i
+min_value = 1500
+recomended_value = 2000
+pdx_org.items.limit(half_items_count).update_all(on_hand_minimum_quantity: min_value, on_hand_recommended_quantity: recomended_value)
+
 # ----------------------------------------------------------------------------
 # Request Units
 # ----------------------------------------------------------------------------


### PR DESCRIPTION

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.


Resolves #4475 

### Description
- Added some logic to the seed script to populate half of the times from Pawnee Diaper Bank Org with a on_hand_minimum_quantity and a on_hand_recommended_quantity for demo and testing purposes

- Originally was recommenced to keep the minimum between 0 and 1000 but after some testing with the existing base_item.json data there are no items that have a qty under 1000 so in order to make for a better demo of the low inventory tile on the dashboard page I went with 1500 for the minimum and 2000 for the recommended. 
   
### Type of change

Basic change of populating data for items to ensure an easier demo experience.

### How Has This Been Tested?

- Tested locally by dropping my database and re-seeding my dev environment with the updated script 

### Screenshots
![Screenshot 2024-07-06 at 3 26 51 PM](https://github.com/rubyforgood/human-essentials/assets/12036882/3d7c9ac9-7b94-4f17-95b3-191f9c7b9926)

