### PR TITLE
4604 - Add Total Quantity header in Distribution Request

### DIFF
--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -36,7 +36,7 @@
       <div class="distribution-title">
         <legend class="<%= 'with-request' if distribution.request %>">Items in this distribution</legend>
         <% if distribution.request %>
-          <div class="distribution-request-unit">Add Quantity (Total Units)</div>
+          <div class="distribution-request-unit">Quantity - Total Units</div>
           <div class="distribution-request-unit">Requested</div>
         <% end %>
       </div>

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -36,6 +36,7 @@
       <div class="distribution-title">
         <legend class="<%= 'with-request' if distribution.request %>">Items in this distribution</legend>
         <% if distribution.request %>
+          <div class="distribution-request-unit">Add Quantity (Total Units)</div>
           <div class="distribution-request-unit">Requested</div>
         <% end %>
       </div>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #4604 

### Description
 Add Quantity (Total Units) as a heading over the quantity.



### Type of change

<!-- Please delete options that are not relevant. -->
* New header add header in request distribution page (non-breaking change which adds functionality)

### How Has This Been Tested?
- [x] Manulaay by Visiting to the page and seeing the Add Quantity (Total Units) header  above the Quantity 

### Screenshots
![Screenshot from 2024-09-13 22-01-47](https://github.com/user-attachments/assets/7b423603-1761-4d4d-98b7-63a7ce17dfec)

