### PR TITLE
#4403: Show units in new/edit distribution

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -192,3 +192,30 @@ div.low_priority_warning {
   margin: 5px;
   text-align: center;
 }
+
+.distribution-title {
+  display: flex;
+}
+
+legend.with-request {
+  float: none;
+  width: 80%;
+  display: inline-block;
+}
+
+div.distribution-request-unit {
+  display: inline-block;
+  flex: 1;
+  text-align: right;
+  margin-right: 20px;
+  font-size: 1.5em;
+}
+
+.li-requested {
+  font-size: 1.5em;
+  width: 100px;
+  min-width: 100px;
+  text-align: right;
+  margin-right: 20px;
+  white-space: nowrap;
+}

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -109,7 +109,11 @@ class DistributionsController < ApplicationController
         # does not match any known Request
         @distribution.request = Request.find(request_id)
       end
-      @distribution.line_items.build if @distribution.line_items.size.zero?
+      if @distribution.line_items.size.zero?
+        @distribution.line_items.build
+      elsif request_id
+        @distribution.initialize_request_items
+      end
       @items = current_organization.items.alphabetized
       if Event.read_events?(current_organization)
         inventory = View::Inventory.new(@distribution.organization_id)

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -166,6 +166,7 @@ class DistributionsController < ApplicationController
 
   def edit
     @distribution = Distribution.includes(:line_items).includes(:storage_location).find(params[:id])
+    @distribution.initialize_request_items
     if (!@distribution.complete? && @distribution.future?) ||
         current_user.has_role?(Role::ORG_ADMIN, current_organization)
       @distribution.line_items.build if @distribution.line_items.size.zero?
@@ -202,6 +203,7 @@ class DistributionsController < ApplicationController
     else
       flash[:error] = insufficient_error_message(result.error.message)
       @distribution.line_items.build if @distribution.line_items.size.zero?
+      @distribution.initialize_request_items
       @items = current_organization.items.alphabetized
       @storage_locations = current_organization.storage_locations.active_locations.alphabetized
       render :edit

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -96,7 +96,7 @@ module Itemizable
     has_many :items, through: :line_items
     accepts_nested_attributes_for :line_items,
                                   allow_destroy: true,
-                                  reject_if: proc { |l| l[:item_id].blank? || l[:quantity].blank? }
+                                  reject_if: proc { |l| l[:item_id].blank? }
 
     has_many :item_categories, through: :items
 

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -96,7 +96,7 @@ module Itemizable
     has_many :items, through: :line_items
     accepts_nested_attributes_for :line_items,
                                   allow_destroy: true,
-                                  reject_if: proc { |l| l[:item_id].blank? || l[:quantity].blank?}
+                                  reject_if: proc { |l| l[:item_id].blank? || l[:quantity].blank? }
 
     has_many :item_categories, through: :items
 

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -96,7 +96,7 @@ module Itemizable
     has_many :items, through: :line_items
     accepts_nested_attributes_for :line_items,
                                   allow_destroy: true,
-                                  reject_if: proc { |l| l[:item_id].blank? || l[:quantity].blank? || l[:quantity].to_i.zero? }
+                                  reject_if: proc { |l| l[:item_id].blank? || l[:quantity].blank?}
 
     has_many :item_categories, through: :items
 

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -96,7 +96,7 @@ module Itemizable
     has_many :items, through: :line_items
     accepts_nested_attributes_for :line_items,
                                   allow_destroy: true,
-                                  reject_if: proc { |l| l[:item_id].blank? }
+                                  reject_if: proc { |l| l[:item_id].blank? || l[:quantity].blank? || l[:quantity].to_i.zero? }
 
     has_many :item_categories, through: :items
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -173,7 +173,7 @@ class Distribution < ApplicationRecord
   private
 
   def line_items_quantity_is_positive
-    line_items_quantity_is_at_least(0)
+    line_items_quantity_is_at_least(1)
   end
 
   def reset_shipping_cost

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -28,6 +28,10 @@ class LineItem < ApplicationRecord
 
   delegate :name, to: :item
 
