### PR TITLE
4578: Better wording on request sent page

### DIFF
--- a/app/views/partners/requests/_success.html.erb
+++ b/app/views/partners/requests/_success.html.erb
@@ -7,7 +7,7 @@
   <div class='text-green-600 md:text-left'>
     <h3 class='text-4xl font-extrabold'>Request has been successfully created!</h3>
     <p class='text-lg'>
-      <span class='font-extrabold'><%= current_partner.organization.name %></span> should have received the request. <br> You should also be receiving a email confirmation in a few minutes.
+      We've sent  <span class='font-extrabold'><%= current_partner.organization.name %></span> your request.<br> We will send you an email confirmation in a few minutes.
     </p>
   </div>
 </div>


### PR DESCRIPTION
Resolves #4578

### Description

Text changes on the page that is shown after the partner submits a request. 

[ Organization name] should have received the request.
to
We've sent [Organization name] your request.

Change
You should also be receiving a email confirmation in a few minutes.
to
We will send you an email confirmation in a few minutes.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

The change is tested manually. 

To see this page, sign in as [verifed@example.com](mailto:verifed@example.com), then click on Quantity, fill a couple of items and quantities, click submit (and if a confirmation page appears, click "It's correct'. A page like the following will appear.

### Screenshots
<img width="1710" alt="Screenshot 2024-08-06 at 2 32 40 PM" src="https://github.com/user-attachments/assets/191a8e41-ac20-4b4c-81ee-095c993c2b98">

