### PR TITLE
#4593 Fix distribution export, item columns in alphabetically order

### DIFF
--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -118,7 +118,7 @@ module Exports
     def item_headers
       return @item_headers if @item_headers
 
-      @item_headers = @organization.items.order(:created_at).distinct.select([:created_at, :name]).map(&:name)
+      @item_headers = @organization.items.select("DISTINCT ON (LOWER(name)) items.name").order("LOWER(name) ASC").map(&:name)
     end
 
     def build_row_data(distribution)

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Exports::ExportDistributionsCSVService do
     let(:item_id) { duplicate_item.id }
     let(:item_name) { duplicate_item.name }
     let(:filters) { {by_item_id: item_id} }
-    let(:all_org_items) { Item.where(organization:).uniq.sort_by(&:created_at) }
+    let(:all_org_items) { Item.where(organization:).uniq.sort_by { |item| item.name.downcase } }
 
     let(:total_item_quantities) do
       template = all_org_items.pluck(:name).index_with(0)


### PR DESCRIPTION

# Checklist:

- [x] - I have performed a self-review of my own code,
- [x] - I have commented my code, particularly in hard-to-understand areas,
- [x] - I have made corresponding changes to the documentation,
- [x] - I have added tests that prove my fix is effective or that my feature works,
- [x] - New and existing unit tests pass locally with my changes ("bundle exec rake")

Resolves #4593 

### Description
Reorder item-related columns in the distribution export to be in lower-case alphabetical order.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

- [x] Automated tests have been added to confirm that item-related columns are now exported in lower-case alphabetical order.
- [x] Manual testing was conducted by exporting distributions and verifying the order of columns.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

before 
![image](https://github.com/user-attachments/assets/76550e34-e8d9-4374-82fa-05dcf60c08f3)
![image](https://github.com/user-attachments/assets/4fa651f5-6e0f-4c62-8e61-6549034d8304)
![image](https://github.com/user-attachments/assets/22c48ff1-baf9-4da0-aba7-a32b7fc1c574)

after 
![image](https://github.com/user-attachments/assets/90882cb0-3ae4-4cda-9b9a-96446b6d3943)
![image](https://github.com/user-attachments/assets/05d12993-f56e-451c-b77b-70cfe01d119a)
![image](https://github.com/user-attachments/assets/25b3d177-18d0-45ee-9dda-03f1ddb78997)

as can we see in before image the last column was "Kit" after "Wipes" which "wipes" should be at last column if we order it alphabetically, which I try to fix to reorder it alphabetically and the result was in after images ("wipes" was in the last order)

At first I was confused because the title of the issue is "items columns are no longer in alphabetical order", but after dig deeper it was never in alphabetical order since first (found the discussion here https://github.com/rubyforgood/human-essentials/pull/4070, it is said that it sorted by "created_at" column). 

Look forward for feedback, thankyou.
