### PR TITLE
Add annotation to rendered views for easier development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,6 +84,10 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  # Adds comments to rendered views so you know which partials are being rendered
+  # more easily.
+  config.action_view.annotate_rendered_view_with_filenames = true
+
   require "socket"
   require "ipaddr"
   config.web_console.allowed_ips = Socket.ip_address_list.reduce([]) do |res, addrinfo|


### PR DESCRIPTION
Resolves N/A

### Description

This is a nice little addition to help the development experience. It helps you find which partials are being rendered right in the template in development. See https://blog.corsego.com/annotate-views for a quick example of what it looks like

### Type of change
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
Tested locally

### Screenshots
N/A
