### PR TITLE
Fix scanning new barcode item issue (#4592)

### DIFF
--- a/app/views/barcode_items/create.js.erb
+++ b/app/views/barcode_items/create.js.erb
@@ -12,10 +12,7 @@ $('#trigger-field-id').val('');
 // Notify the user
 toastr.success("Barcode Added to Inventory");
 
-// Locate the row where the barcode was entered from
-line_item = $('#' + source_field).closest('.nested-fields');
-// Set the values in the form. This is replicating some logic from barcode_items.js.erb
-$(line_item).find('[data-quantity]').val(quantity);
-$(line_item).find('[value="' + item_id + '"]').attr("selected", true);
-$('#__add_line_item').trigger('click');
-$("input.__barcode_item_lookup").last().focus();
+// Trigger the capture_entry/barcode_item_lookup functions with a return keypress
+// which fills in the item name and quantity, adds new item, and changes focus
+return_keypress = $.Event( "keypress", { which: 13 } )
+$("input.__barcode_item_lookup").last().trigger(return_keypress);

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -490,6 +490,7 @@ RSpec.describe "Donations", type: :system, js: true do
             click_on "Save"
           end
 
+          # form updates
           within "#donation_line_items" do
             barcode_field = page.find(:xpath, "//input[@id='_barcode-lookup-0']").value
             expect(barcode_field).to eq(new_barcode)
@@ -498,7 +499,12 @@ RSpec.describe "Donations", type: :system, js: true do
             item_field = page.find(:xpath, "//select[@id='donation_line_items_attributes_0_item_id']").value
             expect(item_field).to eq(Item.first.id.to_s)
           end
-          # form updates
+
+          # new line item was added and has focus
+          within "#donation_line_items" do
+            expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
+            expect(page).to have_css('#_barcode-lookup-1', focused: true)
+          end
         end
 
         context "When the barcode is a global barcode" do


### PR DESCRIPTION

Resolves #4592 

### Description
Made a change so that the new barcode item modal triggers a return keypress once saved. Which then looks up the newly created barcode, fills in details, adds new item, and changes focus. 

An alternative approach would have been to fix/add that logic to the new barcode modal. The advantage being that we avoid one additional request (to `/barcode_items/find.json?barcode_item[value]=XXXX`), because we already know the item name/quantity. But the disadvantage being that we have that javascript logic in two places (`create.js` modal and `barcode_items.js` utility), so that's why I chose the first approach.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Tested locally on firefox and chrome. Clicking "Save" after adding a new barcode item adds a new line item and switches focus to it.
- Added a few assertions to the corresponding donations system spec.
