### PR TITLE
Fix flaky distributions by county spec

### DIFF
--- a/spec/system/distributions_by_county_system_spec.rb
+++ b/spec/system/distributions_by_county_system_spec.rb
@@ -18,8 +18,9 @@ RSpec.feature "Distributions by County", type: :system do
       partner_1.profile.served_areas.each do |served_area|
         expect(page).to have_text(served_area.county.name)
       end
-      expect(page).to have_text("50", count: 4)
-      expect(page).to have_text("$525.00", count: 4)
+
+      expect(page).to have_css("table tbody tr td", text: "50", exact_text: true, count: 4)
+      expect(page).to have_css("table tbody tr td", text: "$525.00", exact_text: true, count: 4)
     end
 
     it("works for this year") do
@@ -31,8 +32,9 @@ RSpec.feature "Distributions by County", type: :system do
       partner_1.profile.served_areas.each do |served_area|
         expect(page).to have_text(served_area.county.name)
       end
-      expect(page).to have_text("25", count: 4)
-      expect(page).to have_text("$262.50", count: 4)
+
+      expect(page).to have_css("table tbody tr td", text: "25", exact_text: true, count: 4)
+      expect(page).to have_css("table tbody tr td", text: "$262.50", exact_text: true, count: 4)
     end
 
     it("works for prior year") do
@@ -53,8 +55,8 @@ RSpec.feature "Distributions by County", type: :system do
       partner_1.profile.served_areas.each do |served_area|
         expect(page).to have_text(served_area.county.name)
       end
-      expect(page).to have_text("25", count: 4)
-      expect(page).to have_text("$262.50", count: 4)
+      expect(page).to have_css("table tbody tr td", text: "25", exact_text: true, count: 4)
+      expect(page).to have_css("table tbody tr td", text: "$262.50", exact_text: true, count: 4)
     end
 
     it("works for last 12 months") do
@@ -75,8 +77,8 @@ RSpec.feature "Distributions by County", type: :system do
       partner_1.profile.served_areas.each do |served_area|
         expect(page).to have_text(served_area.county.name)
       end
-      expect(page).to have_text("25", count: 4)
-      expect(page).to have_text("$262.50", count: 4)
+      expect(page).to have_css("table tbody tr td", text: "25", exact_text: true, count: 4)
+      expect(page).to have_css("table tbody tr td", text: "$262.50", exact_text: true, count: 4)
     end
   end
 


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
This test is flaky and blocking PR #4797 from passing all the tests.
The issue is we are searching for the text "25" which sometimes shows up as the county number, so the count of that text is then wrong.
Error:
```
Failures:

  1) Distributions by County handles time ranges properly works for this year
     Failure/Error: expect(page).to have_text("25", count: 4)
       expected to find text "25" 4 times but found 5 times in "Need Help?\n1\nDiaper McDiaperface\n \nDashboard\n \nDonations\n \nPurchases\n \nRequests\n \nDistributions\n \nPick Ups & Deliveries\n \nPartner Agencies\n \nInventory\n \nCommunity\n \nReports\n Activity Graph\n Annual Survey\n History\n Distributions - Summary\n Distributions - By County\n Distributions - Itemized\n Distributions - Trends\n Donations - Summary\n Donations - Itemized\n Donations - Manufacturer\n Donations - Trends\n Product Drives - Summary\n Purchases - Summary\n Purchases - Trends\nEstimated Distributions by County for Some Unique Name\n Home\nDistributions\n Filter\nCounty\tEstimated total items\tEstimated total market value\nCounty 26\t25\t$262.50\nCounty 28\t25\t$262.50\nCounty 25\t25\t$262.50\nCounty 27\t25\t$262.50\nUnspecified\t0\t$0.00\nHuman Essentials was built with  by Ruby for Good.". (However, it was found 22 times including non-visible text.)
```
Example screenshot when it fails:
(Note the text "25" appears 5 times instead of 4 due to the county name)
![image](https://github.com/user-attachments/assets/fe868f2f-7be3-4e22-a648-d154f0b97011)

### Type of change
* Fix flaky test

### How Has This Been Tested?
Difficult to reproduce locally, but should fix it in CI.