### PR TITLE
Resolves #4675 Add year to month labels on trend reports

### DIFF
--- a/app/helpers/historical_trends_helper.rb
+++ b/app/helpers/historical_trends_helper.rb
@@ -16,6 +16,15 @@ module HistoricalTrendsHelper
 
   def last_12_months
     current_month = Time.zone.now.month
-    MONTHS.rotate(current_month)
+    current_year = Time.zone.now.year
+    return_array = MONTHS.rotate(current_month)
+    return_array.each_with_index do |month, index|
+      return_array[index] = if index >= (MONTHS.length - current_month)
+        "#{month} #{current_year}"
+      else
+        "#{month} #{current_year - 1}"
+      end
+    end
+    return_array
   end
 end

--- a/app/helpers/historical_trends_helper.rb
+++ b/app/helpers/historical_trends_helper.rb
@@ -17,12 +17,15 @@ module HistoricalTrendsHelper
   def last_12_months
     current_month = Time.zone.now.month
     current_year = Time.zone.now.year
+    last_year = current_year - 1
     return_array = MONTHS.rotate(current_month)
     return_array.each_with_index do |month, index|
+      # Last current_month entries are in the current year, earlier entries are
+      # in the previous year.
       return_array[index] = if index >= (MONTHS.length - current_month)
         "#{month} #{current_year}"
       else
-        "#{month} #{current_year - 1}"
+        "#{month} #{last_year}"
       end
     end
     return_array

--- a/spec/helpers/historical_trends_helper_spec.rb
+++ b/spec/helpers/historical_trends_helper_spec.rb
@@ -2,22 +2,25 @@ require "rspec"
 
 RSpec.describe HistoricalTrendsHelper do
   describe "#last_12_months" do
-    it "returns the last 12 months starting from July when the current month is June" do
+    it "returns the last 12 months starting from July 2023 when the current month is June 2024" do
       allow_any_instance_of(Time).to receive(:month).and_return(6)
+      allow_any_instance_of(Time).to receive(:year).and_return(2024)
 
-      expect(last_12_months).to eq(["Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "Jan", "Feb", "Mar", "Apr", "May", "Jun"])
+      expect(last_12_months).to eq(["Jul 2023", "Aug 2023", "Sep 2023", "Oct 2023", "Nov 2023", "Dec 2023", "Jan 2024", "Feb 2024", "Mar 2024", "Apr 2024", "May 2024", "Jun 2024"])
     end
 
-    it "returns the last 12 months starting from Feb when the current month is Jan" do
+    it "returns the last 12 months starting from Feb 1999 when the current month is Jan 2000" do
       allow_any_instance_of(Time).to receive(:month).and_return(1)
+      allow_any_instance_of(Time).to receive(:year).and_return(2000)
 
-      expect(last_12_months).to eq(["Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "Jan"])
+      expect(last_12_months).to eq(["Feb 1999", "Mar 1999", "Apr 1999", "May 1999", "Jun 1999", "Jul 1999", "Aug 1999", "Sep 1999", "Oct 1999", "Nov 1999", "Dec 1999", "Jan 2000"])
     end
 
-    it "returns the last 12 months starting from Jan when the current month is Dec" do
+    it "returns the last 12 months starting from Jan 2010 when the current month is Dec 2010" do
       allow_any_instance_of(Time).to receive(:month).and_return(12)
+      allow_any_instance_of(Time).to receive(:year).and_return(2010)
 
-      expect(last_12_months).to eq(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"])
+      expect(last_12_months).to eq(["Jan 2010", "Feb 2010", "Mar 2010", "Apr 2010", "May 2010", "Jun 2010", "Jul 2010", "Aug 2010", "Sep 2010", "Oct 2010", "Nov 2010", "Dec 2010"])
     end
   end
 end


### PR DESCRIPTION
Resolves #4675

### Description

This PR modifies the month labels on the X axis of the trend reports report to include the year. It accomplishes this by modifying `HistoricalTrendsHelper.last_12_months` to add the year to the list of months it returns which will be used as categories by highcharts to create the trend reports.

A two digit year was considered, but a four digit year still allows plenty of space between labels in the X axis while being more explicit so that option was chosen.

I considered creating a separate `last_12_months_with_years` function to preserve the behavior of `last_12_months`. However, since `last_12_months` is currently only used to create categories for the trend reports, it seemed unnecessary.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I updated the automated test `spec/helpers/historical_trends_helper_spec.rb` to expect `HistoricalTrendsHelper.last_12_months` will return a list of months with years.

### Screenshots
<details>
<summary>Before</summary>

![#4675 Before](https://github.com/user-attachments/assets/f1e6ee39-96dc-4a4f-9d11-a75d79f3670f)

</details>

<details>
<summary>After</summary>

![#4675 After](https://github.com/user-attachments/assets/f3ad5cfb-3441-4f00-8872-a6d2a29b48aa)

</details>