### PR TITLE
Fix a Rails 7.2 deprecation

### DIFF
--- a/app/models/partners/child.rb
+++ b/app/models/partners/child.rb
@@ -22,7 +22,7 @@
 module Partners
   class Child < Base
     has_paper_trail
-    serialize :child_lives_with, Array
+    serialize :child_lives_with, type: Array
     belongs_to :family
     has_many :child_item_requests, dependent: :destroy
 

--- a/app/models/partners/family.rb
+++ b/app/models/partners/family.rb
@@ -31,7 +31,7 @@ module Partners
     belongs_to :partner, class_name: '::Partner'
     has_many :children, dependent: :destroy
     has_many :authorized_family_members, dependent: :destroy
-    serialize :sources_of_income, Array
+    serialize :sources_of_income, type: Array
     validates :guardian_first_name, :guardian_last_name, :guardian_zip_code, presence: true
 
     include Filterable


### PR DESCRIPTION
I was getting this warning when booting rails:

```
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.
```