### PR TITLE
Clock backup fix

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -34,6 +34,6 @@ module Clockwork
     rake = Rake.application
     rake.init
     rake.load_rakefile
-    rake["backup_db"].invoke
+    rake["backup_db_rds"].invoke
   end
 end

--- a/lib/tasks/backup_db_rds.rake
+++ b/lib/tasks/backup_db_rds.rake
@@ -1,5 +1,5 @@
 desc "Update the development db to what is being used in prod"
-task :backup_db => :environment do
+task :backup_db_rds => :environment do
   system("echo Performing dump of the database.")
 
   current_time = Time.current.strftime("%Y%m%d%H%M%S")

--- a/lib/tasks/backup_db_rds.rake
+++ b/lib/tasks/backup_db_rds.rake
@@ -6,7 +6,7 @@ task :backup_db_rds => :environment do
 
   system("echo Copying of the database...")
   backup_filename = "#{current_time}.rds.dump"
-  system("PGPASSWORD=#{ENV["DIAPER_DB_PASSWORD"]} pg_dump -Fc -v --host=#{ENV["DIAPER_DB_HOST"]} --username=#{ENV["DIAPER_DB_USERNAME"]} --dbname=#{ENV["DIAPER_DB_DATABASE"]} -f #{backup_filename}")
+  system("PGPASSWORD='#{ENV["DIAPER_DB_PASSWORD"]}' pg_dump -Fc -v --host=#{ENV["DIAPER_DB_HOST"]} --username=#{ENV["DIAPER_DB_USERNAME"]} --dbname=#{ENV["DIAPER_DB_DATABASE"]} -f #{backup_filename}")
 
   account_name = ENV["AZURE_STORAGE_ACCOUNT_NAME"]
   account_key = ENV["AZURE_STORAGE_ACCESS_KEY"]


### PR DESCRIPTION
This fixes the production backup script, verified through manual execution on the node.

I also had to upgrade the CLI postgres client on the node to postgres-client-16 (which I did manually, not seeing a way to declare it easily)