### PR TITLE
Fix distributions labels

### DIFF
--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -117,7 +117,7 @@
                 <th>Delivery method</th>
                 <th>Shipping Cost</th>
                 <th>Comments</th>
-                <th>State</th>
+                <th>Status</th>
                 <th class="text-right" style="width: 400px">Actions</th>
               </tr>
               </thead>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -38,17 +38,17 @@
               <div class="row">
                 <% if @items.present? %>
                   <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
-                    <%= filter_select(label: "Filter by item", scope: :by_item_id, collection: @items, selected: @selected_item) %>
+                    <%= filter_select(label: "Filter by Item", scope: :by_item_id, collection: @items, selected: @selected_item) %>
                   </div>
                 <% end %>
                 <% if @item_categories.present? %>
                   <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
-                    <%= filter_select(label: "Filter by item category", scope: :by_item_category_id, collection: @item_categories, selected: @selected_item_category) %>
+                    <%= filter_select(label: "Filter by Item Category", scope: :by_item_category_id, collection: @item_categories, selected: @selected_item_category) %>
                   </div>
                 <% end %>
                 <% if @partners.present? %>
                   <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
-                    <%= filter_select(scope: :by_partner, collection: @partners, selected: @selected_partner) %>
+                    <%= filter_select(label: "Filter by Partner", scope: :by_partner, collection: @partners, selected: @selected_partner) %>
                   </div>
                 <% end %>
                 <% if @storage_locations.present? %>
@@ -60,7 +60,7 @@
                   <%= filter_select(label: "Filter by Status", scope: :by_state, collection: @statuses, key: :last, value: :first, selected: @selected_status) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                  <%= label_tag "Date Range" %>
+                  <%= label_tag "Date Range", "Date Range" %>
                   <%= render partial: "shared/date_range_picker", locals: {css_class: "form-control"} %>
                 </div>
               </div><!-- /.row -->
@@ -109,12 +109,12 @@
                 <% elsif filter_params[:by_item_category_id].present? %>
                   <th class="numeric">Total in <%= @item_categories.find { |ic| ic.id == filter_params[:by_item_category_id].to_i }&.name %></th>
                 <% else %>
-                  <th class="numeric">Total items</th>
+                  <th class="numeric">Total Items</th>
                 <% end %>
                 <!-- End Quantity -->
 
-                <th class="numeric">Total value</th>
-                <th>Delivery method</th>
+                <th class="numeric">Total Value</th>
+                <th>Delivery Method</th>
                 <th>Shipping Cost</th>
                 <th>Comments</th>
                 <th>Status</th>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -117,7 +117,7 @@
                 <th>Delivery Method</th>
                 <th>Shipping Cost</th>
                 <th>Comments</th>
-                <th>Status</th>
+                <th>State</th>
                 <th class="text-right" style="width: 400px">Actions</th>
               </tr>
               </thead>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -99,7 +99,7 @@
               <tr>
                 <th>ID</th>
                 <th>Partner</th>
-                <th class="date">Inital Allocation</th>
+                <th class="date">Initial Allocation</th>
                 <th class="date">Date of Distribution</th>
                 <th>Source Inventory</th>
 


### PR DESCRIPTION
### Description
I was on the Distributions page and noticed a typo in a column name. Since I was submitting an edit, I did a light proofread of the page and decided to make a few more changes:
- [Update: this change is being pulled out of this PR. See comment below.] Changed the column "State" to read "Status." I believe Status is what was intended + more widely used/better understood in this context + the filter is labeled "Filter by Status"
- Made capitalization consistent throughout filter labels and column names to make page look spiffier


### Type of change

Non-breaking edits

### Screenshots
Before:
<img width="1521" alt="Before changes" src="https://github.com/user-attachments/assets/342a2dab-4b05-436f-89c9-0281b853abcb">

After:
<img width="1520" alt="After changes" src="https://github.com/user-attachments/assets/99f19bbc-fe81-4c4f-89f5-0ae4af2c9b99">

