### PR TITLE
3052 partner confirmation

### DIFF
--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -38,7 +38,7 @@ module Partners
         partner_user_id: current_user.id,
         family_requests_attributes: family_requests_attributes,
         for_families: true
-      ).create_only
+      ).initialize_only
       if @partner_request.valid?
         @total_items = @partner_request.total_items_fromstr
         @quota_exceeded = current_partner.quota_exceeded?(@total_items)

--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -40,7 +40,7 @@ module Partners
         for_families: true
       ).initialize_only
       if @partner_request.valid?
-        @total_items = @partner_request.total_items_fromstr
+        @total_items = @partner_request.total_items
         @quota_exceeded = current_partner.quota_exceeded?(@total_items)
         body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
         render json: {valid: true, body: body}

--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -68,6 +68,8 @@ module Partners
         for_families: true
       ).create_only
       if @partner_request.valid?
+        @total_items = @partner_request.total_items_fromstr
+        @quota_exceeded = @total_items > current_partner.quota.to_i
         body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
         render json: {valid: true, body: body}
       else

--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -39,6 +39,8 @@ module Partners
         family_requests_attributes: individuals_request_params[:items_attributes]&.values
       ).create_only
       if @partner_request.valid?
+        @total_items = @partner_request.total_items_fromstr
+        @quota_exceeded = @total_items > current_partner.quota.to_i
         body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
         render json: {valid: true, body: body}
       else

--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -39,7 +39,7 @@ module Partners
         family_requests_attributes: individuals_request_params[:items_attributes]&.values
       ).initialize_only
       if @partner_request.valid?
-        @total_items = @partner_request.total_items_fromstr
+        @total_items = @partner_request.total_items
         @quota_exceeded = current_partner.quota_exceeded?(@total_items)
         body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
         render json: {valid: true, body: body}

--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -32,6 +32,20 @@ module Partners
       end
     end
 
+    def validate
+      @partner_request = Partners::FamilyRequestCreateService.new(
+        partner_user_id: current_user.id,
+        comments: individuals_request_params[:comments],
+        family_requests_attributes: individuals_request_params[:items_attributes]&.values
+      ).create_only
+      if @partner_request.valid?
+        body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
+        render json: {valid: true, body: body}
+      else
+        render json: {valid: false}
+      end
+    end
+
     private
 
     def individuals_request_params

--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -37,7 +37,7 @@ module Partners
         partner_user_id: current_user.id,
         comments: individuals_request_params[:comments],
         family_requests_attributes: individuals_request_params[:items_attributes]&.values
-      ).create_only
+      ).initialize_only
       if @partner_request.valid?
         @total_items = @partner_request.total_items_fromstr
         @quota_exceeded = current_partner.quota_exceeded?(@total_items)

--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -40,7 +40,7 @@ module Partners
       ).create_only
       if @partner_request.valid?
         @total_items = @partner_request.total_items_fromstr
-        @quota_exceeded = @total_items > current_partner.quota.to_i
+        @quota_exceeded = current_partner.quota_exceeded?(@total_items)
         body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
         render json: {valid: true, body: body}
       else

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -46,7 +46,7 @@ module Partners
         partner_user_id: current_user.id,
         comments: partner_request_params[:comments],
         item_requests_attributes: partner_request_params[:item_requests_attributes]&.values || []
-      ).create_only
+      ).initialize_only
 
       if @partner_request.valid?
         @total_items = @partner_request.total_items_fromstr

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -50,7 +50,7 @@ module Partners
 
       if @partner_request.valid?
         @total_items = @partner_request.total_items_fromstr
-        @quota_exceeded = @total_items > current_partner.quota.to_i
+        @quota_exceeded = current_partner.quota_exceeded?(@total_items)
         body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
         render json: {valid: true, body: body}
       else

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -41,6 +41,21 @@ module Partners
       end
     end
 
+    def validate
+      @partner_request = Partners::RequestCreateService.new(
+        partner_user_id: current_user.id,
+        comments: partner_request_params[:comments],
+        item_requests_attributes: partner_request_params[:item_requests_attributes]&.values || []
+      ).create_only
+
+      if @partner_request.valid?
+        body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
+        render json: {valid: true, body: body}
+      else
+        render json: {valid: false}
+      end
+    end
+
     private
 
     def partner_request_params

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -49,6 +49,8 @@ module Partners
       ).create_only
 
       if @partner_request.valid?
