### PR TITLE
Remove implicit rails_helper require

### DIFF
--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -1,5 +1,4 @@
 =begin
-require "rails_helper"
 
 RSpec.describe AdminsController, type: :controller do
   let(:organization) { create(:organization) }

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe HelpController, type: :controller do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe ApplicationHelper, type: :helper do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/helpers/product_drive_helper_spec.rb
+++ b/spec/helpers/product_drive_helper_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe ProductDriveHelper, type: :helper do
   describe '#is_virtual' do
     context 'when the product drive was held virtually' do

--- a/spec/helpers/purchases_helper_spec.rb
+++ b/spec/helpers/purchases_helper_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe PurchasesHelper, type: :helper do
   describe "#new_purchase_default_location" do
     helper do

--- a/spec/helpers/ui_helper_spec.rb
+++ b/spec/helpers/ui_helper_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe UiHelper, type: :helper do
   describe 'optional_data_text' do
     subject { helper.optional_data_text(field) }

--- a/spec/jobs/historical_data_cache_job_spec.rb
+++ b/spec/jobs/historical_data_cache_job_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe HistoricalDataCacheJob, type: :job do
   include ActiveJob::TestHelper
 

--- a/spec/jobs/reminder_deadline_job_spec.rb
+++ b/spec/jobs/reminder_deadline_job_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ReminderDeadlineJob, type: :job do
   describe '#perform' do
     subject { -> { described_class.perform_now } }

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -15,7 +15,6 @@
 #  updated_at           :datetime         not null
 #  ndbn_member_id       :bigint
 #
-require 'rails_helper'
 
 RSpec.describe AccountRequest, type: :model do
   let(:account_request) { create(:account_request) }

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -12,8 +12,6 @@
 #  user_id             :bigint
 #
 
-require 'rails_helper'
-
 RSpec.describe Audit, type: :model do
   let(:organization) { create(:organization) }
 

--- a/spec/models/base_item_spec.rb
+++ b/spec/models/base_item_spec.rb
@@ -13,8 +13,6 @@
 #  updated_at    :datetime         not null
 #
 
-require "rails_helper"
-
 RSpec.describe BaseItem, type: :model do
   let(:organization) { create(:organization) }
 

--- a/spec/models/broadcast_announcement_spec.rb
+++ b/spec/models/broadcast_announcement_spec.rb
@@ -11,7 +11,6 @@
 #  organization_id :bigint
 #  user_id         :bigint           not null
 #
-require "rails_helper"
 
 RSpec.describe BroadcastAnnouncement, type: :model do
   it { should belong_to(:organization).optional }

--- a/spec/models/concerns/deadlinable_spec.rb
+++ b/spec/models/concerns/deadlinable_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Deadlinable, type: :model do
   let(:dummy_class) do
     Class.new do

--- a/spec/models/county_spec.rb
+++ b/spec/models/county_spec.rb
@@ -9,7 +9,6 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
-require "rails_helper"
 
 RSpec.describe County, type: :model do
   it { should have_many(:served_areas) }

--- a/spec/models/item_category_spec.rb
+++ b/spec/models/item_category_spec.rb
@@ -9,7 +9,6 @@
 #  updated_at      :datetime         not null
 #  organization_id :integer          not null
 #
-require 'rails_helper'
 
 RSpec.describe ItemCategory, type: :model do
   describe 'validations' do

--- a/spec/models/kit_allocation_spec.rb
+++ b/spec/models/kit_allocation_spec.rb
@@ -10,7 +10,6 @@
 #  organization_id     :bigint           not null
 #  storage_location_id :bigint           not null
 #
-require "rails_helper"
 
 RSpec.describe KitAllocation, type: :model do
   describe "versioning" do

--- a/spec/models/kit_spec.rb
+++ b/spec/models/kit_spec.rb
@@ -11,7 +11,6 @@
 #  updated_at          :datetime         not null
 #  organization_id     :integer          not null
 #
-require 'rails_helper'
 
 RSpec.describe Kit, type: :model do
   let(:organization) { create(:organization) }

