### PR TITLE
[#4504] Add step-wise partner profile edit form

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -98,3 +98,13 @@
     margin-top: 40px;
   }
 }
+
+.accordion-button.saving::after {
+  background-image:  none;
+  content: "Saving...";
+  font-size: 0.875rem;
+  color: #005568;
+  transform: none;
+  width: 3rem;
+  cursor: not-allowed;
+}

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -28,7 +28,7 @@ module Partners
         flash.now[:error] = "There is a problem. Try again:  %s" % result.error
         if Flipper.enabled?("partner_step_form")
           error_keys = current_partner.profile.errors.attribute_names
-          @sections_with_errors = Partners::SectionErrorService.new(error_keys).call
+          @sections_with_errors = Partners::SectionErrorService.sections_with_errors(error_keys)
           render "partners/profiles/step/edit"
         else
           render :edit

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -20,7 +20,11 @@ module Partners
       if result.success?
         flash[:success] = "Details were successfully updated."
         if Flipper.enabled?("partner_step_form")
-          redirect_to edit_partners_profile_path
+          if params[:save_review]
+            redirect_to partners_profile_path
+          else
+            redirect_to edit_partners_profile_path
+          end
         else
           redirect_to partners_profile_path
         end

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -5,6 +5,13 @@ module Partners
     def edit
       @counties = County.in_category_name_order
       @client_share_total = current_partner.profile.client_share_total
+
+      if Flipper.enabled?("partner_step_form")
+        @sections_with_errors = []
+        render "partners/profiles/step/edit"
+      else
+        render "edit"
+      end
     end
 
     def update
@@ -12,10 +19,20 @@ module Partners
       result = PartnerProfileUpdateService.new(current_partner, partner_params, profile_params).call
       if result.success?
         flash[:success] = "Details were successfully updated."
-        redirect_to partners_profile_path
+        if Flipper.enabled?("partner_step_form")
+          redirect_to edit_partners_profile_path
+        else
+          redirect_to partners_profile_path
+        end
       else
-        flash[:error] = "There is a problem. Try again:  %s" % result.error
-        render :edit
+        flash.now[:error] = "There is a problem. Try again:  %s" % result.error
+        if Flipper.enabled?("partner_step_form")
+          error_keys = current_partner.profile.errors.attribute_names
+          @sections_with_errors = Partners::SectionErrorService.new(error_keys).call
+          render "partners/profiles/step/edit"
+        else
+          render :edit
+        end
       end
     end
 

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -31,10 +31,6 @@ module PartnersHelper
     partner.invited? || partner.recertification_required?
   end
 
-  def submit_for_approval_disabled?(partner_profile)
-    partner_profile.errors.any?
-  end
-
   # In step-wise editing of the partner profile, the partial name is used as the section header by default.
   # This helper allows overriding the header with a custom display name if needed.
   def partial_display_name(partial)

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -27,6 +27,28 @@ module PartnersHelper
     end
   end
 
+  def show_submit_for_approval?(partner)
+    partner.invited? || partner.recertification_required?
+  end
+
+  def submit_for_approval_disabled?(partner_profile)
+    partner_profile.errors.any?
+  end
+
+  # In step-wise editing of the partner profile, the partial name is used as the section header by default.
+  # This helper allows overriding the header with a custom display name if needed.
+  def partial_display_name(partial)
+    custom_names = {
+      'attached_documents' => 'Additional Documents'
+    }
+
+    custom_names[partial] || partial.humanize
+  end
+
+  def section_with_errors?(section, sections_with_errors = [])
+    sections_with_errors.include?(section)
+  end
+
   def partner_status_badge(partner)
     if partner.status == "approved"
       tag.span partner.display_status, class: %w(badge badge-pill badge-primary bg-primary float-right)

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -27,10 +27,6 @@ module PartnersHelper
     end
   end
 
-  def show_submit_for_approval?(partner)
-    partner.invited? || partner.recertification_required?
-  end
-
   # In step-wise editing of the partner profile, the partial name is used as the section header by default.
   # This helper allows overriding the header with a custom display name if needed.
   def partial_display_name(partial)

--- a/app/javascript/controllers/accordion_controller.js
+++ b/app/javascript/controllers/accordion_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="accordion"
+// Intercepts form submission and disables the open/close section buttons.
+export default class extends Controller {
+  static targets = [ "form" ]
+
+  disableOpenClose(event) {
+    event.preventDefault();
+
+    const buttons = this.element.querySelectorAll(".accordion-button");
+    buttons.forEach(button => {
+      button.disabled = true;
+      button.classList.add("saving");
+    });
+
+    this.formTarget.requestSubmit();
+  }
+}

--- a/app/models/partners/profile.rb
+++ b/app/models/partners/profile.rb
@@ -142,13 +142,23 @@ module Partners
       # their allocation actually is
       total = client_share_total
       if total != 0 && total != 100
-        errors.add(:base, "Total client share must be 0 or 100")
+        if Flipper.enabled?("partner_step_form")
+          # need to set errors on specific fields within the form so that it can be mapped to a section
+          errors.add(:client_share, "Total client share must be 0 or 100")
+        else
+          errors.add(:base, "Total client share must be 0 or 100")
+        end
       end
     end
 
     def has_at_least_one_request_setting
       if !(enable_child_based_requests || enable_individual_requests || enable_quantity_based_requests)
-        errors.add(:base, "At least one request type must be set")
+        if Flipper.enabled?("partner_step_form")
+          # need to set errors on specific fields within the form so that it can be mapped to a section
+          errors.add(:enable_child_based_requests, "At least one request type must be set")
+        else
+          errors.add(:base, "At least one request type must be set")
+        end
       end
     end
 

--- a/app/services/partner_create_service.rb
+++ b/app/services/partner_create_service.rb
@@ -16,12 +16,12 @@ class PartnerCreateService
         @partner.save!
 
         Partners::Profile.create!({
-                                      partner_id: @partner.id,
-                                      name: @partner.name,
-                                      enable_child_based_requests: organization.enable_child_based_requests,
-                                      enable_individual_requests: organization.enable_individual_requests,
-                                      enable_quantity_based_requests: organization.enable_quantity_based_requests
-                                    })
+                                    partner_id: @partner.id,
+                                    name: @partner.name,
+                                    enable_child_based_requests: organization.enable_child_based_requests,
+                                    enable_individual_requests: organization.enable_individual_requests,
+                                    enable_quantity_based_requests: organization.enable_quantity_based_requests
+                                  })
       rescue StandardError => e
         errors.add(:base, e.message)
         raise ActiveRecord::Rollback

