### PR TITLE
Resolves #4740 - Add new default date range

### DIFF
--- a/app/helpers/date_range_helper.rb
+++ b/app/helpers/date_range_helper.rb
@@ -1,7 +1,7 @@
 # Encapsulates methods used on the Dashboard that need some business logic
 module DateRangeHelper
   def date_range_params
-    params.dig(:filters, :date_range).presence || this_year
+    params.dig(:filters, :date_range).presence || default_date
   end
 
   def date_range_label
@@ -23,8 +23,10 @@ module DateRangeHelper
     end
   end
 
-  def this_year
-    "January 1, #{Time.zone.today.year} - December 31, #{Time.zone.today.year}"
+  def default_date
+    start_date = 2.months.ago.to_date
+    end_date = 1.month.from_now.to_date
+    "#{start_date.strftime("%B %d, %Y")} - #{end_date.strftime("%B %d, %Y")}"
   end
 
   def selected_interval

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -90,6 +90,7 @@ $(document).ready(function(){
       format: "MMMM D, YYYY",
       ranges: {
         customRanges: {
+          'Default': [today.minus({'months': 2}).toJSDate(), today.plus({'months': 1}).toJSDate()],
           'All Time': [today.minus({ 'years': 100 }).toJSDate(), today.plus({ 'years': 1 }).toJSDate()],
           'Today': [today.toJSDate(), today.toJSDate()],
           'Yesterday': [today.minus({'days': 1}).toJSDate(), today.minus({'days': 1}).toJSDate()],

--- a/spec/support/date_range_picker_shared_example.rb
+++ b/spec/support/date_range_picker_shared_example.rb
@@ -20,10 +20,29 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
   let(:user) { create(:user, organization: organization) }
 
   let!(:very_old) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2000, 7, 31), :organization => organization) }
+  let!(:two_months_ago) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2019, 5, 31), :organization => organization) }
   let!(:recent) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2019, 7, 24), :organization => organization) }
   let!(:today) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2019, 7, 31), :organization => organization) }
+  let!(:one_month_ahead) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2019, 8, 31), :organization => organization) }
   let!(:one_year_ahead) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2020, 7, 31), :organization => organization) }
   let!(:two_years_ahead) { create(described_class.to_s.underscore.to_sym, date_field.to_sym => Time.zone.local(2021, 7, 31), :organization => organization) }
+
+  context "when choosing 'Default'" do
+    before do
+      sign_out user
+      travel_to Time.zone.local(2019, 7, 31)
+      sign_in user
+    end
+
+    after do
+      travel_back
+    end
+
+    it "shows only 4 records" do
+      visit subject
+      expect(page).to have_css("table tbody tr", count: 4)
+    end
+  end
 
   context "when choosing 'All Time'" do
     before do
@@ -41,7 +60,7 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
       date_range = "#{Time.zone.local(1919, 7, 1).to_formatted_s(:date_picker)} - #{Time.zone.local(2020, 7, 31).to_formatted_s(:date_picker)}"
       fill_in "filters_date_range", with: date_range
       find(:id, 'filters_date_range').native.send_keys(:enter)
-      expect(page).to have_css("table tbody tr", count: 4)
+      expect(page).to have_css("table tbody tr", count: 6)
     end
   end
 

--- a/spec/system/product_drive_system_spec.rb
+++ b/spec/system/product_drive_system_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
     it "Shows the expected filters with the expected values and in alphabetical order for name filter" do
       expect(page.find("select[name='filters[by_name]']").find(:xpath, 'option[2]').text).to eq "Alpha Test name 3"
       expect(page.has_select?('filters[by_name]', with_options: @product_drives.map(&:name))).to be true
-      expect(page.has_field?('filters_date_range', with: this_year))
+      expect(page.has_field?('filters_date_range', with: default_date))
     end
 
     it "shows the expected product drives" do


### PR DESCRIPTION
Resolves #4740 

### Description
* Change the default date range for all filters to 60 days prior, 30 days in the future.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
* add test cases for default range in date_range_picker_shared_example

