### PR TITLE
Fix issue with event history -- duplicate distribution.

### DIFF
--- a/db/migrate/20241112184800_fix_invalid_distribution_event20241112.rb
+++ b/db/migrate/20241112184800_fix_invalid_distribution_event20241112.rb
@@ -1,0 +1,12 @@
+class FixInvalidDistributionEvent20241112 < ActiveRecord::Migration[7.1]
+  def change
+    return unless Rails.env.production?
+
+    # We are not sure why yet, but this org was able to create a distribution
+    # that put them at a negative inventory. Later playback of the events with
+    # validation turned on then raised it as an error. For now we are deleting
+    # the distribution and event directly.
+    Event.where(id: 42075, eventable_type: 'Distribution', eventable_id: 789204).first.destroy
+    Distribution.find(789204).destroy
+  end
+end


### PR DESCRIPTION
### Description
Urgent data fix for support issue from 11:17 am November 12, 2024

A duplicate distribution was created, which caused the inventory for an item to go below 0.  
This disabled the bank from being able to do any entry.


This PR deleted the offending event history and distribution

***** Don't deploy this without triple checking my work!  ****  (or managing to test it against a local copy of prod)  

Note:  I branched this off of production rather than main - not sure if that was the right call, but the intention is that it go to production independently of the other current changes on main.


### Type of change
Data fix
### How Has This Been Tested?

As of 20241112, 13:55 this has not been tested, as I was unable to bring down a current copy of production.
