### PR TITLE
Adds required to Payment Total To Purchase form #4614

### DIFF
--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -27,7 +27,8 @@
       <div class="col-xs-8 col-md-6">
         <%= f.input :amount_spent,
                     label: "Purchase Total",
-                    wrapper: :input_group %>
+                    wrapper: :input_group,
+                    required: true %>
       </div>
     </div>
 


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/human-essentials/issues/4614
Description: Adds asterisk to payment total fields on the purchase forms
Type of change: bug fix
Manually Tested
![75E78214-D51E-44CA-9757-3284EC90775E](https://github.com/user-attachments/assets/52f1e064-37c5-4e5a-b324-c4fc6664f1b6)

![B500A1F5-AA01-4461-B91B-A4834E227620](https://github.com/user-attachments/assets/f2b9022d-1360-47f6-a564-186f60b3e655)
