### PR TITLE
Change button from 'Promote to Admin' to 'Edit User'

### DIFF
--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -17,11 +17,10 @@
         <ul class="dropdown-menu">
           <li>
             <%=
-              edit_button_to(
-                promote_to_org_admin_organization_path(user_id: user.id),
-                {text: 'Promote to Admin'},
-                {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}}
-              )
+            edit_button_to(
+              edit_admin_user_path(user),
+              {text: 'Edit User'}
+            )
             %>
           </li>
           <li>

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -157,6 +157,17 @@ RSpec.describe "Admin::Organizations", type: :request do
         get admin_organization_path({ id: organization.id })
         expect(response).to be_successful
       end
+
+      context "with an organization user" do
+        let!(:user) { create(:user, organization: organization) }
+
+        it "provides links to edit the user" do
+          get admin_organization_path({ id: organization.id })
+
+          expect(response.body).to include("Edit User")
+          expect(response.body).to include(edit_admin_user_path(user.id))
+        end
+      end
     end
 
     describe "PUT #update" do

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "Admin Organization Management", type: :system, js: true, seed_items: false do
-  include ActionView::RecordIdentifier
-
   around do |ex|
     Kaminari.config.default_per_page = 3
     ex.run

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -153,15 +153,5 @@ RSpec.describe "Admin Organization Management", type: :system, js: true, seed_it
       expect(page).to have_content("Default email text")
       expect(page).to have_content("Users")
     end
-
-    it "can edit a user within an organization" do
-      user = create(:user, name: "User to be edited", organization: foo_org)
-      visit admin_organization_path({id: foo_org.id})
-
-      click_button dom_id(user, "dropdownMenu")
-      click_link "Edit User"
-
-      expect(page).to have_content("Editing User #{user.name}")
-    end
   end
 end

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Admin Organization Management", type: :system, js: true, seed_items: false do
+  include ActionView::RecordIdentifier
+
   around do |ex|
     Kaminari.config.default_per_page = 3
     ex.run
@@ -150,6 +152,16 @@ RSpec.describe "Admin Organization Management", type: :system, js: true, seed_it
       expect(page).to have_content("Contact Info")
       expect(page).to have_content("Default email text")
       expect(page).to have_content("Users")
+    end
+
+    it "can edit a user within an organization" do
+      user = create(:user, name: "User to be edited", organization: foo_org)
+      visit admin_organization_path({id: foo_org.id})
+
+      click_button dom_id(user, "dropdownMenu")
+      click_link "Edit User"
+
+      expect(page).to have_content("Editing User #{user.name}")
     end
   end
 end


### PR DESCRIPTION
Resolves #4664

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
Changed the 'Promote to Admin' button to 'Edit User', allowing the super admin to change the user's role from the admin/users/edit page.

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* This change requires a documentation update

### How Has This Been Tested?

- Added a test to ensure that the super admin the link to edit the user on the organization's page
- Manually tested


![Screenshot from 2024-10-02 23-58-00](https://github.com/user-attachments/assets/051bdb85-d382-4e4b-8d8b-7f73a59c12bb)
