### PR TITLE
handling old/stale account requests

### DIFF
--- a/app/controllers/admin/account_requests_controller.rb
+++ b/app/controllers/admin/account_requests_controller.rb
@@ -1,4 +1,6 @@
 class Admin::AccountRequestsController < AdminController
+  before_action :set_account_request, only: [:reject, :close]
+
   def index
     @open_account_requests = AccountRequest.requested.order('created_at DESC')
       .page(params[:open_page]).per(15)
@@ -11,12 +13,24 @@ class Admin::AccountRequestsController < AdminController
   end
 
   def reject
-    account_request = AccountRequest.find(account_request_params[:id])
-    account_request.reject!(account_request_params[:rejection_reason])
+    @account_request.reject!(account_request_params[:rejection_reason])
     redirect_to admin_account_requests_path, notice: "Account request rejected!"
+  end
+
+  def close
+    @account_request.close!(account_request_params[:rejection_reason])
+    redirect_to admin_account_requests_path, notice: "Account request closed!"
+  rescue => e
+    redirect_to admin_account_requests_path, alert: e.message
   end
 
   def account_request_params
     params.require(:account_request).permit(:id, :rejection_reason)
+  end
+
+  private
+
+  def set_account_request
+    @account_request = AccountRequest.find(account_request_params[:id])
   end
 end

--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -30,10 +30,10 @@ class AccountRequest < ApplicationRecord
 
   has_one :organization, dependent: :nullify
 
-  enum status: %w[started user_confirmed admin_approved rejected].map { |v| [v, v] }.to_h
+  enum status: %w[started user_confirmed admin_approved rejected admin_closed].map { |v| [v, v] }.to_h
 
   scope :requested, -> { where(status: %w[started user_confirmed]) }
-  scope :closed, -> { where(status: %w[admin_approved rejected]) }
+  scope :closed, -> { where(status: %w[admin_approved rejected admin_closed]) }
 
   def self.get_by_identity_token(identity_token)
     decrypted_token = JWT.decode(identity_token, Rails.application.secret_key_base, true, { algorithm: 'HS256' })
@@ -62,6 +62,11 @@ class AccountRequest < ApplicationRecord
     organization.present?
   end
 
+  # @return [Boolean]
+  def can_be_closed?
+    started? || user_confirmed?
+  end
+
   def confirm!
     update!(confirmed_at: Time.current, status: 'user_confirmed')
     AccountRequestMailer.approval_request(account_request_id: id).deliver_later
@@ -71,6 +76,12 @@ class AccountRequest < ApplicationRecord
   def reject!(reason)
     update!(status: 'rejected', rejection_reason: reason)
     AccountRequestMailer.rejection(account_request_id: id).deliver_later
+  end
+
+  # @param reason [String]
+  def close!(reason)
+    raise 'Cannot be closed from this state' unless can_be_closed?
+    update!(status: 'admin_closed', rejection_reason: reason)
   end
 
   private

--- a/app/views/admin/account_requests/_open_account_request.html.erb
+++ b/app/views/admin/account_requests/_open_account_request.html.erb
@@ -13,5 +13,10 @@
   <td><%= js_button(text: 'Reject',
                     icon: 'ban',
                     class: 'reject-button',
-                    data: { request_id: open_account_request.id }) %></td>
+                    data: { request_id: open_account_request.id, modal: 'reject' }) %></td>
+  <td><%= js_button(text: 'Close (Admin)',
+                  icon: 'times',
+                  class: 'reject-button',
+                  data: { request_id: open_account_request.id, modal: 'close' }) %></td>
+
 </tr>

--- a/app/views/admin/account_requests/_rejection_modal.html.erb
+++ b/app/views/admin/account_requests/_rejection_modal.html.erb
@@ -1,19 +1,18 @@
-<div class="modal" id="rejection-modal">
+<div class="modal" id="reject-modal">
   <div class="modal-dialog">
-
-    <!-- Modal content-->
+    <!-- Dynamic modal content-->
     <div class="modal-content">
       <div class="modal-header">
-        <h4 class="modal-title">
-          Reject Account Request
+        <h4 class="modal-title" style="text-transform:capitalize">
         </h4>
         <button type="button" class="close btn-close" data-bs-dismiss="modal">&times;</button>
       </div>
       <div class="modal-body">
-        <%= simple_form_for AccountRequest.new, url: reject_admin_account_requests_path, method: :post do |f| %>
+        <%= simple_form_for AccountRequest.new, url: '', method: :post do |f| %>
           <%= f.hidden_field :id, id: :reject_account_request_id %>
           <div class="form-inputs">
             <%= f.input :rejection_reason, required: true, autofocus: true, wrapper: :input_group %>
+            <a class="text-danger" style="display:none">Reason must be provided</a>
           </div>
           <%= submit_button %>
         <% end %>
@@ -23,14 +22,24 @@
   </div>
 
 </div>
-
+<!-- set url and title dynamically -->
 <script type="module">
   $(() => {
     $('.reject-button').click((event) => {
       event.preventDefault();
+      let url = `/admin/account_requests/${$(event.target).data('modal')}`
+
       $('#account_request_rejection_reason').val('');
       $('#reject_account_request_id').val($(event.target).data('requestId'));
-      $('#rejection-modal').modal('show');
+      $('#new_account_request').attr('action', url)
+      $('.modal-title').text(`${$(event.target).data('modal')} Account Request`)
+      $('#reject-modal').modal('show');
+    })
+    $('button[type="submit"]').click((event) => {
+      if($('#reject-modal #account_request_rejection_reason').val().trim() === ''){
+        event.preventDefault();
+        $('.text-danger').show()
+      }
     })
   })
 </script>

