### PR TITLE
4516 fix child requests for inactive children

### DIFF
--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -61,7 +61,7 @@ module Partners
         end
       end
 
-      children = current_partner.children.active.where(id: children_ids).joins(:requested_items).select('children.*', :item_id)
+      children = current_partner.children.where(id: children_ids).joins(:requested_items).select('children.*', :item_id)
 
       children_grouped_by_item_id = children.group_by(&:item_id)
       children_grouped_by_item_id.map do |item_id, item_requested_children|

--- a/spec/requests/partners/family_requests_controller_spec.rb
+++ b/spec/requests/partners/family_requests_controller_spec.rb
@@ -55,5 +55,15 @@ RSpec.describe Partners::FamilyRequestsController, type: :request do
 
       expect(response.request.flash[:notice]).to eql "Requested items successfully!"
     end
+
+    it "creates the correct child item requests" do
+      partner.update!(status: :approved)
+
+      subject
+
+      expect(Partners::ChildItemRequest.find_by(child_id: children[0].id)).to be_present
+      expect(Partners::ChildItemRequest.find_by(child_id: children[1].id)).to be_nil
+      expect(Partners::ChildItemRequest.find_by(child_id: children[2].id)).to be_present
+    end
   end
 end


### PR DESCRIPTION
Resolves #4516

### Description
When building the query in [build_family_requests_attributes](https://github.com/rubyforgood/human-essentials/blob/main/app/controllers/partners/family_requests_controller.rb#L54-L70), only active children were getting selected.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

1. Create a new child item request
2. Ensure that at least one inactive child is selected
3. Submit the item request
4. Verify that all children that are inactive but were selected has an items on their detail page