### PR TITLE
Resolves #4771 add unicity on low inventory query items returned

### DIFF
--- a/app/queries/low_inventory_query.rb
+++ b/app/queries/low_inventory_query.rb
@@ -1,7 +1,7 @@
 class LowInventoryQuery
   def self.call(organization)
     inventory = View::Inventory.new(organization.id)
-    items = inventory.all_items
+    items = inventory.all_items.uniq(&:item_id)
 
     low_inventory_items = []
     items.each do |item|

--- a/spec/queries/low_inventory_query_spec.rb
+++ b/spec/queries/low_inventory_query_spec.rb
@@ -84,4 +84,32 @@ RSpec.describe LowInventoryQuery do
       })
     }
   end
+
+  context "when items are in multiple storage locations" do
+    let(:recommended_quantity) { 300 }
+    let(:secondary_storage_location) { create :storage_location, organization: organization }
+    let!(:secondary_purchase) {
+      create :purchase,
+        :with_items,
+        organization: organization,
+        storage_location: secondary_storage_location,
+        item: item,
+        item_quantity: inventory_item_quantity,
+        issued_at: Time.current
+    }
+
+    it {
+      expect(subject.count).to eq 1
+    }
+
+    it {
+      is_expected.to include({
+        id: item.id,
+        name: item.name,
+        on_hand_minimum_quantity: 0,
+        on_hand_recommended_quantity: 300,
+        total_quantity: 200
+      })
+    }
+  end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #4771  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

This should fix repeated rows on the dashboard low inventory report. 
This seems like the least drastic change to the LowInventoryQuery, though I was considering another approach with `Item.where(...)` but that would seem like rewriting a lot of the logic that already exists in `View::Inventory` and `InventoryAggregate`

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

This adds a couple of cases to the `low_inventory_query_spec.rb` file testing the length and contents of a `LowInventoryQuery.call()` when an Item is edited in two different `storage_locations`.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

Before : 
![Capture d'écran 2024-11-13 221814](https://github.com/user-attachments/assets/1370698d-1883-4c8d-91e4-2e0a1e932275)

After : 
![Capture d'écran 2024-11-13 221740](https://github.com/user-attachments/assets/1ef0aa7e-a569-4a5a-a5e6-343ca60504f3)

