### PR TITLE
Fix disappearing category dropdown on new item form

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -51,6 +51,7 @@ class ItemsController < ApplicationController
       # Define a @item to be used in the `new` action to be rendered with
       # the provided parameters. This is required to render the page again
       # with the error + the invalid parameters
+      @item_categories = current_organization.item_categories
       @item = current_organization.items.new(item_params)
       flash[:error] = result.error.record.errors.full_messages.to_sentence
       render action: :new


### PR DESCRIPTION
Resolves #4674

### Description
This change addresses the issue where the category dropdown disappears after submitting an invalid "New Item" form. The change ensures that the `@item_categories` variable is correctly populated even after an error occurs, allowing users to select a category without issues.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
The following tests were conducted to verify the changes:
1. Log in as an organization admin.
2. Navigate to the "New Item" page.
3. Attempt to save a blank form.
4. Verify that the category dropdown remains accessible and functional after the error is triggered.