--- a/app/services/partner_create_service.rb
+++ b/app/services/partner_create_service.rb
@@ -16,12 +16,12 @@ class PartnerCreateService
         @partner.save!
 
         Partners::Profile.create!({
-                                    partner_id: @partner.id,
-                                    name: @partner.name,
-                                    enable_child_based_requests: organization.enable_child_based_requests,
-                                    enable_individual_requests: organization.enable_individual_requests,
-                                    enable_quantity_based_requests: organization.enable_quantity_based_requests
-                                  })
+                                      partner_id: @partner.id,
+                                      name: @partner.name,
+                                      enable_child_based_requests: organization.enable_child_based_requests,
+                                      enable_individual_requests: organization.enable_individual_requests,
+                                      enable_quantity_based_requests: organization.enable_quantity_based_requests
+                                    })
       rescue StandardError => e
         errors.add(:base, e.message)
         raise ActiveRecord::Rollback

--- a/app/services/partners/section_error_service.rb
+++ b/app/services/partners/section_error_service.rb
@@ -3,15 +3,9 @@ module Partners
   # should expand when validation errors occur. This helps users easily locate and fix
   # fields with errors in specific sections.
   #
-  # Why this service is needed:
-  # In the Partner Profile step-wise form, fields are grouped within collapsible sections.
-  # When validation errors happen, this service maps the fields with errors to their sections,
-  # ensuring the relevant sections open automatically so users can address the issues directly.
-  #
   # Usage:
   #   error_keys = [:website, :pick_up_name, :enable_quantity_based_requests]
-  #   service = Partners::SectionErrorService.new(error_keys)
-  #   sections_with_errors = service.call
+  #   sections_with_errors = Partners::SectionErrorService.sections_with_errors(error_keys)
   #   # => ["media_information", "pick_up_person", "partner_settings"]
   #
   class SectionErrorService
@@ -23,31 +17,14 @@ module Partners
       area_served: %i[client_share county_id]
     }
 
-    # Initializes a new SectionErrorService with a set of error attribute keys.
-    #
-    # @param error_keys [Array<Symbol>] Array of attribute keys representing the fields with errors.
-    def initialize(error_keys)
-      @error_keys = error_keys
-    end
-
     # Returns a list of unique sections that contain errors based on the given error keys.
     #
+    # @param error_keys [Array<Symbol>] Array of attribute keys representing the fields with errors.
     # @return [Array<String>] An array of section names containing errors.
-    def call
-      @error_keys.map { |key| section_for_field(key) }.compact.uniq
-    end
-
-    private
-
-    # Maps an individual error field to its corresponding section.
-    #
-    # @param field [Symbol] The field (error key) to map to a section.
-    # @return [String, nil] The section name containing the field, or nil if the field has no associated section.
-    def section_for_field(field)
-      SECTION_FIELD_MAPPING.each do |section, fields|
-        return section.to_s if fields.include?(field)
-      end
-      nil
+    def self.sections_with_errors(error_keys)
+      error_keys.flat_map do |key|
+        SECTION_FIELD_MAPPING.find { |_section, fields| fields.include?(key) }&.first
+      end.compact.uniq.map(&:to_s)
     end
   end
 end

--- a/app/services/partners/section_error_service.rb
+++ b/app/services/partners/section_error_service.rb
@@ -1,0 +1,53 @@
+module Partners
+  # SectionErrorService identifies which sections of the Partner Profile step-wise form
+  # should expand when validation errors occur. This helps users easily locate and fix
+  # fields with errors in specific sections.
+  #
+  # Why this service is needed:
+  # In the Partner Profile step-wise form, fields are grouped within collapsible sections.
+  # When validation errors happen, this service maps the fields with errors to their sections,
+  # ensuring the relevant sections open automatically so users can address the issues directly.
+  #
+  # Usage:
+  #   error_keys = [:website, :pick_up_name, :enable_quantity_based_requests]
+  #   service = Partners::SectionErrorService.new(error_keys)
+  #   sections_with_errors = service.call
+  #   # => ["media_information", "pick_up_person", "partner_settings"]
+  #
+  class SectionErrorService
+    # Maps form sections to the associated fields (error keys) that belong to them.
+    SECTION_FIELD_MAPPING = {
+      media_information: %i[no_social_media_presence website twitter facebook instagram],
+      partner_settings: %i[enable_child_based_requests enable_individual_requests enable_quantity_based_requests],
+      pick_up_person: %i[pick_up_email pick_up_name pick_up_phone],
+      area_served: %i[client_share county_id]
+    }
+
+    # Initializes a new SectionErrorService with a set of error attribute keys.
+    #
+    # @param error_keys [Array<Symbol>] Array of attribute keys representing the fields with errors.
+    def initialize(error_keys)
+      @error_keys = error_keys
+    end
+
+    # Returns a list of unique sections that contain errors based on the given error keys.
+    #
+    # @return [Array<String>] An array of section names containing errors.
+    def call
+      @error_keys.map { |key| section_for_field(key) }.compact.uniq
+    end
+
+    private
+
+    # Maps an individual error field to its corresponding section.
+    #
+    # @param field [Symbol] The field (error key) to map to a section.
+    # @return [String, nil] The section name containing the field, or nil if the field has no associated section.
+    def section_for_field(field)
+      SECTION_FIELD_MAPPING.each do |section, fields|
+        return section.to_s if fields.include?(field)
+      end
+      nil
+    end
+  end
+end

--- a/app/views/layouts/partners/application.html.erb
+++ b/app/views/layouts/partners/application.html.erb
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Human Essentials</title>
   <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+
   <%= csrf_meta_tags %>
 
   <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet">

--- a/app/views/partners/profiles/step/_accordion_section.html.erb
+++ b/app/views/partners/profiles/step/_accordion_section.html.erb
@@ -1,0 +1,24 @@
+<%# locals: (f:, partner:, section_id:, section_title:, icon_class:, partial_name:, sections_with_errors:) %>
+
+<div class="accordion-item">
+  <h2 class="accordion-header">
+    <button
+      class="accordion-button <%= section_with_errors?(section_id, sections_with_errors) ? '' : 'collapsed' %>"
+      type="button" data-bs-toggle="collapse" data-bs-target="#<%= section_id %>"
+      aria-expanded="<%= section_with_errors?(section_id, sections_with_errors) %>"
+      aria-controls="<%= section_id %>">
+      <div class="d-flex justify-content-between align-items-center w-100">
+        <div class="fs-4">
+          <i class="fa <%= icon_class %> mr-2"></i>
+          <%= section_title %>
+        </div>
+      </div>
+    </button>
+  </h2>
+  <div id="<%= section_id %>"
+    class="accordion-collapse collapse <%= section_with_errors?(section_id, sections_with_errors) ? 'show' : '' %>">
+    <div class="accordion-body">
+      <%= render "partners/profiles/step/#{partial_name}_form" , f: f, partner: partner, profile: partner.profile %>
+    </div>
+  </div>
+</div>

