### PR TITLE
4743 extend all time date range to future

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -90,7 +90,7 @@ $(document).ready(function(){
       format: "MMMM D, YYYY",
       ranges: {
         customRanges: {
-          'All Time': [today.minus({ 'years': 100}).toJSDate(), today.toJSDate()],
+          'All Time': [today.minus({ 'years': 100 }).toJSDate(), today.plus({ 'years': 1 }).toJSDate()],
           'Today': [today.toJSDate(), today.toJSDate()],
           'Yesterday': [today.minus({'days': 1}).toJSDate(), today.minus({'days': 1}).toJSDate()],
           'Last 7 Days': [today.minus({'days': 6}).toJSDate(), today.toJSDate()],

--- a/spec/support/date_range_picker_shared_example.rb
+++ b/spec/support/date_range_picker_shared_example.rb
@@ -22,6 +22,7 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
   let!(:very_old) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2000, 7, 31), :organization => organization) }
   let!(:recent) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2019, 7, 24), :organization => organization) }
   let!(:today) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2019, 7, 31), :organization => organization) }
+  let!(:one_year_ahead) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2020, 7, 31), :organization => organization) }
 
   context "when choosing 'All Time'" do
     before do
@@ -36,10 +37,10 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
 
     it "shows all the records" do
       visit subject
-      date_range = "#{Time.zone.local(1919, 7, 1).to_formatted_s(:date_picker)} - #{Time.zone.local(2019, 7, 31).to_formatted_s(:date_picker)}"
+      date_range = "#{Time.zone.local(1919, 7, 1).to_formatted_s(:date_picker)} - #{Time.zone.local(2020, 7, 31).to_formatted_s(:date_picker)}"
       fill_in "filters_date_range", with: date_range
       find(:id, 'filters_date_range').native.send_keys(:enter)
-      expect(page).to have_css("table tbody tr", count: 3)
+      expect(page).to have_css("table tbody tr", count: 4)
     end
   end
 

--- a/spec/support/date_range_picker_shared_example.rb
+++ b/spec/support/date_range_picker_shared_example.rb
@@ -23,6 +23,7 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
   let!(:recent) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2019, 7, 24), :organization => organization) }
   let!(:today) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2019, 7, 31), :organization => organization) }
   let!(:one_year_ahead) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2020, 7, 31), :organization => organization) }
+  let!(:two_years_ahead) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2021, 7, 31), :organization => organization) }
 
   context "when choosing 'All Time'" do
     before do


### PR DESCRIPTION
Resolves #4743 

### Description
* Change the "All time" date range to include 1 year into the future

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
* I added tests to the date_range_picker_shared_example.rb to ensure that elements up to 1 year in the future are being displayed.