+  # Used in a distribution that was initialized from a request. The `item_request` will be
+  # populated here.
+  attr_accessor :requested_item
+
   def quantity_must_be_a_number_within_range
     if quantity && quantity > MAX_INT
       errors.add(:quantity, "must be less than #{MAX_INT}")

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -9,7 +9,7 @@ class DistributionUpdateService < DistributionService
     perform_distribution_service do
       @old_issued_at = distribution.issued_at
       @old_delivery_method = distribution.delivery_method
-      @params[:line_items_attributes]&.delete_if { |_, a| a[:quantity].to_i.zero?}
+      @params[:line_items_attributes]&.delete_if { |_, a| a[:quantity].to_i.zero? }
 
       # remove line_items with zero quantity
 

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -9,7 +9,7 @@ class DistributionUpdateService < DistributionService
     perform_distribution_service do
       @old_issued_at = distribution.issued_at
       @old_delivery_method = distribution.delivery_method
-      @params[:line_items_attributes].delete_if { |_, a| a[:quantity].to_i.zero?}
+      @params[:line_items_attributes]&.delete_if { |_, a| a[:quantity].to_i.zero?}
 
       # remove line_items with zero quantity
 

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -9,6 +9,9 @@ class DistributionUpdateService < DistributionService
     perform_distribution_service do
       @old_issued_at = distribution.issued_at
       @old_delivery_method = distribution.delivery_method
