### PR TITLE
Fixes-4474-by-switching-onboarding-logic-in-ui

### DIFF
--- a/app/views/dashboard/_getting_started_prompt.html.erb
+++ b/app/views/dashboard/_getting_started_prompt.html.erb
@@ -3,7 +3,7 @@
 <% location_criteria_met = org_stats.storage_locations_added > 0 %>
 <% donation_criteria_met = org_stats.donation_sites_added > 0 %>
 <% inventory_criteria_met = org_stats.locations_with_inventory.length > 0 %>
-<% criterias = [ partner_criteria_met, location_criteria_met, donation_criteria_met, inventory_criteria_met ] %>
+<% criterias = [ location_criteria_met, partner_criteria_met, donation_criteria_met, inventory_criteria_met ] %>
 <% current_step = criterias.find_index(false) %>
 
 <% if current_step.present? %>
@@ -30,35 +30,11 @@
                 current_step: current_step,
                 criterias: criterias,
                 lines: ["line-right", "line-right line-left", "line-right line-left", "line-left"],
-                step_labels: ["Partner Agencies", "Storage Locations", "Donation Sites", "Inventory"]
+                step_labels: ["Storage Locations", "Partner Agencies", "Donation Sites", "Inventory"]
               } %>
             </div>
 
             <div class="col-md-12 org-stats-box-container<%= current_step == 0 ? '' : ' d-none visible-xs' %>">
-              <div class="org-stats-box">
-                <div class="box-body text-center position-relative">
-                  <div class="org-stats-icon">
-                    <% if partner_criteria_met %>
-                      <i class="fa fa-check-circle-o fa-2x success" aria-hidden="true"></i>
-                    <% else %>
-                      <i class="fa fa-users fa-2x" aria-hidden="true"></i>
-                    <% end %>
-                    <h4><%= pluralize(org_stats.partners_added, 'Partner Agency') %> Added</h4>
-                  </div>
-
-                  <p class="org-stats-desc">
-                    To start building your community in Human Essentials, import a list of your current partner agencies or add them individually.
-                  </p>
-
-                  <div id="org-stats-call-to-action-partners">
-                    <% partner_link_text = partner_criteria_met ? "Add More Partners" : "Add a Partner" %>
-                    <%= new_button_to new_partner_path, { text: partner_link_text, size: "md" } %>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="col-md-12 org-stats-box-container<%= current_step == 1 ? '' : ' d-none visible-xs' %>">
               <div class="org-stats-box">
                 <div class="box-body text-center position-relative">
                   <div class="org-stats-icon">
@@ -77,6 +53,30 @@
                   <div id="org-stats-call-to-action-storage-locations">
                     <% location_link_text = location_criteria_met ? "Add More Storage Locations" : "Add a Storage Location" %>
                     <%= new_button_to new_storage_location_path, { text: location_link_text, size: "md" } %>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-md-12 org-stats-box-container<%= current_step == 1 ? '' : ' d-none visible-xs' %>">
+              <div class="org-stats-box">
+                <div class="box-body text-center position-relative">
+                  <div class="org-stats-icon">
+                    <% if partner_criteria_met %>
+                      <i class="fa fa-check-circle-o fa-2x success" aria-hidden="true"></i>
+                    <% else %>
+                      <i class="fa fa-users fa-2x" aria-hidden="true"></i>
+                    <% end %>
+                    <h4><%= pluralize(org_stats.partners_added, 'Partner Agency') %> Added</h4>
+                  </div>
+
+                  <p class="org-stats-desc">
+                    To start building your community in Human Essentials, import a list of your current partner agencies or add them individually.
+                  </p>
+
+                  <div id="org-stats-call-to-action-partners">
+                    <% partner_link_text = partner_criteria_met ? "Add More Partners" : "Add a Partner" %>
+                    <%= new_button_to new_partner_path, { text: partner_link_text, size: "md" } %>
                   </div>
                 </div>
               </div>

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -23,18 +23,18 @@ RSpec.describe "Dashboard", type: :system, js: true do
       expect(org_dashboard_page).not_to have_add_donation_site_call_to_action
       expect(org_dashboard_page).not_to have_add_inventory_call_to_action
 
