### PR TITLE
Add RDS backup script

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -30,7 +30,7 @@ module Clockwork
     end
   end
 
-  every(4.hours, "Backup prod DB to Azure blob storage", :if => lambda { |_| Rails.env.production? }) do
+  every(4.hours, "Backup prod DB to Azure blob storage", if: lambda { |_| Rails.env.production? }) do
     rake = Rake.application
     rake.init
     rake.load_rakefile

--- a/clock.rb
+++ b/clock.rb
@@ -29,4 +29,11 @@ module Clockwork
       rake["reset_demo"].invoke
     end
   end
+
+  every(4.hours, "Backup prod DB to Azure blob storage", :if => lambda { |_| Rails.env.production? }) do
+    rake = Rake.application
+    rake.init
+    rake.load_rakefile
+    rake["backup_db"].invoke
+  end
 end

--- a/lib/tasks/backup_db_rds.rake
+++ b/lib/tasks/backup_db_rds.rake
@@ -1,0 +1,21 @@
+desc "Update the development db to what is being used in prod"
+task :backup_db => :environment do
+  system("echo Performing dump of the database.")
+
+  current_time = Time.current.strftime("%Y%m%d%H%M%S")
+
+  system("echo Copying of the database...")
+  backup_filename = "#{current_time}.rds.dump"
+  system("PGPASSWORD=#{ENV["DIAPER_DB_PASSWORD"]} pg_dump -Fc -v --host=#{ENV["DIAPER_DB_HOST"]} --username=#{ENV["DIAPER_DB_USERNAME"]} --dbname=#{ENV["DIAPER_DB_DATABASE"]} -f #{backup_filename}")
+
+  account_name = ENV["AZURE_STORAGE_ACCOUNT_NAME"]
+  account_key = ENV["AZURE_STORAGE_ACCESS_KEY"]
+
+  blob_client = Azure::Storage::Blob::BlobService.create(
+    storage_account_name: account_name,
+    storage_access_key: account_key
+  )
+
+  system("echo Uploading #{backup_filename}")
+  blob_client.create_block_blob("backups", backup_filename, File.read(backup_filename))
+end

--- a/lib/tasks/fetch_latest_db.rake
+++ b/lib/tasks/fetch_latest_db.rake
@@ -56,7 +56,7 @@ def fetch_latest_backups
   #
   # Retrieve the most up to date version of the DB dump
   #
-  backup = backups.select { |b| b.name.match?(".dump") }.sort do |a,b|
+  backup = backups.select { |b| b.name.match?(".rds.dump") }.sort do |a,b|
     Time.parse(a.properties[:last_modified]) <=> Time.parse(b.properties[:last_modified])
   end.reverse.first
 


### PR DESCRIPTION
We don't know where the existing `backup_db` Rake task is being run - it doesn't seem to be Cloud66, Azure, Heroku or Fly.io. It's still connecting to the old Azure Postgres database.

This adds a new Rake task that dumps the RDS database so we can use it in the fetch_latest_db script.