### PR TITLE
[WIP] #4398: Support units in requests

### DIFF
--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -12,6 +12,10 @@ module Partners
       @partner_request.item_requests.build
 
       @requestable_items = PartnerFetchRequestableItemsService.new(partner_id: current_partner.id).call
+      # hash of (item ID => hash of (request unit name => request unit plural name))
+      @item_units = current_partner.organization.items.to_h do |i|
+        [i.id, i.request_units.to_h { |u| [u.name, u.name.pluralize] }]
+      end
     end
 
     def show
@@ -44,7 +48,7 @@ module Partners
     private
 
     def partner_request_params
-      params.require(:request).permit(:comments, item_requests_attributes: [:item_id, :quantity])
+      params.require(:request).permit(:comments, item_requests_attributes: [:item_id, :quantity, :request_unit])
     end
   end
 end

--- a/app/javascript/controllers/item_units_controller.js
+++ b/app/javascript/controllers/item_units_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="form-input"
+export default class extends Controller {
+  static targets = ["itemSelect", "requestSelect"]
+  static values = {
+    // hash of (item ID => hash of (request unit name => request unit plural name))
+    "itemUnits": Object
+  }
+
+  addOption(val, text, selected) {
+    let option = document.createElement("option");
+    option.value = val;
+    option.text = text;
+    if (selected) {
+      option.selected = true;
+    }
+    this.requestSelectTarget.appendChild(option);
+  }
+
+  clearOptions() {
+    while (this.requestSelectTarget.options.length > 0) {
+      this.requestSelectTarget.remove(this.requestSelectTarget.options[0])
+    }
+  }
+
+  itemSelected() {
+    if (!this.hasRequestSelectTarget) {
+      return;
+    }
+    let option = this.itemSelectTarget.options[this.itemSelectTarget.selectedIndex]
+    let units = this.itemUnitsValue[option.value]
+    this.clearOptions()
+    this.addOption('', 'Units')
+    for (const [index, [name, displayName]] of Object.entries(Object.entries(units))) {
+      this.addOption(name, displayName, index === "0")
+    }
+  }
+
+}

--- a/app/javascript/controllers/item_units_controller.js
+++ b/app/javascript/controllers/item_units_controller.js
@@ -24,16 +24,26 @@ export default class extends Controller {
     }
   }
 
