### PR TITLE
add restriction non negative partner quota

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -51,7 +51,7 @@ class Partner < ApplicationRecord
   validates :email, presence: true, uniqueness: { case_sensitive: false },
     format: { with: URI::MailTo::EMAIL_REGEXP, on: :create }
 
-  validates :quota, numericality: true, allow_blank: true
+  validates :quota, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
 
   validate :correct_document_mime_type
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe Partner, type: :model do
     end
 
     it { should validate_numericality_of(:quota).allow_nil }
+
+    it "validates that the quota is greater than or equal to 0" do
+      expect(build(:partner, quota: -1)).not_to be_valid
+      expect(build(:partner, quota: 0)).to be_valid
+      expect(build(:partner, quota: 1)).to be_valid
+    end
   end
 
   context "callbacks" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #4657

### Description
Add validation to ensure the quota field is not negative.

### Type of change

<!-- Please delete options that are not relevant. -->

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

- login in as [org_admin1@example.com](mailto:org_admin1@example.com)
- From the left hand menu: Partner Agencies | All Partners
- click on a Partner, then on "Edit Partner Information"
- Enter a negative number in quota, then "Update Partner".
- It saves.
- A validation will appear, preventing saving if it is negative.


### Screenshots

![image](https://github.com/user-attachments/assets/328bc75d-5dcc-40d1-8685-9334e39d7d0e)


