### PR TITLE
[#4594] allow zero inventory items to be selected for audit

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -10,7 +10,7 @@ class AuditsController < ApplicationController
   end
 
   def show
-    @items = View::Inventory.items_for_location(@audit.storage_location)
+    @items = View::Inventory.items_for_location(@audit.storage_location, include_omitted: true)
   end
 
   def edit
@@ -93,7 +93,7 @@ class AuditsController < ApplicationController
   end
 
   def set_items
-    @items = current_organization.items.alphabetized
+    @items = current_organization.items.where(active: true).alphabetized
   end
 
   def save_audit_status_and_redirect(params)

--- a/app/views/audits/_form.html.erb
+++ b/app/views/audits/_form.html.erb
@@ -14,7 +14,7 @@
               </div>
               <div class="box-body">
                 <%= simple_form_for @audit, data: { controller: "form-input" }, html: {class: "storage-location-required"} do |f| %>
-                  <%= render partial: "storage_locations/source", object: f, locals: { label: "Storage location", error: "What storage location are you auditing?" } %>
+                  <%= render partial: "storage_locations/source", object: f, locals: { label: "Storage location", error: "What storage location are you auditing?", include_omitted_items: true } %>
                   <fieldset style="margin-bottom: 2rem;">
                     <legend>Items in this audit</legend>
                     <div id="audit_line_items" class="line-item-fields" data-capture-barcode="true">

--- a/spec/requests/audits_requests_spec.rb
+++ b/spec/requests/audits_requests_spec.rb
@@ -50,6 +50,21 @@ RSpec.describe "Audits", type: :request do
         get new_audit_path
         expect(response).to be_successful
       end
+
+      it 'only includes active items in the line item select dropdown' do
+        create(:item, name: "TestActiveItem", organization: organization)
+        create(:item, name: "TestInactiveItem", organization: organization, active: false)
+
+        get new_audit_path
+        expect(response).to have_http_status(:ok)
+
+        html = Nokogiri::HTML(response.body)
+        options = html.css('select[name="audit[line_items_attributes][0][item_id]"] option')
+        option_values = options.map { |option| option.text.strip }
+
+        expect(option_values).to include('TestActiveItem')
+        expect(option_values).not_to include('TestInactiveItem')
+      end
     end
 
     describe "GET #edit" do

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -68,6 +68,46 @@ RSpec.describe "Audit management", type: :system, js: true do
           end
         end
 
+        it "allows auditing items that are not in a storage location", :js do
+          item = create(:item, name: "TestItemNotInStorageLocation", organization: organization)
+          audit_quantity = 1234
+          visit new_audit_path
+
+          await_select2("#audit_line_items_attributes_0_item_id") do
+            select storage_location.name, from: "Storage location"
+          end
+          select item.name, from: "audit_line_items_attributes_0_item_id"
+          fill_in "audit_line_items_attributes_0_quantity", with: audit_quantity
+
+          accept_confirm do
+            click_button "Confirm Audit"
+          end
+          expect(page.find(".alert-info")).to have_content "Audit is confirmed"
+          expect(page).to have_content(item.name)
+          expect(page).to have_content(audit_quantity)
+
+          accept_confirm do
+            click_link "Finalize Audit"
+          end
+          expect(page.find(".alert-info")).to have_content "Audit is Finalized"
+
+          event = Event.last
+          expect(event.type).to eq "AuditEvent"
+          event_line_item = Event.last.data.items.first
+          expect(event_line_item.item_id).to eq item.id
+          expect(event_line_item.quantity).to eq audit_quantity
+        end
+
+        it "does not display inactive items for selection" do
+          item = create(:item, name: "TestInactiveItem", organization: organization, active: false)
+          create(:storage_location, :with_items, item: item, item_quantity: 10, organization: organization)
+          visit new_audit_path
+
+          select_element = find('#audit_line_items_attributes_0_item_id', visible: :all)
+          option_texts = select_element.all('option', visible: :all).map(&:text)
+          expect(option_texts).not_to include(item.name)
+        end
+
         it "allows user to add items that do not yet have a barcode", :js do
           item_without_barcode = create(:item)
           new_barcode = "00000000"

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -98,16 +98,6 @@ RSpec.describe "Audit management", type: :system, js: true do
           expect(event_line_item.quantity).to eq audit_quantity
         end
 
-        it "does not display inactive items for selection" do
-          item = create(:item, name: "TestInactiveItem", organization: organization, active: false)
-          create(:storage_location, :with_items, item: item, item_quantity: 10, organization: organization)
-          visit new_audit_path
-
-          select_element = find('#audit_line_items_attributes_0_item_id', visible: :all)
-          option_texts = select_element.all('option', visible: :all).map(&:text)
-          expect(option_texts).not_to include(item.name)
-        end
-
         it "allows user to add items that do not yet have a barcode", :js do
           item_without_barcode = create(:item)
           new_barcode = "00000000"


### PR DESCRIPTION
Resolves #4594 

### Description

Allow newly added items that are not in a storage location to be selected for audit, which effectively initializes them. 

Also ensure inactive items cannot be selected for audit. That last part about inactive items was discovered in further [discussion on the issue](https://github.com/rubyforgood/human-essentials/issues/4594#issuecomment-2515030503).

### Type of change

Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

For automated testing, see two new tests added to `spec/system/audit_system_spec.rb`:
1. allows auditing items that are not in a storage location
2. does not display inactive items for selection

For manual testing, create a new item, then create a new audit, pick a storage location, you should be able to select the new item for audit.

Also on the new audit screen, if you interact with the item dropdown _before_ selecting a storage location, it should not include inactive items. In the seed data, `Adult Briefs (Large/X-Large)` is an inactive item.

### Screenshots

Create new item:
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/9498e756-1c37-424a-86af-b3a1e96c7421">

Verify item not in any location:
<img width="1623" alt="image" src="https://github.com/user-attachments/assets/e3a14eb8-afce-4b67-8a4c-b9133ec5f077">

Start new audit - new item is selectable:
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/89129711-1315-43e4-967c-104ae51539f7">

Save progress - item shows up:
<img width="1106" alt="image" src="https://github.com/user-attachments/assets/ab8142ec-0897-4fde-b111-97a0d912ac04">