--- a/app/views/admin/account_requests/index.html.erb
+++ b/app/views/admin/account_requests/index.html.erb
@@ -103,14 +103,3 @@
     </div>
   </div>
 </section>
-
-<script type="module">
-  $(() => {
-    $('.reject-button').click((event) => {
-      event.preventDefault();
-      $('#account_request_rejection_reason').val('');
-      $('#reject_account_request_id').val($(event.target).data('requestId'));
-      $('#rejection-modal').modal('show');
-    })
-  })
-</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
     resources :barcode_items
     resources :account_requests, only: [:index] do
       post :reject, on: :collection
+      post :close, on: :collection
       get :for_rejection, on: :collection
     end
     resources :questions

--- a/spec/controllers/admin/account_requests_controller_spec.rb
+++ b/spec/controllers/admin/account_requests_controller_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Admin::AccountRequestsController, type: :controller do
+  before do
+    sign_in(create(:super_admin, organization: nil))
+  end
+
+  let(:account_request) { create(:account_request, status: :admin_approved) }
+
+  describe "POST #close" do
+    it "should not close the account request if it is invalid" do
+      post :close, params: {account_request: {id: account_request.id}}
+      expect(flash[:alert]).to eq("Cannot be closed from this state")
+      expect(response).to redirect_to(admin_account_requests_path)
+    end
+  end
+end

--- a/spec/system/admin/account_requests_system_spec.rb
+++ b/spec/system/admin/account_requests_system_spec.rb
@@ -29,10 +29,23 @@ RSpec.describe "Account Requests Admin", type: :system do
       end
 
       it 'should reject the account', js: true do
-        find(%(a[data-request-id="#{request4.id}"])).click
+        find(%(a[data-modal="reject"][data-request-id="#{request4.id}"])).click
         fill_in 'account_request_rejection_reason', with: 'Because I said so'
         click_on 'Save'
         expect(request4.reload).to be_rejected
+        within "#closed-account-requests" do
+          expect(page).to have_content(request4.name)
+        end
+        within '#open-account-requests' do
+          expect(page).not_to have_content(request4.name)
+        end
+      end
+
+      it 'should close the account', js: true do
+        find(%(a[data-modal="close"][data-request-id="#{request4.id}"])).click
+        fill_in 'account_request_rejection_reason', with: 'Because I said so'
+        click_on 'Save'
+        expect(request4.reload).to be_admin_closed
         within "#closed-account-requests" do
           expect(page).to have_content(request4.name)
         end
@@ -89,7 +102,7 @@ RSpec.describe "Account Requests Admin", type: :system do
       end
 
       it 'should reject the account', js: true do
-        find(%(a[data-request-id="#{request4.id}"])).click
+        find(%(a[data-modal="reject"][data-request-id="#{request4.id}"])).click
         fill_in 'account_request_rejection_reason', with: 'Because I said so'
         click_on 'Save'
         expect(request4.reload).to be_rejected
@@ -99,6 +112,33 @@ RSpec.describe "Account Requests Admin", type: :system do
         within '#open-account-requests' do
           expect(page).not_to have_content(request4.name)
         end
+      end
+
+      it 'should close the account', js: true do
+        find(%(a[data-modal="close"][data-request-id="#{request4.id}"])).click
+        fill_in 'account_request_rejection_reason', with: 'Because I said so'
+        click_on 'Save'
+        expect(request4.reload).to be_admin_closed
+        within "#closed-account-requests" do
+          expect(page).to have_content(request4.name)
+        end
+        within '#open-account-requests' do
+          expect(page).not_to have_content(request4.name)
+        end
+      end
+
+      it "should validate the rejection reason on reject modal" do
+        find(%(a[data-modal="reject"][data-request-id="#{request4.id}"])).click
+        fill_in 'account_request_rejection_reason', with: ''
+        click_on 'Save'
+        expect(page).to have_content('Reason must be provided')
+      end
+
+      it "should validate the rejection reason on close modal" do
+        find(%(a[data-modal="close"][data-request-id="#{request4.id}"])).click
+        fill_in 'account_request_rejection_reason', with: ' '
+        click_on 'Save'
+        expect(page).to have_content('Reason must be provided')
       end
     end
   end


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title includes "WIP" if work is in progress.

Resolves #4514

### Description
 This new button allows admin users to close old and stale Account requests without sending emails or notifications. this new feature is relevant to clean up data easily. my approach for the solution was:
- I reused the existing button 'Reject' and its modal by a dynamic code in javascript
- unnecessary code was removed and reactors were made
- following the current pattern of no-rest actions, the 'close' action was created
- create test files

### Type of change
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
running these files
- account_request_spec.rb
- account_requests_controller_spec.rb
- manually testing

### Screenshots
![Screenshot from 2024-08-30 15-57-34](https://github.com/user-attachments/assets/4776e363-b600-4203-bc55-b180e8a9bc7d)
![Screenshot from 2024-08-30 15-57-06](https://github.com/user-attachments/assets/9dcd0f49-5704-4d4c-afd2-1f6d18db5325)
![Screenshot from 2024-08-30 15-56-35](https://github.com/user-attachments/assets/a9e94a4d-480b-4f11-845c-f08ee8f16f20)