+        @total_items = @partner_request.total_items_fromstr
+        @quota_exceeded = @total_items > current_partner.quota.to_i
         body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
         render json: {valid: true, body: body}
       else

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -49,7 +49,7 @@ module Partners
       ).initialize_only
 
       if @partner_request.valid?
-        @total_items = @partner_request.total_items_fromstr
+        @total_items = @partner_request.total_items
         @quota_exceeded = current_partner.quota_exceeded?(@total_items)
         body = render_to_string(template: 'partners/requests/validate', formats: [:html], layout: false)
         render json: {valid: true, body: body}

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -250,6 +250,10 @@ class Partner < ApplicationRecord
     }
   end
 
+  def quota_exceeded?(total)
+    quota.present? && total > quota
+  end
+
   private
 
   def families_served_count

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -34,6 +34,8 @@ class Request < ApplicationRecord
 
   validates :distribution_id, uniqueness: true, allow_nil: true
   validate :item_requests_uniqueness_by_item_id
+  validate :not_completely_empty
+
   before_save :sanitize_items_data
 
   include Filterable
@@ -72,6 +74,12 @@ class Request < ApplicationRecord
 
     self.request_items = request_items.map do |item|
       item.merge("item_id" => item["item_id"]&.to_i, "quantity" => item["quantity"]&.to_i)
+    end
+  end
+
+  def not_completely_empty
+    if comments.blank? && item_requests.blank?
+      errors.add(:base, "completely empty request")
     end
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -56,6 +56,10 @@ class Request < ApplicationRecord
     request_items.sum { |item| item["quantity"] }
   end
 
+  def total_items_fromstr
+    request_items.sum { |item| item["quantity"].to_i }
+  end
+
   def user_email
     partner_user_id ? User.find_by(id: partner_user_id).email : Partner.find_by(id: partner_id).email
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -36,7 +36,7 @@ class Request < ApplicationRecord
   validate :item_requests_uniqueness_by_item_id
   validate :not_completely_empty
 
-  before_save :sanitize_items_data
+  after_validation :sanitize_items_data
 
   include Filterable
   # add request item scope to allow filtering distributions by request item
@@ -54,10 +54,6 @@ class Request < ApplicationRecord
 
   def total_items
     request_items.sum { |item| item["quantity"] }
-  end
-
-  def total_items_fromstr
-    request_items.sum { |item| item["quantity"].to_i }
   end
 
   def user_email

--- a/app/services/partners/family_request_create_service.rb
+++ b/app/services/partners/family_request_create_service.rb
@@ -39,6 +39,15 @@ module Partners
       self
     end
 
+    def create_only
+      Partners::RequestCreateService.new(
+        partner_user_id: partner_user_id,
+        comments: comments,
+        for_families: @for_families,
+        item_requests_attributes: item_requests_attributes
+      ).create_only
+    end
+
     private
 
     def valid?

--- a/app/services/partners/family_request_create_service.rb
+++ b/app/services/partners/family_request_create_service.rb
@@ -39,13 +39,13 @@ module Partners
       self
     end
 
-    def create_only
+    def initialize_only
       Partners::RequestCreateService.new(
         partner_user_id: partner_user_id,
         comments: comments,
         for_families: @for_families,
         item_requests_attributes: item_requests_attributes
-      ).create_only
+      ).initialize_only
     end
 
     private

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -44,6 +44,16 @@ module Partners
       self
     end
 
+    def create_only
+      partner_request = ::Request.new(partner_id: partner.id,
+        organization_id: organization_id,
+        comments: comments,
+        partner_user_id: partner_user_id)
+      partner_request = populate_item_request(partner_request)
+      partner_request.assign_attributes(additional_attrs)
+      partner_request
+    end
+
     private
 
     attr_reader :partner_user_id, :comments, :item_requests_attributes, :additional_attrs

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -40,7 +40,7 @@ module Partners
       self
     end
 
