### PR TITLE
Add indicator fields to partner export

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -73,6 +73,10 @@ class Distribution < ApplicationRecord
     where("issued_at > :start_date AND issued_at <= :end_date",
           start_date: Time.zone.today.beginning_of_week.beginning_of_day, end_date: Time.zone.today.end_of_week.end_of_day)
   end
+  scope :in_last_12_months, -> do
+    where("issued_at > :start_date AND issued_at <= :end_date",
+          start_date: 12.months.ago.beginning_of_day, end_date: Time.zone.today.end_of_day)
+  end
 
   delegate :name, to: :partner, prefix: true
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -48,6 +48,7 @@ class Distribution < ApplicationRecord
   enum delivery_method: { pick_up: 0, delivery: 1, shipped: 2 }
   scope :active, -> { joins(:line_items).joins(:items).where(items: { active: true }) }
   scope :with_diapers, -> { joins(line_items: :item).merge(Item.disposable.or(Item.cloth_diapers)) }
+  scope :with_period_supplies, -> { joins(line_items: :item).merge(Item.period_supplies) }
   # add item_id scope to allow filtering distributions by item
   scope :by_item_id, ->(item_id) { includes(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -47,6 +47,7 @@ class Distribution < ApplicationRecord
   enum state: { scheduled: 5, complete: 10 }
   enum delivery_method: { pick_up: 0, delivery: 1, shipped: 2 }
   scope :active, -> { joins(:line_items).joins(:items).where(items: { active: true }) }
+  scope :with_diapers, -> { joins(line_items: :item).merge(Item.disposable.or(Item.cloth_diapers)) }
   # add item_id scope to allow filtering distributions by item
   scope :by_item_id, ->(item_id) { includes(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -186,7 +186,8 @@ class Partner < ApplicationRecord
       "Contact Phone",
       "Contact Email",
       "Notes",
-      "Providing Diapers"
+      "Providing Diapers",
+      "Providing Period Supplies"
     ]
   end
 
@@ -204,12 +205,17 @@ class Partner < ApplicationRecord
       contact_person[:phone],
       contact_person[:email],
       notes,
-      providing_diapers
+      providing_diapers,
+      providing_period_supplies
     ]
   end
 
   def providing_diapers
     distributions.with_diapers.any? ? "Y" : "N"
+  end
+
+  def providing_period_supplies
+    distributions.with_period_supplies.any? ? "Y" : "N"
   end
 
   def contact_person

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -211,11 +211,11 @@ class Partner < ApplicationRecord
   end
 
   def providing_diapers
-    distributions.with_diapers.any? ? "Y" : "N"
+    distributions.in_last_12_months.with_diapers.any? ? "Y" : "N"
   end
 
   def providing_period_supplies
-    distributions.with_period_supplies.any? ? "Y" : "N"
+    distributions.in_last_12_months.with_period_supplies.any? ? "Y" : "N"
   end
 
   def contact_person

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -185,7 +185,8 @@ class Partner < ApplicationRecord
       "Contact Name",
       "Contact Phone",
       "Contact Email",
-      "Notes"
+      "Notes",
+      "Providing Diapers"
     ]
   end
 
@@ -202,8 +203,13 @@ class Partner < ApplicationRecord
       contact_person[:name],
       contact_person[:phone],
       contact_person[:email],
-      notes
+      notes,
+      providing_diapers
     ]
+  end
+
+  def providing_diapers
+    distributions.with_diapers.any? ? "Y" : "N"
   end
 
   def contact_person

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -139,6 +139,34 @@ RSpec.describe Distribution, type: :model do
       end
     end
 