-      # After we create a partner, ensure that we are on step 2 (Partner Agency)
-      create(:partner, organization: organization)
+      # After we create a storage, ensure that we are on step 2 (Partner Agency)
+      create(:storage_location, organization: organization)
       org_dashboard_page.visit
 
       expect(org_dashboard_page).to     have_getting_started_guide
-      expect(org_dashboard_page).not_to have_add_partner_call_to_action
-      expect(org_dashboard_page).to     have_add_storage_location_call_to_action
+      expect(org_dashboard_page).to     have_add_partner_call_to_action
+      expect(org_dashboard_page).not_to have_add_storage_location_call_to_action
       expect(org_dashboard_page).not_to have_add_donation_site_call_to_action
       expect(org_dashboard_page).not_to have_add_inventory_call_to_action
 
-      # After we create a storage location, ensure that we are on step 3 (Donation Site)
-      create(:storage_location, organization: organization)
+      # After we create a partner agency, ensure that we are on step 3 (Donation Site)
+      create(:partner, organization: organization)
       org_dashboard_page.visit
 
       expect(org_dashboard_page).to     have_getting_started_guide

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
       # rubocop:disable Layout/ExtraSpacing
 
-      # When dashboard loads, ensure that we are on step 1 (Partner Agencies)
+      # When dashboard loads, ensure that we are on step 1 (Storage Locations)
       expect(org_dashboard_page).to     have_getting_started_guide
-      expect(org_dashboard_page).to     have_add_partner_call_to_action
-      expect(org_dashboard_page).not_to have_add_storage_location_call_to_action
+      expect(org_dashboard_page).to     have_add_storage_location_call_to_action
+      expect(org_dashboard_page).not_to have_add_partner_call_to_action
       expect(org_dashboard_page).not_to have_add_donation_site_call_to_action
       expect(org_dashboard_page).not_to have_add_inventory_call_to_action
 
-      # After we create a partner, ensure that we are on step 2 (Storage Locations)
+      # After we create a partner, ensure that we are on step 2 (Partner Agency)
       create(:partner, organization: organization)
       org_dashboard_page.visit
 

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
       expect(org_dashboard_page).not_to have_add_donation_site_call_to_action
       expect(org_dashboard_page).not_to have_add_inventory_call_to_action
 
-      # After we create a storage, ensure that we are on step 2 (Partner Agency)
+      # After we create a storage location, ensure that we are on step 2 (Partner Agency)
       create(:storage_location, organization: organization)
       org_dashboard_page.visit
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4474

### Description
This PR changes the order of the bank onboarding process so that we start with the storage locations and then we move to partners. 
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?
1. I have tested this locally by siging in to a (newly seeded) local copy as [org_admin2@example.com](mailto:org_admin2@example.com)
2. With my current changes you should start the bank onboarding process with step 1 being storage locations. Once you fill in the details the next step will be partners and you can use the new storage you created. 
3. I continued until the final step and the onboarding continues to work. 
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots for style changes, highlight edited element.-->
### New changes showing step 1
![Screenshot 2024-07-08 at 8 21 11 PM](https://github.com/rubyforgood/human-essentials/assets/22033020/de6a408b-bb6a-4ccb-aaef-0e3a07dce814)

### After filling out storage location 
![Screenshot 2024-07-08 at 8 21 59 PM](https://github.com/rubyforgood/human-essentials/assets/22033020/4fbf780d-2b43-4d38-8191-a3e60a91ef45)

### After filing out partner agency
![Screenshot 2024-07-08 at 8 23 54 PM](https://github.com/rubyforgood/human-essentials/assets/22033020/59409e35-fb17-42f3-8a1c-82d4ff937a58)

