### PR TITLE
Remove redundant db indexes

### DIFF
--- a/db/migrate/20241204133041_remove_index_on_name_from_counties_table.rb
+++ b/db/migrate/20241204133041_remove_index_on_name_from_counties_table.rb
@@ -1,0 +1,7 @@
+class RemoveIndexOnNameFromCountiesTable < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :counties, :name, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20241204133506_remove_index_on_organization_id_from_events_table.rb
+++ b/db/migrate/20241204133506_remove_index_on_organization_id_from_events_table.rb
@@ -1,0 +1,7 @@
+class RemoveIndexOnOrganizationIdFromEventsTable < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :events, :organization_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20241204133715_remove_index_on_user_id_from_users_roles_table.rb
+++ b/db/migrate/20241204133715_remove_index_on_user_id_from_users_roles_table.rb
@@ -1,0 +1,7 @@
+class RemoveIndexOnUserIdFromUsersRolesTable < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :users_roles, :user_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_12_184800) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_04_133715) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -202,7 +202,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_12_184800) do
     t.datetime "updated_at", null: false
     t.enum "category", default: "US_County", null: false, enum_type: "category"
     t.index ["name", "region"], name: "index_counties_on_name_and_region", unique: true
-    t.index ["name"], name: "index_counties_on_name"
     t.index ["region"], name: "index_counties_on_region"
   end
 
@@ -298,7 +297,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_12_184800) do
     t.bigint "user_id"
     t.string "group_id"
     t.index ["organization_id", "event_time"], name: "index_events_on_organization_id_and_event_time"
-    t.index ["organization_id"], name: "index_events_on_organization_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 
@@ -812,7 +810,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_12_184800) do
     t.bigint "role_id"
     t.index ["role_id"], name: "index_users_roles_on_role_id"
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
-    t.index ["user_id"], name: "index_users_roles_on_user_id"
   end
 
   create_table "vendors", force: :cascade do |t|


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
While familiarizing myself with the database schema, I noticed we have some indexes that are redundant.

Context: Composite indexes are able to be used when query conditions include fields involving the leftmost fields. So an index on `(a, b)` can be used for querying by `a` and `b` or by `a` alone. (But not queries only involving `b`). We currently have a few indexs on both `(a, b)` and `(a)`, so this PR is to remove the indexes on `(a)` leaving only the composite index.

Why remove these redundant indexes? It's not a priority but they do take up storage space in the database and they have a performance impact on write operations (because whenever those columns are updated, the indexes also need to be updated).

### Type of change

Technical debt?

### How Has This Been Tested?
See screenshots below.

### Screenshots
Example before and after for removing the index on `user_id` from the `user_roles` table

Before:
You can see it is using the index only on `user_id` (`index_users_roles_on_user_id`).
![Screenshot from 2024-12-04 14-57-17](https://github.com/user-attachments/assets/4874d6fe-0670-49b9-b3ff-9275df9bac43)

After:
That index no longer exists after the migration, but it is still able to perform an index scan by using the compound index on `user_id, role_id`.
![Screenshot from 2024-12-04 14-57-51](https://github.com/user-attachments/assets/85a766ff-6bc1-4858-a3c7-75185e9e751b)

Note: If you want to test this locally, you might have to insert rows into the database because when the table is too small postgres sometimes chooses to use a sequential scan.