### PR TITLE
[#4807] Help partner to remember to submit profile for approval:

### DIFF
--- a/app/views/partners/profiles/_actions.html.erb
+++ b/app/views/partners/profiles/_actions.html.erb
@@ -1,0 +1,31 @@
+<%# locals: (partner:) %>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card card-primary">
+          <div class="card-footer">
+            <% if partner.approved? %>
+              <%= link_to '', class: 'btn btn-info disabled' do %>
+                <i class="fa fa-check"></i> Approved
+              <% end %>
+            <% elsif partner.awaiting_review? %>
+              <%= link_to '', class: "btn btn-warning disabled" do %>
+                <i class="fa fa-clock"></i> Pending Approval
+              <% end %>
+            <% else %>
+              <%= link_to partners_approval_request_path, method: :post, class: "btn btn-success" do %>
+                <i class="fa fa-paper-plane"></i> Submit for Approval
+              <% end %>
+            <% end %>
+
+            <%= link_to edit_partners_profile_path, class: 'btn btn-primary' do %>
+              <i class="fa fa-pencil"></i> Update Information
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/show.html.erb
+++ b/app/views/partners/profiles/show.html.erb
@@ -22,6 +22,8 @@
   </div><!-- /.container-fluid -->
 </section>
 
+<%= render 'actions', partner: current_partner %>
+
 <div class="row">
   <div class="col-md-12">
       <div class="container-fluid">
@@ -42,37 +44,4 @@
     </div>
 </div>
 
-<section class="content">
-  <div class="container-fluid">
-    <div class="row">
-      <!-- left column -->
-      <div class="col-md-12">
-        <!-- jquery validation -->
-        <div class="card card-primary">
-          <div class="card-footer">
-            <% if current_partner.approved? %>
-              <%= link_to '', class: 'btn btn-info disabled' do %>
-                <i class="fa fa-check"></i> Approved
-              <% end %>
-            <% elsif current_partner.awaiting_review? %>
-              <%= link_to '', class: "btn btn-warning disabled" do %>
-                <i class="fa fa-clock"></i> Pending Approval
-              <% end %>
-            <% else %>
-              <%= link_to partners_approval_request_path, method: :post, class: "btn btn-success" do %>
-                <i class="fa fa-paper-plane"></i> Submit for Approval
-              <% end %>
-            <% end %>
-
-            <%= link_to edit_partners_profile_path, class: 'btn btn-primary' do %>
-              <i class="fa fa-pencil"></i> Update Information
-            <% end %>
-          </div>
-        </div>
-        <!-- /.card -->
-      </div>
-      <!--/.col (left) -->
-    </div>
-    <!-- /.row -->
-  </div><!-- /.container-fluid -->
-</section>
+<%= render 'actions', partner: current_partner %>

--- a/spec/system/partners/approval_process_spec.rb
+++ b/spec/system/partners/approval_process_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Approval process for partners", type: :system, js: true do
         before do
           click_on 'My Profile'
           assert page.has_content? 'Uninvited'
-          click_on 'Update Information'
+          all('a', text: 'Update Information').last.click
 
           fill_in 'Other Agency Type', with: 'Lorem'
 
@@ -41,7 +41,7 @@ RSpec.describe "Approval process for partners", type: :system, js: true do
           click_on 'Update Information'
           assert page.has_content? 'Details were successfully updated.'
 
-          find_link(text: 'Submit for Approval').click
+          all('a', text: 'Submit for Approval').last.click
           assert page.has_content? 'You have submitted your details for approval.'
           assert page.has_content? 'Awaiting Review'
         end
@@ -77,7 +77,7 @@ RSpec.describe "Approval process for partners", type: :system, js: true do
       login_as(partner_user)
       visit partner_user_root_path
       click_on 'My Profile'
-      click_on 'Submit for Approval'
+      all('a', text: 'Submit for Approval').last.click
     end
 
     it "should render an error message", :aggregate_failures do


### PR DESCRIPTION
Resolves #4807 

### Description
A quick follow-on from #4789.

This duplicates the action buttons/links "Submit for Approval" and "Update Information" at the top of the Partner Profile view (they continue to render at the bottom of the view). Since it's a long view, this serves as a visual reminder to the partner user that they still need to submit their profile for approval.

Note that this feature is _not_ behind the flag (`Flipper.enable(:partner_step_form)`) because it's useful even without step-wise editing. i.e. the partner profile view is long regardless.

**Tech Notes**

Took this opportunity to extract the actions to a partial with strict locals for the `partner` variable, which is required to determine what actions get displayed. 

### Type of change
New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Maintained system tests at `spec/system/partners/approval_process_spec.rb`

For manual testing:
* Login as org admin
* Create and invite a new partner
* As a partner, accept the invitation from the email link
* Click on "My Profile" from left nav
* You're navigated to `http://localhost:3000/partners/profile` and should see the action buttons  "Submit for Approval" and "Update Information" both at top and bottom of the view.

### Screenshots
The same action buttons (that are actually links) added to top of view:
![image](https://github.com/user-attachments/assets/65ba4baa-db6d-4269-9532-4f9a43a33835)