--- a/spec/models/manufacturer_spec.rb
+++ b/spec/models/manufacturer_spec.rb
@@ -9,8 +9,6 @@
 #  organization_id :bigint
 #
 
-require "rails_helper"
-
 RSpec.describe Manufacturer, type: :model do
   context "Validations" do
     subject { build(:manufacturer) }

--- a/spec/models/ndbn_member_spec.rb
+++ b/spec/models/ndbn_member_spec.rb
@@ -7,7 +7,6 @@
 #  updated_at     :datetime         not null
 #  ndbn_member_id :bigint           not null, primary key
 #
-require "rails_helper"
 
 RSpec.describe NDBNMember, type: :model do
   describe "validations" do

--- a/spec/models/partners/authorized_family_member_spec.rb
+++ b/spec/models/partners/authorized_family_member_spec.rb
@@ -12,7 +12,6 @@
 #  updated_at    :datetime         not null
 #  family_id     :bigint
 #
-require "rails_helper"
 
 RSpec.describe Partners::AuthorizedFamilyMember, type: :model do
   describe 'associations' do

--- a/spec/models/partners/child_item_request_spec.rb
+++ b/spec/models/partners/child_item_request_spec.rb
@@ -12,7 +12,6 @@
 #  child_id                    :bigint
 #  item_request_id             :bigint
 #
-require 'rails_helper'
 
 RSpec.describe Partners::ChildItemRequest, type: :model do
   describe 'associations' do

--- a/spec/models/partners/child_spec.rb
+++ b/spec/models/partners/child_spec.rb
@@ -19,7 +19,6 @@
 #  agency_child_id      :string
 #  family_id            :bigint
 #
-require "rails_helper"
 
 RSpec.describe Partners::Child, type: :model do
   describe 'associations' do

--- a/spec/models/partners/family_request_spec.rb
+++ b/spec/models/partners/family_request_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Partners::FamilyRequest do
   describe "Partners::FamilyRequest.new_with_attrs" do
     it "creates a new FamilyRequest with attributes" do

--- a/spec/models/partners/family_spec.rb
+++ b/spec/models/partners/family_spec.rb
@@ -26,8 +26,6 @@
 #  partner_id                :bigint
 #
 
-require "rails_helper"
-
 RSpec.describe Partners::Family, type: :model do
   describe "associations" do
     it { should belong_to(:partner) }

--- a/spec/models/partners/item_request_spec.rb
+++ b/spec/models/partners/item_request_spec.rb
@@ -13,7 +13,6 @@
 #  old_partner_request_id :integer
 #  partner_request_id     :bigint
 #
-require "rails_helper"
 
 RSpec.describe Partners::ItemRequest, type: :model do
   let(:organization) { create(:organization) }

--- a/spec/models/partners/profile_spec.rb
+++ b/spec/models/partners/profile_spec.rb
@@ -79,7 +79,6 @@
 #  essentials_bank_id             :bigint
 #  partner_id                     :integer
 #
-require "rails_helper"
 
 RSpec.describe Partners::Profile, type: :model do
   describe "associations" do

--- a/spec/models/partners/served_area_spec.rb
+++ b/spec/models/partners/served_area_spec.rb
@@ -9,7 +9,6 @@
 #  county_id          :bigint           not null
 #  partner_profile_id :bigint           not null
 #
-require "rails_helper"
 
 RSpec.describe Partners::ServedArea, type: :model do
   it { should belong_to(:partner_profile) }

--- a/spec/models/product_drive_participant_spec.rb
+++ b/spec/models/product_drive_participant_spec.rb
@@ -16,8 +16,6 @@
 #  organization_id :integer
 #
 
-require "rails_helper"
-
 RSpec.describe ProductDriveParticipant, type: :model do
   it_behaves_like "provideable"
 

--- a/spec/models/product_drive_spec.rb
+++ b/spec/models/product_drive_spec.rb
@@ -12,8 +12,6 @@
 #  organization_id :bigint
 #
 
