### PR TITLE
4788 - Fixing Partner Message On Invite Email

### DIFF
--- a/app/views/users/mailer/invitation_instructions.html.erb
+++ b/app/views/users/mailer/invitation_instructions.html.erb
@@ -346,6 +346,7 @@
                     <p>Hello <%= @resource.email %></p>
                     <% if @resource.partner.present? && is_primary_partner %>
                       <p>You've been invited to become a partner with <strong><%= organization.name %>!</strong></p>
+                      <p><%= organization.invitation_text %></p>
                       <p>Please click the link below to accept your invitation and create an account and you'll be able to begin requesting distributions.</p>
                       <p><strong> Please contact <%= organization.email %> if you are encountering any issues. </strong></p>
                     <% elsif @resource.partner.present? && !is_primary_partner %>

--- a/docs/user_guide/bank/getting_started_customization.md
+++ b/docs/user_guide/bank/getting_started_customization.md
@@ -115,6 +115,8 @@ Hello [Partner's email]
 
 You've been invited to become a partner with Pawnee Diaper Bank!
 
+[Customer Partner Invitation Message If Present]
+
 Please click the link below to accept your invitation and create an account and you'll be able to begin requesting Distributions.
 
 Please contact [Bank's email] if you are encountering any issues.

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe CustomDeviseMailer, type: :mailer do
       let(:partner) do
         partner = create(:partner, :uninvited)
         partner.primary_user.delete
+        partner.organization.update!(invitation_text: "Custom Invitation Text")
         partner.reload
         partner
       end
@@ -17,6 +18,7 @@ RSpec.describe CustomDeviseMailer, type: :mailer do
 
       it "invites to primary user" do
         expect(mail.subject).to eq("You've been invited to be a partner with #{user.partner.organization.name}")
+        expect(mail.html_part.body).to include(partner.organization.invitation_text)
         expect(mail.html_part.body).to include("You've been invited to become a partner with <strong>#{user.partner.organization.name}!</strong>")
       end
     end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #4788  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
Custom Invitation Message Was not appearing in the partner invitation mail

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
I wrote a test case which can be seen in the PR changes. It basically tests whether custom message got included in the invite email or not


### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

<img width="615" alt="Screenshot 2024-11-27 at 10 26 13 PM" src="https://github.com/user-attachments/assets/d031e508-9ff7-4892-a16e-a43fffe47794">
attachments/assets/7a6ce83a-08fe-483b-a46a-23fb3d3986b8">
<img width="1436" alt="Screenshot 2024-11-27 at 10 27 03 PM" src="https://github.com/user-attachments/assets/eba4981d-886a-4ccf-a679-0582b60599e4">

