### PR TITLE
Resolves #4537 fix storage location when total inventory is 0

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -176,7 +176,7 @@ class DistributionsController < ApplicationController
       if Event.read_events?(current_organization)
         inventory = View::Inventory.new(@distribution.organization_id)
         @storage_locations = current_organization.storage_locations.active_locations.alphabetized.select do |storage_loc|
-          inventory.quantity_for(storage_location: storage_loc.id).positive?
+          !inventory.quantity_for(storage_location: storage_loc.id).negative?
         end
       else
         @storage_locations = current_organization.storage_locations.active_locations.has_inventory_items.alphabetized


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4537 <!--fill issue number-->

### Description
Fixes so that you can see original storage location of a distribution when storage location's total inventory is 0
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Passes test suite
Manual testing
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
<img width="747" alt="image" src="https://github.com/user-attachments/assets/b78234de-4f36-427b-86c9-0317ea09c05c">
