### PR TITLE
Partner Profile : clean up social media, request types and pick up emails

### DIFF
--- a/db/migrate/20241204111437_cleanup_invalid_partner_profiles.rb
+++ b/db/migrate/20241204111437_cleanup_invalid_partner_profiles.rb
@@ -3,7 +3,7 @@ class CleanupInvalidPartnerProfiles < ActiveRecord::Migration[7.1]
     # ActiveRecord::Base.logger = Logger.new(STDOUT)
     invalid_profiles = Partners::Profile.all.reject(&:valid?)
 
-    return if !invalid_profiles
+    return if !invalid_profiles.present?
 
     invalid_profiles.each do |profile|
       # address invalid social media section
@@ -38,11 +38,11 @@ class CleanupInvalidPartnerProfiles < ActiveRecord::Migration[7.1]
         if pick_up == "none" or pick_up == "na" or pick_up == "n/a" or pick_up == "see above"
           profile.pick_up_email = ""
         else
-          profile.pick_up_email.sub!("/",",")
-          profile.pick_up_email.sub!(";",",")
-          profile.pick_up_email.sub!(" or ", ", ")
-          profile.pick_up_email.sub!(" and ", ", ")
-          profile.pick_up_email.sub!(" & ", ", ")
+          profile.pick_up_email.gsub!("/",",")
+          profile.pick_up_email.gsub!(";",",")
+          profile.pick_up_email.gsub!(" or ", ", ")
+          profile.pick_up_email.gsub!(" and ", ", ")
+          profile.pick_up_email.gsub!(" & ", ", ")
         end
 
         if(!profile.valid?)  ## If we can't fix the email,  append it to the name so we don't lose the information aspect

--- a/db/migrate/20241204111437_cleanup_invalid_partner_profiles.rb
+++ b/db/migrate/20241204111437_cleanup_invalid_partner_profiles.rb
@@ -1,0 +1,61 @@
+class CleanupInvalidPartnerProfiles < ActiveRecord::Migration[7.1]
+  def up
+    # ActiveRecord::Base.logger = Logger.new(STDOUT)
+    invalid_profiles = Partners::Profile.all.reject(&:valid?)
+
+    return if !invalid_profiles
+
+    invalid_profiles.each do |profile|
+      # address invalid social media section
+
+      unless (profile.website.present? ||
+        profile.twitter.present? ||
+        profile.facebook.present? ||
+        profile.instagram.present? ||
+        profile.no_social_media_presence ||
+        profile.partner.partials_to_show.exclude?("media_information"))
+        profile.no_social_media_presence = true
+      end
+
+      # address no request types set
+
+      unless(profile.enable_quantity_based_requests || profile.enable_individual_requests || profile.enable_child_based_requests)
+        profile.enable_quantity_based_requests = profile.partner.organization.enable_quantity_based_requests
+        profile.enable_individual_requests = profile.partner.organization.enable_individual_requests
+        profile.enable_child_based_requests = profile.partner.organization.enable_child_based_requests
+      end
+
+
+
+      # address bad pickup email
+
+      unless profile.valid?
+        # if profile is not valid at this point,  it is a bad pickup email
+
+        pick_up = profile.pick_up_email
+        pick_up.downcase!
+        pick_up.strip!
+        if pick_up == "none" or pick_up == "na" or pick_up == "n/a" or pick_up == "see above"
+          profile.pick_up_email = ""
+        else
+          profile.pick_up_email.sub!("/",",")
+          profile.pick_up_email.sub!(";",",")
+          profile.pick_up_email.sub!(" or ", ", ")
+          profile.pick_up_email.sub!(" and ", ", ")
+          profile.pick_up_email.sub!(" & ", ", ")
+        end
+
+        if(!profile.valid?)  ## If we can't fix the email,  append it to the name so we don't lose the information aspect
+          profile.pick_up_name += ", email: " + profile.pick_up_email
+          profile.pick_up_email = ""
+        end
+      end
+
+      profile.save!
+
+    end
+  end
+  def down
+  # irreversible
+  end
+end


### PR DESCRIPTION

Required before #4801 
### Description
This cleans up the partner profiles so they will be valid
- if nothing in the social media area, and social media is required, sets "no social media"
- if no request types are enabled,  enables all from the organization
- removes invalid email if obviously meant to  none (e.g. "n/a"), 
- converts email separators to ","
- if email still not valid,  appends to name, as " email: [remaining email], and blanks the email


Ran against production data with puts in place to check reasonablilty of that last step

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

Ran against production copy.   

