### PR TITLE
[#4789] add step-wise editing for banks view of partner profile

### DIFF
--- a/app/views/profiles/step/edit.html.erb
+++ b/app/views/profiles/step/edit.html.erb
@@ -1,0 +1,36 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-12">
+        <% content_for :title, "Editing - #{@partner.name}" %>
+        <h1><i class="fa fa-edit"></i>&nbsp;&nbsp;Editing Partner - <%= @partner.name %>
+        </h1>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="alert alert-info mx-5 mt-3" role="alert">
+  Instructions: Please fill out the following form sections carefully. Ensure that all required fields are completed.
+</div>
+
+<div data-controller="accordion">
+  <%= simple_form_for @partner,
+            url: profile_path,
+            data: { controller: "form-input", accordion_target: "form" },
+            html: {role: 'form', class: 'form-horizontal'} do |f| %>
+
+    <%= render 'partners/profiles/step/form_actions', f: f, partner: @partner %>
+
+    <div class="accordion mx-5 mt-3" id="accordionExample">
+      <%= render 'partners/profiles/step/accordion_section', f: f, partner: @partner, section_id: 'agency_information', section_title: 'Agency Information', icon_class: 'fa-edit', partial_name: 'agency_information', sections_with_errors: @sections_with_errors %>
+      <%= render 'partners/profiles/step/accordion_section', f: f, partner: @partner, section_id: 'program_delivery_address', section_title: 'Program / Delivery Address', icon_class: 'fa-map', partial_name: 'program_delivery_address', sections_with_errors: @sections_with_errors %>
+      <% @partner.partials_to_show.each do |partial| %>
+        <%= render 'partners/profiles/step/accordion_section', f: f, partner: @partner, section_id: partial, section_title: partial_display_name(partial), icon_class: 'fa-cogs', partial_name: partial, sections_with_errors: @sections_with_errors %>
+      <% end %>
+      <%= render 'partners/profiles/step/accordion_section', f: f, partner: @partner, section_id: 'partner_settings', section_title: 'Settings', icon_class: 'fa-cog', partial_name: 'partner_settings', sections_with_errors: @sections_with_errors %>
+    </div>
+
+    <%= render 'partners/profiles/step/form_actions', f: f, partner: @partner %>
+  <% end %>
+</div>

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -380,6 +380,106 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
       end
     end
 
+    describe "#edit_profile" do
+      let!(:partner) { create(:partner, name: "Frank") }
+      subject { edit_profile_path(partner.id) }
+
+      context "when step-wise editing is enabled" do
+        before do
+          Flipper.enable(:partner_step_form)
+          visit subject
+        end
+
+        it "displays all sections in a closed state by default" do
+          within ".accordion" do
+            expect(page).to have_css("#agency_information.accordion-collapse.collapse", visible: false)
+            expect(page).to have_css("#program_delivery_address.accordion-collapse.collapse", visible: false)
+
+            partner.partials_to_show.each do |partial|
+              expect(page).to have_css("##{partial}.accordion-collapse.collapse", visible: false)
+            end
+          end
+        end
+
+        it "allows sections to be opened, closed, filled in any order, and reviewed" do
+          # Media
+          find("button[data-bs-target='#media_information']").click
+          expect(page).to have_css("#media_information.accordion-collapse.collapse.show", visible: true)
+          within "#media_information" do
+            fill_in "Website", with: "https://www.example.com"
+          end
+          find("button[data-bs-target='#media_information']").click
+          expect(page).to have_css("#media_information.accordion-collapse.collapse", visible: false)
+
+          # Executive director
+          find("button[data-bs-target='#executive_director']").click
+          expect(page).to have_css("#executive_director.accordion-collapse.collapse.show", visible: true)
+          within "#executive_director" do
+            fill_in "Executive Director Name", with: "Lisa Smith"
+          end
+
+          # Save Progress
+          all("input[type='submit'][value='Save Progress']").last.click
+          expect(page).to have_css(".alert-success", text: "Details were successfully updated.")
+
+          # Save and Review
+          all("input[type='submit'][value='Save and Review']").last.click
+          expect(current_path).to eq(partner_path(partner.id))
+          expect(page).to have_css(".alert-success", text: "Details were successfully updated.")
+        end
+
+        it "displays the edit view with sections containing validation errors expanded" do
+          # Open up Media section and clear out website value
+          find("button[data-bs-target='#media_information']").click
+          within "#media_information" do
+            fill_in "Website", with: ""
+          end
+
+          # Open Pick up person section and fill in 4 email addresses
+          find("button[data-bs-target='#pick_up_person']").click
+          within "#pick_up_person" do
+            fill_in "Pick Up Person's Email", with: "email1@example.com, email2@example.com, email3@example.com, email4@example.com"
+          end
+
+          # Open Partner Settings section and uncheck all options
+          find("button[data-bs-target='#partner_settings']").click
+          within "#partner_settings" do
+            uncheck "Enable Quantity-based Requests" if has_checked_field?("Enable Quantity-based Requests")
+            uncheck "Enable Child-based Requests (unclick if you only do bulk requests)" if has_checked_field?("Enable Child-based Requests (unclick if you only do bulk requests)")
+            uncheck "Enable Requests for Individuals" if has_checked_field?("Enable Requests for Individuals")
+          end
+
+          # Save Progress
+          all("input[type='submit'][value='Save Progress']").last.click
+
+          # Expect an alert-danger message containing validation errors
+          expect(page).to have_css(".alert-danger", text: /There is a problem/)
+          expect(page).to have_content("No social media presence must be checked if you have not provided any of Website, Twitter, Facebook, or Instagram.")
+          expect(page).to have_content("Enable child based requests At least one request type must be set")
+          expect(page).to have_content("Pick up email can't have more than three email addresses")
+
+          # Expect media section, executive director section, and partner settings section to be opened
+          expect(page).to have_css("#media_information.accordion-collapse.collapse.show", visible: true)
+          expect(page).to have_css("#pick_up_person.accordion-collapse.collapse.show", visible: true)
+          expect(page).to have_css("#partner_settings.accordion-collapse.collapse.show", visible: true)
+
+          # Try to Submit and Review from error state
+          all("input[type='submit'][value='Save and Review']").last.click
+
+          # Expect an alert-danger message containing validation errors
+          expect(page).to have_css(".alert-danger", text: /There is a problem/)
+          expect(page).to have_content("No social media presence must be checked if you have not provided any of Website, Twitter, Facebook, or Instagram.")
+          expect(page).to have_content("Enable child based requests At least one request type must be set")
+          expect(page).to have_content("Pick up email can't have more than three email addresses")
+
+          # Expect media section, executive director section, and partner settings section to be opened
+          expect(page).to have_css("#media_information.accordion-collapse.collapse.show", visible: true)
+          expect(page).to have_css("#pick_up_person.accordion-collapse.collapse.show", visible: true)
+          expect(page).to have_css("#partner_settings.accordion-collapse.collapse.show", visible: true)
+        end
+      end
+    end
+
     describe "#approve_partner" do
       let(:tooltip_message) do
         "Partner has not requested approval yet. Partners are able to request approval by going into 'My Organization' and clicking 'Request Approval' button."


### PR DESCRIPTION
Resolves #4789

### Description

Similar to the [4504](https://github.com/rubyforgood/human-essentials/pull/4766) work, this modifies the bank's view of editing a partner profile to also be a step-wise, using Bootstrap Accordion. Fortunately all the same partials that were introduced for partner profile can be re-used here.

### Type of change

New feature/follow-on.

### How Has This Been Tested?

Automated tests added at `spec/system/partner_system_spec.rb`, see `describe "#edit_profile" do`.

For manual testing:

Start by enabling the feature flag in a Rails console `bin/rails c`:
```ruby
Flipper.enable(:partner_step_form)
```

1. Login as org admin
2. From left nav, select Partner Agencies -> All Partners
3. Click on any Partner name
4. From the Partner Profile information (you might need to scroll down a bit to get to this section), click on "Edit Information"
5. You should be on the partner profile edit view with all sections in a closed accordion state (see screenshots section)
6. Functionality is the same as what was done in [4504](https://github.com/rubyforgood/human-essentials/pull/4766) (including error handling). Except clicking Save and Review will navigate to the banks Partner Profile view at for example: `http://localhost:3000/partners/8#partner-information`

### Screenshots

![image](https://github.com/user-attachments/assets/a27b615b-06f3-4e8b-8af9-3eed7cc00c38)
