### PR TITLE
Adding counties to partner export for NDBN reporting

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -185,7 +185,8 @@ class Partner < ApplicationRecord
       "Contact Name",
       "Contact Phone",
       "Contact Email",
-      "Notes"
+      "Notes",
+      "Counties Served"
     ]
   end
 
@@ -202,7 +203,8 @@ class Partner < ApplicationRecord
       contact_person[:name],
       contact_person[:phone],
       contact_person[:email],
-      notes
+      notes,
+      profile.county_list_by_region
     ]
   end
 

--- a/app/models/partners/profile.rb
+++ b/app/models/partners/profile.rb
@@ -128,7 +128,7 @@ module Partners
 
     def county_list_by_region
       # provides a county list in case insensitive alpha order, by region, then county name
-      self.counties.order(%w(lower(region) lower(name))).pluck(:name).join("; ")
+      counties.order(%w(lower(region) lower(name))).pluck(:name).join("; ")
     end
 
     private

--- a/app/models/partners/profile.rb
+++ b/app/models/partners/profile.rb
@@ -91,6 +91,7 @@ module Partners
 
     has_many :served_areas, foreign_key: "partner_profile_id", class_name: "Partners::ServedArea", dependent: :destroy, inverse_of: :partner_profile
 
+    has_many :counties, through: :served_areas
     accepts_nested_attributes_for :served_areas, allow_destroy: true
 
     has_many_attached :documents
@@ -127,9 +128,7 @@ module Partners
 
     def county_list_by_region
       # provides a county list in case insensitive alpha order, by region, then county name
-      counties = served_areas.map(&:county).uniq
-      counties.sort_by! { |county| [county.region.downcase, county.name.downcase] }  # Our current world only has the US states, so downcasing the region doesn't really matter.
-      counties.pluck(:name).join("; ")
+      self.counties.order(%w(lower(region) lower(name))).pluck(:name).join("; ")
     end
 
     private

--- a/app/models/partners/profile.rb
+++ b/app/models/partners/profile.rb
@@ -125,6 +125,14 @@ module Partners
       pick_up_email.split(/,|\s+/).compact_blank
     end
 
+    def county_list_by_region
+      # provides a county list in case insensitive alpha order, by region, then county name
+      counties = served_areas.map(&:county).uniq
+      counties.sort_by!{ |county| [county.region.downcase, county.name.downcase]}  # Our current world only has the US states, so downcasing the region doesn't really matter.
+      counties.pluck(:name).join("; ")
+    end
+
+
     private
 
     def check_social_media

--- a/app/models/partners/profile.rb
+++ b/app/models/partners/profile.rb
@@ -128,10 +128,9 @@ module Partners
     def county_list_by_region
       # provides a county list in case insensitive alpha order, by region, then county name
       counties = served_areas.map(&:county).uniq
-      counties.sort_by!{ |county| [county.region.downcase, county.name.downcase]}  # Our current world only has the US states, so downcasing the region doesn't really matter.
+      counties.sort_by! { |county| [county.region.downcase, county.name.downcase] }  # Our current world only has the US states, so downcasing the region doesn't really matter.
       counties.pluck(:name).join("; ")
     end
-
 
     private
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -315,9 +315,20 @@ RSpec.describe Partner, type: :model do
                                other_agency_type: other_agency_type
                              })
       partner.update(notes: notes)
+
+
     end
 
-    it "should has the info in the columns order" do
+    it "should have the expected info in the columns order" do
+      county_1 = create(:county, name: "High County, Maine", region: "Maine")
+      county_2 = create(:county, name: "laRue County, Louisiana", region: "Louisiana")
+      county_3 = create(:county, name: "Ste. Anne County, Louisiana", region: "Louisiana")
+      create(:partners_served_area, partner_profile: partner.profile, county: county_1, client_share: 50)
+      create(:partners_served_area, partner_profile: partner.profile, county: county_2, client_share: 40)
+      create(:partners_served_area, partner_profile: partner.profile, county: county_3, client_share: 10)
+      partner.profile.reload # not sure if this is needed
+      # county ordering is a bit esoteric -- it is human alphabetical by county within region (region is state)
+      correctly_ordered_counties = "laRue County, Louisiana; Ste. Anne County, Louisiana; High County, Maine"
       expect(partner.csv_export_attributes).to eq([
         partner.name,
         partner.email,
@@ -330,7 +341,8 @@ RSpec.describe Partner, type: :model do
         contact_name,
         contact_phone,
         contact_email,
-        notes
+        notes,
+        correctly_ordered_counties
       ])
     end
   end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -315,8 +315,6 @@ RSpec.describe Partner, type: :model do
                                other_agency_type: other_agency_type
                              })
       partner.update(notes: notes)
