### PR TITLE
Fix distribution filtering by category bug and refactor for performance (#4590)

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -64,6 +64,7 @@ class DistributionsController < ApplicationController
     @selected_location = filter_params[:by_location]
     # FIXME: one of these needs to be removed but it's unclear which at this point
     @statuses = Distribution.states.transform_keys(&:humanize)
+    @distributions_with_inactive_items = @distributions.joins(:inactive_items).pluck(:id)
 
     respond_to do |format|
       format.html

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -43,9 +43,10 @@ class DistributionsController < ApplicationController
 
     @distributions = current_organization
                      .distributions
+                     .order(issued_at: :desc)
                      .includes(:partner, :storage_location)
                      .apply_filters(filter_params.except(:date_range), helpers.selected_range)
-    @paginated_distributions = @distributions.order('issued_at DESC').page(params[:page])
+    @paginated_distributions = @distributions.page(params[:page])
     @items = current_organization.items.alphabetized.select(:id, :name)
     @item_categories = current_organization.item_categories.select(:id, :name)
     @storage_locations = current_organization.storage_locations.active_locations.alphabetized.select(:id, :name)
@@ -54,9 +55,9 @@ class DistributionsController < ApplicationController
     @distribution_totals = @distributions.unscope(:order, :includes).to_totals_hash
     @total_value_all_distributions = total_value(@distribution_totals)
     @total_items_all_distributions = total_quantity(@distribution_totals)
-    paginated_ids = @paginated_distributions.ids
-    @total_value_paginated_distributions = total_value(@distribution_totals.slice(*paginated_ids))
-    @total_items_paginated_distributions = total_quantity(@distribution_totals.slice(*paginated_ids))
+    paginated_distribution_totals = @distribution_totals.slice(*@paginated_distributions.ids)
+    @total_value_paginated_distributions = total_value(paginated_distribution_totals)
+    @total_items_paginated_distributions = total_quantity(paginated_distribution_totals)
     @selected_item_category = filter_params[:by_item_category_id]
     @selected_partner = filter_params[:by_partner]
     @selected_status = filter_params[:by_state]

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -19,21 +19,6 @@ module DistributionHelper
     calendar_distributions_url(hash: crypt.encrypt_and_sign(current_organization.id))
   end
 
-  def quantity_by_item_id(distribution, item_id)
-    item_id = Integer(item_id)
-    quantities = distribution.line_items.quantities_by_name
-
-    single_item = quantities.values.find { |li| item_id == li[:item_id] } || {}
-    single_item[:quantity]
-  end
-
-  def quantity_by_item_category_id(distribution, item_category_id)
-    item_category_id = Integer(item_category_id)
-    quantities = distribution.line_items.quantities_by_category
-
-    quantities[item_category_id]
-  end
-
   def distribution_shipping_cost(shipping_cost)
     (shipping_cost && shipping_cost != 0) ? number_to_currency(shipping_cost) : ""
   end

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -20,11 +20,7 @@ module Itemizable
 
     # @return [Array<Item>] or [Item::ActiveRecord_Relation]
     def inactive_items
-      if line_items.loaded?
-        line_items.map(&:item).select { |i| !i.active? }
-      else
-        items.inactive
-      end
+      line_items.map(&:item).select { |i| !i.active? }
     end
 
     has_many :line_items, as: :itemizable, inverse_of: :itemizable do
@@ -98,6 +94,8 @@ module Itemizable
     end
 
     has_many :items, through: :line_items
+    has_many :inactive_items, -> { inactive }, through: :line_items, source: :item
+
     accepts_nested_attributes_for :line_items,
                                   allow_destroy: true,
                                   reject_if: proc { |l| l[:item_id].blank? || l[:quantity].blank? }

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -18,9 +18,13 @@ module Itemizable
       inactive_items.any?
     end
 
-    # @return [Array<Item>]
+    # @return [Array<Item>] or [Item::ActiveRecord_Relation]
     def inactive_items
-      line_items.map(&:item).select { |i| !i.active? }
+      if line_items.loaded?
+        line_items.map(&:item).select { |i| !i.active? }
+      else
+        items.inactive
+      end
     end
 
     has_many :line_items, as: :itemizable, inverse_of: :itemizable do

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -48,9 +48,9 @@ class Distribution < ApplicationRecord
   enum delivery_method: { pick_up: 0, delivery: 1, shipped: 2 }
   scope :active, -> { joins(:line_items).joins(:items).where(items: { active: true }) }
   # add item_id scope to allow filtering distributions by item
-  scope :by_item_id, ->(item_id) { includes(:items).where(items: { id: item_id }) }
+  scope :by_item_id, ->(item_id) { joins(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner
-  scope :by_item_category_id, ->(item_category_id) { includes(:items).where(items: { item_category_id: item_category_id }) }
+  scope :by_item_category_id, ->(item_category_id) { joins(:items).where(items: { item_category_id: item_category_id }) }
   scope :by_partner, ->(partner_id) { where(partner_id: partner_id) }
   # location scope to allow filtering distributions by location
   scope :by_location, ->(storage_location_id) { where(storage_location_id: storage_location_id) }

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -48,9 +48,9 @@ class Distribution < ApplicationRecord
   enum delivery_method: { pick_up: 0, delivery: 1, shipped: 2 }
   scope :active, -> { joins(:line_items).joins(:items).where(items: { active: true }) }
   # add item_id scope to allow filtering distributions by item
-  scope :by_item_id, ->(item_id) { joins(:items).where(items: { id: item_id }) }
+  scope :by_item_id, ->(item_id) { includes(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner
-  scope :by_item_category_id, ->(item_category_id) { joins(:items).where(items: { item_category_id: item_category_id }) }
+  scope :by_item_category_id, ->(item_category_id) { includes(:items).where(items: { item_category_id: item_category_id }) }
   scope :by_partner, ->(partner_id) { where(partner_id: partner_id) }
   # location scope to allow filtering distributions by location
   scope :by_location, ->(storage_location_id) { where(storage_location_id: storage_location_id) }
@@ -65,9 +65,7 @@ class Distribution < ApplicationRecord
       .apply_filters(filters, date_range)
   }
   scope :apply_filters, ->(filters, date_range) {
-    includes(:partner, :storage_location, :line_items, :items)
-      .order(issued_at: :desc)
-      .class_filter(filters.merge(during: date_range))
+    class_filter(filters.merge(during: date_range))
   }
   scope :this_week, -> do
     where("issued_at > :start_date AND issued_at <= :end_date",
@@ -75,6 +73,24 @@ class Distribution < ApplicationRecord
   end
 
   delegate :name, to: :partner, prefix: true
+
+  # Returns hash of total quantity and value of items per distribution
+  # Ex: {7=>{quantity: 13309, value: 43000}, 22=>{quantity: 0, value: 0}, ...)
+  #
+  # @return [Hash<Integer, Hash<Symbol, Integer>>]
+  def self.to_totals_hash
+    left_joins(line_items: [:item])
+      .group("distributions.id, line_items.id, items.id")
+      .pluck(
+        Arel.sql(
+          "distributions.id,
+          sum(line_items.quantity) OVER (PARTITION BY distributions.id) AS quantity,
+          sum(COALESCE(items.value_in_cents, 0) * line_items.quantity) OVER (PARTITION BY distributions.id) AS value"
+        )
+      ).to_h do |(id, quantity, value)|
+        [id, {quantity: quantity || 0, value: value || 0}]
+      end
+  end
 
   def distributed_at
     if is_midnight(issued_at)

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -48,9 +48,9 @@ class Distribution < ApplicationRecord
   enum delivery_method: { pick_up: 0, delivery: 1, shipped: 2 }
   scope :active, -> { joins(:line_items).joins(:items).where(items: { active: true }) }
   # add item_id scope to allow filtering distributions by item
-  scope :by_item_id, ->(item_id) { joins(:items).where(items: { id: item_id }) }
+  scope :by_item_id, ->(item_id) { includes(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner
-  scope :by_item_category_id, ->(item_category_id) { joins(:items).where(items: { item_category_id: item_category_id }) }
+  scope :by_item_category_id, ->(item_category_id) { includes(:items).where(items: { item_category_id: item_category_id }) }
   scope :by_partner, ->(partner_id) { where(partner_id: partner_id) }
   # location scope to allow filtering distributions by location
   scope :by_location, ->(storage_location_id) { where(storage_location_id: storage_location_id) }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -53,6 +53,7 @@ class Item < ApplicationRecord
   # Add spec for these
   scope :kits, -> { where.not(kit_id: nil) }
   scope :loose, -> { where(kit_id: nil) }
+  scope :inactive, -> { where.not(active: true) }
 
   scope :visible, -> { where(visible_to_partners: true) }
   scope :alphabetized, -> { order(:name) }

--- a/app/services/distribution_totals_service.rb
+++ b/app/services/distribution_totals_service.rb
@@ -50,7 +50,7 @@ class DistributionTotalsService
   #
   # @return [Hash<Integer, Integer>]
   def calculate_values(distributions)
-    distributions
+    Distribution
       .where(id: distributions.class_filter(filter_params))
       .left_joins(line_items: [:item])
       .group("distributions.id, line_items.id, items.id")

--- a/app/services/distribution_totals_service.rb
+++ b/app/services/distribution_totals_service.rb
@@ -1,0 +1,46 @@
+class DistributionTotalsService
+  def initialize(distributions)
+    @distribution_totals = calculate_totals(distributions)
+  end
+
+  def total_quantity(filter_ids = [])
+    totals = filter_ids.present? ? distribution_totals.slice(*filter_ids) : distribution_totals
+    totals.sum { |_, totals| totals[:quantity] }
+  end
+
+  def total_value(filter_ids = [])
+    totals = filter_ids.present? ? distribution_totals.slice(*filter_ids) : distribution_totals
+    totals.sum { |_, totals| totals[:value] }
+  end
+
+  def fetch_value(id)
+    distribution_totals.dig(id, :value)
+  end
+
+  def fetch_quantity(id)
+    distribution_totals.dig(id, :quantity)
+  end
+
+  private
+
+  attr_reader :distribution_totals
+
+  # Returns hash of total quantity and value of items per distribution
+  # Ex: {7=>{quantity: 13309, value: 43000}, 22=>{quantity: 0, value: 0}, ...)
+  #
+  # @return [Hash<Integer, Hash<Symbol, Integer>>]
+  def calculate_totals(distributions)
+    distributions
+      .left_joins(line_items: [:item])
+      .group("distributions.id, line_items.id, items.id")
+      .pluck(
+        Arel.sql(
+          "distributions.id,
+          sum(line_items.quantity) OVER (PARTITION BY distributions.id) AS quantity,
+          sum(COALESCE(items.value_in_cents, 0) * line_items.quantity) OVER (PARTITION BY distributions.id) AS value"
+        )
+      ).to_h do |(id, quantity, value)|
+        [id, {quantity: quantity || 0, value: value || 0}]
+      end
+  end
+end

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -12,17 +12,18 @@
   <td><%= distribution_row.comment %></td>
   <td><%= distribution_row.state&.humanize %></td>
 
+  <% distribution_has_inactive_item = @distributions_with_inactive_items.include?(distribution_row.id) %>
   <td class="text-right">
     <%= view_button_to distribution_path(distribution_row) %>
-    <% if (!distribution_row.complete? && !distribution_row.future?) || current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
-      <%= edit_button_to edit_distribution_path(distribution_row), enabled: !distribution_row.has_inactive_item? %>
+    <% if (!distribution_row.complete? && !distribution_row.future?) || current_user.has_cached_role?(Role::ORG_ADMIN, current_organization) %>
+      <%= edit_button_to edit_distribution_path(distribution_row), enabled: !distribution_has_inactive_item %>
     <% end %>
     <%= print_button_to print_distribution_path(distribution_row, format: :pdf) %>
     <%= delete_button_to distribution_path(distribution_row),
           { confirm: "Are you sure you want to reclaim this distribution to #{distribution_row.partner.name}?",
             text: "Reclaim",
-            icon: "undo", enabled: !distribution_row.has_inactive_item? } %>
-    <% if distribution_row.has_inactive_item? %>
+            icon: "undo", enabled: !distribution_has_inactive_item } %>
+    <% if distribution_has_inactive_item %>
       <div class="low_priority_warning">Has Inactive Items</div>
     <% end %>
   </td>

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -5,8 +5,8 @@
   <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %></td>
   <td><%= distribution_row.storage_location.name %></td>
 
-  <td class="numeric"><%= fetch_distribution_quantity(distribution_row.id) %></td>
-  <td class="numeric"><%= dollar_value(fetch_distribution_value(distribution_row.id)) %></td>
+  <td class="numeric"><%= @distribution_totals.fetch_quantity(distribution_row.id) %></td>
+  <td class="numeric"><%= dollar_value(@distribution_totals.fetch_value(distribution_row.id)) %></td>
   <td><%= distribution_row.delivery_method.humanize %></td>
   <td><%= distribution_shipping_cost(distribution_row.shipping_cost) %></td>
   <td><%= distribution_row.comment %></td>

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -5,17 +5,8 @@
   <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %></td>
   <td><%= distribution_row.storage_location.name %></td>
 
-  <!-- Quantity -->
-  <% if filter_params[:by_item_id].present? %>
-    <td class="numeric"><%= quantity_by_item_id(distribution_row, filter_params[:by_item_id]) %></td>
-  <% elsif filter_params[:by_item_category_id].present? %>
-    <td class="numeric"><%= quantity_by_item_category_id(distribution_row, filter_params[:by_item_category_id]) %></td>
-  <% else %>
-    <td class="numeric"><%= distribution_row.line_items.total %></td>
-  <% end %>
-  <!-- End Quantity -->
-
-  <td class="numeric"><%= dollar_value(distribution_row.value_per_itemizable) %></td>
+  <td class="numeric"><%= fetch_distribution_quantity(distribution_row.id) %></td>
+  <td class="numeric"><%= dollar_value(fetch_distribution_value(distribution_row.id)) %></td>
   <td><%= distribution_row.delivery_method.humanize %></td>
   <td><%= distribution_shipping_cost(distribution_row.shipping_cost) %></td>
   <td><%= distribution_row.comment %></td>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -113,15 +113,7 @@
                 <% end %>
                 <!-- End Quantity -->
 
-                <!-- Value -->
-                <% if filter_params[:by_item_id].present? %>
-                  <th class="numeric">Value of <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
-                <% elsif filter_params[:by_item_category_id].present? %>
-                  <th class="numeric">Value of <%= @item_categories.find { |ic| ic.id == filter_params[:by_item_category_id].to_i }&.name %></th>
-                <% else %>
-                  <th class="numeric">Total Value</th>
-                <% end %>
-                <!-- End Value -->
+                <th class="numeric">Total Value</th>
 
                 <th>Delivery Method</th>
                 <th>Shipping Cost</th>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -69,7 +69,7 @@
                 <%= clear_filter_button %>
                 <span class="float-right">
                   <%=
-                    if @distributions.length > 0
+                    if @distributions.any?
                       download_button_to(
                         distributions_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)),
                         text: "Export Distributions"
@@ -113,7 +113,16 @@
                 <% end %>
                 <!-- End Quantity -->
 
-                <th class="numeric">Total Value</th>
+                <!-- Value -->
+                <% if filter_params[:by_item_id].present? %>
+                  <th class="numeric">Value of <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
+                <% elsif filter_params[:by_item_category_id].present? %>
+                  <th class="numeric">Value of <%= @item_categories.find { |ic| ic.id == filter_params[:by_item_category_id].to_i }&.name %></th>
+                <% else %>
+                  <th class="numeric">Total Value</th>
+                <% end %>
+                <!-- End Value -->
+
                 <th>Delivery Method</th>
                 <th>Shipping Cost</th>
                 <th>Comments</th>

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -175,6 +175,18 @@ RSpec.describe "Distributions", type: :request do
           expect(item_total_header.text).to eq("Total in #{item_category.name}")
           expect(item_value_header.text).to eq("Total Value")
         end
+
+        it "doesn't show duplicate distributions" do
+          # Add another item in given category so that a JOIN clauses would produce duplicates
+          item.update(item_category: item_category_2, value_in_cents: 50)
+
+          get distributions_path, params: params
+
+          page = Nokogiri::HTML(response.body)
+          distribution_rows = page.css("table tbody tr")
+
+          expect(distribution_rows.count).to eq(1)
+        end
       end
     end
 

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -122,19 +122,20 @@ RSpec.describe "Distributions", type: :request do
           expect(distribution.total_quantity).to eq(20)
           expect(distribution.value_per_itemizable).to eq(2000)
 
-          # displays value/quantity of filtered item in distribution
+          # displays quantity of filtered item in distribution
+          # displays total value of distribution
           expect(item_quantity.text).to eq("10")
-          expect(item_value.text).to eq("$10.00")
+          expect(item_value.text).to eq("$20.00")
         end
 
-        it "changes the total quantity/value headers" do
+        it "changes the total quantity header" do
           get distributions_path, params: params
 
           page = Nokogiri::HTML(response.body)
           item_total_header, item_value_header = page.css("table thead tr th.numeric")
 
           expect(item_total_header.text).to eq("Total #{item.name}")
-          expect(item_value_header.text).to eq("Value of #{item.name}")
+          expect(item_value_header.text).to eq("Total Value")
         end
       end
 
@@ -159,19 +160,20 @@ RSpec.describe "Distributions", type: :request do
           expect(distribution.total_quantity).to eq(20)
           expect(distribution.value_per_itemizable).to eq(2000)
 
-          # displays value/quantity of filtered item in distribution
+          # displays quantity of filtered item in distribution
+          # displays total value of distribution
           expect(item_quantity.text).to eq("10")
-          expect(item_value.text).to eq("$10.00")
+          expect(item_value.text).to eq("$20.00")
         end
 
-        it "changes the total quantity/value headers" do
+        it "changes the total quantity header" do
           get distributions_path, params: params
 
           page = Nokogiri::HTML(response.body)
           item_total_header, item_value_header = page.css("table thead tr th.numeric")
 
           expect(item_total_header.text).to eq("Total in #{item_category.name}")
-          expect(item_value_header.text).to eq("Value of #{item_category.name}")
+          expect(item_value_header.text).to eq("Total Value")
         end
       end
     end


### PR DESCRIPTION
Resolves #4590 <!--fill issue number-->

### Description

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (#4590)
~~* New feature (filtering distributions by item category/id now shows the value of those items in the distribution NOT total distribution value)~~
* Performance improvement (to `/distributions` page)

### How Has This Been Tested?
Added request specs

### Screenshots

**Below is out of date. That behavior will be moved to a new PR if it is desired**
Note changes in table header for value and value amounts are now just of those items. (Many items from seeds have no value which is why the number is either very low or blank.)

![Screenshot from 2024-11-28 15-03-44](https://github.com/user-attachments/assets/e9432937-5032-446e-b89a-698b290aaf37)

![Screenshot from 2024-11-28 15-03-29](https://github.com/user-attachments/assets/6cf3b127-b767-4388-af3a-8c6e52c583cc)

Because we are no longer loading all the `line_items` and `items` for every distribution into memory, this `/distributions` page is now faster. Object allocation dropped significantly and it went from ~480ms to ~170ms in my development environment (seed data + laptop). But not sure what production env/data looks like. 

Before:
![Screenshot from 2024-11-28 14-29-52](https://github.com/user-attachments/assets/1a207ec3-e3d6-4cda-ba6d-fc327d810c3f)
After:
![Screenshot from 2024-11-28 14-29-59](https://github.com/user-attachments/assets/89874383-6007-42af-b082-30ee910aa619)

