### PR TITLE
Add new purchase information on summary report view

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,6 +14,11 @@ class ReportsController < ApplicationController
   def purchases_summary
     @purchases = current_organization.purchases.during(helpers.selected_range)
     @recent_purchases = @purchases.recent.includes(:vendor)
+    @period_supplies = @purchases.sum(:amount_spent_on_period_supplies_cents)
+    @diapers = @purchases.sum(:amount_spent_on_diapers_cents)
+    @adult_incontinence = @purchases.sum(:amount_spent_on_adult_incontinence_cents)
+    @other = @purchases.sum(:amount_spent_on_other_cents)
+    @total_items = @purchases.joins(:line_items).sum(:quantity)
   end
 
   def product_drives_summary

--- a/app/views/reports/purchases_summary.html.erb
+++ b/app/views/reports/purchases_summary.html.erb
@@ -13,6 +13,15 @@
     spent
     <%= @selected_date_range_label %>
   </h3>
+  <div class="box-body" style="margin: 40px">
+    <h4> Total spent on diapers: <%= dollar_presentation @diapers %></h4>
+    <h4> Total spent on period supplies: <%= dollar_presentation @period_supplies %> </h4>
+    <h4> Total spent on adult incontinence: <%= dollar_presentation @adult_incontinence %> </h4>
+    <h4> Total spent on other: <%= dollar_presentation @other %> </h4>
+  </div>
+  <div style="margin: 40px">
+    <h4> Total items: <%= @total_items %> </h4>
+  </div>
   <div class="box-body">
     <h4>Recent purchases</h4>
     <%= render partial: "purchase", collection: @recent_purchases, as: :purchase %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -709,6 +709,7 @@ end
 # ----------------------------------------------------------------------------
 
 suppliers = %w(Target Wegmans Walmart Walgreens)
+amount_items = %w(period_supplies diapers adult_incontinence other)
 comments = [
   "Maecenas ante lectus, vestibulum pellentesque arcu sed, eleifend lacinia elit. Cras accumsan varius nisl, a commodo ligula consequat nec. Aliquam tincidunt diam id placerat rutrum.",
   "Integer a molestie tortor. Duis pretium urna eget congue porta. Fusce aliquet dolor quis viverra volutpat.",
@@ -726,12 +727,17 @@ dates_generator = DispersedPastDatesGenerator.new
     comment: comments.sample,
     organization_id: pdx_org.id,
     storage_location_id: storage_location.id,
-    amount_spent_in_cents: rand(200..10_000),
     issued_at: purchase_date,
     created_at: purchase_date,
     updated_at: purchase_date,
-    vendor_id: vendor.id
+    vendor_id: vendor.id,
+    amount_spent_on_period_supplies_cents: rand(0..5_000),
+    amount_spent_on_diapers_cents: rand(0..5_000),
+    amount_spent_on_adult_incontinence_cents: rand(0..5_000),
+    amount_spent_on_other_cents: rand(0..5_000)
   )
+
+  purchase.amount_spent_in_cents = amount_items.map{|i| purchase.send("amount_spent_on_#{i}_cents")}.sum
 
   rand(1..5).times do
     purchase.line_items.push(LineItem.new(quantity: rand(1..1000),

--- a/spec/requests/reports/purchases_summary_requests_spec.rb
+++ b/spec/requests/reports/purchases_summary_requests_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe "Purchases", type: :request do
     describe "GET #index" do
       it "shows a list of recent purchases" do
         get reports_purchases_summary_path
+        expect(response.body).to include("Total spent on diapers")
+        expect(response.body).to include("Total spent on adult incontinence")
+        expect(response.body).to include("Total spent on other")
+        expect(response.body).to include("Total items")
         expect(response.body).to include("Recent purchases")
       end
     end


### PR DESCRIPTION
Resolves #4680

### Description
this is additional information for the purchase reports, it includes :
Total spent on diapers: -- sum of the amount spent on diapers on all purchases during the filter time period
Total spent on period supplies: sum of the amount spent on period supplies on all purchases during the filter time period
Total spent on adult incontinence: -- sum of the amount spent on adult incontinence on all purchases during the filter time period
Total spent on other: -- sum of the amount spent on other on all purchases during the filter time period
Total Items -- total number of items purchased during the filter time period

### Type
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- I modified the existing tests for that view
- I tested manually

### Screenshots
![Screenshot from 2024-10-16 15-32-46](https://github.com/user-attachments/assets/ee7c9293-a303-4915-b28d-abe669c97be6)