+      @params[:line_items_attributes].delete_if { |_, a| a[:quantity].to_i.zero?}
+
+      # remove line_items with zero quantity
 
       ItemizableUpdateService.call(
         itemizable: distribution,

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -33,13 +33,18 @@
     <%= f.input :comment, label: "Comment" %>
 
     <fieldset style="margin-bottom: 2rem">
-      <legend>Items in this distribution</legend>
+      <div class="distribution-title">
+        <legend class="<%= 'with-request' if distribution.request %>">Items in this distribution</legend>
+        <% if distribution.request %>
+          <div class="distribution-request-unit">Requested</div>
+        <% end %>
+      </div>
       <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
-          <%= render 'line_items/line_item_fields', form: f %>
+          <%= render 'line_items/line_item_fields', form: f, locals: { show_request_items: true } %>
       </div>
       <div class="row links justify-content-end">
         <%= add_element_button "Add Another Item", container_selector: "#distribution_line_items" , id: "__add_line_item" do %>
-          <%= render 'line_items/line_item_fields', form: f, object: LineItem.new %>
+          <%= render 'line_items/line_item_fields', form: f, object: LineItem.new, locals: { show_request_items: true } %>
         <% end %>
       </div>
 

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -28,7 +28,7 @@
                             label: false,
                             input_html: { class: "quantity my-0", data: { quantity: "" } } %>
           </div>
-          <% if form.object.request %>
+          <% if form.object.respond_to?(:request) && form_object.request %>
             <div class="li-requested mx-2">
               <% if requested&.request_unit.present? %>
                 <%= pluralize(requested.quantity, requested.request_unit) %>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -3,12 +3,14 @@
   <section class="nested-fields line_item_section">
     <div class="row mt-2 d-flex flex-row align-items-center justify-content-between">
       <div class='d-flex flex-column justify-content-center'>
-        <div class='d-flex flex-row align-items-center'>
-          <%= render partial: "barcode_items/barcode_item_lookup",
-            locals: { index: field&.options[:child_index] || "new_item"  } %>
-          <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner mx-2"> </div>
-        </div>
-        <label class='my-1 mx-auto font-weight-normal'>OR</label>
+        <% if requested.blank? %>
+          <div class='d-flex flex-row align-items-center'>
+            <%= render partial: "barcode_items/barcode_item_lookup",
+              locals: { index: field&.options[:child_index] || "new_item"  } %>
+            <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner mx-2"> </div>
+          </div>
+          <label class='my-1 mx-auto font-weight-normal'>OR</label>
+        <% end %>
         <div class='d-flex flex-row'>
           <span class="li-name w-100">
             <%= field.input :item_id,

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -28,7 +28,7 @@
                             label: false,
                             input_html: { class: "quantity my-0", data: { quantity: "" } } %>
           </div>
-          <% if form.object.respond_to?(:request) && form_object.request %>
+          <% if form.object.respond_to?(:request) && form.object.request %>
             <div class="li-requested mx-2">
               <% if requested&.request_unit.present? %>
                 <%= pluralize(requested.quantity, requested.request_unit) %>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,4 +1,5 @@
 <%= form.simple_fields_for :line_items, defined?(object) ? object : nil  do |field| %>
+  <% requested = field.object.requested_item %>
   <section class="nested-fields line_item_section">
     <div class="row mt-2 d-flex flex-row align-items-center justify-content-between">
       <div class='d-flex flex-column justify-content-center'>
@@ -10,15 +11,34 @@
         <label class='my-1 mx-auto font-weight-normal'>OR</label>
         <div class='d-flex flex-row'>
           <span class="li-name w-100">
-            <%= field.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false, input_html: { class: "my-0 line_item_name", "data-controller": "select2" } %>
+            <%= field.input :item_id,
+                            disabled: requested.present?,
+                            collection: @items, prompt: "Choose an item",
+                            include_blank: "",
+                            label: false,
+                            input_html: { class: "my-0 line_item_name", "data-controller": "select2" } %>
+            <% if requested.present? %>
+              <%= field.input :item_id, as: :hidden %>
+            <% end %>
           </span>
           <div class="li-quantity mx-2">
             <%= field.input :quantity,
-              as: :string,
-              placeholder: "Quantity",
-              label: false,
-              input_html: { class: "quantity my-0", data: { quantity: "" } } %>
+                            as: :string,
+                            placeholder: "Quantity",
+                            label: false,
+                            input_html: { class: "quantity my-0", data: { quantity: "" } } %>
           </div>
+          <% if form.object.request %>
+            <div class="li-requested mx-2">
+              <% if requested&.request_unit.present? %>
+                <%= pluralize(requested.quantity, requested.request_unit) %>
+              <% elsif requested %>
+                <%= requested.quantity %>
+              <% else %>
+                N/A
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -35,5 +35,14 @@ FactoryBot.define do
     trait :inactive do
       active { false }
     end
+
+    trait :with_unit do
+      transient do
+        unit { "pack" }
+      end
+      after(:create) do |item, evaluator|
+        create(:item_unit, name: evaluator.unit, item: item)
+      end
+    end
   end
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
     request_items { random_request_items }
     comments { "Urgent" }
     partner_user { ::User.partner_users.first || create(:partner_user) }
+    item_requests { [] }
 
     # For compatibility we can take in a list of request_items and turn it into a
     # list of item_requests

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -250,11 +250,9 @@ RSpec.describe Distribution, type: :model do
         item2 = create(:item, name: "Item2", organization: organization)
         request = create(:request,
           organization: organization,
-          partner_user: create(:partner_user),
-          request_items: [
-            { item_id: item1.id, quantity: 15 },
-            { item_id: item2.id, quantity: 18 }
-          ])
+          partner_user: create(:partner_user))
+        create(:item_request, request: request, item_id: item1.id, quantity: 15)
+        create(:item_request, request: request, item_id: item2.id, quantity: 18)
         distribution = Distribution.new
         distribution.copy_from_request(request.id)
         expect(distribution.line_items.size).to eq 2

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -133,7 +133,19 @@ RSpec.describe "Distributions", type: :request do
 
     describe "GET #new" do
       let!(:partner) { create(:partner, organization: organization) }
