### PR TITLE
Add `[DO NOT REPLY]` to the `from` name of accounts email for mailers

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = '"Human Essentials" <accounts@humanessentials.app>'
+  config.mailer_sender = '"[DO NOT REPLY] Human Essentials" <accounts@humanessentials.app>'
 
   # Configure the class responsible to send e-mails.
   config.mailer = "CustomDeviseMailer"


### PR DESCRIPTION
Resolves #4521 <!--fill issue number-->

### Description

This PR updates the `from` name for all the emails sent using the `accounts@humanessentials.app` email address to include `[DO NOT REPLY]`. These changes are implemented in the [`CustomDeviseMailer`](https://github.com/Sukhpreet-s/human-essentials/blob/33e31a5b00765ab56b1801e772f76f1570f18bb1/app/mailers/custom_devise_mailer.rb#L2).

It seems only some of the emails, those set up by Devise, use the `accounts@humanessentials.app` email address, as [other mailers override](https://github.com/rubyforgood/human-essentials/blob/55f6ac9fd97286c2511f5dedd80156255e5bf962/app/mailers/application_mailer.rb#L2-L5) the from address to `no-reply@humanessentials.app`. These non-Devise mailers, with the `from` name format "Please do not reply to this email as this mailbox is not monitored — Human Essentials", remain unchanged as they are outside this issue's scope.

#### Observation notes:

While working on this issue, I noticed that some emails are not sent to users at all.

List of Devise configured emails that are set-up to send (**changed** in this PR):

- Inviting/re-inviting users
- Reset password instructions - This email is sent when 'Forgot Password' button is used from the main Login page.

List of Devise configured emails that are **not** set-up to send (**unchanged**):

- Email changed - requires `confirmable` module
- Password changed - the mailer function is not executed by default. Use callback to execute it.
- Confirmation instruction - requires `confirmable` module
- Unlock instruction - requires `localable` module

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This fix is tested manually. 

I haven't added any tests for this since the tests for other mailers are only checking for the email address in the `from` name and not for the text part. Please let me know if we should still add tests to check if `[DO NOT REPLY]` is included.

Steps to reproduce the `Invitation Instructions` email:
1. Log in [as Organization Admin with `org_admin1@example.com` email](https://github.com/rubyforgood/human-essentials/blob/main/CONTRIBUTING.md#credentials).
2. Click on `My Organization` in the left navigation bar.
3. Scroll all the way to bottom and click `Invite User to this Organization` button.
4. Enter any valid email in the email input box and click `Invite User`.
5. You should receive the email with `[DO NOT REPLY]` in the `from` name.

Steps to reproduce the `Reset Password` email:
1. Log out if already logged in.
6. Navigate to the sign in page by clicking `Login` button.
7. Click on `Forgot your password?` link.
8. Enter `org_admin1@example.com` in the email input box and click the `Send me reset password instructions`.
9. You should receive the email with `[DO NOT REPLY]` in the `from` name.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<details><summary>When inviting new user to an Organization:</summary>
<h3>Before</h3>
<img src="https://github.com/user-attachments/assets/454cc5ef-250b-4439-8697-a3fbf1dffb5c" />
<h3>After</h3>
<img src="https://github.com/user-attachments/assets/aac0f253-506c-4126-ad11-063d27b28446" />
</details>

<details><summary>When resetting the password:</summary>
<h3>Before</h3>
<img src="https://github.com/user-attachments/assets/7317de1c-748f-47a6-adf9-3e37b6b8089a" />
<h3>After</h3>
<img src="https://github.com/user-attachments/assets/e1681328-8dca-4219-9b5d-95a36055559b" />
</details>