--- a/app/views/partners/profiles/step/_agency_distribution_information_form.html.erb
+++ b/app/views/partners/profiles/step/_agency_distribution_information_form.html.erb
@@ -1,0 +1,15 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <h3><strong>Agency Distribution Information</strong></h3>
+
+  <div class="form-group">
+    <%= pf.input :distribution_times, label: "Distribution Times", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :new_client_times, label: "New Client Times", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :more_docs_required, label: "More Docs Required", class: "form-control" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_agency_information_form.html.erb
+++ b/app/views/partners/profiles/step/_agency_information_form.html.erb
@@ -1,0 +1,51 @@
+<div class="form-group">
+  <%= f.input :name, label: "Agency Name", required: true, class: "form-control" %>
+</div>
+
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :agency_type, collection: Partner::AGENCY_TYPES.values, label: "Agency Type",  class: "form-control", wrapper: :input_group %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :other_agency_type, label: "Other Agency Type", class: "form-control" %>
+  </div>
+
+  <div class="form-group row">
+    <label class="control-label col-md-3">501(c)(3) IRS Determination Letter</label>
+    <% if profile.proof_of_partner_status.attached? %>
+      <div class="col-md-8">
+        Attached file: <%= link_to profile.proof_of_partner_status.blob['filename'], rails_blob_path(profile.proof_of_partner_status), class: "font-weight-bold" %>
+        <%= pf.file_field :proof_of_partner_status, class: "form-control-file" %>
+      </div>
+    <% else %>
+      <div class="col-md-8">
+        <%= pf.file_field :proof_of_partner_status, class: "form-control-file" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :agency_mission, as: :text, label: "Agency Mission", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :address1, label: "Address (line 1)", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :address2, label: "Address (line 2)", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :city, label: "City", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :state, label: "State", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :zip_code, label: "Zip Code", class: "form-control" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_agency_stability_form.html.erb
+++ b/app/views/partners/profiles/step/_agency_stability_form.html.erb
@@ -1,0 +1,52 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :founded, label: "Year Founded", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :form_990, label: "Form 990 Filed", as: :radio_buttons, class: "form-control" %>
+  </div>
+
+  <% if profile.proof_of_form_990.attached? %>
+    <div class="form-group">
+      <label>Attached file: </label>
+      <%= link_to profile.proof_of_form_990.blob['filename'], rails_blob_path(profile.proof_of_form_990), class: "font-weight-bold" %>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= pf.file_field :proof_of_form_990, class: "form-control-file" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :program_name, label: "Program Name(s)", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :program_description, label: "Program Description(s)", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :program_age, label: "Agency Age", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :evidence_based, label: "Evidence Based?", as: :radio_buttons, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :case_management, label: "Case Management", as: :radio_buttons, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :essentials_use, label: "How Are Essentials (e.g. diapers, period supplies) Used In Your Program?", as: :text, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :receives_essentials_from_other, label: "Do You Receive Essentials From Other Sources?", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :currently_provide_diapers, label: "Currently Providing Diapers?", as: :radio_buttons, class: "form-control" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_area_served_form.html.erb
+++ b/app/views/partners/profiles/step/_area_served_form.html.erb
@@ -1,0 +1,26 @@
+<%= f.simple_fields_for :profile, profile do |pf| %>
+  <div data-controller="area-served">
+    <fieldset style="margin-bottom: 2rem">
+      <legend></legend>
+      <div id="served_areas" class="partner-served-area-fields partner-served-areas">
+        <%= render 'served_areas/served_area_fields', form: pf %>
+      </div>
+
+      <div class="partner-served_areas-total-row row">
+        <div class="partners-served-areas-total-prompt col-w">Total is:</div>
+        <span id="partners-served-areas-client-share-total" class="partners-served-areas-total-value col-2 numeric" data-area-served-target="total">
+          <%= @client_share_total %> %
+        </span>
+        <div id="partners-served-areas-client-share-total-warning" class="partners-served-areas-total-warning col-8" data-area-served-target="warning">
+          The total client share must be either 0 or 100 %.
+        </div>
+      </div>
+
+      <div class="row links justify-content-end">
+        <%= add_element_button "Add Another County", container_selector: "#served_areas", id: "__add_partner_served_area" do %>
+          <%= render 'served_areas/served_area_fields', form: pf, object: Partners::ServedArea.new %>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_attached_documents_form.html.erb
+++ b/app/views/partners/profiles/step/_attached_documents_form.html.erb
@@ -1,0 +1,15 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <% if profile.documents.attached? %>
+      <strong>Attached files:</strong>
+      <ul>
+        <% profile.documents.each do |doc| %>
+          <li><%= link_to doc.blob['filename'], rails_blob_path(doc), class: "font-weight-bold" %></li>
+        <% end %>
+      </ul>
+      <%= pf.file_field :documents, multiple: true, class: "form-control-file" %>
+    <% else %>
+      <%= pf.file_field :documents, multiple: true, class: "form-control-file" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_executive_director_form.html.erb
+++ b/app/views/partners/profiles/step/_executive_director_form.html.erb
@@ -1,0 +1,26 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :executive_director_name, label: "Executive Director Name", class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :executive_director_phone, label: "Executive Director Phone", class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :executive_director_email, label: "Executive Director Email", class: "form-control" %>
+  </div>
+
+  <h3 class="pt-3"><strong>Primary Contact</strong></h3>
+
+  <div class="form-group">
+    <%= pf.input :primary_contact_name, label: "Primary Contact Name", class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :primary_contact_phone, label: "Primary Contact Phone", class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :primary_contact_mobile, label: "Primary Contact Cell", class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :primary_contact_email, label: "Primary Contact Email", class: "form-control" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_form_actions.html.erb
+++ b/app/views/partners/profiles/step/_form_actions.html.erb
@@ -4,10 +4,6 @@
   <%= f.button :submit, "Save Progress", class: 'btn btn-primary mr-2', data: { action: "click->accordion#disableOpenClose" } %>
 
   <% if show_submit_for_approval?(current_partner) %>
-    <% if submit_for_approval_disabled?(current_partner.profile) %>
-      <span class="btn btn-success disabled">Submit Profile for Approval</span>
-    <% else %>
-      <%= link_to 'Submit Profile for Approval', partners_approval_request_path, method: :post, class: 'btn btn-success' %>
-    <% end %>
+    <%= link_to 'Submit Profile for Approval', partners_approval_request_path, method: :post, class: 'btn btn-success' %>
   <% end %>
 </div>

--- a/app/views/partners/profiles/step/_form_actions.html.erb
+++ b/app/views/partners/profiles/step/_form_actions.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (f:, partner:) %>
+
+<div class="form-group mt-4 d-flex justify-content-start mx-5">
+  <%= f.button :submit, "Save Progress", class: 'btn btn-primary mr-2', data: { action: "click->accordion#disableOpenClose" } %>
+
+  <% if show_submit_for_approval?(current_partner) %>
+    <% if submit_for_approval_disabled?(current_partner.profile) %>
+      <span class="btn btn-success disabled">Submit Profile for Approval</span>
+    <% else %>
+      <%= link_to 'Submit Profile for Approval', partners_approval_request_path, method: :post, class: 'btn btn-success' %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/partners/profiles/step/_form_actions.html.erb
+++ b/app/views/partners/profiles/step/_form_actions.html.erb
@@ -1,9 +1,6 @@
 <%# locals: (f:, partner:) %>
 
 <div class="form-group mt-4 d-flex justify-content-start mx-5">