-require "rails_helper"
-
 RSpec.describe ProductDrive, type: :model do
   let(:organization) { create(:organization) }
   let(:product_drive) { create(:product_drive, organization: organization) }

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -9,7 +9,6 @@
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
-require "rails_helper"
 
 RSpec.describe Question, type: :model do
   describe "scope for_partners" do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -10,7 +10,6 @@
 #  old_resource_id :bigint
 #  resource_id     :bigint
 #
-require "rails_helper"
 
 RSpec.describe Role, type: :model do
   describe "Validations" do

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -16,8 +16,6 @@
 #  organization_id :integer
 #
 
-require "rails_helper"
-
 RSpec.describe Vendor, type: :model do
   it_behaves_like "provideable"
 

--- a/spec/requests/account_requests_spec.rb
+++ b/spec/requests/account_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "/account_requests", type: :request do
   describe "GET #new" do
     it "renders a successful response" do

--- a/spec/requests/adjustments_requests_spec.rb
+++ b/spec/requests/adjustments_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Adjustments", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/admin/account_requests_requests_spec.rb
+++ b/spec/requests/admin/account_requests_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Admin::AccountRequestsController', type: :request do
   let(:organization) { create(:organization) }
 

--- a/spec/requests/admin/barcode_items_requests_spec.rb
+++ b/spec/requests/admin/barcode_items_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Admin::BarcodeItemsController', type: :request do
   let(:organization) { create(:organization) }
 

--- a/spec/requests/admin/base_items_requests_spec.rb
+++ b/spec/requests/admin/base_items_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Admin::BaseItems", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/admin/broadcast_announcements_spec.rb
+++ b/spec/requests/admin/broadcast_announcements_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "BroadcastAnnouncements", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:super_admin, organization: organization) }

--- a/spec/requests/admin/ndbn_members_spec.rb
+++ b/spec/requests/admin/ndbn_members_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "NDBNMembers", type: :request do
   let(:user) { create(:super_admin) }
 

--- a/spec/requests/admin/partners_requests_spec.rb
+++ b/spec/requests/admin/partners_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Admin::Partners", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/admin/questions_spec.rb
+++ b/spec/requests/admin/questions_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Admin::Questions", type: :request do
   context "while signed in as a super admin" do
     before do

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Admin::UsersController", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/audits_requests_spec.rb
+++ b/spec/requests/audits_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Audits", type: :request do
   let(:organization) { create(:organization) }
   let(:organization_admin) { create(:organization_admin, organization: organization) }

--- a/spec/requests/broadcast_announcements_spec.rb
+++ b/spec/requests/broadcast_announcements_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "BroadcastAnnouncements", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/dashboard_requests_spec.rb
+++ b/spec/requests/dashboard_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Dashboard", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/distributions_by_county_spec.rb
+++ b/spec/requests/distributions_by_county_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "DistributionsByCounties", type: :request do
   include_examples "distribution_by_county"
 

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Distributions", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/donation_sites_requests_spec.rb
+++ b/spec/requests/donation_sites_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "DonationSites", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Donations", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/events_requests_spec.rb
+++ b/spec/requests/events_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Events", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:organization_admin, organization: organization) }

--- a/spec/requests/item_categories_requests_spec.rb
+++ b/spec/requests/item_categories_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "ItemCategories", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Items", type: :request do
   let(:organization) { create(:organization, short_name: "my_org") }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/kit_requests_spec.rb
+++ b/spec/requests/kit_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "/kits", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Organizations", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -1,7 +1,5 @@
 # spec/requests/partner_users_controller_spec.rb
 
-require "rails_helper"
-
 RSpec.describe PartnerUsersController, type: :request do
   let!(:partner) { create(:partner) } # Assuming you have a factory for creating partners
   let!(:user) { create(:user) } # Assuming you have a factory for creating users

--- a/spec/requests/partners/children_requests_spec.rb
+++ b/spec/requests/partners/children_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "/partners/children", type: :request do
   let(:partner_user) { partner.primary_user }
   let(:partner) { create(:partner) }

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "/partners/dashboard", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/partners/distributions_spec.rb
+++ b/spec/requests/partners/distributions_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "/partners/distributions", type: :request do
   let(:partner) { create(:partner) }
   let(:partner_user) { partner.primary_user }