+    describe "in_last_12_months >" do
+      context "when the current date is December 31, 2023" do
+        before do
+          travel_to Time.zone.local(2023, 12, 31)
+        end
+
+        after do
+          travel_back
+        end
+
+        it "includes distributions issued within the last 12 months" do
+          included_distribution = create(:distribution, organization: organization, issued_at: Time.zone.local(2023, 1, 1))
+          excluded_distribution = create(:distribution, organization: organization, issued_at: Time.zone.local(2022, 12, 30))
+          distributions = Distribution.in_last_12_months
+          expect(distributions).to include(included_distribution)
+          expect(distributions).not_to include(excluded_distribution)
+        end
+
+        it "includes distributions up to the current date and excludes future ones" do
+          current_distribution = create(:distribution, organization: organization, issued_at: Time.zone.local(2023, 12, 31))
+          future_distribution = create(:distribution, organization: organization, issued_at: Time.zone.local(2024, 1, 1))
+          distributions = Distribution.in_last_12_months
+          expect(distributions).to include(current_distribution)
+          expect(distributions).not_to include(future_distribution)
+        end
+      end
+    end
+
     describe "by_item_id >" do
       it "only returns distributions with given item id" do
         # create 2 items with unique ids

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -176,6 +176,39 @@ RSpec.describe Distribution, type: :model do
         expect(Distribution.by_location(location_1.id)).not_to include(dist2)
       end
     end
