### PR TITLE
Fix for village diaper bank kit/item problem

### DIFF
--- a/db/migrate/20241106184508_remove_excess_kit_village_diaper_bank.rb
+++ b/db/migrate/20241106184508_remove_excess_kit_village_diaper_bank.rb
@@ -1,0 +1,6 @@
+class RemoveExcessKitVillageDiaperBank < ActiveRecord::Migration[7.1]
+  def change
+    return unless Rails.env.production?
+    Kit.find(204).destroy
+  end
+end


### PR DESCRIPTION
# Description
This migration deletes kit 204 from production.   See human essentials support discussion starting Oct 9, 2024, 12:36 pm for details.

This kit is an orphan, in that the item associated with it was deleted.    

Tested by running without the check that we are in production against a copy of production data.