### PR TITLE
Fix Distribution#new,#create,#edit to only show active items

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -117,7 +117,7 @@ class DistributionsController < ApplicationController
       elsif request_id
         @distribution.initialize_request_items
       end
-      @items = current_organization.items.alphabetized
+      @items = current_organization.items.active.alphabetized
       @partner_list = current_organization.partners.where.not(status: 'deactivated').alphabetized
 
       inventory = View::Inventory.new(@distribution.organization_id)
@@ -147,7 +147,7 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build
       @distribution.copy_from_donation(params[:donation_id], params[:storage_location_id])
     end
-    @items = current_organization.items.alphabetized
+    @items = current_organization.items.active.alphabetized
     @partner_list = current_organization.partners.where.not(status: 'deactivated').alphabetized
 
     inventory = View::Inventory.new(current_organization.id)
@@ -173,7 +173,7 @@ class DistributionsController < ApplicationController
     if (!@distribution.complete? && @distribution.future?) ||
         current_user.has_role?(Role::ORG_ADMIN, current_organization)
       @distribution.line_items.build if @distribution.line_items.size.zero?
-      @items = current_organization.items.alphabetized
+      @items = current_organization.items.active.alphabetized
       @partner_list = current_organization.partners.alphabetized
       @audit_warning = current_organization.audits
         .where(storage_location_id: @distribution.storage_location_id)
@@ -204,7 +204,7 @@ class DistributionsController < ApplicationController
       flash[:error] = insufficient_error_message(result.error.message)
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @distribution.initialize_request_items
-      @items = current_organization.items.alphabetized
+      @items = current_organization.items.active.alphabetized
       @storage_locations = current_organization.storage_locations.active_locations.alphabetized
       render :edit
     end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -46,7 +46,6 @@ class Distribution < ApplicationRecord
 
   enum state: { scheduled: 5, complete: 10 }
   enum delivery_method: { pick_up: 0, delivery: 1, shipped: 2 }
-  scope :active, -> { joins(:line_items).joins(:items).where(items: { active: true }) }
   # add item_id scope to allow filtering distributions by item
   scope :by_item_id, ->(item_id) { includes(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -233,6 +233,20 @@ RSpec.describe "Distributions", type: :request do
         expect(response).to have_error
       end
 
+      it "renders #new on failure with only active items in dropdown" do
+        create(:item, organization: organization, name: 'Active Item')
+        create(:item, :inactive, organization: organization, name: 'Inactive Item')
+
+        post distributions_path(distribution: { comment: nil, partner_id: nil, storage_location_id: nil }, format: :turbo_stream)
+        expect(response).to have_http_status(400)
+
+        page = Nokogiri::HTML(response.body)
+        selectable_items = page.at_css("select.line_item_name").text.split("\n")
+
+        expect(selectable_items).to include("Active Item")
+        expect(selectable_items).not_to include("Inactive Item")
+      end
+
       context "Deactivated partners should not be displayed in partner dropdown" do
         before do
           create(:partner, name: 'Active Partner', organization: organization, status: "approved")
@@ -273,6 +287,18 @@ RSpec.describe "Distributions", type: :request do
         # default should be nothing selected
         page = Nokogiri::HTML(response.body)
         expect(page.css('#distribution_storage_location_id option[selected]')).to be_empty
+      end
+
+      it "should only show active items in item dropdown" do
+        create(:item, :inactive, organization: organization, name: 'Inactive Item')
+
+        get new_distribution_path(default_params)
+
+        page = Nokogiri::HTML(response.body)
+        selectable_items = page.at_css("select#barcode_item_barcodeable_id").text.split("\n")
+
+        expect(selectable_items).to include("Item 1", "Item 2")
+        expect(selectable_items).not_to include("Inactive Item")
       end
 
       context "with org default but no partner default" do
@@ -570,6 +596,19 @@ RSpec.describe "Distributions", type: :request do
         get edit_distribution_path(id: distribution.id)
         expect(response.body).to include("Deactivated Partner")
         expect(response.body).to include("Active Partner")
+      end
+
+      it "should only show active items in item dropdown" do
+        create(:item, organization: organization, name: 'Active Item')
+        create(:item, :inactive, organization: organization, name: 'Inactive Item')
+
+        get edit_distribution_path(id: distribution.id)
+
+        page = Nokogiri::HTML(response.body)
+        selectable_items = page.at_css("select#barcode_item_barcodeable_id").text.split("\n")
+
+        expect(selectable_items).to include("Active Item")
+        expect(selectable_items).not_to include("Inactive Item")
       end
 
       context 'with units' do


### PR DESCRIPTION
Resolves #3988

### Description
Previously we were showing inactive items in the item dropdown for distributions in some situations. When we render the page, inactive items were shown, but after the ajax call to fetch inventory quantities (like when a storage location is selected) the inactive items were removed.

After this change, inactive items are never shown.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Added new request specs and tested manually.

An easy way to test this manually is to disable Javascript in the browser (I used ublock origin for ad blocking and it provides an easy way to toggle javascript on and off).

Otherwise if you try to edit a distribution currently, the ajax call to update the item dropdown might occur too fast for you to see the inactive items.

If testing manually, the `/distributions`, `/distributions/new` (both before clicking save and after clicking save with validation errors), and `/distributions/edit` pages all had this issue.