+
+    describe "with_diapers >" do
+      let(:disposable_item) { create(:item, base_item: create(:base_item, category: "Diapers - Childrens")) }
+      let(:cloth_diaper_item) { create(:item, base_item: create(:base_item, category: "Diapers - Cloth (Kids)")) }
+      let(:non_diaper_item) { create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items")) }
+
+      it "only includes distributions with disposable or cloth_diaper items" do
+        dist1 = create(:distribution, :with_items, item: disposable_item)
+        dist2 = create(:distribution, :with_items, item: cloth_diaper_item)
+        dist3 = create(:distribution, :with_items, item: non_diaper_item)
+
+        distributions = Distribution.with_diapers
+        expect(distributions.count).to eq(2)
+        expect(distributions).to include(dist1)
+        expect(distributions).to include(dist2)
+        expect(distributions).not_to include(dist3)
+      end
+    end
+
+    describe "with_period_supplies >" do
+      let(:period_supplies_item) { create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items")) }
+      let(:non_period_supplies_item) { create(:item, base_item: create(:base_item, category: "Diapers - Childrens")) }
+
+      it "only includes distributions with period supplies items" do
+        dist1 = create(:distribution, :with_items, item: period_supplies_item)
+        dist2 = create(:distribution, :with_items, item: non_period_supplies_item)
+
+        distributions = Distribution.with_period_supplies
+        expect(distributions.count).to eq(1)
+        expect(distributions).to include(dist1)
+        expect(distributions).not_to include(dist2)
+      end
+    end
   end
 
   context "Callbacks >" do

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -300,6 +300,7 @@ RSpec.describe Partner, type: :model do
     let(:other_agency_type) { "Another Agency Name" }
     let(:notes) { "Some notes" }
     let(:providing_diapers) { "N" }
+    let(:providing_period_supplies) { "N" }
 
     before do
       partner.profile.update({
@@ -332,12 +333,14 @@ RSpec.describe Partner, type: :model do
         contact_phone,
         contact_email,
         notes,
-        providing_diapers
+        providing_diapers,
+        providing_period_supplies
       ])
     end
 
     context "when partner has a distribution" do
       let(:providing_diapers) { "Y" }
+      let(:providing_period_supplies) { "Y" }
       let(:distribution) { create(:distribution, partner: partner) }
       let(:item) { create(:item) }
 
@@ -364,6 +367,18 @@ RSpec.describe Partner, type: :model do
 
       context "with a cloth diaper item" do
         include_examples "providing_diapers check", :cloth_diapers
+      end
+
+      context "with a period supplies item" do
+        before do
+          create(:line_item, item: item, itemizable: distribution)
+          # Mock the given scope to at least satisfy one item
+          allow(Item).to receive(:period_supplies) { Item.where(id: item.id) }
+        end
+
+        it "should have Y as providing_period_supplies" do
+          expect(partner.csv_export_attributes[13]).to eq(providing_period_supplies)
+        end
       end
     end
   end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe Partner, type: :model do
     end
 
     context "when partner only has distribution older than a 12 months" do
-      let(:distribution) { create(:distribution, issued_at: 24.months.ago.beginning_of_day, partner: partner) }
+      let(:distribution) { create(:distribution, issued_at: (12.months.ago.beginning_of_day - 1.day), partner: partner) }
       let(:disposable_diapers_item) { create(:item, base_item: create(:base_item, category: "Diapers - Childrens")) }
       let(:cloth_diapers_item) { create(:item, base_item: create(:base_item, category: "Diapers - Cloth (Kids)")) }
       let(:period_supplies_item) { create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items")) }

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -299,8 +299,8 @@ RSpec.describe Partner, type: :model do
     let(:agency_type) { Partner::AGENCY_TYPES["OTHER"] }
     let(:other_agency_type) { "Another Agency Name" }
     let(:notes) { "Some notes" }
-    let(:providing_diapers) { "N" }
-    let(:providing_period_supplies) { "N" }
+    let(:providing_diapers) { {value: "N", index: 13} }
+    let(:providing_period_supplies) { {value: "N", index: 14} }
 
     before do
       partner.profile.update({
@@ -343,18 +343,18 @@ RSpec.describe Partner, type: :model do
         contact_email,
         notes,
         correctly_ordered_counties,
-        providing_diapers,
-        providing_period_supplies
+        providing_diapers[:value],
+        providing_period_supplies[:value]
       ])
     end
 
     context "when partner has a distribution in the last 12 months" do
-      let(:providing_diapers) { "Y" }
-      let(:providing_period_supplies) { "Y" }
       let(:distribution) { create(:distribution, partner: partner) }
 
       shared_examples "providing_diapers check" do |scope|
         before do
+          providing_diapers[:value] = "Y"
+
           case scope
           when :disposable
             item = create(:item, base_item: create(:base_item, category: "Diapers - Childrens"))
@@ -366,7 +366,7 @@ RSpec.describe Partner, type: :model do
         end
 
         it "should have Y as providing_diapers" do
-          expect(partner.csv_export_attributes[12]).to eq(providing_diapers)
+          expect(partner.csv_export_attributes[providing_diapers[:index]]).to eq(providing_diapers[:value])
         end
       end
 
@@ -380,12 +380,14 @@ RSpec.describe Partner, type: :model do
 
       context "with a period supplies item" do
         before do
+          providing_period_supplies[:value] = "Y"
+
           item = create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items"))
           create(:line_item, item: item, itemizable: distribution)
         end
 
         it "should have Y as providing_period_supplies" do
-          expect(partner.csv_export_attributes[13]).to eq(providing_period_supplies)
+          expect(partner.csv_export_attributes[providing_period_supplies[:index]]).to eq(providing_period_supplies[:value])
         end
       end
     end
@@ -403,11 +405,11 @@ RSpec.describe Partner, type: :model do
       end
 
       it "should have N as providing_diapers" do
-        expect(partner.csv_export_attributes[12]).to eq(providing_diapers)
+        expect(partner.csv_export_attributes[providing_diapers[:index]]).to eq(providing_diapers[:value])
       end
 
       it "should have N as providing_period_supplies" do
-        expect(partner.csv_export_attributes[13]).to eq(providing_period_supplies)
+        expect(partner.csv_export_attributes[providing_period_supplies[:index]]).to eq(providing_period_supplies[:value])
       end
     end
   end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Partner, type: :model do
       ])
     end
 
-    context "when partner has a distribution" do
+    context "when partner has a distribution in the last 12 months" do
       let(:providing_diapers) { "Y" }
       let(:providing_period_supplies) { "Y" }
       let(:distribution) { create(:distribution, partner: partner) }
@@ -377,6 +377,27 @@ RSpec.describe Partner, type: :model do
         it "should have Y as providing_period_supplies" do
           expect(partner.csv_export_attributes[13]).to eq(providing_period_supplies)
         end
+      end
+    end
+
+    context "when partner only has distribution older than a 12 months" do
+      let(:distribution) { create(:distribution, issued_at: 24.months.ago.beginning_of_day, partner: partner) }
+      let(:disposable_diapers_item) { create(:item, base_item: create(:base_item, category: "Diapers - Childrens")) }
+      let(:cloth_diapers_item) { create(:item, base_item: create(:base_item, category: "Diapers - Cloth (Kids)")) }
+      let(:period_supplies_item) { create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items")) }
+
+      before do
+        create(:line_item, item: disposable_diapers_item, itemizable: distribution)
+        create(:line_item, item: cloth_diapers_item, itemizable: distribution)
+        create(:line_item, item: period_supplies_item, itemizable: distribution)
+      end
+
+      it "should have N as providing_diapers" do
+        expect(partner.csv_export_attributes[12]).to eq(providing_diapers)
+      end
+
+      it "should have N as providing_period_supplies" do
+        expect(partner.csv_export_attributes[13]).to eq(providing_period_supplies)
       end
     end
   end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -342,18 +342,17 @@ RSpec.describe Partner, type: :model do
       let(:providing_diapers) { "Y" }
       let(:providing_period_supplies) { "Y" }
       let(:distribution) { create(:distribution, partner: partner) }
-      let(:item) { create(:item) }
 
       shared_examples "providing_diapers check" do |scope|
         before do
+          case scope
+          when :disposable
+            item = create(:item, base_item: create(:base_item, category: "Diapers - Childrens"))
+          when :cloth_diapers
+            item = create(:item, base_item: create(:base_item, category: "Diapers - Cloth (Kids)"))
+          end
+
           create(:line_item, item: item, itemizable: distribution)
-
-          # Mock both scopes to return empty collection by default
-          allow(Item).to receive(:disposable) { Item.none }
-          allow(Item).to receive(:cloth_diapers) { Item.none }
-
-          # Mock the given scope to at least satisfy one item
-          allow(Item).to receive(scope) { Item.where(id: item.id) }
         end
 
         it "should have Y as providing_diapers" do
@@ -371,9 +370,8 @@ RSpec.describe Partner, type: :model do
 
       context "with a period supplies item" do
         before do
+          item = create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items"))
           create(:line_item, item: item, itemizable: distribution)
-          # Mock the given scope to at least satisfy one item
-          allow(Item).to receive(:period_supplies) { Item.where(id: item.id) }
         end
 
         it "should have Y as providing_period_supplies" do


### PR DESCRIPTION
Partial #3067 <!--fill issue number-->

### Description

This PR adds 2 new columns, at the end of existing columns, in the partner export file:
1. `Providing Diapers`: "Y" or "N", depending if the partner has at least one distribution **_(in the last 12 months)_** with an item of scope [`:disposable`](https://github.com/rubyforgood/human-essentials/blob/63e05a2c5971295b43601336afda8cfdf3f7bbf6/app/models/item.rb#L81-L86) or [`:cloth_diapers`](https://github.com/rubyforgood/human-essentials/blob/63e05a2c5971295b43601336afda8cfdf3f7bbf6/app/models/item.rb#L88-L93).
2. `Providing Period Supplies`: "Y" or "N", depending if the partner has at least one distribution **_(in the last 12 months)_** with an item of scope [`:period_supplies`](https://github.com/rubyforgood/human-essentials/blob/63e05a2c5971295b43601336afda8cfdf3f7bbf6/app/models/item.rb#L100-L103).

> [!NOTE]
> The criteria for finding whether a Partner has been provided with "Diapers" is if the Partner has at least one distribution with an item of **either [`:disposable`](https://github.com/rubyforgood/human-essentials/blob/63e05a2c5971295b43601336afda8cfdf3f7bbf6/app/models/item.rb#L81-L86) OR [`:cloth_diapers`](https://github.com/rubyforgood/human-essentials/blob/63e05a2c5971295b43601336afda8cfdf3f7bbf6/app/models/item.rb#L88-L93) scope, OR [both scopes](https://github.com/rubyforgood/human-essentials/blob/63e05a2c5971295b43601336afda8cfdf3f7bbf6/app/models/item.rb#L81-L93).**

> [!NOTE]
> The filter for finding distributions within the last 12 months is based on `issued_at` attribute of `Distribution` model.

<details><summary>Example:</summary>
<p>

Providing Diapers | Providing Period Supplies
-- | --
N | N
Y | Y
Y | Y
Y | N
N | N
N | N
Y | Y

</p>
</details> 

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Manually and added test cases for:
1. Adding both columns in the right place/order
2. If a partner has a distribution with a `:disposable` item, then it should have `"Y"` for the `Providing Diapers` column.
4. If a partner has a distribution with a `:cloth_diapers` item, then it should have `"Y"` for the `Providing Diapers` column.
5. If a partner has a distribution with a `:period_supplies` item, then it should have `"Y"` for the `Providing Period Supplies` column.
6. If a partner has a distribution with items satisfying all the above scopes (`:disposable`, `:cloth_diapers`, and `:period_supplies`) **but** the distribution is older than 12 months, then it should have "N" for both `Providing Diapers` and `Providing Period Supplies` columns.