-
-
     end
 
     it "should have the expected info in the columns order" do

--- a/spec/models/partners/profile_spec.rb
+++ b/spec/models/partners/profile_spec.rb
@@ -310,8 +310,8 @@ RSpec.describe Partners::Profile, type: :model do
   describe "county_list" do
     it "provides a county list in human-alpha by county within region order" do
       county_1 = create(:county, name: "High County, Maine", region: "Maine")
-      county_2 = create(:county, name: "laRue County, Louisiana", region: "Louisiana" )
-      county_3 = create(:county, name: "Ste. Anne County, Louisiana", region: "Louisiana" )
+      county_2 = create(:county, name: "laRue County, Louisiana", region: "Louisiana")
+      county_3 = create(:county, name: "Ste. Anne County, Louisiana", region: "Louisiana")
       profile = create(:partner_profile)
       create(:partners_served_area, partner_profile: profile, county: county_1, client_share: 50)
       create(:partners_served_area, partner_profile: profile, county: county_2, client_share: 40)

--- a/spec/models/partners/profile_spec.rb
+++ b/spec/models/partners/profile_spec.rb
@@ -307,6 +307,21 @@ RSpec.describe Partners::Profile, type: :model do
     end
   end
 
+  describe "county_list" do
+    it "provides a county list in human-alpha by county within region order" do
+      county_1 = create(:county, name: "High County, Maine", region: "Maine")
+      county_2 = create(:county, name: "laRue County, Louisiana", region: "Louisiana" )
+      county_3 = create(:county, name: "Ste. Anne County, Louisiana", region: "Louisiana" )
+      profile = create(:partner_profile)
+      create(:partners_served_area, partner_profile: profile, county: county_1, client_share: 50)
+      create(:partners_served_area, partner_profile: profile, county: county_2, client_share: 40)
+      create(:partners_served_area, partner_profile: profile, county: county_3, client_share: 10)
+      profile.reload
+      ## This is human-alpha by county within region (i.e. state)
+      expect(profile.county_list_by_region).to eq("laRue County, Louisiana; Ste. Anne County, Louisiana; High County, Maine")
+    end
+  end
+
   describe "versioning" do
     it { is_expected.to be_versioned }
   end

--- a/spec/models/partners/profile_spec.rb
+++ b/spec/models/partners/profile_spec.rb
@@ -312,11 +312,15 @@ RSpec.describe Partners::Profile, type: :model do
       county_1 = create(:county, name: "High County, Maine", region: "Maine")
       county_2 = create(:county, name: "laRue County, Louisiana", region: "Louisiana")
       county_3 = create(:county, name: "Ste. Anne County, Louisiana", region: "Louisiana")
+      county_4 = create(:county, name: "Other County, Louisiana", region: "Louisiana")
       profile = create(:partner_profile)
+      profile_2 = create(:partner_profile)
       create(:partners_served_area, partner_profile: profile, county: county_1, client_share: 50)
       create(:partners_served_area, partner_profile: profile, county: county_2, client_share: 40)
       create(:partners_served_area, partner_profile: profile, county: county_3, client_share: 10)
+      create(:partners_served_area, partner_profile: profile_2, county: county_4)
       profile.reload
+      profile_2.reload
       ## This is human-alpha by county within region (i.e. state)
       expect(profile.county_list_by_region).to eq("laRue County, Louisiana; Ste. Anne County, Louisiana; High County, Maine")
     end


### PR DESCRIPTION


Partial #3067  <!--fill issue number-->

### Description

This adds a list of counties served, in case-insensitive order by county name within region,  to the partner export

 

### Type of change

* New feature (non-breaking change which adds functionality)
* 
### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
- added automated tests
- also checked manually on local (against seed only)
- have not yet run against a prod copy

