### PR TITLE
change profile terminology

### DIFF
--- a/app/views/layouts/partners/navigation/_sidebar.html.erb
+++ b/app/views/layouts/partners/navigation/_sidebar.html.erb
@@ -17,7 +17,7 @@
   <li class="nav-item">
     <%= link_to(edit_partners_profile_path, class: "nav-link") do %>
       <i class="nav-icon fa fa-cog"></i>
-      <p>Edit My Organization</p>
+      <p>Edit My Profile</p>
     <% end %>
   </li>
 

--- a/app/views/layouts/partners/navigation/_sidebar.html.erb
+++ b/app/views/layouts/partners/navigation/_sidebar.html.erb
@@ -10,7 +10,7 @@
   <li class="nav-item">
     <%= link_to(partners_profile_path, class: "nav-link") do %>
       <i class="nav-icon fa fa-building"></i>
-      <p>My Organization</p>
+      <p>My Profile</p>
     <% end %>
   </li>
 

--- a/app/views/partners/_partner_row.html.erb
+++ b/app/views/partners/_partner_row.html.erb
@@ -34,10 +34,10 @@
         <%= invite_button_to(invite_partner_path(partner_row), confirm: "Send an invitation to #{partner_row.name} to begin using the partner application?") %>
       <% end %>
     <% when "invited" %>
-      <%= view_button_to partner_path(partner_row) + "#partner-information", { text: "Review Application", icon: "check", type: "warning" } %>
+      <%= view_button_to partner_path(partner_row) + "#partner-information", { text: "Review Applicant's Profile", icon: "check", type: "warning" } %>
       <%= invite_button_to(invite_partner_path(partner_row), confirm: "Re-send an invitation to #{partner_row.name}?", text: 'Re-send Invite') %>
     <% when "awaiting_review" %>
-      <%= view_button_to partner_path(partner_row) + "#partner-information", { text: "Review Application", icon: "check", type: "warning" } %>
+      <%= view_button_to partner_path(partner_row) + "#partner-information", { text: "Review Applicant's Profile", icon: "check", type: "warning" } %>
     <% when "approved" %>
       <%= button_to recertify_partner_partner_path(partner_row), data: { confirm: "Recertify partner #{partner_row.name}?"}, class: "btn btn-xs bg-red" do %>
         <i class="fa fa-refresh"></i> Request Recertification

--- a/app/views/partners/profiles/edit.html.erb
+++ b/app/views/partners/profiles/edit.html.erb
@@ -3,7 +3,7 @@
     <div class="row mb-2">
       <div class="col-sm-6">
         <% content_for :title, "Editing - #{current_partner.name}" %>
-        <h1><i class="fa fa-edit"></i>&nbsp;&nbsp;Edit My Organization&nbsp;&nbsp;&nbsp;
+        <h1><i class="fa fa-edit"></i>&nbsp;&nbsp;Edit My Profile&nbsp;&nbsp;&nbsp;
           <%= partner_status_badge(current_partner) %>
           <small>for <%= current_partner.name %></small>
         </h1>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -189,7 +189,7 @@
         <section class="card card-info card-outline" id='partner-information'>
           <div class="card-header">
             <div class="clearfix">
-              <h2 class="card-title">Application & Information</h2>
+              <h2 class="card-title">Partner Profile</h2>
             </div>
             <div class='pull-right'>
               <% unless @partner.approved? %>

--- a/docs/user_guide/bank/essentials_dashboard.md
+++ b/docs/user_guide/bank/essentials_dashboard.md
@@ -19,7 +19,7 @@ This is pretty much what it sounds like - a list of the requests from your partn
 ![bottom of dashboard page](images/essentials/dashboard/essentials_dashboard_2.png)
 
 #### Partner Approvals
