### PR TITLE
Improve client share error message

### DIFF
--- a/app/models/partners/served_area.rb
+++ b/app/models/partners/served_area.rb
@@ -16,6 +16,6 @@ module Partners
     belongs_to :partner_profile, class_name: "Partners::Profile"
     belongs_to :county
     validates :client_share, numericality: {only_integer: true}
-    validates :client_share, inclusion: {in: 1..100}
+    validates :client_share, inclusion: {in: 1..100, message: "Client share must be between 1 and 100 inclusive"}
   end
 end

--- a/spec/models/partners/served_area_spec.rb
+++ b/spec/models/partners/served_area_spec.rb
@@ -11,19 +11,27 @@
 #
 
 RSpec.describe Partners::ServedArea, type: :model do
-  it { should belong_to(:partner_profile) }
-  it { should belong_to(:county) }
+  describe "validations" do
+    let(:served_area_nil_client_share) { build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: nil) }
+    it { should belong_to(:partner_profile) }
+    it { should belong_to(:county) }
 
-  it "must only allow integer client shares" do
-    expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 50)).to be_valid
-    expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 50.5)).not_to be_valid
-  end
+    it "displays a user friendly error message for nil client shares" do
+      expect(served_area_nil_client_share).not_to be_valid
+      expect(served_area_nil_client_share.errors.messages[:client_share]).to match_array(["Client share must be between 1 and 100 inclusive", "is not a number"])
+    end
 
-  it "must only allow valid client share values" do
-    expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 0)).not_to be_valid
-    expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 101)).not_to be_valid
-    expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 1)).to be_valid
-    expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 100)).to be_valid
+    it "must only allow integer client shares" do
+      expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 50)).to be_valid
+      expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 50.5)).not_to be_valid
+    end
+
+    it "must only allow valid client share values" do
+      expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 0)).not_to be_valid
+      expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 101)).not_to be_valid
+      expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 1)).to be_valid
+      expect(build(:partners_served_area, partner_profile: create(:partner_profile), county: create(:county), client_share: 100)).to be_valid
+    end
   end
 
   describe "versioning" do

--- a/spec/services/partner_profile_update_service_spec.rb
+++ b/spec/services/partner_profile_update_service_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe PartnerProfileUpdateService do
           expect(profile.served_areas.size).to eq(2)
           result = PartnerProfileUpdateService.new(profile.partner, partner_params, incorrect_attributes_missing_client_share).call
           expect(result.success?).to eq(false)
-          expect(result.error.to_s).to include("Validation failed: Served areas client share is not a number, Served areas client share is not included in the list")
+          expect(result.error.to_s).to include("Validation failed: Served areas client share is not a number, Served areas client share Client share must be between 1 and 100 inclusive")
           profile.reload
           expect(profile.served_areas.size).to eq(2)
         end


### PR DESCRIPTION
Resolves #4673 

### Description
This PR modifies the error message that partners will see when they attempt to add another county to "area served" and do not submit a value for the "client share" field.  The error message will now be "Something didn't work quite right -- try again? Validation failed: Served areas client share is not a number, Served areas Client share must be between 1 and 100 inclusive".

I do think it looks a little goofy to have `Client` capitalized in the `Served areas Client share must be between 1 and 100 inclusive` message.  I included that because I wanted to verbatim copy the error message suggested in issue #4673.  I would be happy to refactor and change the capitalization. 


### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
- I added an automated test to `spec/models/partners/served_area_spec.rb`
- I updated an automated test in `spec/services/partner_profile_update_service_spec.rb` to expect the updated message.
- I manually recreated the bug and witnessed the new error message.  I will copy below the repro steps from issue #4673 

1. <p dir="auto">sign in as <a href="mailto:org_admin1@example.com">org_admin1@example.com</a><br>
2. Click "Partner Agencies", then "All Partners".  Click a Partner, then scroll down and click "Edit information".<br>
3. Find the Area Served section<br>
4. Click "Add Another County".<br>
5. Choose a "County or Equivalent".  Do not fill in the client share % field beside it.<br>
6. Go to the bottom of the page and click "Update Information".</p>


### Screenshots
<details>
<Summary>New inline error message</summary>

![Issue4673InlineError](https://github.com/user-attachments/assets/1d990b8a-3df2-432e-8ecf-026712e3b1d3)

</details>

<details>
<Summary>New error message at top of page</summary>

![Issue4673TopOfPageError](https://github.com/user-attachments/assets/1e268e7c-d5b5-485a-9943-2f7d61b83680)

</details>