-    def create_only
+    def initialize_only
       partner_request = ::Request.new(partner_id: partner.id,
         organization_id: organization_id,
         comments: comments,

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -26,10 +26,6 @@ module Partners
         end
       end
 
-      if @partner_request.comments.blank? && @partner_request.item_requests.blank?
-        errors.add(:base, 'completely empty request')
-      end
-
       return self if errors.present?
 
       Request.transaction do

--- a/app/views/partners/family_requests/new.html.erb
+++ b/app/views/partners/family_requests/new.html.erb
@@ -69,8 +69,10 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-12">
-        <div class="card mb-4">
-          <%= form_with(url: partners_family_requests_path, method: 'post') do %>
+        <div class="card mb-4"
+          data-controller="confirmation"
+          data-confirmation-pre-check-path-value="<%= validate_partners_family_requests_path(format: :json) %>">
+          <%= form_with(url: partners_family_requests_path, method: 'post', data: { confirmation_target: "form" }) do |f| %>
             <div id="filterrific_results">
               <%= render(
                 partial: 'partners/family_requests/list',
@@ -81,10 +83,21 @@
             <hr>
 
             <div class="card-footer">
-              <%= submit_tag("Submit Essentials Request", class: "btn btn-success") %>
+              <%= submit_tag("Submit Essentials Request", class: "btn btn-success", data: { action: "click->confirmation#openModal" }) %>
               <%= link_to "Cancel Request", partners_requests_path, class: "btn btn-danger" %>
             </div>
           <% end %>
+
+          <%# Confirmation modal: See confirmation_controller.js for how this gets displayed %>
+          <%# and app/controllers/partners/family_requests_controller.rb#validate for how it gets populated. %>
+          <div id="partnerFamilyRequestConfirmationModal"
+            class="modal confirm"
+            aria-labelledby="partnerFamilyRequestConfirmationModal"
+            aria-hidden="true"
+            tabindex="-1"
+            data-bs-backdrop="static"
+            data-confirmation-target="modal">
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/partners/individuals_requests/new.html.erb
+++ b/app/views/partners/individuals_requests/new.html.erb
@@ -23,7 +23,9 @@
     <div class="row">
       <div class="col-md-12">
         <!-- Default box -->
-        <div class="card">
+        <div class="card"
+          data-controller="confirmation"
+          data-confirmation-pre-check-path-value="<%= validate_partners_individuals_requests_path(format: :json) %>">
           <div class="card-body">
 
             <% if @errors.present? %>
@@ -31,7 +33,7 @@
             <% end %>
 
             <%= simple_form_for @request, url: partners_individuals_requests_path, html: {role: 'form', class: 'form-horizontal'},
-              data: {controller: 'form-input'} do |form| %>
+              data: {controller: 'form-input', confirmation_target: "form"} do |form| %>
 
               <%= form.input :comments, label: "Comments:", as: :text, class: "form-control", wrapper: :input_group %>
 
@@ -58,10 +60,21 @@
 
               <div class="card-footer">
                 <!-- TODO(chaserx): we should add some js to prevent submission if the items selected are the blank option or any item has an empty quantity -->
-                <%= form.submit("Submit Essentials Request", class: "btn btn-success") %>
+                <%= form.submit("Submit Essentials Request", class: "btn btn-success", data: { action: "click->confirmation#openModal" }) %>
                 <%= link_to "Cancel Request", partners_requests_path, class: "btn btn-danger" %>
               </div>
             <% end %>
+
+          <%# Confirmation modal: See confirmation_controller.js for how this gets displayed %>
+          <%# and app/controllers/partners/individuals_requests_controller.rb#validate for how it gets populated. %>
+          <div id="partnerIndividualRequestConfirmationModal"
+            class="modal confirm"
+            aria-labelledby="partnerIndividualRequestConfirmationModal"
+            aria-hidden="true"
+            tabindex="-1"
+            data-bs-backdrop="static"
+            data-confirmation-target="modal">
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/partners/requests/new.html.erb
+++ b/app/views/partners/requests/new.html.erb
@@ -23,7 +23,9 @@
     <div class="row">
       <div class="col-md-12">
         <!-- Default box -->
-        <div class="card">
+        <div class="card"
+          data-controller="confirmation"
+          data-confirmation-pre-check-path-value="<%= validate_partners_requests_path(format: :json) %>">
           <div class="card-body">
 
             <% if @errors.present? %>
@@ -31,7 +33,7 @@
             <% end %>
 
             <%= simple_form_for @partner_request, url: partners_requests_path(@partner_request),
-              html: {role: 'form', class: 'form-horizontal'}, method: :post, data: { controller: 'form-input' } do |form| %>
+              html: {role: 'form', class: 'form-horizontal'}, method: :post, data: { controller: 'form-input', confirmation_target: "form" } do |form| %>
               <%= form.input :comments, label: "Comments:", as: :text, class: "form-control", wrapper: :input_group %>
 
               <table class='table'>
@@ -56,9 +58,20 @@
           </div>
               <div class="card-footer">
                 <!-- TODO(chaserx): we should add some js to prevent submission if the items selected are the blank option or any item has an empty quantity -->
-                <%= form.submit("Submit Essentials Request", class: "btn btn-success") %> <%= link_to "Cancel Request", partners_requests_path, class: "btn btn-danger" %>
+                <%= form.submit("Submit Essentials Request", class: "btn btn-success", data: { action: "click->confirmation#openModal" }) %> <%= link_to "Cancel Request", partners_requests_path, class: "btn btn-danger" %>
               </div>
             <% end %>
+
+          <%# Confirmation modal: See confirmation_controller.js for how this gets displayed %>
+          <%# and app/controllers/partners/requests_controller.rb#validate for how it gets populated. %>
+          <div id="partnerRequestConfirmationModal"
+            class="modal confirm"
+            aria-labelledby="partnerRequestConfirmationModal"
+            aria-hidden="true"
+            tabindex="-1"
+            data-bs-backdrop="static"
+            data-confirmation-target="modal">
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/partners/requests/validate.html.erb
+++ b/app/views/partners/requests/validate.html.erb
@@ -1,0 +1,34 @@
+<div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Request Confirmation</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Item Name</th>
+                <th>Total Items</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @partner_request.item_requests.each do |line_item| %>
+                <tr>
+                  <td><%= line_item.name %></td>
+                  <td><%= line_item.quantity %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+
+          <div class="message fs-5">
+            <p>Please confirm that the above list is what you meant to request.</p>
+          </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="No I need to make changes">No, I need to make changes</button>
+        <button type="button" class="btn btn-primary" data-action="confirmation#submitForm">Yes, it's correct</button>
+      </div>
+    </div>
+  </div>

--- a/app/views/partners/requests/validate.html.erb
+++ b/app/views/partners/requests/validate.html.erb
@@ -5,27 +5,40 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-          <table class="table">
-            <thead>
+        <%# Items and quantities %>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Item Name</th>
+              <th>Total Items</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @partner_request.item_requests.each do |line_item| %>
               <tr>
-                <th>Item Name</th>
-                <th>Total Items</th>
+                <td><%= line_item.name %></td>
+                <td><%= line_item.quantity %></td>
               </tr>
-            </thead>
-            <tbody>
-              <% @partner_request.item_requests.each do |line_item| %>
-                <tr>
-                  <td><%= line_item.name %></td>
-                  <td><%= line_item.quantity %></td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
+            <% end %>
+          </tbody>
+        </table>
 
-          <div class="message fs-5">
-            <p>Please confirm that the above list is what you meant to request.</p>
+        <%# Confirmation message %>
+        <div class="message fs-5">
+          <p>Please confirm that the above list is what you meant to request.</p>
+        </div>
+
+        <%# Quota exceeded warning %>
+        <% if @quota_exceeded %>
+          <div class="alert alert-warning" role="alert">
+            You are ordering
+            <span class="fw-bolder fst-italic" data-testid="partner-request-confirmation-total"><%= @total_items %></span>
+            total items, are you sure?
           </div>
+        <% end %>
       </div>
+
+      <%# Actions %>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="No I need to make changes">No, I need to make changes</button>
         <button type="button" class="btn btn-primary" data-action="confirmation#submitForm">Yes, it's correct</button>

--- a/app/views/partners/requests/validate.html.erb
+++ b/app/views/partners/requests/validate.html.erb
@@ -32,7 +32,7 @@
         <% if @quota_exceeded %>
           <div class="alert alert-warning" role="alert">
             You are ordering
-            <span class="fw-bolder fst-italic" data-testid="partner-request-confirmation-total"><%= @total_items %></span>
+            <span class="fw-bolder fst-italic"><%= @total_items %></span>
             total items, are you sure?
           </div>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,9 +35,21 @@ Rails.application.routes.draw do
   namespace :partners do
     resource :dashboard, only: [:show]
     resource :help, only: [:show]
-    resources :requests, only: [:show, :new, :index, :create]
-    resources :individuals_requests, only: [:new, :create]
-    resources :family_requests, only: [:new, :create]
+    resources :requests, only: [:show, :new, :index, :create] do
+      collection do
+        post :validate
+      end
+    end
+    resources :individuals_requests, only: [:new, :create] do
+      collection do
+        post :validate
+      end
+    end
+    resources :family_requests, only: [:new, :create] do
+      collection do
+        post :validate
+      end
+    end
     resources :users, only: [:index, :new, :create, :edit, :update]
     resource :profile, only: [:show, :edit, :update]
     resource :approval_request, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,19 +36,13 @@ Rails.application.routes.draw do
     resource :dashboard, only: [:show]
     resource :help, only: [:show]
     resources :requests, only: [:show, :new, :index, :create] do
-      collection do
-        post :validate
-      end
+      post :validate, on: :collection
     end
     resources :individuals_requests, only: [:new, :create] do
-      collection do
-        post :validate
-      end
+      post :validate, on: :collection
     end
     resources :family_requests, only: [:new, :create] do
-      collection do
-        post :validate
-      end
+      post :validate, on: :collection
     end
     resources :users, only: [:index, :new, :create, :edit, :update]
     resource :profile, only: [:show, :edit, :update]

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -379,6 +379,28 @@ RSpec.describe Partner, type: :model do
     end
   end
 
+  describe "#quota_exceeded?" do
+    it "returns true if partner has a quota and the total given is greater than quota" do
+      partner = build_stubbed(:partner, quota: 100)
+      expect(partner.quota_exceeded?(200)).to eq(true)
+    end
+
+    it "returns false if partner has a quota and the total given is equal to quota" do
+      partner = build_stubbed(:partner, quota: 100)
+      expect(partner.quota_exceeded?(100)).to eq(false)
+    end
+
+    it "returns false if partner has a quota and the total given is less than quota" do
+      partner = build_stubbed(:partner, quota: 100)
+      expect(partner.quota_exceeded?(50)).to eq(false)
+    end
+
+    it "returns false if partner has no quota" do
+      partner = build_stubbed(:partner, quota: nil)
+      expect(partner.quota_exceeded?(50)).to eq(false)
+    end
+  end
+
   describe "versioning" do
     it { is_expected.to be_versioned }
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -50,9 +50,14 @@ RSpec.describe Request, type: :model do
     let(:id_one) { create(:item).id }
     let(:id_two) { create(:item).id }
     let(:request) { create(:request, request_items: [{ item_id: id_one, quantity: 15 }, { item_id: id_two, quantity: 18 }]) }
+    let(:request_with_strings) { create(:request, request_items: [{ item_id: id_one, quantity: "15" }, { item_id: id_two, quantity: "18" }]) }
 
     it "adds the quantity of all items in the request" do
       expect(request.total_items).to eq(33)
+    end
+
+    it "adds the quantity of all items in the request when they are strings" do
+      expect(request_with_strings.total_items).to eq(33)
     end
   end
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -87,6 +87,39 @@ RSpec.describe Request, type: :model do
         expect(subject.errors[:item_requests]).to include("should have unique item_ids")
       end
     end
+
+    context "when request is completely empty" do
+      let(:empty_request) { build(:request, comments: "", item_requests: []) }
+
+      it "is not valid" do
+        expect(empty_request).to_not be_valid
+        expect(empty_request.errors[:base]).to include("completely empty request")
+      end
+    end
+
+    context "when request has comments" do
+      let(:request_with_comments) { build(:request, comments: "Some comments", item_requests: []) }
+
+      it "is valid" do
+        expect(request_with_comments).to be_valid
+      end
+    end
+
+    context "when request has item_requests" do
+      let(:request_with_item_requests) { build(:request, comments: "", item_requests: [build(:item_request, item: item_one, quantity: 5)]) }
+
+      it "is valid" do
+        expect(request_with_item_requests).to be_valid
+      end
+    end
+
+    context "when request has both comments and item_requests" do
+      let(:request_with_both) { build(:request, comments: "Some comments", item_requests: [build(:item_request, item: item_two, quantity: 3)]) }
+
+      it "is valid" do
+        expect(request_with_both).to be_valid
+      end
+    end
   end
 
   describe "versioning" do

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -143,4 +143,33 @@ RSpec.describe Partners::RequestCreateService do
       end
     end
   end
+
+  describe "#create_only" do
+    subject { described_class.new(**args).create_only }
+    let(:args) do
+      {
+        partner_user_id: partner_user.id,
+        comments: comments,
+        item_requests_attributes: item_requests_attributes
+      }
+    end
+    let(:partner_user) { partner.primary_user }
+    let(:partner) { create(:partner) }
+    let(:comments) { Faker::Lorem.paragraph }
+    let(:item) { FactoryBot.create(:item) }
+    let(:item_requests_attributes) do
+      [
+        ActionController::Parameters.new(
+          item_id: item.id,
+          quantity: 25
+        )
+      ]
+    end
+
+    it "creates a partner request in memory only" do
+      expect(subject.id).to be_nil
+      expect(subject.item_requests.first.item.name).to eq(item.name)
+      expect(subject.item_requests.first.quantity).to eq("25")
+    end
+  end
 end

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -144,8 +144,8 @@ RSpec.describe Partners::RequestCreateService do
     end
   end
 
-  describe "#create_only" do
-    subject { described_class.new(**args).create_only }
+  describe "#initialize_only" do
+    subject { described_class.new(**args).initialize_only }
     let(:args) do
       {
         partner_user_id: partner_user.id,

--- a/spec/system/partners/family_requests_system_spec.rb
+++ b/spec/system/partners/family_requests_system_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe "Family requests", type: :system, js: true do
       end
 
       find('input[type="submit"]').click
+      expect(page).to have_selector("#partnerFamilyRequestConfirmationModal")
+      within "#partnerFamilyRequestConfirmationModal" do
+        click_button "Yes, it's correct"
+      end
+
       expect(page).to have_text("Request Details")
       click_link "Your Previous Requests"
       expect(page).to have_text("Request History")
@@ -90,4 +95,3 @@ RSpec.describe "Family requests", type: :system, js: true do
     end
   end
 end
-


### PR DESCRIPTION
Resolves #3052 

### Description

This adds a confirmation modal to the three types of Partner requests:
1. Quantity Request
2. Individual Request
3. Family Request

Also, if the partner has a `quota`, then the confirmation modal will show a warning, although it does not expose the quota quantity to the partner user.

The confirmation modal is implemented in a similar way as was done with [Distribution Confirmation](https://github.com/rubyforgood/human-essentials/pull/4367) for organizations.

Note that the seed data does not currently contain any partners with quotas so if you want to view the additional warning message, you can run the following in a Rails console prior to making a request as a partner:

```ruby
# Or whichever partner you want to test with
partner = Partner.first
# Set quota to whatever integer value you want
partner.update!(quota: 50)
# Now in the application, make a request for this partner with total quantity of items exceeding the quota.
```

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

For manual testing:

1. Login as a test partner `verified@example.com`
2. Click "Essentials Requests" from the left side navigation menu
3. Click on "Create Request" for "Quantity"
4. Fill out the New Request form, adding several items
5. Click "Submit Essentials Request"
6. You should see a Request Confirmation modal listing the items you've added, and it gives you a chance to go back to the form to make further changes, or submit if it's correct. 

You can repeat the above for Child request and Individual request. In those cases, you don't directly add items but rather select by child/guardian or specify number of individuals, and the system translates these to item name and totals for display in the modal.

### Screenshots

Example of Quantity Request confirmation modal:
![image](https://github.com/user-attachments/assets/d635b021-29f4-4acf-9124-67a85f273bbb)

Example of Family/Child Request confirmation modal with quota warning:
![image](https://github.com/user-attachments/assets/49090d91-61e8-4f37-bb4b-91c7976ca19e)

Example of Individual Request confirmation modal:
![image](https://github.com/user-attachments/assets/fad392d0-b3c3-4289-b604-55f5b1e7fc87)

