### PR TITLE
handling old/stale account requests

### DIFF
--- a/app/controllers/admin/account_requests_controller.rb
+++ b/app/controllers/admin/account_requests_controller.rb
@@ -1,4 +1,6 @@
 class Admin::AccountRequestsController < AdminController
+  before_action :set_account_request, only: [:reject, :close]
+
   def index
     @open_account_requests = AccountRequest.requested.order('created_at DESC')
       .page(params[:open_page]).per(15)
@@ -11,12 +13,25 @@ class Admin::AccountRequestsController < AdminController
   end
 
   def reject
-    account_request = AccountRequest.find(account_request_params[:id])
-    account_request.reject!(account_request_params[:rejection_reason])
+    @account_request.reject!(account_request_params[:rejection_reason])
     redirect_to admin_account_requests_path, notice: "Account request rejected!"
+  end
+
+  def close
+    if @account_request.close!(account_request_params[:rejection_reason])
+      redirect_to admin_account_requests_path, notice: "Account request closed!"
+    else
+      redirect_to admin_account_requests_path, error: "Account cannot be closed"
+    end
   end
 
   def account_request_params
     params.require(:account_request).permit(:id, :rejection_reason)
+  end
+
+  private
+
+  def set_account_request
+    @account_request = AccountRequest.find(account_request_params[:id])
   end
 end

--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -30,10 +30,10 @@ class AccountRequest < ApplicationRecord
 
   has_one :organization, dependent: :nullify
 
-  enum status: %w[started user_confirmed admin_approved rejected].map { |v| [v, v] }.to_h
+  enum status: %w[started user_confirmed admin_approved rejected admin_closed].map { |v| [v, v] }.to_h
 
   scope :requested, -> { where(status: %w[started user_confirmed]) }
-  scope :closed, -> { where(status: %w[admin_approved rejected]) }
+  scope :closed, -> { where(status: %w[admin_approved rejected admin_closed]) }
 
   def self.get_by_identity_token(identity_token)
     decrypted_token = JWT.decode(identity_token, Rails.application.secret_key_base, true, { algorithm: 'HS256' })
@@ -62,6 +62,11 @@ class AccountRequest < ApplicationRecord
     organization.present?
   end
 
+  # @return [Boolean]
+  def can_be_closed?
+    started? || user_confirmed?
+  end
+
   def confirm!
     update!(confirmed_at: Time.current, status: 'user_confirmed')
     AccountRequestMailer.approval_request(account_request_id: id).deliver_later
@@ -71,6 +76,12 @@ class AccountRequest < ApplicationRecord
   def reject!(reason)
     update!(status: 'rejected', rejection_reason: reason)
     AccountRequestMailer.rejection(account_request_id: id).deliver_later
+  end
+
+  # @param reason [String]
+  def close!(reason)
+    return false unless can_be_closed?
+    update(status: 'admin_closed', rejection_reason: reason)
   end
 
   private

--- a/app/views/admin/account_requests/_close_admin_modal.html.erb
+++ b/app/views/admin/account_requests/_close_admin_modal.html.erb
@@ -1,16 +1,16 @@
-<div class="modal" id="rejection-modal">
+<div class="modal" id="close-modal">
   <div class="modal-dialog">
 
     <!-- Modal content-->
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title">
-          Reject Account Request
+          Close Account Request
         </h4>
         <button type="button" class="close btn-close" data-bs-dismiss="modal">&times;</button>
       </div>
       <div class="modal-body">
-        <%= simple_form_for AccountRequest.new, url: reject_admin_account_requests_path, method: :post do |f| %>
+        <%= simple_form_for AccountRequest.new, url: close_admin_account_requests_path, method: :post do |f| %>
           <%= f.hidden_field :id, id: :reject_account_request_id %>
           <div class="form-inputs">
             <%= f.input :rejection_reason, required: true, autofocus: true, wrapper: :input_group %>

--- a/app/views/admin/account_requests/_open_account_request.html.erb
+++ b/app/views/admin/account_requests/_open_account_request.html.erb
@@ -13,5 +13,10 @@
   <td><%= js_button(text: 'Reject',
                     icon: 'ban',
                     class: 'reject-button',
-                    data: { request_id: open_account_request.id }) %></td>
+                    data: { request_id: open_account_request.id, modal: 'rejection' }) %></td>
+  <td><%= js_button(text: 'Close(Admin)',
+                  icon: 'times',
+                  class: 'reject-button',
+                  data: { request_id: open_account_request.id, modal: 'close' }) %></td>
+
 </tr>

--- a/app/views/admin/account_requests/index.html.erb
+++ b/app/views/admin/account_requests/index.html.erb
@@ -44,6 +44,7 @@
 </section>
 
 <%= render partial: 'rejection_modal' %>
+<%= render partial: 'close_admin_modal' %>
 
 <section class="content-header">
   <div class="container-fluid">
@@ -108,9 +109,10 @@
   $(() => {
     $('.reject-button').click((event) => {
       event.preventDefault();
-      $('#account_request_rejection_reason').val('');
-      $('#reject_account_request_id').val($(event.target).data('requestId'));
-      $('#rejection-modal').modal('show');
+      let classModal = $(event.target).data('modal')
+      $(`#${classModal}-modal #account_request_rejection_reason`).val('');
+      $(`#${classModal}-modal #reject_account_request_id`).val($(event.target).data('requestId'));
+      $(`#${classModal}-modal`).modal('show');
     })
   })
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
     resources :barcode_items
     resources :account_requests, only: [:index] do
       post :reject, on: :collection
+      post :close, on: :collection
       get :for_rejection, on: :collection
     end
     resources :questions

--- a/spec/controllers/admin/account_requests_controller_spec.rb
+++ b/spec/controllers/admin/account_requests_controller_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Admin::AccountRequestsController, type: :controller do
+  before do
+    sign_in(create(:super_admin, organization: nil))
+  end
+
+  let(:account_request) { create(:account_request) }
+  let(:rejection_params) do
+    {
+      account_request: {
+        id: account_request.id,
+        rejection_reason: "some rejection reason"
+      }
+    }
+  end
+
+  describe "POST #reject" do
+    it "should reject the account request" do
+      post :reject, params: rejection_params
+      expect(account_request.reload).to be_rejected
+      expect(flash[:notice]).to eq("Account request rejected!")
+      expect(response).to redirect_to(admin_account_requests_path)
+    end
+  end
+
+  describe "POST #close" do
+    it "should close the account request" do
+      post :close, params: rejection_params
+      expect(account_request.reload).to be_admin_closed
+      expect(flash[:notice]).to eq("Account request closed!")
+      expect(response).to redirect_to(admin_account_requests_path)
+    end
+  end
+end


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

Resolves #001 4514

### Description
 This new button allows admin users to close old and stale Account requests without sending emails or notifications. this new feature is relevant to clean up data easily. my approach for the solution was:
- reuse the existing button 'Reject' and its modal by a dynamic code in javascript
- unnecessary code was removed and reactors were made
- following the current pattern of no-rest actions, the 'close' action was created
- create test files

### Type of change

<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
running these files
- account_request_spec.rb
- account_requests_controller_spec.rb
- manually testing

### Screenshots