### PR TITLE
Validate issued_at field to prevent future dates further than 1 year

### DIFF
--- a/app/models/concerns/issued_at.rb
+++ b/app/models/concerns/issued_at.rb
@@ -10,6 +10,7 @@ module IssuedAt
     scope :by_issued_at, ->(issued_at) { where(issued_at: issued_at.beginning_of_month..issued_at.end_of_month) }
     scope :for_year, ->(year) { where("extract(year from issued_at) = ?", year) }
     validate :issued_at_cannot_be_before_2000
+    validate :issued_at_cannot_be_further_than_1_year
   end
 
   private
@@ -21,6 +22,12 @@ module IssuedAt
   def issued_at_cannot_be_before_2000
     if issued_at.present? && issued_at < Date.new(2000, 1, 1)
       errors.add(:issued_at, "Cannot be before 2000")
+    end
+  end
+
+  def issued_at_cannot_be_further_than_1_year
+    if issued_at.present? && issued_at > DateTime.now.next_year
+      errors.add(:issued_at, "cannot be more than 1 year in the future")
     end
   end
 end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe Distribution, type: :model do
       expect(d).not_to be_valid
     end
 
+    it "ensures that the issued at is no later than 1 year" do
+      d = build(:distribution, issued_at: DateTime.now.next_year(2).to_s)
+      expect(d).not_to be_valid
+    end
+
     context "when delivery method is shipped" do
       context "shipping cost is negative" do
         let(:distribution) { build(:distribution, delivery_method: "shipped", shipping_cost: -13) }

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe Donation, type: :model do
       d = build(:donation, issued_at: '1999-12-31')
       expect(d).not_to be_valid
     end
+    it "ensures that the issued at is no later than 1 year" do
+      d = build(:donation, issued_at: DateTime.now.next_year(2).to_s)
+      expect(d).not_to be_valid
+    end
   end
 
   context "Callbacks >" do

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe Purchase, type: :model do
       p = build(:purchase, issued_at: "1999-12-31")
       expect(p).not_to be_valid
     end
+    it "ensures that the issued at is no later than 1 year" do
+      p = build(:purchase, issued_at: DateTime.now.next_year(2).to_s)
+      expect(p).not_to be_valid
+    end
   end
 
   context "Callbacks >" do

--- a/spec/services/calendar_service_spec.rb
+++ b/spec/services/calendar_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CalendarService do
           partner: partner1, storage_location: storage_location)
         create(:distribution, issued_at: time_zone.local(2019, 1, 1),
           partner: partner2, storage_location: storage_location)
-        create(:distribution, issued_at: time_zone.local(2023, 3, 17),
+        create(:distribution, issued_at: time_zone.local(2022, 3, 17),
           partner: partner2, storage_location: storage_location)
         result = described_class.calendar(organization.id)
         expected = <<~ICAL
@@ -58,8 +58,8 @@ RSpec.describe CalendarService do
            e
           END:VEVENT
           BEGIN:VEVENT
-          DTSTART;TZID=America/New_York:20230316T210000
-          DTEND;TZID=America/New_York:20230316T211500
+          DTSTART;TZID=America/New_York:20220316T210000
+          DTEND;TZID=America/New_York:20220316T211500
           LOCATION:1500 Remount Road\\, Front Royal\\, VA 22630
           SUMMARY:Pickup from Partner 2
           URL;VALUE=URI:https://humanessentials.app/diaper_bank/distributions/schedul


### PR DESCRIPTION
Resolves #4742

### Description

Add a new validation to the `issued_at` field which is present on the donation, distribution, and purchase models. The new validation ensures that the field can not be set to a date that is further than one year into the future, as this causes unexpected behaviour when the models are later filtered.

An alternative solution could be to add this validation to the models themselves, but putting it in the centralized location was an existing pattern and made more sense.

Tradeoff: Are there valid use cases where we might want to have set this date to further than one year ahead?

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added new unit tests following existing patterns for all affected models and ensured they passed

### Screenshots

**Note**: Although not pictured, I also tested that the validation is run when the date on a purchase, donation, or distribution is edited after creation.

<details><summary>📸 Validation error shown on new donation</summary>
<img width="1085" alt="Screen Shot 2024-10-28 at 9 59 30 PM" src="https://github.com/user-attachments/assets/8ff5c4e7-b08d-44ec-a8ed-28be7f863f78">
</details>

<details><summary>📸 Validation error shown on new purchase</summary>
<img width="1085" alt="Screen Shot 2024-10-28 at 9 59 00 PM" src="https://github.com/user-attachments/assets/229bf122-2888-48c5-b302-1bd7f8484981">
</details>

<details><summary>📸 Validation error shown on new distribution</summary>
<img width="1085" alt="Screen Shot 2024-10-28 at 9 58 41 PM" src="https://github.com/user-attachments/assets/e73efa96-650d-435c-b4ce-acb4d61dfbbf">
<details>