### PR TITLE
Minor css improvements

### DIFF
--- a/app/assets/stylesheets/simple_form-bootstrap/_form_abbr.scss
+++ b/app/assets/stylesheets/simple_form-bootstrap/_form_abbr.scss
@@ -1,5 +1,6 @@
 // Source: http://simple-form-bootstrap.plataformatec.com.br/documentation
 
-abbr[title] {
+form abbr[title] {
   text-decoration: none;
+  cursor: inherit;
 }

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -77,7 +77,7 @@ SimpleForm.setup do |config|
   config.wrappers :vertical_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0 font-weight-bold' do |ba|
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0 font-weight-bold float-none' do |ba|
       ba.use :label_text
     end
     b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
@@ -436,3 +436,4 @@ SimpleForm.setup do |config|
   #   time:          :custom_multi_select
   # }
 end
+

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -80,7 +80,7 @@ SimpleForm.setup do |config|
     b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0 font-weight-bold float-none' do |ba|
       ba.use :label_text
     end
-    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
   end


### PR DESCRIPTION
(Doesn't resolve any issue)

### Description
These are all minor styling changes. I know this kind of thing is not a priority but what can I say, I got distracted.

Three small changes:
1. Remove styling of <abbr> tags. These tags are used by the simple form gem to annotate required fields. It appears that the underlining was meant to be removed (or was removed at some point), but the AdminLTE css was overwriting it in when precompiled into `application.css`.
2. In the edit distribution form, the radio buttons are misaligned in Firefox (but not Chrome), so I fixed it.
3. When editing radio buttons, the text is sometimes green? It appears simple form/bootstrap is trying to mark them as valid, but in a way that doesn't make sense. For example on the edit organization screen, any radio button field marked yes will appear green, and those marked no will appear black. When I don't think a "No" response is less valid than a "Yes" response.

See screenshots below:

### Type of change

Purely UI style changes.

### How Has This Been Tested?
I tested the changes manually in Firefox and Chrome, but no specs were added. I can add some if needed, but not sure how much value would be added.

### Screenshots
1. Required field styling change. Note the underlining of the asterisks.
Before:
![Screenshot from 2024-10-25 10-08-30](https://github.com/user-attachments/assets/705899d5-8d95-4ed3-ad02-c7d04942159e)
After: 
![Screenshot from 2024-10-25 10-10-38](https://github.com/user-attachments/assets/b9ae1951-3407-4299-911c-979c85cd00e2)
2. Edit distribution issue in Firefox. Note the "Pick up" radio button alignment.
Before: ![Screenshot from 2024-10-25 10-12-36](https://github.com/user-attachments/assets/9c20262a-9cf6-4b2d-bf02-dca6b77db958)
After: ![Screenshot from 2024-10-25 10-13-22](https://github.com/user-attachments/assets/600b52aa-3e10-46a0-9817-36f722a17535)
3. Note how every input section that was marked "Yes" is in green. 
Before: ![Screenshot from 2024-10-25 10-06-41](https://github.com/user-attachments/assets/61b95bfc-4cbd-4627-bda2-34187e1edfda)
After: ![Screenshot from 2024-10-25 10-07-29](https://github.com/user-attachments/assets/7365941e-fb56-473b-9173-8025d8517d14)
