### PR TITLE
[Resolves #4633] Improve confirmation text when saving new audit

### DIFF
--- a/app/views/audits/_form.html.erb
+++ b/app/views/audits/_form.html.erb
@@ -31,7 +31,9 @@
                   </fieldset>
 
                   <div class="card-footer">
-                    <%= submit_button({ text: 'Confirm Audit', name: 'confirm_audit', icon: 'check-circle', align: 'left', size: 'md'}, {confirm: 'Are you sure?'}) %>
+                    <%= submit_button({ text: 'Confirm Audit', name: 'confirm_audit', icon: 'check-circle', align: 'left', size: 'md'}, {
+                        confirm: "Are you sure?\n\nPlease note that this audit must also be finalized by someone with organization admin rights before changes to inventory will take place.\n\nWe strongly recommend completing that step before doing any further actions that affect inventory.",
+                    }) %>
                     <%= submit_button({text: 'Save Progress', name: 'save_progress', size: 'md'}) %>
                   </div>
                 <% end %>


### PR DESCRIPTION
Resolves #4633 

### Description

- This change adds more detail to the confirmation text displayed to a user when submitting a new audit.
- I opted to just add on to the existing text in the ERB file, instead of creating a new pattern for custom confirmation dialogs.
- I had to switch the string to double quotes to allow the new lines to be picked up. Is there a different way we would like to format it?

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I did not add any additional tests as this felt like a "styling change" as described [here](https://github.com/rubyforgood/human-essentials/blob/main/CONTRIBUTING.md#:~:text=You%20probably%20don%27t%20need%20to%20write%20new%20tests%20when%20simple%20re%2Dstylings%20are%20done%20(ie.%20the%20page%20may%20look%20slightly%20different%20but%20the%20Test%20suite%20is%20unaffected%20by%20those%20changes).) in the contributing guidelines. 
Should I be writing a system test for this change regardless?

### Screenshots
|Before|After|
|---|---|
|<img width="455" alt="Screen Shot 2024-10-14 at 1 27 08 PM" src="https://github.com/user-attachments/assets/5fba5c13-bf72-4fde-907f-7ed97a160784">|<img width="455" alt="Screen Shot 2024-10-14 at 12 21 39 PM" src="https://github.com/user-attachments/assets/3c6afa86-bf61-47ec-bbc6-ed767ada04cf">|
