### PR TITLE
4523: Fix user info disappearing on validation failure for new org requests

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -46,13 +46,14 @@ class Admin::OrganizationsController < AdminController
 
   def create
     @organization = Organization.new(organization_params)
+    @user = User.new(user_params)
 
     if @organization.save
       Organization.seed_items(@organization)
-      @user = UserInviteService.invite(name: user_params[:name],
-                                       email: user_params[:email],
-                                       roles: [Role::ORG_USER, Role::ORG_ADMIN],
-                                       resource: @organization)
+      UserInviteService.invite(name: user_params[:name],
+                               email: user_params[:email],
+                               roles: [Role::ORG_USER, Role::ORG_ADMIN],
+                               resource: @organization)
       SnapshotEvent.publish(@organization) # need one to start with
       redirect_to admin_organizations_path, notice: "Organization added!"
     else

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -85,6 +85,14 @@ RSpec.describe "Admin::Organizations", type: :request do
           expect(subject).to render_template("new")
           expect(flash[:error]).to be_present
         end
+
+        it "preserves user attributes" do
+          post admin_organizations_path({ organization: invalid_params })
+
+          expect(subject).to render_template("new")
+          expect(response.body).to include(invalid_params[:user][:name])
+          expect(response.body).to include(invalid_params[:user][:email])
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #4523  <!--fill issue number-->

### Description
Fixes issue where user info would disappear when creating new organizations from an account request.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested manually locally and added a request spec. 