### PR TITLE
[hotfix] Add scrolling to confirmation modals for many items display

### DIFF
--- a/app/views/distributions/validate.html.erb
+++ b/app/views/distributions/validate.html.erb
@@ -4,7 +4,7 @@
         <h5 class="modal-title">Distribution Confirmation</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-body">
+      <div class="modal-body" style="max-height: 60vh; overflow-y: auto;">
         <p class="lead">You are about to create a distribution for
           <span class="fw-bolder fst-italic"
             data-testid="distribution-confirmation-partner"><%= @dist.partner_name %></span>

--- a/app/views/partners/requests/validate.html.erb
+++ b/app/views/partners/requests/validate.html.erb
@@ -4,7 +4,7 @@
         <h5 class="modal-title">Request Confirmation</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-body">
+      <div class="modal-body" style="max-height: 60vh; overflow-y: auto;">
         <%# Items and quantities %>
         <table class="table">
           <thead>


### PR DESCRIPTION
Hotfix/follow-on to #3052 

### Description

Follow-on from Slack discussion with myself and @cielf: For partner request confirmation modal, if there are many items in the request and user is on a small-ish screen, then it only shows the middle portion of the table in the modal, and they can't see all the content and interact with it such as clicking Yes/No buttons.

### Type of change

Hotfix: Added scrolling to the modal body for partner confirmation modal. While I was at it, noticed the distribution confirmation modal introduced back in #3090 had the same issue so I fixed that as well.

### How Has This Been Tested?

To try this out, follow the same steps as desribed in https://github.com/rubyforgood/human-essentials/pull/4553 and https://github.com/rubyforgood/human-essentials/pull/4367, but add a lot of items, at least 9 or 10. And then size down your browser window. When the confirmation modal appears, you should be able to scroll through the contents and interact with the Yes/No buttons.

### Screenshots

I'm on a Mac so the scrollbars only appear when scrolling, it might look different on Windows.

#### Partner Request
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/6320189d-6baf-40f1-b2bb-29fbe3c78457">
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/65ffbb8b-ce5a-4191-a0e8-762b8d894421">

#### Distribution
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/3ac709b8-17ce-482b-8042-d1dbaf5cd291">
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/8fcbee76-8735-45e2-96b4-61b9b3e54a09">