-  <%= f.button :submit, "Save Progress", class: 'btn btn-primary mr-2', data: { action: "click->accordion#disableOpenClose" } %>
-
-  <% if show_submit_for_approval?(current_partner) %>
-    <%= link_to 'Submit Profile for Approval', partners_approval_request_path, method: :post, class: 'btn btn-success' %>
-  <% end %>
+  <%= f.submit "Save Progress", class: 'btn btn-primary mr-2', data: { action: "click->accordion#disableOpenClose" } %>
+  <%= f.submit "Save and Review", name: "save_review", class: 'btn btn-success' %>
 </div>

--- a/app/views/partners/profiles/step/_media_information_form.html.erb
+++ b/app/views/partners/profiles/step/_media_information_form.html.erb
@@ -1,0 +1,22 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :website, label: "Website", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :facebook, label: "Facebook", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :twitter, label: "Twitter", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :instagram, label: "Instagram", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.check_box :no_social_media_presence, as: :boolean %>&nbsp;
+    <%= pf.label :no_social_media_presence, "No Social Media Presence" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_organizational_capacity_form.html.erb
+++ b/app/views/partners/profiles/step/_organizational_capacity_form.html.erb
@@ -1,0 +1,13 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :client_capacity, label: "Client Capacity", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :storage_space, label: "Storage Space", as: :radio_buttons, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :describe_storage_space, label: "Storage Space Description", class: "form-control" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_partner_settings_form.html.erb
+++ b/app/views/partners/profiles/step/_partner_settings_form.html.erb
@@ -1,0 +1,22 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <% if pf.object.organization.enable_quantity_based_requests? %>
+    <div class="form-group">
+      <%= pf.check_box :enable_quantity_based_requests, as: :boolean %>&nbsp;
+      <%= pf.label :enable_quantity_based_requests, "Enable Quantity-based Requests" %>
+    </div>
+  <% end %>
+
+  <% if pf.object.organization.enable_child_based_requests? %>
+    <div class="form-group">
+      <%= pf.check_box :enable_child_based_requests, as: :boolean %>&nbsp;
+      <%= pf.label :enable_child_based_requests, "Enable Child-based Requests (unclick if you only do bulk requests)" %>
+    </div>
+  <% end %>
+
+  <% if pf.object.organization.enable_individual_requests? %>
+    <div class="form-group">
+      <%= pf.check_box :enable_individual_requests, as: :boolean %>&nbsp;
+      <%= pf.label :enable_individual_requests, "Enable Requests for Individuals" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/partners/profiles/step/_pick_up_person_form.html.erb
+++ b/app/views/partners/profiles/step/_pick_up_person_form.html.erb
@@ -1,0 +1,11 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :pick_up_name, label: "Pick Up Person Name", class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :pick_up_phone, label: "Pick Up Person's Phone #", class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :pick_up_email, label: "Pick Up Person's Email", class: "form-control" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_population_served_form.html.erb
+++ b/app/views/partners/profiles/step/_population_served_form.html.erb
@@ -1,0 +1,58 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :income_requirement_desc, label: "Clients Have An Income Requirement to Work With You?",
+              as: :radio_buttons, class: "form-control", wrapper: :input_group,
+              wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :income_verification, label: "Do You Verify The Income Of Your Clients?",
+              as: :radio_buttons, class: "form-control", wrapper: :input_group,
+              wrapper_html: {class: "form-yesno"}, input_html: {class: "radio-yesno"} %>
+  </div>
+
+  <h3 class="pt-3"><strong>Race/Ethnicity of Client Base</strong></h3>
+
+  <div class="form-group">
+    <%= pf.input :population_black, label: "% African American", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :population_white, label: "% Caucasian", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :population_hispanic, label: "% Hispanic", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :population_asian, label: "% Asian", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :population_american_indian, label: "% American Indian", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :population_island, label: "% Pacific Island", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :population_multi_racial, label: "% Multi-racial", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :population_other, label: "% Other", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :zips_served, label: "Zip Codes Served", class: "form-control", wrapper: :input_group %>
+  </div>
+
+  <h3 class="pt-3"><strong>Poverty Information of Those Served</strong></h3>
+
+  <div class="form-group">
+    <%= pf.input :at_fpl_or_below, label: "% At FPL or Below", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :above_1_2_times_fpl, label: "% Above 1-2 times FPL", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :greater_2_times_fpl, label: "% Greater than 2 times FPL", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+  <div class="form-group">
+    <%= pf.input :poverty_unknown, label: "% Poverty Unknown", as: :integer, class: "form-control", wrapper: :input_group %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_program_delivery_address_form.html.erb
+++ b/app/views/partners/profiles/step/_program_delivery_address_form.html.erb
@@ -1,0 +1,21 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :program_address1, label: "Address (line 1)", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :program_address2, label: "Address (line 2)", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :program_city, label: "City", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :program_state, label: "State", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :program_zip_code, label: "Zip Code", class: "form-control" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/_sources_of_funding_form.html.erb
+++ b/app/views/partners/profiles/step/_sources_of_funding_form.html.erb
@@ -1,0 +1,17 @@
+<%= f.fields_for :profile, profile do |pf| %>
+  <div class="form-group">
+    <%= pf.input :sources_of_funding, label: "Sources Of Funding", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :sources_of_diapers, label: "How do you currently obtain diapers?", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :essentials_budget, label: "Essentials Budget", class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= pf.input :essentials_funding_source, label: "Essentials Funding Source", class: "form-control" %>
+  </div>
+<% end %>

--- a/app/views/partners/profiles/step/edit.html.erb
+++ b/app/views/partners/profiles/step/edit.html.erb
@@ -33,80 +33,12 @@
     <%= render 'partners/profiles/step/form_actions', f: f, partner: current_partner %>
 
     <div class="accordion mx-5 mt-3" id="accordionExample">