-      let(:request) { create(:request, partner: partner, organization: organization) }
+      let(:request) { create(:request, partner: partner, organization: organization, item_requests: item_requests) }
+      let(:items) {
+        [
+          create(:item, :with_unit, organization: organization, name: 'Item 1', unit: 'pack'),
+          create(:item, organization: organization, name: 'Item 2')
+        ]
+      }
+      let(:item_requests) {
+        [
+          create(:item_request, item: items[0], quantity: 50, request_unit: 'pack'),
+          create(:item_request, item: items[1], quantity: 25)
+        ]
+      }
       let(:storage_location) { create(:storage_location, :with_items, organization: organization) }
       let(:default_params) { { request_id: request.id } }
 
@@ -164,6 +176,44 @@ RSpec.describe "Distributions", type: :request do
           expect(response).to be_successful
           page = Nokogiri::HTML(response.body)
           expect(page.css(%(#distribution_storage_location_id option[selected][value="#{storage_location.id}"]))).not_to be_empty
+        end
+      end
+
+      context 'with units' do
+        before(:each) do
+          Flipper.enable(:enable_packs)
+        end
+
+        it 'should behave correctly' do
+          get new_distribution_path(default_params)
+          expect(response).to be_successful
+          page = Nokogiri::HTML(response.body)
+
+          # should have a disabled select and a hidden input
+          expect(page.css('select[disabled][name="distribution[line_items_attributes][0][item_id]"]')).not_to be_empty
+          expect(page.css('input[name="distribution[line_items_attributes][0][item_id]"]')).not_to be_empty
+          expect(page.css('select[disabled][name="distribution[line_items_attributes][1][item_id]"]')).not_to be_empty
+          expect(page.css('input[name="distribution[line_items_attributes][1][item_id]"]')).not_to be_empty
+
+          # input with packs should be blank
+          expect(page.css('#distribution_line_items_attributes_0_quantity').attr('value')).to eq(nil)
+
+          # input with no packs should show quantity
+          expect(page.css('#distribution_line_items_attributes_1_quantity').attr('value').value).to eq('25')
+        end
+
+        context 'with no request' do
+          it 'should have no inputs' do
+            get new_distribution_path({})
+            expect(response).to be_successful
+            page = Nokogiri::HTML(response.body)
+
+            # blank input shown
+            expect(page.css('select[name="distribution[line_items_attributes][0][item_id]"]')).not_to be_empty
+            expect(page.css('#distribution_line_items_attributes_0_quantity').attr('value')).to eq(nil)
+            # in the template
+            expect(page.css('select[name="distribution[line_items_attributes][1][item_id]"]')).not_to be_empty
+          end
         end
       end
     end
@@ -412,6 +462,76 @@ RSpec.describe "Distributions", type: :request do
         create(:audit, storage_location: create(:storage_location))
         get edit_distribution_path(id: distribution.id)
         expect(response.body).not_to include("You’ve had an audit since this distribution was started.")
+      end
+
+      context 'with units' do
+        let!(:request) {
+          create(:request,
+            partner: partner,
+            organization: organization,
+            distribution_id: distribution.id,
+            item_requests: item_requests)
+        }
+        let(:items) {
+          [
+            create(:item, :with_unit, organization: organization, name: 'Item 1', unit: 'pack'),
+            create(:item, organization: organization, name: 'Item 2'),
+            create(:item, organization: organization, name: 'Item 3')
+          ]
+        }
+        let!(:item_requests) {
+          [
+            create(:item_request, item: items[0], quantity: 50, request_unit: 'pack'),
+            create(:item_request, item: items[1], quantity: 25)
+          ]
+        }
+        before(:each) do
+          Flipper.enable(:enable_packs)
+          create(:line_item, itemizable: distribution, item_id: items[0].id, quantity: 25)
+          create(:line_item, itemizable: distribution, item_id: items[2].id, quantity: 10)
+        end
+
+        it 'should behave correctly' do
+          get edit_distribution_path(id: distribution.id)
+          expect(response).to be_successful
+          page = Nokogiri::HTML(response.body)
+
+          # should have a regular select and no hidden input
+          expect(page.css('select[disabled][name="distribution[line_items_attributes][0][item_id]"]')).not_to be_empty
+          expect(page.css('input[name="distribution[line_items_attributes][0][item_id]"]')).not_to be_empty
+
+          # should have a regular select and no hidden input
+          expect(page.css('select[name="distribution[line_items_attributes][1][item_id]"]')).not_to be_empty
+          expect(page.css('select[disabled][name="distribution[line_items_attributes][1][item_id]"]')).to be_empty
+          expect(page.css('input[name="distribution[line_items_attributes][1][item_id]"]')).to be_empty
+
+          # should have a disabled select and a hidden input
+          expect(page.css('select[disabled][name="distribution[line_items_attributes][2][item_id]"]')).not_to be_empty
+          expect(page.css('input[name="distribution[line_items_attributes][2][item_id]"]')).not_to be_empty
+
+          # existing inputs should show numbers
+          expect(page.css('#distribution_line_items_attributes_0_quantity').attr('value').value).to eq('25')
+          expect(page.css('#distribution_line_items_attributes_1_quantity').attr('value').value).to eq('10')
+
+          # input from request should show 0
+          expect(page.css('#distribution_line_items_attributes_2_quantity').attr('value').value).to eq('0')
+        end
+
+        context 'with no request' do
+          it 'should have everything enabled' do
+            request.destroy
+            get edit_distribution_path(id: distribution.id)
+            expect(response).to be_successful
+            page = Nokogiri::HTML(response.body)
+
+            expect(page.css('select[name="distribution[line_items_attributes][0][item_id]"]')).not_to be_empty
+            expect(page.css('select[disabled][name="distribution[line_items_attributes][0][item_id]"]')).to be_empty
+            expect(page.css('input[name="distribution[line_items_attributes][0][item_id]"]')).to be_empty
+            expect(page.css('select[name="distribution[line_items_attributes][1][item_id]"]')).not_to be_empty
+            expect(page.css('select[disabled][name="distribution[line_items_attributes][1][item_id]"]')).to be_empty
+            expect(page.css('input[name="distribution[line_items_attributes][1][item_id]"]')).to be_empty
+          end
+        end
       end
 
       # Bug fix #4537

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -596,6 +596,8 @@ RSpec.feature "Distributions", type: :system do
       items = storage_location.items.pluck(:id).sample(2)
       request_items = [{ "item_id" => items[0], "quantity" => 10 }, { "item_id" => items[1], "quantity" => 10 }]
       @request = create :request, organization: organization, request_items: request_items
+      create(:item_request, request: @request, item_id: items[0], quantity: 10)
+      create(:item_request, request: @request, item_id: items[1], quantity: 10)
 
       visit request_path(id: @request.id)
       click_on "Fulfill request"
@@ -629,6 +631,8 @@ RSpec.feature "Distributions", type: :system do
       items = storage_location.items.pluck(:id).sample(2)
       request_items = [{ "item_id" => items[0], "quantity" => 1000000 }, { "item_id" => items[1], "quantity" => 10 }]
       @request = create :request, organization: organization, request_items: request_items
+      create(:item_request, request: @request, item_id: items[0], quantity: 1000000)
+      create(:item_request, request: @request, item_id: items[1], quantity: 10)
 
       visit request_path(id: @request.id)
       click_on "Fulfill request"


### PR DESCRIPTION
This makes a number of changes related to showing requested items and packs on the distribution pages.

![image](https://github.com/user-attachments/assets/ebebb853-9ba7-4e75-8baf-82eae389a0a9)

*   Editing distributions will silently remove any items that have a quantity of 0. Before this threw an error. All other itemizables and new distributions should remain the same.
*   Distribution New / Edit pages now show all items requested (regardless of whether there is a current line item in the distribution with that requested item). All requested items are disabled on the distribution page and cannot be changed. (Quantity can be changed to 0 though.)
*   Request units are now shown on the distribution page if relevant.

See the original issue (#4403) for more details.