### PR TITLE
Have the annual survey handle null zip codes

### DIFF
--- a/app/services/reports/partner_info_report_service.rb
+++ b/app/services/reports/partner_info_report_service.rb
@@ -37,7 +37,7 @@ module Reports
     end
 
     def partner_zipcodes_serviced
-      partner_agency_profiles.map(&:zips_served).uniq.sort.join(', ')
+      partner_agency_profiles.map(&:zips_served).uniq.compact.sort.join(', ')
     end
   end
 end

--- a/spec/services/reports/partner_info_report_service_spec.rb
+++ b/spec/services/reports/partner_info_report_service_spec.rb
@@ -8,29 +8,58 @@ RSpec.describe Reports::PartnerInfoReportService, type: :service do
   end
 
   describe '#report' do
-    it 'should report zero values' do
-      expect(report.report).to eq({
-                                    entries: { "Number of Partner Agencies" => 0,
-                                               "Zip Codes Served" => "" },
-                                    name: "Partner Agencies and Service Area"
-                                  })
+    context "with no partners available" do
+      it 'should report zero values' do
+        expect(report.report).to eq({
+                                      entries: { "Number of Partner Agencies" => 0,
+                                                 "Zip Codes Served" => "" },
+                                      name: "Partner Agencies and Service Area"
+                                    })
+      end
     end
 
-    it 'should report normal values' do
-      p1 = create(:partner, :uninvited, organization: organization, name: 'Partner 1')
-      p1.profile.update!(zips_served: '90210-1234', agency_type: Partner::AGENCY_TYPES['CAREER'])
-      p2 = create(:partner, :uninvited, organization: organization, name: 'Partner 2')
-      p2.profile.update!(zips_served: '12345', agency_type: Partner::AGENCY_TYPES['CAREER'])
-      p3 = create(:partner, :uninvited, organization: organization, name: 'Partner 3')
-      p3.profile.update!(zips_served: '09876-3564', agency_type: Partner::AGENCY_TYPES['EDU'])
+    context "with partners available" do
+      let!(:p1) do
+        create(:partner, :uninvited, organization: organization, name: 'Partner 1') do |p|
+          p.profile.update!(zips_served: '90210-1234', agency_type: Partner::AGENCY_TYPES['CAREER'])
+        end
+      end
+      let!(:p2) do
+        create(:partner, :uninvited, organization: organization, name: 'Partner 2') do |p|
+          p.profile.update!(zips_served: '12345', agency_type: Partner::AGENCY_TYPES['CAREER'])
+        end
+      end
+      let!(:p3) do
+        create(:partner, :uninvited, organization: organization, name: 'Partner 3') do |p|
+          p.profile.update!(zips_served: '09876-3564', agency_type: Partner::AGENCY_TYPES['EDU'])
+        end
+      end
 
-      expect(report.report).to eq({
-                                    entries: { "Agency Type: Career technical training" => 2,
-                                               "Agency Type: Education program" => 1,
-                                               "Number of Partner Agencies" => 3,
-                                               "Zip Codes Served" => "09876-3564, 12345, 90210-1234" },
-                                    name: "Partner Agencies and Service Area"
-                                  })
+      context "with all profiles have zips_served" do
+        it 'should report normal values' do
+          expect(report.report).to eq({
+                                        entries: { "Agency Type: Career technical training" => 2,
+                                                   "Agency Type: Education program" => 1,
+                                                   "Number of Partner Agencies" => 3,
+                                                   "Zip Codes Served" => "09876-3564, 12345, 90210-1234" },
+                                        name: "Partner Agencies and Service Area"
+                                      })
+        end
+      end
+
+      context "with some profiles missing zip_served" do
+        before { p2.profile.update!(zips_served: nil) }
+
+        it 'should report normal values' do
+          expect(report.report).to eq({
+                                        entries: { "Agency Type: Career technical training" => 2,
+                                                   "Agency Type: Education program" => 1,
+                                                   "Number of Partner Agencies" => 3,
+                                                   "Zip Codes Served" => "09876-3564, 90210-1234" },
+                                        name: "Partner Agencies and Service Area"
+                                      })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4575

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
- If some partner profile has nil `zips_served`, then the code breaks while generating the annual survey.
- This PR handles it such that we exclude that empty zipcode from the calculation

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
- Make sure you have some partner profiles with empty zips served.
- Then try to generate the annual survey. 
- It should not break the page

