### PR TITLE
fix: fix migration for prod data

### DIFF
--- a/db/migrate/20240704214509_backfill_partner_child_requested_items.rb
+++ b/db/migrate/20240704214509_backfill_partner_child_requested_items.rb
@@ -1,7 +1,13 @@
 class BackfillPartnerChildRequestedItems < ActiveRecord::Migration[7.1]
-  def change
-    Partners::Child.unscoped.where.not(item_needed_diaperid: nil).each do |child|
-      child.requested_items << Item.find_by(id: child.item_needed_diaperid)
+  def up
+    safety_assured do
+      execute <<-SQL
+      INSERT INTO children_items (child_id, item_id)
+      SELECT children.id, items.id
+      FROM children
+      LEFT JOIN items ON children.item_needed_diaperid = items.id
+      WHERE items.id IS NOT NULL AND children.item_needed_diaperid IS NOT NULL
+      SQL
     end
   end
 end


### PR DESCRIPTION
Fixes #3797 

Prod had some bad data that caused the migration to fail since it would attempt to create requested items where those items no longer existed.