### PR TITLE
Add row for grand totals to storage locations index view

### DIFF
--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -98,6 +98,14 @@ class StorageLocation < ApplicationRecord
     inventory&.total_value_in_dollars(storage_location: id)
   end
 
+  def inventory_total_quantity(inventory = nil)
+    if inventory
+      inventory.quantity_for(storage_location: id)
+    else
+      size
+    end
+  end
+
   def to_csv
     org = organization
 

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -98,14 +98,6 @@ class StorageLocation < ApplicationRecord
     inventory&.total_value_in_dollars(storage_location: id)
   end
 
-  def inventory_total_quantity(inventory = nil)
-    if inventory
-      inventory.quantity_for(storage_location: id)
-    else
-      size
-    end
-  end
-
   def to_csv
     org = organization
 

--- a/app/views/storage_locations/_storage_location_row.html.erb
+++ b/app/views/storage_locations/_storage_location_row.html.erb
@@ -3,8 +3,8 @@
   <td><%= storage_location.address %></td>
   <td><%= storage_location.square_footage %></td>
   <td><%= storage_location.warehouse_type %></td>
-  <td><%= @inventory.quantity_for(storage_location: storage_location.id) %></td>
-  <td><%= number_to_currency(storage_location.inventory_total_value_in_dollars(@inventory)) %></td>
+  <td class="text-right"><%= @inventory.quantity_for(storage_location: storage_location.id) %></td>
+  <td class="text-right"><%= number_to_currency(storage_location.inventory_total_value_in_dollars(@inventory)) %></td>
   <td class="text-right">
     <%= view_button_to storage_location %>
     <%= edit_button_to edit_storage_location_path(storage_location) %>

--- a/app/views/storage_locations/index.html.erb
+++ b/app/views/storage_locations/index.html.erb
@@ -87,7 +87,7 @@
               <tr>
                 <td colspan="4"><strong>Total</strong></td>
                 <td class="text-right">
-                  <%= @storage_locations.sum { |sl| sl.inventory_total_quantity(@inventory) } %>
+                  <%= @storage_locations.sum { |sl| @inventory.quantity_for(storage_location: sl.id) } %>
                 </td>
                 <td class="text-right"><%= number_to_currency(@storage_locations.sum(&:inventory_total_value_in_dollars)) %></td>
                 <td></td>

--- a/app/views/storage_locations/index.html.erb
+++ b/app/views/storage_locations/index.html.erb
@@ -84,6 +84,13 @@
               </thead>
               <tbody>
               <%= render partial: "storage_location_row", collection: @storage_locations, as: :storage_location %>
+              <tr>
+                <td colspan="4"><strong>Total</strong></td>
+                <td>
+                  <%= @storage_locations.sum { |sl| sl.inventory_total_quantity(@inventory) } %>
+                </td>
+                <td><%= number_to_currency(@storage_locations.sum(&:inventory_total_value_in_dollars)) %></td>
+              </tr>
               </tbody>
             </table>
           </div>

--- a/app/views/storage_locations/index.html.erb
+++ b/app/views/storage_locations/index.html.erb
@@ -89,7 +89,7 @@
                 <td class="text-right">
                   <%= @storage_locations.sum { |sl| @inventory.quantity_for(storage_location: sl.id) } %>
                 </td>
-                <td class="text-right"><%= number_to_currency(@storage_locations.sum(&:inventory_total_value_in_dollars)) %></td>
+                <td class="text-right"><%= number_to_currency(@storage_locations.sum { |sl| sl.inventory_total_value_in_dollars(@inventory) }) %></td>
                 <td></td>
               </tr>
               </tbody>

--- a/app/views/storage_locations/index.html.erb
+++ b/app/views/storage_locations/index.html.erb
@@ -77,8 +77,8 @@
                 <th>Address</th>
                 <th>Square Footage</th>
                 <th>Warehouse Type</th>
-                <th>Total Inventory</th>
-                <th>Fair Market Value</th>
+                <th class="text-right">Total Inventory</th>
+                <th class="text-right">Fair Market Value</th>
                 <th class="text-center">Actions</th>
               </tr>
               </thead>
@@ -86,10 +86,11 @@
               <%= render partial: "storage_location_row", collection: @storage_locations, as: :storage_location %>
               <tr>
                 <td colspan="4"><strong>Total</strong></td>
-                <td>
+                <td class="text-right">
                   <%= @storage_locations.sum { |sl| sl.inventory_total_quantity(@inventory) } %>
                 </td>