--- a/spec/requests/partners/family_requests_controller_spec.rb
+++ b/spec/requests/partners/family_requests_controller_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Partners::FamilyRequestsController, type: :request do
   let(:partner) { create(:partner) }
   let(:params) do

--- a/spec/requests/partners/family_requests_spec.rb
+++ b/spec/requests/partners/family_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "/partners/family", type: :request do
   let(:partner_user) { partner.primary_user }
   let(:partner) { create(:partner) }

--- a/spec/requests/partners/individuals_requests_controller_spec.rb
+++ b/spec/requests/partners/individuals_requests_controller_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Partners::IndividualsRequestsController, type: :request do
   let(:organization) { create(:organization, :with_items) }
   let(:partner) { create(:partner, status: :approved, organization: organization) }

--- a/spec/requests/partners/profiles_requests_county_spec.rb
+++ b/spec/requests/partners/profiles_requests_county_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "/partners/profiles", type: :request do
   describe "basic" do
     let(:organization) { create(:organization, name: "Favourite Bank", partner_form_fields: []) }

--- a/spec/requests/partners/profiles_requests_spec.rb
+++ b/spec/requests/partners/profiles_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "/partners/profiles", type: :request do
   let(:partner) { create(:partner, name: "Partnerrific") }
   let(:partner_user) { partner.primary_user }

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "/partners/requests", type: :request do
   let(:organization) { create(:organization) }
   let(:partner) { create(:partner, organization: organization) }

--- a/spec/requests/partners/user_requests_spec.rb
+++ b/spec/requests/partners/user_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "/partners/users", type: :request do
   let(:partner) { create(:partner) }
   let(:partner_user) { partner.primary_user }

--- a/spec/requests/product_drive_participants_requests_spec.rb
+++ b/spec/requests/product_drive_participants_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "ProductDriveParticipants", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "ProductDrives", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Purchases", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/activity_graph_spec.rb
+++ b/spec/requests/reports/activity_graph_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Reports::ActivityGraph", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/annual_reports_requests_spec.rb
+++ b/spec/requests/reports/annual_reports_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Annual Reports", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/distributions_summary_requests_spec.rb
+++ b/spec/requests/reports/distributions_summary_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Distributions", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/donations_summary_spec.rb
+++ b/spec/requests/reports/donations_summary_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Reports::DonationsSummary", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/itemized_distributions_spec.rb
+++ b/spec/requests/reports/itemized_distributions_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Reports::ItemizedDistributions", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/itemized_donations_spec.rb
+++ b/spec/requests/reports/itemized_donations_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Reports::ItemizedDonations", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/manufacturer_donations_summary_spec.rb
+++ b/spec/requests/reports/manufacturer_donations_summary_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Reports::ManufacturerDonationsSummary", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/product_drives_summary_spec.rb
+++ b/spec/requests/reports/product_drives_summary_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Reports::ProductDrivesSummary", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/reports/purchases_summary_requests_spec.rb
+++ b/spec/requests/reports/purchases_summary_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Purchases", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Requests', type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/sessions_requests_spec.rb
+++ b/spec/requests/sessions_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Sessions", type: :request, order: :defined do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/static_requests_spec.rb
+++ b/spec/requests/static_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Static", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/requests/users/omniauth_callbacks_requests_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Users - Omniauth Callbacks", type: :request do
   before do
     Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]

--- a/spec/requests/users_requests_spec.rb
+++ b/spec/requests/users_requests_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Users", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }

--- a/spec/routing/account_requests_routing_spec.rb
+++ b/spec/routing/account_requests_routing_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe AccountRequestsController, type: :routing do
   describe "routing" do
     it "routes to #new" do

--- a/spec/services/distribution_destroy_service_spec.rb
+++ b/spec/services/distribution_destroy_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe DistributionDestroyService do
   describe '#call' do
     subject { described_class.new(distribution_id).call }

