### PR TITLE
4636 - Relocate product drives menu items under Community

### DIFF
--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -5,27 +5,6 @@
       <p>Dashboard</p>
     <% end %>
   </li>
-  <li class="nav-item has-treeview <%= menu_open?(['product_drives']) %>">
-    <a href="#" class="nav-link <%= active_class(['product_drives']) %>">
-      <i class="nav-icon fas fa-trophy"></i>
-      <p>Product Drives
-        <i class="fas fa-angle-left right"></i></p>
-    </a>
-    <ul class="nav nav-treeview">
-      <li class="nav-item <%= 'active' if current_page?(product_drives_path) %>">
-        <%= link_to(product_drives_path, class: "nav-link #{"active" if current_page?(product_drives_path)}") do %>
-          <i class="nav-icon far fa-circle"></i>
-          <p>All Product Drives</p>
-        <% end %>
-      </li>
-      <li class="nav-item <%= 'active' if current_page?(new_product_drive_path) %>">
-        <%= link_to(new_product_drive_path, class: "nav-link #{"active" if current_page?(new_product_drive_path)}") do %>
-          <i class="nav-icon far fa-circle"></i>
-          <p>New Product Drive</p>
-        <% end %>
-      </li>
-    </ul>
-  </li>
   <li class="nav-item has-treeview <%= menu_open?(['donations']) %>">
     <a href="#" class="nav-link <%= active_class(['donations']) %>">
       <i class="nav-icon fa fa-gratipay"></i>
@@ -148,8 +127,8 @@
       </li>
     </ul>
   </li>
-  <li class="nav-item has-treeview <%= menu_open?(['donation_sites', 'product_drive_participants', 'manufacturers', 'vendors']) %>">
-    <a href="#" class="nav-link <%= active_class(['donation_sites', 'product_drive_participants', 'manufacturers', 'vendors']) %>">
+  <li class="nav-item has-treeview <%= menu_open?(['donation_sites', 'product_drives', 'product_drives/new', 'product_drive_participants', 'manufacturers', 'vendors']) %>">
+    <a href="#" class="nav-link <%= active_class(['donation_sites', 'product_drives', 'product_drives/new', 'product_drive_participants', 'manufacturers', 'vendors']) %>">
       <i class="nav-icon fa fa-laptop"></i>
       <p>Community
         <i class="fas fa-angle-left right"></i></p>
@@ -158,6 +137,16 @@
       <li class="nav-item <%= active_class(['donation_sites']) %>">
         <%= link_to(donation_sites_path, class: "nav-link #{active_class(['donation_sites'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Donation Sites
+        <% end %>
+      </li>
+      <li class="nav-item <%= 'active' if current_page?(product_drives_path) %>">
+        <%= link_to(product_drives_path, class: "nav-link #{"active" if current_page?(product_drives_path)}") do %>
+          <i class="nav-icon far fa-circle"></i> All Product Drives
+        <% end %>
+      </li>
+      <li class="nav-item <%= 'active' if current_page?(new_product_drive_path) %>">
+        <%= link_to(new_product_drive_path, class: "nav-link #{"active" if current_page?(new_product_drive_path)}") do %>
+          <i class="nav-icon far fa-circle"></i> New Product Drive
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['product_drive_participants']) %>">

--- a/spec/system/navigation_system_spec.rb
+++ b/spec/system/navigation_system_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Navigation", type: :system, js: true do
     context "with organization admin" do
       let(:user) { create(:organization_admin) }
       # 2389 Links was missing Forecasting, which is available to an organization admin
-      let(:links) { ["Dashboard", "Donations", "Purchases", "Requests", "Product Drives", "Distributions", "Pick Ups & Deliveries", "Partner Agencies", "Inventory", "Community", "Reports", "My Organization"] }
+      let(:links) { ["Dashboard", "Donations", "Purchases", "Requests", "Distributions", "Pick Ups & Deliveries", "Partner Agencies", "Inventory", "Community", "Reports", "My Organization"] }
 
       it "shows navigation options" do
         sidebar = page.find(".sidebar")


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4636 <!--fill issue number-->

### Description

In the left-hand menu, move the product drive elements under Community
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

Move the Product Drive to the community tabs and remove the Product Drive from the menu. 

- [x] navigational tests pass
- [x]  menu updated as described

 
<!-- Please delete options that are not relevant. -->

### How Has This Been Tested?

- [x] visited The Link and checked for the active state
- [x] use Mobile View for Responsive 
- [x] modify the test to pass system test
- [ ] Documentation update

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Note: **This change involves relocating the "Product Drives" menu items under "Community," which affects the left-hand menu structure. As a result, the user guide will need to be updated, and many screenshots will need to be redone to reflect the new menu layout. Please ensure that these changes are accounted for in the documentation update.**
### Screenshots

After Changes
![image](https://github.com/user-attachments/assets/8a2033c8-8122-47f8-9499-b402c05a3d3e)