-                <td><%= number_to_currency(@storage_locations.sum(&:inventory_total_value_in_dollars)) %></td>
+                <td class="text-right"><%= number_to_currency(@storage_locations.sum(&:inventory_total_value_in_dollars)) %></td>
+                <td></td>
               </tr>
               </tbody>
             </table>

--- a/spec/requests/storage_locations_requests_spec.rb
+++ b/spec/requests/storage_locations_requests_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe "StorageLocations", type: :request do
             Storage Location with Items,123 Donation Site Way,100,Residential space used,3,1,1,1,0
             Storage Location with Unique Items,Smithsonian Conservation Center new,100,Residential space used,5,0,0,0,5
             Test Storage Location,123 Donation Site Way,100,Residential space used,0,0,0,0,0
+            Test Storage Location 1,123 Donation Site Way,100,Residential space used,0,0,0,0,0
           CSV
           expect(response.body).to eq(csv)
         end

--- a/spec/system/storage_location_system_spec.rb
+++ b/spec/system/storage_location_system_spec.rb
@@ -92,6 +92,23 @@ RSpec.describe "Storage Locations", type: :system, js: true do
       end
     end
 
+    it "displays the correct grand totals across all storage locations" do
+      item = create(:item, name: "Needle", value_in_cents: 100)
+
+      location1 = create(:storage_location, name: "Location 1")
+      create(:donation, :with_items, item: item, item_quantity: 30, storage_location: location1)
+
+      location2 = create(:storage_location, name: "Location 2")
+      create(:donation, :with_items, item: item, item_quantity: 70, storage_location: location2)
+
+      visit subject
+
+      within "tbody tr:last-child" do
+        expect(page).to have_content(100) # The expected total inventory
+        expect(page).to have_content("$100.00") # The expected total fair market value
+      end
+    end
+
     it "User can filter the #index by those that contain certain items" do
       item = create(:item, name: Faker::Lorem.unique.word)
       create(:item, name: Faker::Lorem.unique.word)
@@ -103,7 +120,7 @@ RSpec.describe "Storage Locations", type: :system, js: true do
       select item.name, from: "filters[containing]"
       click_button "Filter"
 
-      expect(page).to have_css("table tr", count: 2)
+      expect(page).to have_css("table tr", count: 3)
       expect(page).to have_xpath("//table/tbody/tr/td", text: location1.name)
       expect(page).not_to have_xpath("//table/tbody/tr/td", text: location2.name)
       expect(page).not_to have_xpath("//table/tbody/tr/td", text: location3.name)
@@ -111,7 +128,7 @@ RSpec.describe "Storage Locations", type: :system, js: true do
       check "include_inactive_storage_locations"
       click_button "Filter"
 
-      expect(page).to have_css("table tr", count: 3)
+      expect(page).to have_css("table tr", count: 4)
       expect(page).to have_xpath("//table/tbody/tr/td", text: location3.name)
     end
 

--- a/spec/system/storage_location_system_spec.rb
+++ b/spec/system/storage_location_system_spec.rb
@@ -92,23 +92,6 @@ RSpec.describe "Storage Locations", type: :system, js: true do
       end
     end
 
-    it "displays the correct grand totals across all storage locations" do
-      item = create(:item, name: "Needle", value_in_cents: 100)
-
-      location1 = create(:storage_location, name: "Location 1")
-      create(:donation, :with_items, item: item, item_quantity: 30, storage_location: location1)
-
-      location2 = create(:storage_location, name: "Location 2")
-      create(:donation, :with_items, item: item, item_quantity: 70, storage_location: location2)
-
-      visit subject
-
-      within "tbody tr:last-child" do
-        expect(page).to have_content(100) # The expected total inventory
-        expect(page).to have_content("$100.00") # The expected total fair market value
-      end
-    end
-
     it "User can filter the #index by those that contain certain items" do
       item = create(:item, name: Faker::Lorem.unique.word)
       create(:item, name: Faker::Lorem.unique.word)


### PR DESCRIPTION
Resolves #4520

### Description

Display another row at the bottom of the storage locations index that aggregates the total inventory quantity and dollar value across all locations, taking into account any filters applied.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added a new system test that ensures the row is displayed on the index with the correct total values.

Updates existing tests to account for the new row in the table

### Screenshots
<details><summary>📸 Storage locations index (no filters)</summary>
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/8259d3f5-d6d4-4e30-89be-b825cdd28bc6">
</details>
<details><summary>📸 Storage locations index (with filters)</summary>
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/8a6d1d79-47b1-4f77-9028-7301da47f86c">
</details>