-This lists the partner profiles that have been submitted for approval.  Partners can not submit requests until they have been approved.  To review the application, click on the "Review Application" button beside the partner in the Action colum.  For more details on that, see [Approving a partner](pm_approving_a_partner.md)
+This lists the partner profiles that have been submitted for approval.  Partners can not submit requests until they have been approved.  To review the application, click on the "Review Applicant's Profile" button beside the partner in the Action column.  For more details on that, see [Approving a partner](pm_approving_a_partner.md)
 
 #### Bank-wide Low Inventory
 This lists items whose *bank-wide* inventory has fallen below the recommended or minimum quantity levels you have set on the items. If the item's level in inventory across the bank has fallen below the minimum quantity, it will appear in red.

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -22,9 +22,9 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           visit partners_path
 
           assert page.has_content? partner_awaiting_approval.name
-          click_on 'Review Application'
+          click_on "Review Applicant's Profile"
 
-          assert page.has_content?('Application & Information')
+          assert page.has_content?('Partner Profile')
           click_on 'Approve Partner'
           assert page.has_content? 'Partner approved!'
 
@@ -45,7 +45,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 
           assert page.has_content? partner_awaiting_approval.name
 
-          click_on 'Review Application'
+          click_on "Review Applicant's Profile"
           click_on 'Approve Partner'
           assert page.has_content? "Failed to approve partner because: #{fake_error_msg}"
 
@@ -539,5 +539,5 @@ end
 def visit_approval_page(partner_name:)
   visit partners_path
   ele = find('tr', text: partner_name)
-  within(ele) { click_on "Review Application" }
+  within(ele) { click_on "Review Applicant's Profile" }
 end

--- a/spec/system/partners/approval_process_spec.rb
+++ b/spec/system/partners/approval_process_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Approval process for partners", type: :system, js: true do
 
       context 'AND they fill out the form and submit it' do
         before do
-          click_on 'My Organization'
+          click_on 'My Profile'
           assert page.has_content? 'Uninvited'
           click_on 'Update Information'
 
@@ -76,7 +76,7 @@ RSpec.describe "Approval process for partners", type: :system, js: true do
       partner.profile.update(website: '', facebook: '', twitter: '', instagram: '', no_social_media_presence: false, partner_status: 'pending')
       login_as(partner_user)
       visit partner_user_root_path
-      click_on 'My Organization'
+      click_on 'My Profile'
       click_on 'Submit for Approval'
     end
 

--- a/spec/system/profile_served_area_system_spec.rb
+++ b/spec/system/profile_served_area_system_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Partners profile served area behaviour when accessed as bank", t
       expect(page).to have_content("100 %")
       expect(page).not_to have_content("The total client share must be either 0 or 100 %")
       click_on "Update Information"
-      expect(page).to have_content("Application & Information")
+      expect(page).to have_content("Partner Profile")
       expect(page).to have_content("26 %")
     end
 


### PR DESCRIPTION
Resolves #4654

### Description
This PR aims to adjust some terms related to the profile.

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* This change requires a documentation update

### How Has This Been Tested?
- A) In the left hand menu for partners (seen when you log in as [verified@example.com](mailto:verified@example.com)), change "My organization" to "My profile"
- B) On the bank's view of the partner (log in as [org_admin1@example.com](mailto:org_admin1@example.com), click on "Partner Agencies", then "All Partners", then click on a specific partner), change "Application & Information" to "Partner Profile".
- C) Change the "Review application" button in the "All Partners" view to "Review Applicant's Profile"

### Screenshots

### change "My organization" to "My profile"

![image](https://github.com/user-attachments/assets/256fdb12-c454-4ebd-b8f9-bb67fae1bfe7)

### change "Application & Information" to "Partner Profile"
![image](https://github.com/user-attachments/assets/f5478c8c-9365-4a6e-8fb3-74066b8385de)


### "change Review application" button in the "All Partners" view to "Review Applicant's Profile"
![image](https://github.com/user-attachments/assets/5ec96ee2-3a9f-4d32-ad4e-80e9fae685ab)




