### PR TITLE
Fix time zone flakiness in distribution by county specs

### DIFF
--- a/spec/services/distributions_by_county_report_service_spec.rb
+++ b/spec/services/distributions_by_county_report_service_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe DistributionByCountyReportService, type: :service do
   let(:year) { Time.current.year }
-  let(:issued_at_last_year) { Time.current.utc.change(year: year - 1).to_datetime }
+  let(:issued_at_last_year) { Time.current.change(year: year - 1).to_datetime }
   let(:distributions) { [] }
 
   include_examples "distribution_by_county"

--- a/spec/support/distribution_by_county_shared_example.rb
+++ b/spec/support/distribution_by_county_shared_example.rb
@@ -6,7 +6,7 @@ shared_examples_for "distribution_by_county" do
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 
   let(:item_1) { create(:item, value_in_cents: 1050, organization: organization) }
-  let(:issued_at_present) { Time.current.utc.to_datetime }
+  let(:issued_at_present) { Time.current.to_datetime }
   let(:partner_1) {
     p1 = create(:partner, organization: organization)
     p1.profile.served_areas << create_list(:partners_served_area, 4, partner_profile: p1.profile, client_share: 25)

--- a/spec/system/distributions_by_county_system_spec.rb
+++ b/spec/system/distributions_by_county_system_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature "Distributions by County", type: :system do
   include_examples "distribution_by_county"
 
   let(:current_year) { Time.current.year }
-  let(:issued_at_last_year) { Time.current.utc.change(year: current_year - 1).to_datetime }
+  let(:issued_at_last_year) { Time.current.change(year: current_year - 1).to_datetime }
 
   before do
     sign_in(user)
@@ -39,7 +39,7 @@ RSpec.feature "Distributions by County", type: :system do
 
     it("works for prior year") do
       # Should NOT return distribution issued before previous calendar year
-      last_day_of_two_years_ago = Time.current.utc.change(year: current_year - 2, month: 12, day: 31).to_datetime
+      last_day_of_two_years_ago = Time.current.beginning_of_day.change(year: current_year - 2, month: 12, day: 31).to_datetime
       create(:distribution, :with_items, item: item_1, organization: user.organization, partner: partner_1, issued_at: last_day_of_two_years_ago)
 
       # Should return distribution issued during previous calendar year
@@ -47,7 +47,7 @@ RSpec.feature "Distributions by County", type: :system do
       create(:distribution, :with_items, item: item_1, organization: user.organization, partner: partner_1, issued_at: one_year_ago)
 
       # Should NOT return distribution issued after previous calendar year
-      first_day_of_current_year = Time.current.utc.change(year: current_year, month: 1, day: 1).to_datetime
+      first_day_of_current_year = Time.current.end_of_day.change(year: current_year, month: 1, day: 1).to_datetime
       create(:distribution, :with_items, item: item_1, organization: user.organization, partner: partner_1, issued_at: first_day_of_current_year)
 
       visit_distribution_by_county_with_specified_date_range("Prior Year")
@@ -61,7 +61,7 @@ RSpec.feature "Distributions by County", type: :system do
 
     it("works for last 12 months") do
       # Should NOT return disitribution issued before 12 months ago
-      one_year_and_one_day_ago = 1.year.ago.prev_day.to_datetime
+      one_year_and_one_day_ago = 1.year.ago.prev_day.beginning_of_day.to_datetime
       create(:distribution, :with_items, item: item_1, organization: user.organization, partner: partner_1, issued_at: one_year_and_one_day_ago)
 
       # Should return distribution issued during previous 12 months
@@ -69,7 +69,7 @@ RSpec.feature "Distributions by County", type: :system do
       create(:distribution, :with_items, item: item_1, organization: user.organization, partner: partner_1, issued_at: today)
 
       # Should NOT return distribution issued in the future
-      tomorrow = 1.day.from_now.to_datetime
+      tomorrow = 1.day.from_now.end_of_day.to_datetime
       create(:distribution, :with_items, item: item_1, organization: user.organization, partner: partner_1, issued_at: tomorrow)
 
       visit_distribution_by_county_with_specified_date_range("Last 12 Months")


### PR DESCRIPTION
### Description
Apparently some of the specs I added were flaky in two different ways :upside_down_face:

[Example of it failing in CI](https://github.com/rubyforgood/human-essentials/actions/runs/12111153643/job/33762598248)

Error message:

```
  1) Distributions by County handles time ranges properly works for prior year
     Failure/Error: expect(page).to have_css("table tbody tr td", text: "25", exact_text: true, count: 4)
       expected to find visible css "table tbody tr td" with exact text "25" 4 times but there were no matches. Also found "County 14", "50", "$525.00", "County 13", "50", "$525.00", "County 16", "50", "$525.00", "County 15", "50", "$525.00", "Unspecified", "0", "$0.00", which matched the selector but not all filters. 

     [Screenshot Image]: /home/runner/work/human-essentials/human-essentials/tmp/capybara/failures_r_spec_example_groups_distributions_by_county_handles_time_ranges_properly_works_for_prior_year_55.png


     # ./spec/system/distributions_by_county_system_spec.rb:58:in `block (3 levels) in <top (required)>'
```

Pretty sure this is a time zone issue. We query times in Los Angeles time zone during tests. But we were saving times in UTC to the database.  

### Type of change
* Fix flaky spec

### How Has This Been Tested?
Locally