### PR TITLE
Adding partner_step_form to seed so it will be in place for staging and local

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -753,7 +753,8 @@ end
 Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "new_logo")
 Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "read_events")
 Flipper.enable(:read_events)
-
+Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "partner_step_form")
+Flipper.enable(:partner_step_form)
 # ----------------------------------------------------------------------------
 # Account Requests
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
### Description
Adding partner_step_form to seed -- so staging and local will have the reworked partner profile edits.

### Type of change

* enables New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

ran db/setup on local.  Lo and behold,  the partner profile edits changed to the new format.