--- a/spec/services/donation_destroy_service_spec.rb
+++ b/spec/services/donation_destroy_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe DonationDestroyService do
   describe '#call' do
     subject { described_class.new(organization_id: organization_id, donation_id: donation_id) }

--- a/spec/services/exports/export_report_csv_service_spec.rb
+++ b/spec/services/exports/export_report_csv_service_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Exports::ExportReportCSVService do
   describe ".generate_csv_data" do
     it "creates CSV data including headers" do

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Exports::ExportRequestService do
   let(:org) { create(:organization) }
 

--- a/spec/services/historical_trend_service_spec.rb
+++ b/spec/services/historical_trend_service_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe HistoricalTrendService, type: :service do
   let(:organization) { create(:organization) }
   let(:type) { "Donation" }

--- a/spec/services/kit_create_service_spec.rb
+++ b/spec/services/kit_create_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe KitCreateService do
   describe '#call' do
     subject { described_class.new(**args).call }

--- a/spec/services/organization_update_service_spec.rb
+++ b/spec/services/organization_update_service_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe OrganizationUpdateService do
   let(:organization) { create(:organization) }
 

--- a/spec/services/partner_approval_service_spec.rb
+++ b/spec/services/partner_approval_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe PartnerApprovalService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }

--- a/spec/services/partner_create_service_spec.rb
+++ b/spec/services/partner_create_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe PartnerCreateService do
   describe '#call' do
     subject { described_class.new(organization: organization, partner_attrs: partner_attrs).call }

--- a/spec/services/partner_fetch_requestable_items_service_spec.rb
+++ b/spec/services/partner_fetch_requestable_items_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe PartnerFetchRequestableItemsService do
   describe '#call' do
     subject { described_class.new(partner_id: partner.id).call }

--- a/spec/services/partner_invite_service_spec.rb
+++ b/spec/services/partner_invite_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe PartnerInviteService do
   subject { described_class.new(partner: partner).call }
   let(:partner) { create(:partner) }

--- a/spec/services/partner_profile_update_service_spec.rb
+++ b/spec/services/partner_profile_update_service_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe PartnerProfileUpdateService do
   let(:county_1) { create(:county, name: "county1", region: "region1") }
   let(:county_2) { create(:county, name: "county2", region: "region2") }

--- a/spec/services/partner_request_recertification_service_spec.rb
+++ b/spec/services/partner_request_recertification_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe PartnerRequestRecertificationService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }

--- a/spec/services/partners/family_request_create_service_spec.rb
+++ b/spec/services/partners/family_request_create_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Partners::FamilyRequestCreateService do
   describe '#call' do
     subject { described_class.new(**args).call }

--- a/spec/services/partners/fetch_partners_to_remind_now_service_spec.rb
+++ b/spec/services/partners/fetch_partners_to_remind_now_service_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Partners::FetchPartnersToRemindNowService do
   describe ".fetch" do
     subject { described_class.new.fetch }

--- a/spec/services/partners/request_approval_service_spec.rb
+++ b/spec/services/partners/request_approval_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Partners::RequestApprovalService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Partners::RequestCreateService do
   describe '#call' do
     subject { described_class.new(**args).call }

--- a/spec/services/partners/update_family_spec.rb
+++ b/spec/services/partners/update_family_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Partners::UpdateFamily do
   describe "#call" do
     subject { described_class.archive(family) }

--- a/spec/services/profile_update_service_spec.rb
+++ b/spec/services/profile_update_service_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe ProfileUpdateService do
   describe "#update" do
     let(:partner) { create(:partner, name: "Partnerrific") }

--- a/spec/services/service_object_errors_mixin_spec.rb
+++ b/spec/services/service_object_errors_mixin_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ServiceObjectErrorsMixin do
   describe 'self.included' do
     before do

--- a/spec/services/text_interpolator_service_spec.rb
+++ b/spec/services/text_interpolator_service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe TextInterpolatorService, type: :service do
   describe '#call' do
     subject { described_class.new(text, interpolations).call }


### PR DESCRIPTION
While doing another code-review, we noticed that a lot of specs unnecessarily `require 'rails_helper'`. This removes all of those.