### PR TITLE
4655: [BUG] If you have an error on entering a partner group, the Item Categories changes to a yes/no! Obviously wrong! 

### DIFF
--- a/app/controllers/partner_groups_controller.rb
+++ b/app/controllers/partner_groups_controller.rb
@@ -3,7 +3,7 @@ class PartnerGroupsController < ApplicationController
 
   def new
     @partner_group = current_organization.partner_groups.new
-    @item_categories = current_organization.item_categories
+    set_items_categories
   end
 
   def create
@@ -13,12 +13,14 @@ class PartnerGroupsController < ApplicationController
       redirect_to partners_path + "#nav-partner-groups", notice: "Partner group added!"
     else
       flash[:error] = "Something didn't work quite right -- try again?"
+      set_items_categories
       render action: :new
     end
   end
 
   def edit
-    @item_categories = current_organization.item_categories
+    @partner_group = current_organization.partner_groups.find(params[:id])
+    set_items_categories
   end
 
   def update
@@ -27,6 +29,7 @@ class PartnerGroupsController < ApplicationController
       redirect_to partners_path + "#nav-partner-groups", notice: "Partner group edited!"
     else
       flash[:error] = "Something didn't work quite right -- try again?"
+      set_items_categories
       render action: :edit
     end
   end
@@ -50,5 +53,9 @@ class PartnerGroupsController < ApplicationController
 
   def partner_group_params
     params.require(:partner_group).permit(:name, :send_reminders, :deadline_day, :reminder_day, item_category_ids: [])
+  end
+
+  def set_items_categories
+    @item_categories = current_organization.item_categories
   end
 end

--- a/spec/requests/partner_groups_requests_spec.rb
+++ b/spec/requests/partner_groups_requests_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PartnerGroupsController, type: :request do
     describe "GET #new" do
       subject { get new_partner_group_path }
 
-      it "renders the new template and assings variables correctly" do
+      it "renders the new template and assigns variables correctly" do
         get new_partner_group_path
 
         expect(response).to render_template(:new)

--- a/spec/requests/partner_groups_requests_spec.rb
+++ b/spec/requests/partner_groups_requests_spec.rb
@@ -1,0 +1,121 @@
+RSpec.describe PartnerGroupsController, type: :request do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, organization: organization) }
+  let!(:category_item) { create(:item_category, organization: organization, name: "Test Item") }
+  let!(:category_item2) { create(:item_category, organization: organization, name: "Another Test Item") }
+
+  context "While signed in" do
+    before do
+      sign_in(user)
+    end
+
+    describe "GET #new" do
+      subject { get new_partner_group_path }
+
+      it "renders the new template and assings variables correctly" do
+        get new_partner_group_path
+
+        expect(response).to render_template(:new)
+        expect(assigns(:partner_group)).to be_a_new(PartnerGroup)
+        expect(assigns(:item_categories)).to eq([category_item, category_item2])
+        expect(response.body).to include("Test Item")
+        expect(response.body).to include("Another Test Item")
+      end
+    end
+
+    describe "POST #create" do
+      let(:attributes) { nil }
+
+      subject { post partner_groups_path, params: {partner_group: attributes} }
+
+      context "with valid attributes" do
+        let(:attributes) { attributes_for(:partner_group, organization_id: organization.id, name: "partner group") }
+
+        it "creates a new partner group" do
+          expect { subject }.to change(PartnerGroup, :count).by(1)
+          expect(PartnerGroup.last.name).to eq("partner group")
+        end
+
+        it "redirects to the partners path" do
+          expect(subject).to redirect_to(partners_path + "#nav-partner-groups")
+        end
+      end
+
+      context "with invalid attributes" do
+        let(:attributes) { {name: "existing_partner"} }
+        let!(:partner_group) { create(:partner_group, organization: organization, name: "existing_partner") }
+
+        it "does not create a new partner group" do
+          expect { subject }.not_to change(PartnerGroup, :count)
+        end
+
+        it "re-renders the new template with assigned values" do
+          expect(subject).to render_template(:new)
+          expect(assigns(:partner_group)).to be_a_new(PartnerGroup)
+          expect(assigns(:item_categories)).to eq([category_item, category_item2])
+          expect(subject).to have_error("Something didn't work quite right -- try again?")
+          expect(response.body).to include("Test Item")
+          expect(response.body).to include("Another Test Item")
+        end
+      end
+    end
+
+    describe "GET #edit" do
+      let(:partner_group) { create(:partner_group, organization: organization) }
+
+      subject { get edit_partner_group_path(partner_group) }
+
+      it "renders the edit template and assigns variables correctly" do
+        get edit_partner_group_path(partner_group)
+
+        expect(response).to render_template(:edit)
+        expect(assigns(:partner_group)).to eq(partner_group)
+        expect(assigns(:item_categories)).to eq([category_item, category_item2])
+        expect(response.body).to include("Test Item")
+        expect(response.body).to include("Another Test Item")
+      end
+    end
+
+    describe "PATCH #update" do
+      let(:partner_group) { create(:partner_group, organization: organization) }
+      let(:attributes) { nil }
+
+      subject { patch partner_group_path(partner_group), params: {partner_group: attributes} }
+
+      context "with valid attributes" do
+        let(:attributes) { {name: "new name"} }
+
+        it "updates the partner group" do
+          expect { subject }.to change { partner_group.reload.name }.from(partner_group.name).to("new name")
+        end
+
+        it "redirects to the partners path" do
+          expect(subject).to redirect_to(partners_path + "#nav-partner-groups")
+        end
+      end
+
+      context "with invalid attributes" do
+        let(:attributes) { {name: nil} }
+
+        it "does not update the partner group" do
+          expect { subject }.not_to change { partner_group.reload.name }
+        end
+
+        it "re-renders the edit template with assigned values" do
+          expect(subject).to render_template(:edit)
+          expect(assigns(:partner_group)).to eq(partner_group)
+          expect(assigns(:item_categories)).to eq([category_item, category_item2])
+          expect(subject).to have_error("Something didn't work quite right -- try again?")
+          expect(response.body).to include("Test Item")
+          expect(response.body).to include("Another Test Item")
+        end
+      end
+    end
+  end
+
+  context "While not signed in" do
+    let(:object) { create(:partner_group, organization: organization) }
+
+    include_examples "requiring authorization"
+  end
+end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #4655  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

In `partner_groups_controller.rb` I created a method `set_items_categories` to set the value of `@item_categories` and added it to the `create` and `update` methods where it was missing.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Follow the same steps from the issue

> Sign in as [org_admin1@example.com](mailto:org_admin1@example.com)
Left hand menu: Partner Agencies | All Partners.
Choose the "Groups" tab
Note the name of the existing group. (if there isn't one, create one first.)
Click "New Partner Group"
Enter the same name as the existing group
Click "Add Partner Group"

Now it should show all the available category items correctly


To test the `update` method you can start from the step:  'Choose the "Groups" tab' and then: 

Create two partner groups (if there are already at least two, you can skip this part)
Click "Edit" on one of them
Enter the same name as the other group
Click "Update Partner Group"