-
-      <%# Agency Information %>
-      <div class="accordion-item">
-        <h2 class="accordion-header">
-          <button class="accordion-button <%= section_with_errors?('agency_information', @sections_with_errors) ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#agency_information" aria-expanded="<%= section_with_errors?('agency_information', @sections_with_errors) %>" aria-controls="agency_information">
-            <div class='d-flex justify-content-between align-items-center w-100'>
-              <div class='fs-4'>
-                <i class="fa fa-edit mr-2"></i>Agency Information
-              </div>
-            </div>
-          </button>
-        </h2>
-        <div id="agency_information" class="accordion-collapse collapse <%= section_with_errors?('agency_information', @sections_with_errors) ? 'show' : '' %>">
-          <div class="accordion-body">
-            <%= render 'partners/profiles/step/agency_information_form', f: f, partner: current_partner, profile: current_partner.profile %>
-          </div>
-        </div>
-      </div>
-
-      <%# Program Delivery Address %>
-      <div class="accordion-item">
-        <h2 class="accordion-header">
-          <button class="accordion-button <%= section_with_errors?('program_delivery_address', @sections_with_errors) ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#program_delivery_address" aria-expanded="<%= section_with_errors?('program_delivery_address', @sections_with_errors) %>" aria-controls="program_delivery_address">
-            <div class='d-flex justify-content-between align-items-center w-100'>
-              <div class='fs-4'>
-                <i class="fa fa-map mr-2"></i>Program / Delivery Address
-              </div>
-            </div>
-          </button>
-        </h2>
-        <div id="program_delivery_address" class="accordion-collapse collapse <%= section_with_errors?('program_delivery_address', @sections_with_errors) ? 'show' : '' %>">
-          <div class="accordion-body">
-            <%= render 'partners/profiles/step/program_delivery_address_form', f: f, partner: current_partner, profile: current_partner.profile %>
-          </div>
-        </div>
-      </div>
-
-      <%# Based on partner.partials_to_show %>
+      <%= render 'partners/profiles/step/accordion_section', f: f, partner: current_partner, section_id: 'agency_information', section_title: 'Agency Information', icon_class: 'fa-edit', partial_name: 'agency_information', sections_with_errors: @sections_with_errors %>
+      <%= render 'partners/profiles/step/accordion_section', f: f, partner: current_partner, section_id: 'program_delivery_address', section_title: 'Program / Delivery Address', icon_class: 'fa-map', partial_name: 'program_delivery_address', sections_with_errors: @sections_with_errors %>
       <% current_partner.partials_to_show.each do |partial| %>
-        <div class="accordion-item">
-          <h2 class="accordion-header">
-            <button class="accordion-button <%= section_with_errors?(partial, @sections_with_errors) ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#<%= partial %>" aria-expanded="<%= section_with_errors?(partial, @sections_with_errors) %>" aria-controls="<%= partial %>">
-              <div class='d-flex justify-content-between align-items-center w-100'>
-                <div class='fs-4'>
-                  <i class="fa fa-cogs mr-2"></i><%= partial_display_name(partial) %>
-                </div>
-              </div>
-            </button>
-          </h2>
-          <div id="<%= partial %>" class="accordion-collapse collapse <%= section_with_errors?(partial, @sections_with_errors) ? 'show' : '' %>">
-            <div class="accordion-body">
-              <%= render "partners/profiles/step/#{partial}_form", f: f, partner: current_partner, profile: current_partner.profile %>
-            </div>
-          </div>
-        </div>
+        <%= render 'partners/profiles/step/accordion_section', f: f, partner: current_partner, section_id: partial, section_title: partial_display_name(partial), icon_class: 'fa-cogs', partial_name: partial, sections_with_errors: @sections_with_errors %>
       <% end %>
-
-      <%# Partner Settings %>
-      <div class="accordion-item">
-        <h2 class="accordion-header">
-          <button class="accordion-button <%= section_with_errors?('partner_settings', @sections_with_errors) ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#partner_settings" aria-expanded="<%= section_with_errors?('partner_settings', @sections_with_errors) %>" aria-controls="partner_settings">
-            <div class='d-flex justify-content-between align-items-center w-100'>
-              <div class='fs-4'>
-                <i class="fa fa-cog mr-2"></i>Settings
-              </div>
-            </div>
-          </button>
-        </h2>
-        <div id="partner_settings" class="accordion-collapse collapse <%= section_with_errors?('partner_settings', @sections_with_errors) ? 'show' : '' %>">
-          <div class="accordion-body">
-            <%= render 'partners/profiles/step/partner_settings_form', f: f, partner: current_partner, profile: current_partner.profile %>
-          </div>
-        </div>
-      </div>
+      <%= render 'partners/profiles/step/accordion_section', f: f, partner: current_partner, section_id: 'partner_settings', section_title: 'Settings', icon_class: 'fa-cog', partial_name: 'partner_settings', sections_with_errors: @sections_with_errors %>
     </div>
 
     <%= render 'partners/profiles/step/form_actions', f: f, partner: current_partner %>

--- a/app/views/partners/profiles/step/edit.html.erb
+++ b/app/views/partners/profiles/step/edit.html.erb
@@ -1,0 +1,114 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Step Editing - #{current_partner.name}" %>
+        <h1><i class="fa fa-edit"></i>&nbsp;&nbsp;Edit My Organization&nbsp;&nbsp;&nbsp;
+          <%= partner_status_badge(current_partner) %>
+          <small>for <%= current_partner.name %></small>
+        </h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><a href="<%= partner_user_root_path %>"><i class="fa fa-home fa-lg"></i></a></li>
+          <li class="breadcrumb-item">
+            <a href="<%= edit_partners_profile_path %>"><%= "#{current_partner.name}" %></a></li>
+          <li class="breadcrumb-item"><a href="#">Edit</a></li>
+        </ol>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<div class="alert alert-info mx-5 mt-3" role="alert">
+  Instructions: Please fill out the following form sections carefully. Ensure that all required fields are completed.
+</div>
+
+<div data-controller="accordion">
+  <%= simple_form_for current_partner,
+                      data: { controller: "form-input", accordion_target: "form" },
+                      url: partners_profile_path,
+                      html: { multipart: true } do |f| %>
+
+    <%= render 'partners/profiles/step/form_actions', f: f, partner: current_partner %>
+
+    <div class="accordion mx-5 mt-3" id="accordionExample">
+
+      <%# Agency Information %>
+      <div class="accordion-item">
+        <h2 class="accordion-header">
+          <button class="accordion-button <%= section_with_errors?('agency_information', @sections_with_errors) ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#agency_information" aria-expanded="<%= section_with_errors?('agency_information', @sections_with_errors) %>" aria-controls="agency_information">
+            <div class='d-flex justify-content-between align-items-center w-100'>
+              <div class='fs-4'>
+                <i class="fa fa-edit mr-2"></i>Agency Information
+              </div>
+            </div>
+          </button>
+        </h2>
+        <div id="agency_information" class="accordion-collapse collapse <%= section_with_errors?('agency_information', @sections_with_errors) ? 'show' : '' %>">
+          <div class="accordion-body">
+            <%= render 'partners/profiles/step/agency_information_form', f: f, partner: current_partner, profile: current_partner.profile %>
+          </div>
+        </div>
+      </div>
+
+      <%# Program Delivery Address %>
+      <div class="accordion-item">
+        <h2 class="accordion-header">
+          <button class="accordion-button <%= section_with_errors?('program_delivery_address', @sections_with_errors) ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#program_delivery_address" aria-expanded="<%= section_with_errors?('program_delivery_address', @sections_with_errors) %>" aria-controls="program_delivery_address">
+            <div class='d-flex justify-content-between align-items-center w-100'>
+              <div class='fs-4'>
+                <i class="fa fa-map mr-2"></i>Program / Delivery Address
+              </div>
+            </div>
+          </button>
+        </h2>
+        <div id="program_delivery_address" class="accordion-collapse collapse <%= section_with_errors?('program_delivery_address', @sections_with_errors) ? 'show' : '' %>">
+          <div class="accordion-body">
+            <%= render 'partners/profiles/step/program_delivery_address_form', f: f, partner: current_partner, profile: current_partner.profile %>
+          </div>
+        </div>
+      </div>
+
+      <%# Based on partner.partials_to_show %>
+      <% current_partner.partials_to_show.each do |partial| %>
+        <div class="accordion-item">
+          <h2 class="accordion-header">
+            <button class="accordion-button <%= section_with_errors?(partial, @sections_with_errors) ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#<%= partial %>" aria-expanded="<%= section_with_errors?(partial, @sections_with_errors) %>" aria-controls="<%= partial %>">
+              <div class='d-flex justify-content-between align-items-center w-100'>
+                <div class='fs-4'>
+                  <i class="fa fa-cogs mr-2"></i><%= partial_display_name(partial) %>
+                </div>
+              </div>
+            </button>
+          </h2>
+          <div id="<%= partial %>" class="accordion-collapse collapse <%= section_with_errors?(partial, @sections_with_errors) ? 'show' : '' %>">
+            <div class="accordion-body">
+              <%= render "partners/profiles/step/#{partial}_form", f: f, partner: current_partner, profile: current_partner.profile %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <%# Partner Settings %>
+      <div class="accordion-item">
+        <h2 class="accordion-header">
+          <button class="accordion-button <%= section_with_errors?('partner_settings', @sections_with_errors) ? '' : 'collapsed' %>" type="button" data-bs-toggle="collapse" data-bs-target="#partner_settings" aria-expanded="<%= section_with_errors?('partner_settings', @sections_with_errors) %>" aria-controls="partner_settings">
+            <div class='d-flex justify-content-between align-items-center w-100'>
+              <div class='fs-4'>
+                <i class="fa fa-cog mr-2"></i>Settings
+              </div>
+            </div>
+          </button>
+        </h2>
+        <div id="partner_settings" class="accordion-collapse collapse <%= section_with_errors?('partner_settings', @sections_with_errors) ? 'show' : '' %>">
+          <div class="accordion-body">
+            <%= render 'partners/profiles/step/partner_settings_form', f: f, partner: current_partner, profile: current_partner.profile %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <%= render 'partners/profiles/step/form_actions', f: f, partner: current_partner %>
+  <% end %>
+</div>

