### PR TITLE
Display errors taking place during import partner process

### DIFF
--- a/app/controllers/concerns/importable.rb
+++ b/app/controllers/concerns/importable.rb
@@ -27,8 +27,12 @@ module Importable
       data = File.read(params[:file].path, encoding: "BOM|UTF-8")
       csv = CSV.parse(data, headers: true).reject { |row| row.to_hash.values.any?(&:nil?) }
       if csv.count.positive? && csv.first.headers.all? { |header| !header.nil? }
-        resource_model.import_csv(csv, current_organization.id)
-        flash[:notice] = "#{resource_model_humanized} were imported successfully!"
+        errors = resource_model.import_csv(csv, current_organization.id)
+        flash[:notice] = if errors.nil?
+          "#{resource_model_humanized} were imported successfully!"
+        else
+          "The following #{resource_model_humanized} did not import successfully:\n#{errors.join("\n")}"
+        end
       else
         flash[:error] = "Check headers in file!"
       end

--- a/app/models/concerns/provideable.rb
+++ b/app/models/concerns/provideable.rb
@@ -22,6 +22,7 @@ module Provideable
 
         loc.save!
       end
+      nil
     end
 
     def self.csv_export_headers

--- a/app/models/donation_site.rb
+++ b/app/models/donation_site.rb
@@ -46,6 +46,7 @@ class DonationSite < ApplicationRecord
       loc.organization_id = organization
       loc.save!
     end
+    nil
   end
 
   def self.csv_export_headers

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -157,7 +157,7 @@ class Partner < ApplicationRecord
   end
 
   # better to extract this outside of the model
-  def self.import_csv(csv, organization_id)
+  def self.import_csv(csv, organization_id, errors = [])
     organization = Organization.find(organization_id)
 
     csv.each do |row|
@@ -165,7 +165,11 @@ class Partner < ApplicationRecord
 
       svc = PartnerCreateService.new(organization: organization, partner_attrs: hash_rows)
       svc.call
+      if svc.errors.present?
+        errors << "#{svc.partner.name}: #{svc.partner.errors.full_messages.to_sentence}"
+      end
     end
+    errors.empty? ? nil : errors
   end
 
   def self.csv_export_headers

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -121,6 +121,7 @@ class StorageLocation < ApplicationRecord
       loc.organization_id = organization
       loc.save!
     end
+    nil
   end
 
   # NOTE: We should generalize this elsewhere -- Importable concern?

--- a/app/services/partner_create_service.rb
+++ b/app/services/partner_create_service.rb
@@ -11,25 +11,25 @@ class PartnerCreateService
   def call
     @partner = organization.partners.build(partner_attrs)
 
-    unless @partner.valid?
+    if @partner.valid?
+      ActiveRecord::Base.transaction do
+        @partner.save!
+
+        Partners::Profile.create!({
+                                    partner_id: @partner.id,
+                                    name: @partner.name,
+                                    enable_child_based_requests: organization.enable_child_based_requests,
+                                    enable_individual_requests: organization.enable_individual_requests,
+                                    enable_quantity_based_requests: organization.enable_quantity_based_requests
+                                  })
+      rescue StandardError => e
+        errors.add(:base, e.message)
+        raise ActiveRecord::Rollback
+      end
+    else
       @partner.errors.each do |error|
         errors.add(error.attribute, error.message)
       end
-    end
-
-    ActiveRecord::Base.transaction do
-      @partner.save!
-
-      Partners::Profile.create!({
-                                  partner_id: @partner.id,
-                                  name: @partner.name,
-                                  enable_child_based_requests: organization.enable_child_based_requests,
-                                  enable_individual_requests: organization.enable_individual_requests,
-                                  enable_quantity_based_requests: organization.enable_quantity_based_requests
-                                })
-    rescue StandardError => e
-      errors.add(:base, e.message)
-      raise ActiveRecord::Rollback
     end
 
     self

--- a/spec/fixtures/files/partners_with_invalid_email.csv
+++ b/spec/fixtures/files/partners_with_invalid_email.csv
@@ -1,0 +1,4 @@
+name,email
+Partner 1,partner1@example.com
+Partner 2,this is not an email address
+Partner 3,partner3@example.com

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -222,6 +222,26 @@ RSpec.describe "Partners", type: :request do
         expect(response).to have_error "Check headers in file!"
       end
     end
+
+    context "csv file with invalid email address" do
+      let(:file) { fixture_file_upload("partners_with_invalid_email.csv", "text/csv") }
+      subject { post import_csv_partners_path, params: { file: file } }
+
+      it "invokes .import_csv" do
+        expect(model_class).to respond_to(:import_csv).with(2).arguments
+      end
+
+      it "redirects to :index" do
+        subject
+        expect(response).to be_redirect
+      end
+
+      it "presents a flash notice message displaying the import errors" do
+        subject
+        expect(response).to have_notice(/The following #{model_class.name.underscore.humanize.pluralize} did not import successfully:/)
+        expect(response).to have_notice(/Partner 2: Email is invalid/)
+      end
+    end
   end
 
   describe "POST #create" do


### PR DESCRIPTION
Resolves #4688 

### Description
In order to display a message when a partner import is failing I modified the existing `Importable` concern and the Partner model `import_csv` method. This ensures that any validation error (invalid email, name already taken, etc.) gets passed along to be displayed.

The message shown to the user is more specific than the one asked in the issue, but I think it makes sense to display the exact error to the user in order for them to easily fix it.

On a technical note: I chose to modify all `import_csv` methods to return nil if there's no error, or otherwise return an errors array. I'm open to suggestions if there's a better way to do this.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added some requests tests for Partners, and ensured that tests for other models using `import_csv` (DonationSites, StorageLocation, ProductDriveParticipants, Vendors) were still passing.

### Screenshots
**Successful import**
<img width="1234" alt="import success" src="https://github.com/user-attachments/assets/c47ff59e-69ff-41aa-afa3-a48cd0ad5372">

**Import with errors**
<img width="1231" alt="import errors" src="https://github.com/user-attachments/assets/6778edc0-3f1f-4e9c-ac84-b811da60f249">


