### PR TITLE
Fix typo : "Quantity Per Indivudual" should be "Quantity per Individual"

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -48,7 +48,7 @@
                 <td><%= @item.value_in_cents || 0 %></td>
               </tr>
               <tr>
-                <th>Quantity Per Indivudual</th>
+                <th>Quantity per Individual</th>
                 <td><%= @item.distribution_quantity || 0 %></td>
               </tr>
               <tr>

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe "Items", type: :request do
         expect(response.body).to include('CURRENTCATEGORY')
         expect(response.body).to include('Value Per Item')
         expect(response.body).to include('20000')
-        expect(response.body).to include('Quantity Per Indivudual')
+        expect(response.body).to include('Quantity per Individual')
         expect(response.body).to include('2000')
         expect(response.body).to include('On hand minimum quantity')
         expect(response.body).to include('1200')


### PR DESCRIPTION
Resolves #4747 

### Description

"Quantity Per Indivudual" should be "Quantity per Individual"

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue

### Screenshots
![Typofix](https://github.com/user-attachments/assets/e72eb894-bc03-42db-9efa-0ce5d27aaf73)