--- a/app/views/served_areas/_served_area_fields.html.erb
+++ b/app/views/served_areas/_served_area_fields.html.erb
@@ -1,14 +1,14 @@
-<%= form.fields_for :served_areas, defined?(object) ? object : nil  do |f| %>
+<%= form.fields_for :served_areas, defined?(object) ? object : nil  do |fsa| %>
   <section class="nested-fields partner_served_area" data-controller="served-area">
     <div class="row mt-2 d-flex flex-row align-items-center justify-content-between">
       <div class='d-flex flex-column justify-content-center'>
         <div class='d-flex flex-row'>
           <span class="pc-name">
-            <%= f.input :county_id, collection: @counties, prompt: "County or equivalent", include_blank: "",
+            <%= fsa.input :county_id, collection: @counties, prompt: "County or equivalent", include_blank: "",
               label: false,    input_html: { class: "my-0 pc-county-select", "data-controller": "select2" } %>
           </span>
           <div class="mx-2">
-            <%= f.input :client_share, collection: 1..100, placeholder: "Client Share", label: false, input_html: {
+            <%= fsa.input :client_share, collection: 1..100, placeholder: "Client Share", label: false, input_html: {
               class: "pc-client-share percentage-selector",
               "data-area-served-target": "share", "data-served-area-target": "share",
               "data-action": "change->area-served#calculateClientShareTotal keyup->area-served#calculateClientShareTotal" } %>

--- a/spec/helpers/partners_helper_spec.rb
+++ b/spec/helpers/partners_helper_spec.rb
@@ -1,0 +1,42 @@
+describe PartnersHelper, type: :helper do
+  describe "show_submit_for_approval?" do
+    it "returns true if invited" do
+      partner = build_stubbed(:partner, status: :invited)
+      expect(helper.show_submit_for_approval?(partner)).to be_truthy
+    end
+
+    it "returns true if recertification required" do
+      partner = build_stubbed(:partner, status: :recertification_required)
+      expect(helper.show_submit_for_approval?(partner)).to be_truthy
+    end
+
+    it "returns false if awaiting review" do
+      partner = build_stubbed(:partner, status: :awaiting_review)
+      expect(helper.show_submit_for_approval?(partner)).to be_falsey
+    end
+  end
+
+  describe "submit_for_approval_disabled?" do
+    it "returns true if partner profile has errors" do
+      profile = build_stubbed(:partner_profile)
+      profile.errors.add(:base, "Some error message")
+
+      expect(helper.submit_for_approval_disabled?(profile)).to be_truthy
+    end
+
+    it "returns false if partner profile is valid" do
+      profile = build_stubbed(:partner_profile)
+      expect(helper.submit_for_approval_disabled?(profile)).to be_falsey
+    end
+  end
+
+  describe "partial_display_name" do
+    it "returns the humanized name by default" do
+      expect(helper.partial_display_name("agency_stability")).to eq("Agency stability")
+    end
+
+    it "returns the custom display name when overridden" do
+      expect(helper.partial_display_name("attached_documents")).to eq("Additional Documents")
+    end
+  end
+end

--- a/spec/helpers/partners_helper_spec.rb
+++ b/spec/helpers/partners_helper_spec.rb
@@ -16,20 +16,6 @@ describe PartnersHelper, type: :helper do
     end
   end
 
-  describe "submit_for_approval_disabled?" do
-    it "returns true if partner profile has errors" do
-      profile = build_stubbed(:partner_profile)
-      profile.errors.add(:base, "Some error message")
-
-      expect(helper.submit_for_approval_disabled?(profile)).to be_truthy
-    end
-
-    it "returns false if partner profile is valid" do
-      profile = build_stubbed(:partner_profile)
-      expect(helper.submit_for_approval_disabled?(profile)).to be_falsey
-    end
-  end
-
   describe "partial_display_name" do
     it "returns the humanized name by default" do
       expect(helper.partial_display_name("agency_stability")).to eq("Agency stability")

--- a/spec/helpers/partners_helper_spec.rb
+++ b/spec/helpers/partners_helper_spec.rb
@@ -1,21 +1,4 @@
 describe PartnersHelper, type: :helper do
-  describe "show_submit_for_approval?" do
-    it "returns true if invited" do
-      partner = build_stubbed(:partner, status: :invited)
-      expect(helper.show_submit_for_approval?(partner)).to be_truthy
-    end
-
-    it "returns true if recertification required" do
-      partner = build_stubbed(:partner, status: :recertification_required)
-      expect(helper.show_submit_for_approval?(partner)).to be_truthy
-    end
-
-    it "returns false if awaiting review" do
-      partner = build_stubbed(:partner, status: :awaiting_review)
-      expect(helper.show_submit_for_approval?(partner)).to be_falsey
-    end
-  end
-
   describe "partial_display_name" do
     it "returns the humanized name by default" do
       expect(helper.partial_display_name("agency_stability")).to eq("Agency stability")

--- a/spec/models/partners/profile_spec.rb
+++ b/spec/models/partners/profile_spec.rb
@@ -97,13 +97,16 @@ RSpec.describe Partners::Profile, type: :model do
     subject { build(:partner_profile, enable_child_based_requests: false, enable_individual_requests: false, enable_quantity_based_requests: false) }
 
     context "no settings are set to true" do
-      it "should not be valid" do
+      it "sets error at base when feature flag disabled for partner step form" do
+        allow(Flipper).to receive(:enabled?).with("partner_step_form").and_return(false)
+
         expect(subject).to_not be_valid
         expect(subject.errors[:base]).to include("At least one request type must be set")
       end
 
       it "sets error at field level when feature flag enabled for partner step form" do
         allow(Flipper).to receive(:enabled?).with("partner_step_form").and_return(true)
+
         expect(subject).to_not be_valid
         expect(subject.errors[:enable_child_based_requests]).to include("At least one request type must be set")
       end
@@ -262,7 +265,9 @@ RSpec.describe Partners::Profile, type: :model do
     end
 
     context "multiple" do
-      it "sums the client shares " do
+      it "sums the client shares and sets error at base when feature flag disabled for partner step form" do
+        allow(Flipper).to receive(:enabled?).with("partner_step_form").and_return(false)
+
         profile = create(:partner_profile)
         county1 = create(:county, name: "county1", region: "region1")
         county2 = create(:county, name: "county2", region: "region2")

--- a/spec/services/partners/section_error_service_spec.rb
+++ b/spec/services/partners/section_error_service_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Partners::SectionErrorService, type: :service do
-  describe "#call" do
-    subject { described_class.new(error_keys).call }
+  describe ".sections_with_errors" do
+    subject { Partners::SectionErrorService.sections_with_errors(error_keys) }
 
     context "when error keys map to multiple sections" do
       let(:error_keys) { [:website, :pick_up_email, :enable_quantity_based_requests] }

--- a/spec/services/partners/section_error_service_spec.rb
+++ b/spec/services/partners/section_error_service_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Partners::SectionErrorService, type: :service do
+  describe "#call" do
+    subject { described_class.new(error_keys).call }
+
+    context "when error keys map to multiple sections" do
+      let(:error_keys) { [:website, :pick_up_email, :enable_quantity_based_requests] }
+
+      it "returns an array with each section containing an error" do
+        expect(subject).to contain_exactly("media_information", "pick_up_person", "partner_settings")
+      end
+    end
+
+    context "when error keys map to the same section multiple times" do
+      let(:error_keys) { [:website, :twitter, :facebook] }
+
+      it "returns a unique array with only one instance of the section" do
+        expect(subject).to eq(["media_information"])
+      end
+    end
+
+    context "when error keys include fields not mapped to any section" do
+      let(:error_keys) { [:website, :unknown_field, :enable_quantity_based_requests] }
+
+      it "excludes nil values for unmapped fields and returns unique sections" do
+        expect(subject).to eq(["media_information", "partner_settings"])
+      end
+    end
+
+    context "when none of the error keys match any section" do
+      let(:error_keys) { [:unknown_field_1, :unknown_field_2] }
+
+      it "returns an empty array when no sections match" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "when error keys are empty" do
+      let(:error_keys) { [] }
+
+      it "returns an empty array" do
+        expect(subject).to eq([])
+      end
+    end
+  end
+end

--- a/spec/system/partners/profile_edit_system_spec.rb
+++ b/spec/system/partners/profile_edit_system_spec.rb
@@ -43,12 +43,10 @@ RSpec.describe "Partners profile edit", type: :system, js: true do
       all("input[type='submit'][value='Save Progress']").last.click
       expect(page).to have_css(".alert-success", text: "Details were successfully updated.")
 
-      # Submit for Approval
-      expect(page).to have_link("Submit Profile for Approval", href: partners_approval_request_path)
-      first(:link, "Submit Profile for Approval").click
+      # Submit and Review
+      all("input[type='submit'][value='Save and Review']").last.click
       expect(current_path).to eq(partners_profile_path)
-      expect(page).to have_css(".alert-success", text: "You have submitted your details for approval.")
-      expect(page).to have_css(".badge", text: "Awaiting Review")
+      expect(page).to have_css(".alert-success", text: "Details were successfully updated.")
     end
 
     it "displays the edit view with sections containing validation errors expanded" do
@@ -86,8 +84,19 @@ RSpec.describe "Partners profile edit", type: :system, js: true do
       expect(page).to have_css("#pick_up_person.accordion-collapse.collapse.show", visible: true)
       expect(page).to have_css("#partner_settings.accordion-collapse.collapse.show", visible: true)
 
-      # Submit for Approval is still enabled
-      expect(page).to have_link("Submit Profile for Approval", href: partners_approval_request_path)
+      # Try to Submit and Review from error state
+      all("input[type='submit'][value='Save and Review']").last.click
+
+      # Expect an alert-danger message containing validation errors
+      expect(page).to have_css(".alert-danger", text: /There is a problem/)
+      expect(page).to have_content("No social media presence must be checked if you have not provided any of Website, Twitter, Facebook, or Instagram.")
+      expect(page).to have_content("Enable child based requests At least one request type must be set")
+      expect(page).to have_content("Pick up email can't have more than three email addresses")
+
+      # Expect media section, executive director section, and partner settings section to be opened
+      expect(page).to have_css("#media_information.accordion-collapse.collapse.show", visible: true)
+      expect(page).to have_css("#pick_up_person.accordion-collapse.collapse.show", visible: true)
+      expect(page).to have_css("#partner_settings.accordion-collapse.collapse.show", visible: true)
     end
   end
 end

--- a/spec/system/partners/profile_edit_system_spec.rb
+++ b/spec/system/partners/profile_edit_system_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe "Partners profile edit", type: :system, js: true do
+  let!(:partner1) { create(:partner, status: "invited") }
+  let(:partner1_user) { partner1.primary_user }
+
+  context "step-wise editing is enabled" do
+    before do
+      Flipper.enable(:partner_step_form)
+      login_as(partner1_user)
+      visit edit_partners_profile_path
+    end
+
+    it "displays all sections in a closed state by default" do
+      within ".accordion" do
+        expect(page).to have_css("#agency_information.accordion-collapse.collapse", visible: false)
+        expect(page).to have_css("#program_delivery_address.accordion-collapse.collapse", visible: false)
+
+        partner1.partials_to_show.each do |partial|
+          expect(page).to have_css("##{partial}.accordion-collapse.collapse", visible: false)
+        end
+
+        expect(page).to have_css("#partner_settings.accordion-collapse.collapse", visible: false)
+      end
+    end
+
+    it "allows sections to be opened, closed, filled in any order, and submit for approval" do
+      # Media
+      find("button[data-bs-target='#media_information']").click
+      expect(page).to have_css("#media_information.accordion-collapse.collapse.show", visible: true)
+      within "#media_information" do
+        fill_in "Website", with: "https://www.example.com"
+      end
+      find("button[data-bs-target='#media_information']").click
+      expect(page).to have_css("#media_information.accordion-collapse.collapse", visible: false)
+
+      # Executive director
+      find("button[data-bs-target='#executive_director']").click
+      expect(page).to have_css("#executive_director.accordion-collapse.collapse.show", visible: true)
+      within "#executive_director" do
+        fill_in "Executive Director Name", with: "Lisa Smith"
+      end
+
+      # Save Progress
+      all("input[type='submit'][value='Save Progress']").last.click
+      expect(page).to have_css(".alert-success", text: "Details were successfully updated.")
+
+      # Submit for Approval
+      expect(page).to have_link("Submit Profile for Approval", href: partners_approval_request_path)
+      first(:link, "Submit Profile for Approval").click
+      expect(current_path).to eq(partners_profile_path)
+      expect(page).to have_css(".alert-success", text: "You have submitted your details for approval.")
+      expect(page).to have_css(".badge", text: "Awaiting Review")
+    end
+
+    it "displays the edit view with sections containing validation errors expanded" do
+      # Open up Media section and clear out website value
+      find("button[data-bs-target='#media_information']").click
+      within "#media_information" do
+        fill_in "Website", with: ""
+      end
+
+      # Open Pick up person section and fill in 4 email addresses
+      find("button[data-bs-target='#pick_up_person']").click
+      within "#pick_up_person" do
+        fill_in "Pick Up Person's Email", with: "email1@example.com, email2@example.com, email3@example.com, email4@example.com"
+      end
+
+      # Open Partner Settings section and uncheck all options
+      find("button[data-bs-target='#partner_settings']").click
+      within "#partner_settings" do
+        uncheck "Enable Quantity-based Requests" if has_checked_field?("Enable Quantity-based Requests")
+        uncheck "Enable Child-based Requests (unclick if you only do bulk requests)" if has_checked_field?("Enable Child-based Requests (unclick if you only do bulk requests)")
+        uncheck "Enable Requests for Individuals" if has_checked_field?("Enable Requests for Individuals")
+      end
+
+      # Save Progress
+      all("input[type='submit'][value='Save Progress']").last.click
+
+      # Expect an alert-danger message containing validation errors
+      expect(page).to have_css(".alert-danger", text: /There is a problem/)
+      expect(page).to have_content("No social media presence must be checked if you have not provided any of Website, Twitter, Facebook, or Instagram.")
+      expect(page).to have_content("Enable child based requests At least one request type must be set")
+      expect(page).to have_content("Pick up email can't have more than three email addresses")
+
+      # Expect media section, executive director section, and partner settings section to be opened
+      expect(page).to have_css("#media_information.accordion-collapse.collapse.show", visible: true)
+      expect(page).to have_css("#pick_up_person.accordion-collapse.collapse.show", visible: true)
+      expect(page).to have_css("#partner_settings.accordion-collapse.collapse.show", visible: true)
+
+      # Submit for Approval is disabled
+      expect(page).to have_css("span.btn.btn-success.disabled", text: "Submit Profile for Approval")
+    end
+  end
+end

--- a/spec/system/partners/profile_edit_system_spec.rb
+++ b/spec/system/partners/profile_edit_system_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe "Partners profile edit", type: :system, js: true do
       expect(page).to have_css("#pick_up_person.accordion-collapse.collapse.show", visible: true)
       expect(page).to have_css("#partner_settings.accordion-collapse.collapse.show", visible: true)
 
-      # Submit for Approval is disabled
-      expect(page).to have_css("span.btn.btn-success.disabled", text: "Submit Profile for Approval")
+      # Submit for Approval is still enabled
+      expect(page).to have_link("Submit Profile for Approval", href: partners_approval_request_path)
     end
   end
 end


### PR DESCRIPTION
Resolves #4504

### Description

This splits up the very long partner profile edit form into multiple collapsible sections, using the [Bootstrap Accordion](https://getbootstrap.com/docs/5.3/components/accordion/) component. This project already uses Bootstrap so this does not introduce a new dependency.

The first attempt had a "Save and Next" button on each collapsible section, i.e. each one was a separate form that could be submitted individually. The original idea was to save one section and have the user returned to the edit view with the next section automatically opened for a kind of "guided" experience. It was also automatically saving work in progress edits as user collapsed/expanded sections. But this proved to be unworkable for a number of reasons. See #4504 comments for details.

So this solution simplifies things by only having a single form outside of the accordion section. User can click Save Progress which submits the entire form, or Submit for Approval. These action buttons appear both at the top and bottom of the accordion. If any validation errors occur, the user is returned to the edit view with all the sections that have error(s) expanded.


### Type of change

New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

To exercise this feature, start by launching a Rails console `bin/rails c` and enable the new feature flag:

```ruby
Flipper.enable(:partner_step_form)
```

Then with the Rails server running `bin/start`, navigate to `http://localhost:3000`, login as an Org admin, create a new Partner Agency (eg: `testpartner@example.com`) and invite them. Then logout.

A new browser tab should open with the invitation email sent to the new partner. Click on the accept invitation button in this email, and create a password for the new partner. Once logged in, click "Edit my Profile" from the left navigation. You should now see the new step-wise form.

Expand and collapse as many sections as you'd like, and click Save Progress as often as you'd like.

Notice that the bootstrap open/close caret icons change to the word "Saving..." when the form is being submitted. This is to prevent the user from opening further sections and trying to edit in the middle of an update.

To see what the form looks like with multiple validation errors, fill it out as follows, then click Save Progress.

1. Media Information: Make all the social media links blank, and uncheck "No social media"
2. Pick up Person: Enter 4 comma separated emails for pick up email, eg: `aa@test.com, bb@test.com, cc@test.com, dd@test.com`
3. Area served: Add some area(s) that don't add up to 100%
4. Partner Settings: Uncheck all the request settings

If the form renders with validation errors, then the Submit for Approval button should be disabled. Otherwise if partner is in Invited or Recertification status, then the Approval button is enabled. Otherwise the Approval button doesn't appear at all.

Also see system test for automated test: `spec/system/partners/profile_edit_system_spec.rb`

Optionally, disable the feature flag in Rails console `Flipper.disable(:partner_step_form)` and run through the invitation flow again (or use the same partner you already created). In this case, it should behave exactly as it does currently with the very large form.

### Screenshots

Default rendering of step-wise edit form - all sections closed:
![image](https://github.com/user-attachments/assets/a1dfd166-02d2-4819-bc2d-d3ff10732b51)

Multiple sections can be open/closed at once for editing:
![image](https://github.com/user-attachments/assets/0a67777f-7380-40c8-84b5-fe7957cc49ac)

Multiple sections open on validation errors:
![image](https://github.com/user-attachments/assets/ce9ea5f8-3405-46a4-866a-f17fffeb1c6f)