+  connect() {
+    this.itemSelected();
+  }
+
   itemSelected() {
     if (!this.hasRequestSelectTarget) {
       return;
     }
     let option = this.itemSelectTarget.options[this.itemSelectTarget.selectedIndex]
     let units = this.itemUnitsValue[option.value]
-    this.clearOptions()
-    this.addOption('', 'Units')
-    for (const [index, [name, displayName]] of Object.entries(Object.entries(units))) {
-      this.addOption(name, displayName, index === "0")
+    if (!units || Object.keys(units).length === 0) {
+      this.requestSelectTarget.style.display = 'none';
+    }
+    else {
+      this.requestSelectTarget.style.display = 'inline';
+      this.clearOptions()
+      this.addOption('', 'Units')
+      for (const [index, [name, displayName]] of Object.entries(Object.entries(units))) {
+        this.addOption(name, displayName, index === "0")
+      }
     }
   }
 

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -71,6 +71,7 @@ module Partners
         else
           items[input_item['item_id']] = Partners::ItemRequest.new(
             item_id: input_item['item_id'],
+            request_unit: input_item['request_unit'],
             quantity: input_item['quantity'],
             children: input_item['children'] || [], # will create ChildItemRequests if there are any
             name: fetch_organization_item_name(input_item['item_id']),

--- a/app/views/partners/requests/_item_request.html.erb
+++ b/app/views/partners/requests/_item_request.html.erb
@@ -1,13 +1,25 @@
 <%= form.fields_for :item_requests, defined?(object) ? object : nil  do |field| %>
-  <tr>
+  <tr data-controller="item-units" data-item-units-item-units-value="<%= item_units.to_json %>">
     <td>
       <%= field.label :item_id, "Item Requested", {class: 'sr-only'} %>
-      <%= field.select :item_id, @requestable_items, {include_blank: 'Select an item'}, {class: 'form-control'} %>
+      <%= field.select :item_id, @requestable_items, {include_blank: 'Select an item'},
+                       data: { :'item-units-target' => 'itemSelect',
+                               action: 'change->item-units#itemSelected',
+                               class: 'form-control' } %>
     </td>
     <td>
       <%= field.label :quantity, "Quantity", {class: 'sr-only'} %>
       <%= field.number_field :quantity, label: false, step: 1, min: 1, class: 'form-control' %>
     </td>
+
+    <% if current_partner.organization.request_units.any? %>
+      <td>
+        <%= field.label :request_unit, "Unit", {class: 'sr-only'} %>
+        <%= field.select :request_unit, [], {include_blank: 'Units'},
+                         { :'data-item-units-target' => 'requestSelect', class: 'form-control'} %>
+
+      </td>
+    <% end %>
     <td>
       <%= remove_element_button "Remove", container_selector: "tr" %>
     </td>

--- a/app/views/partners/requests/_item_request.html.erb
+++ b/app/views/partners/requests/_item_request.html.erb
@@ -4,8 +4,8 @@
       <%= field.label :item_id, "Item Requested", {class: 'sr-only'} %>
       <%= field.select :item_id, @requestable_items, {include_blank: 'Select an item'},
                        data: { :'item-units-target' => 'itemSelect',
-                               action: 'change->item-units#itemSelected',
-                               class: 'form-control' } %>
+                               action: 'change->item-units#itemSelected'},
+                               class: 'form-control' %>
     </td>
     <td>
       <%= field.label :quantity, "Quantity", {class: 'sr-only'} %>

--- a/app/views/partners/requests/new.html.erb
+++ b/app/views/partners/requests/new.html.erb
@@ -39,15 +39,18 @@
                 <tr>
                   <th>Item Requested</th>
                   <th>Quantity</th>
+                  <% if current_partner.organization.request_units.any? %>
+                    <th>Units (if applicable)</th>
+                  <% end %>
                 </tr>
                 </thead>
                 <tbody class='fields'>
-                  <%= render 'item_request', form: form %>
+                  <%= render partial: 'item_request', locals: { form: form, item_units: @item_units } %>
                 </tbody>
               </table>
               <div>
                 <%= add_element_button('Add Another Item', container_selector: '.fields') do %>
-                  <%= render 'item_request', form: form, object: @partner_request.item_requests.build %>
+                  <%= render partial: 'item_request', locals: { form: form, item_units: @item_units }, object: @partner_request.item_requests.build %>
                 <% end %>
               </div>
 

--- a/db/migrate/20240704214509_backfill_partner_child_requested_items.rb
+++ b/db/migrate/20240704214509_backfill_partner_child_requested_items.rb
@@ -1,5 +1,7 @@
 class BackfillPartnerChildRequestedItems < ActiveRecord::Migration[7.1]
   def change
+    return unless Rails.env.production?
+
     Partners::Child.unscoped.where.not(item_needed_diaperid: nil).each do |child|
       child.requested_items << Item.find_by(id: child.item_needed_diaperid)
     end


### PR DESCRIPTION
Resolves #4398 <!--fill issue number-->

### Description
This shows a Units field if the partner's organization has any custom request units.

If the selected item has any request units, the Unit drop-down is shown and the first custom request unit is selected. Otherwise, the drop-down is not shown.

If the enable_packs flag is off, no behavior change is shown.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Local testing. Still needs specs created.

### Screenshots

<img width="1186" alt="image" src="https://github.com/user-attachments/assets/54a7182b-50bc-4397-ae1e-e4ad0a9811a9">
