### PR TITLE
4596-Restore "reset password" capability -- banks to reset password for partners.

### DIFF
--- a/app/controllers/partner_users_controller.rb
+++ b/app/controllers/partner_users_controller.rb
@@ -53,13 +53,14 @@ class PartnerUsersController < ApplicationController
 
   def reset_password
     user = User.find(params[:id])
-    
+
     user.send_reset_password_instructions
     if user.errors.none?
       redirect_back(fallback_location: root_path, notice: "Password e-mail sent!")
     else
       redirect_back(fallback_location: "/", alert: user.errors.full_messages.to_sentence)
-    end  end
+    end
+  end
 
 
   private

--- a/app/controllers/partner_users_controller.rb
+++ b/app/controllers/partner_users_controller.rb
@@ -51,6 +51,17 @@ class PartnerUsersController < ApplicationController
     end
   end
 
+  def reset_password
+    user = User.find(params[:id])
+    
+    user.send_reset_password_instructions
+    if user.errors.none?
+      redirect_back(fallback_location: root_path, notice: "Password e-mail sent!")
+    else
+      redirect_back(fallback_location: "/", alert: user.errors.full_messages.to_sentence)
+    end  end
+
+
   private
 
   def set_partner

--- a/app/controllers/partner_users_controller.rb
+++ b/app/controllers/partner_users_controller.rb
@@ -55,13 +55,8 @@ class PartnerUsersController < ApplicationController
     user = User.find(params[:id])
 
     user.send_reset_password_instructions
-    if user.errors.none?
-      redirect_back(fallback_location: root_path, notice: "Password e-mail sent!")
-    else
-      redirect_back(fallback_location: "/", alert: user.errors.full_messages.to_sentence)
-    end
+    redirect_back(fallback_location: root_path, notice: "Password e-mail sent!")
   end
-
 
   private
 

--- a/app/views/partner_users/_users.html.erb
+++ b/app/views/partner_users/_users.html.erb
@@ -53,6 +53,9 @@
                   <i class="fa fa-envelope"></i> Resend Invitation
                 <% end %>
               <% end %>
+              <%= button_to reset_password_partner_user_path(partner, user), method: :post, data: { confirm: "Are you sure?" }, class: "btn btn-info btn-xs mb-2" do %>
+                  <i class="fa fa-ban"></i> Reset Password
+              <% end %>
               <%= button_to partner_user_path(partner, user), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-xs" do %>
                   <i class="fa fa-ban"></i> Remove Access
               <% end %>

--- a/app/views/partner_users/_users.html.erb
+++ b/app/views/partner_users/_users.html.erb
@@ -54,7 +54,7 @@
                 <% end %>
               <% end %>
               <%= button_to reset_password_partner_user_path(partner, user), method: :post, data: { confirm: "Are you sure?" }, class: "btn btn-info btn-xs mb-2" do %>
-                  <i class="fa fa-ban"></i> Reset Password
+                  <i class="fa fa-key"></i> Reset Password
               <% end %>
               <%= button_to partner_user_path(partner, user), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-xs" do %>
                   <i class="fa fa-ban"></i> Remove Access

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,7 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :create, :destroy], controller: 'partner_users' do
       member do
         post :resend_invitation
+        post :reset_password
       end
     end
 

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe PartnerUsersController, type: :request do
       )
     end
 
-    context "when the partner needs to reset a user's password" do
+    context "when a bank needs to reset a partner user's password" do
       it "resends the reset password email and redirects back to root_path" do
         expect { post reset_password_partner_user_path(default_params.merge(partner_id: partner, id: partner_user)) }.to change { ActionMailer::Base.deliveries.count }.by(1)
         expect(response).to redirect_to(root_path)

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -111,4 +111,23 @@ RSpec.describe PartnerUsersController, type: :request do
       end
     end
   end
+
+  describe "POST #reset_password" do
+    let!(:partner_user) do
+      UserInviteService.invite(
+        email: "meow@example.com",
+        name: "Meow Mix",
+        roles: [Role::PARTNER],
+        resource: partner
+      )
+    end
+
+    context "when the partner needs to reset a user's password" do
+      it "resends the reset password email and redirects back to root_path" do
+        post reset_password_partner_user_path(default_params.merge(partner_id: partner, id: partner_user))
+        
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe PartnerUsersController, type: :request do
 
     context "when the partner needs to reset a user's password" do
       it "resends the reset password email and redirects back to root_path" do
-        post reset_password_partner_user_path(default_params.merge(partner_id: partner, id: partner_user))
-        
+        expect { post reset_password_partner_user_path(default_params.merge(partner_id: partner, id: partner_user)) }.to change { ActionMailer::Base.deliveries.count }.by(1)
         expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq("Password e-mail sent!")
       end
     end
   end


### PR DESCRIPTION
Resolves #4596

### Description
Added in the "Reset Password" button to the "Manage Users" Partner page.

I implemented this by adding a new action to the partner_users_controller, and added the corresponding route.
There was an existing action under the users_controller to also reset the partner's password, but this did not seem to fit the goal of this issue. This led me to create a new action under the partner_users controller instead.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
For testing, I first tested it by navigating to various partners and verifying that the Reset Password button correctly generated a new email with the correct email address.
I then created an rspec test that executed the new action and verified that a new mailer was created, it redirected successfully, and the correct notice message was flashed.

### Screenshots
<img width="1563" alt="image" src="https://github.com/user-attachments/assets/2223dc66-5bc4-4a7e-a1a5-2307b73cd483">
