### PR TITLE
Fix unexpected issued_at behavior when date field empty.

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -205,6 +205,7 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @distribution.initialize_request_items
       @items = current_organization.items.alphabetized
+      @partner_list = current_organization.partners.alphabetized
       @storage_locations = current_organization.storage_locations.active_locations.alphabetized
       render :edit
     end

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -205,7 +205,6 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @distribution.initialize_request_items
       @items = current_organization.items.active.alphabetized
-      @partner_list = current_organization.partners.alphabetized
       @storage_locations = current_organization.storage_locations.active_locations.alphabetized
       render :edit
     end

--- a/app/models/concerns/issued_at.rb
+++ b/app/models/concerns/issued_at.rb
@@ -5,23 +5,18 @@ module IssuedAt
   extend ActiveSupport::Concern
 
   included do
-    before_create :initialize_issued_at
-    before_save :initialize_issued_at
     scope :by_issued_at, ->(issued_at) { where(issued_at: issued_at.beginning_of_month..issued_at.end_of_month) }
     scope :for_year, ->(year) { where("extract(year from issued_at) = ?", year) }
+    validates :issued_at, presence: true
     validate :issued_at_cannot_be_before_2000
     validate :issued_at_cannot_be_further_than_1_year
   end
 
   private
 
-  def initialize_issued_at
-    self.issued_at ||= created_at&.end_of_day
-  end
-
   def issued_at_cannot_be_before_2000
     if issued_at.present? && issued_at < Date.new(2000, 1, 1)
-      errors.add(:issued_at, "Cannot be before 2000")
+      errors.add(:issued_at, "cannot be before 2000")
     end
   end
 

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -24,7 +24,7 @@
 
 <section class="content">
 
-  <% unless @distribution.future? %>
+  <% if @distribution.issued_at && !@distribution.future? %>
     <div class="alert alert-warning" role="alert">
       The current date is past the date this distribution was scheduled for.
       Please be very careful when editing this record;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,3 +30,11 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  activerecord:
+    attributes:
+      donation:
+        issued_at: "Issue date"
+      purchase:
+        issued_at: "Purchase date"
+      distribution:
+        issued_at: "Distribution date and time"

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe DistributionsController, type: :controller do
             organization_name: organization.id,
             distribution: {
               partner_id: partner.id,
+              issued_at: Date.yesterday,
               storage_location_id: first_storage_location.id,
               line_items_attributes:
               {
@@ -42,6 +43,7 @@ RSpec.describe DistributionsController, type: :controller do
               distribution: {
                 partner_id: partner.id,
                 storage_location_id: second_storage_location.id,
+                issued_at: Date.yesterday,
                 line_items_attributes:
                   {
                     "0": { item_id: second_storage_location.items.first.id, quantity: 18 }
@@ -66,6 +68,7 @@ RSpec.describe DistributionsController, type: :controller do
             distribution: {
               partner_id: partner.id,
               storage_location_id: storage_location.id,
+              issued_at: Date.yesterday,
               line_items_attributes:
                 {
                   "0": { item_id: storage_location.items.first.id, quantity: 18 }
@@ -91,6 +94,7 @@ RSpec.describe DistributionsController, type: :controller do
               distribution: {
                 partner_id: partner.id,
                 storage_location_id: storage_location.id,
+                issued_at: Date.yesterday,
                 line_items_attributes:
                   {
                     "0": { item_id: storage_location.items.first.id, quantity: 18 },
@@ -134,6 +138,7 @@ RSpec.describe DistributionsController, type: :controller do
             distribution: {
               partner_id: partner.id,
               storage_location_id: storage_location.id,
+              issued_at: Date.yesterday,
               line_items_attributes:
                 {
                   "0": { item_id: item1.id, quantity: 18 },
@@ -172,6 +177,7 @@ RSpec.describe DistributionsController, type: :controller do
             distribution: {
               partner_id: partner.id,
               storage_location_id: storage_location.id,
+              issued_at: Date.yesterday,
               line_items_attributes:
                 {
                   "0": { item_id: item1.id, quantity: 18 },
@@ -199,6 +205,7 @@ RSpec.describe DistributionsController, type: :controller do
             distribution: {
               partner_id: partner.id,
               storage_location_id: storage_location.id,
+              issued_at: Date.yesterday,
               line_items_attributes:
                 {
                   "0": { item_id: storage_location.items.first.id, quantity: 0 }
@@ -235,6 +242,7 @@ RSpec.describe DistributionsController, type: :controller do
             id: distribution.id,
             distribution: {
               storage_location_id: distribution.storage_location.id,
+              issued_at: Date.yesterday,
               line_items_attributes:
                 {
                   "0": { item_id: item1.id, quantity: 18 },
@@ -309,6 +317,7 @@ RSpec.describe DistributionsController, type: :controller do
             id: distribution.id,
             distribution: {
               storage_location_id: distribution.storage_location.id,
+              issued_at: Date.yesterday,
               line_items_attributes:
                 {
                   "0": { item_id: item1.id, quantity: 4 },

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe DonationsController, type: :controller do
           donation: { storage_location_id: storage_location.id,
                       donation_site_id: donation_site.id,
                       source: "Donation Site",
+                      issued_at: Date.yesterday,
                       line_items: line_items }
         }
         expect(response).to redirect_to(donations_path)

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     storage_location
     partner
     organization { Organization.try(:first) || create(:organization) }
-    issued_at { nil }
+    issued_at { Time.current }
     delivery_method { :pick_up }
     state { :scheduled }
 

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     comment { "It's a fine day for diapers." }
     storage_location
     organization { Organization.try(:first) || create(:organization) }
-    issued_at { nil }
+    issued_at { Time.current }
 
     factory :manufacturer_donation do
       manufacturer

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     purchased_from { "Google" }
     storage_location
     organization { Organization.try(:first) || create(:organization) }
-    issued_at { nil }
+    issued_at { Time.current }
     amount_spent_in_cents { 10_00 }
     vendor { Vendor.try(:first) || create(:vendor) }
 

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -179,17 +179,6 @@ RSpec.describe Distribution, type: :model do
   end
 
   context "Callbacks >" do
-    it "initializes the issued_at field to default to midnight if it wasn't explicitly set" do
-      yesterday = 1.day.ago
-      today = Time.zone.today
-
-      distribution = create(:distribution, created_at: yesterday, issued_at: today)
-      expect(distribution.issued_at.to_date).to eq(today)
-
-      distribution = create(:distribution, created_at: yesterday)
-      expect(distribution.issued_at).to eq(distribution.created_at.end_of_day)
-    end
-
     context "#before_save" do
       context "#reset_shipping_cost" do
         context "when delivery_method is other then shipped" do

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -61,17 +61,6 @@ RSpec.describe Donation, type: :model do
   end
 
   context "Callbacks >" do
-    it "inititalizes the issued_at field to default to midnight if it wasn't explicitly set" do
-      yesterday = 1.day.ago
-      today = Time.zone.today
-
-      donation = create(:donation, created_at: yesterday, issued_at: today)
-      expect(donation.issued_at.to_date).to eq(today)
-
-      donation = create(:donation, created_at: yesterday)
-      expect(donation.issued_at).to eq(donation.created_at.end_of_day)
-    end
-
     it "automatically combines duplicate line_item records when they're created" do
       donation = build(:donation)
       item = create(:item)

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -87,17 +87,6 @@ RSpec.describe Purchase, type: :model do
   end
 
   context "Callbacks >" do
-    it "inititalizes the issued_at field to default to midnight if it wasn't explicitly set" do
-      yesterday = 1.day.ago
-      today = Time.zone.today
-
-      purchase = create(:purchase, created_at: yesterday, issued_at: today)
-      expect(purchase.issued_at.to_date).to eq(today)
-
-      purchase = create(:purchase, created_at: yesterday)
-      expect(purchase.issued_at).to eq(purchase.created_at.end_of_day)
-    end
-
     it "automatically combines duplicate line_item records when they're created" do
       purchase = build(:purchase)
       item = create(:item)

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -211,8 +211,9 @@ RSpec.describe "Distributions", type: :request do
     describe "POST #create" do
       let!(:storage_location) { create(:storage_location, organization: organization) }
       let!(:partner) { create(:partner, organization: organization) }
+      let(:issued_at) { Time.current }
       let(:distribution) do
-        { storage_location_id: storage_location.id, partner_id: partner.id, delivery_method: :delivery }
+        { storage_location_id: storage_location.id, partner_id: partner.id, issued_at:, delivery_method: :delivery }
       end
 
       it "redirects to #show on success" do
@@ -245,6 +246,17 @@ RSpec.describe "Distributions", type: :request do
           expect(response).to have_error
           expect(response.body).not_to include("Deactivated Partner")
           expect(response.body).to include("Active Partner")
+        end
+      end
+
+      context "with missing issued_at field" do
+        let(:issued_at) { "" }
+
+        it "fails and returns validation error message" do
+          post distributions_path(distribution:, format: :turbo_stream)
+
+          expect(response).to have_http_status(400)
+          expect(flash[:error]).to include("Distribution date and time can't be blank")
         end
       end
     end
@@ -486,6 +498,26 @@ RSpec.describe "Distributions", type: :request do
       it "returns a 200" do
         patch distribution_path(distribution_params)
         expect(response.status).to redirect_to(distribution_path(distribution.to_param))
+      end
+
+      context "with invalid issued_at field" do
+        let(:distribution_params) do
+          { id: distribution.id,
+            distribution: {
+              partner_id: partner.id,
+              storage_location_id: location.id,
+              'issued_at(1i)' => issued_at.to_date.year,
+              'issued_at(2i)' => issued_at.to_date.month,
+              'issued_at(3i)' => nil # day part of date missing
+            }}
+        end
+
+        it "fails and returns validation error message" do
+          patch distribution_path(distribution_params)
+
+          expect(flash[:error]).to include("Distribution date and time can't be blank")
+          expect(response).not_to redirect_to(anything)
+        end
       end
 
       describe "when changing storage location" do

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -504,10 +504,9 @@ RSpec.describe "Distributions", type: :request do
       include_examples "requiring authorization"
     end
 
-    describe "PATCH #update" do
-      let(:partner_name) { "Patrick" }
+    describe "POST #update" do
       let(:location) { create(:storage_location, organization: organization) }
-      let(:partner) { create(:partner, name: partner_name, organization: organization) }
+      let(:partner) { create(:partner, organization: organization) }
 
       let(:distribution) { create(:distribution, partner: partner, organization: organization) }
       let(:issued_at) { distribution.issued_at }
@@ -544,15 +543,6 @@ RSpec.describe "Distributions", type: :request do
 
           expect(flash[:error]).to include("Distribution date and time can't be blank")
           expect(response).not_to redirect_to(anything)
-        end
-
-        it "renders storage location dropdowns" do
-          patch distribution_path(distribution_params)
-
-          page = Nokogiri::HTML(response.body)
-          selectable_partners = page.at_css("select#distribution_partner_id").text.split("\n")
-
-          expect(selectable_partners).to include("Patrick")
         end
       end
 

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -478,9 +478,10 @@ RSpec.describe "Distributions", type: :request do
       include_examples "requiring authorization"
     end
 
-    describe "POST #update" do
+    describe "PATCH #update" do
+      let(:partner_name) { "Patrick" }
       let(:location) { create(:storage_location, organization: organization) }
-      let(:partner) { create(:partner, organization: organization) }
+      let(:partner) { create(:partner, name: partner_name, organization: organization) }
 
       let(:distribution) { create(:distribution, partner: partner, organization: organization) }
       let(:issued_at) { distribution.issued_at }
@@ -517,6 +518,15 @@ RSpec.describe "Distributions", type: :request do
 
           expect(flash[:error]).to include("Distribution date and time can't be blank")
           expect(response).not_to redirect_to(anything)
+        end
+
+        it "renders storage location dropdowns" do
+          patch distribution_path(distribution_params)
+
+          page = Nokogiri::HTML(response.body)
+          selectable_partners = page.at_css("select#distribution_partner_id").text.split("\n")
+
+          expect(selectable_partners).to include("Patrick")
         end
       end
 

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -64,16 +64,16 @@ RSpec.describe "Purchases", type: :request do
       let!(:storage_location) { create(:storage_location, organization: organization) }
       let(:line_items) { [attributes_for(:line_item)] }
       let(:vendor) { create(:vendor, organization: organization) }
+      let(:purchase) do
+        { storage_location_id: storage_location.id,
+          purchased_from: "Google",
+          vendor_id: vendor.id,
+          amount_spent: 10,
+          issued_at: Time.current,
+          line_items: line_items }
+      end
 
       context "on success" do
-        let(:purchase) do
-          { storage_location_id: storage_location.id,
-            purchased_from: "Google",
-            vendor_id: vendor.id,
-            amount_spent: 10,
-            line_items: line_items }
-        end
-
         it "redirects to GET#edit" do
           expect { post purchases_path(purchase: purchase) }
             .to change { Purchase.count }.by(1)
@@ -100,6 +100,15 @@ RSpec.describe "Purchases", type: :request do
           post purchases_path(purchase: { storage_location_id: nil, amount_spent: nil })
           expect(response).to be_successful # Will render :new
           expect(response.body).to include('Failed to create purchase due to')
+        end
+
+        context "with invalid issued_at param" do
+          it "flashes the correct validation error" do
+            issued_at = ""
+            post purchases_path(purchase: purchase.merge(issued_at:))
+
+            expect(flash[:error]).to include("Purchase date can't be blank")
+          end
         end
       end
     end
@@ -129,6 +138,15 @@ RSpec.describe "Purchases", type: :request do
                  View::Inventory.new(organization.id)
                    .quantity_for(storage_location: purchase.storage_location_id, item_id: line_item.item_id)
                }.by(5)
+      end
+
+      context "with invalid issued_at" do
+        it "redirects to index after update" do
+          purchase = create(:purchase, purchased_from: "Google")
+          put purchase_path(id: purchase.id, purchase: { issued_at: "" })
+
+          expect(flash[:alert]).to include("Purchase date can't be blank")
+        end
       end
 
       describe "when removing a line item" do

--- a/spec/services/distribution_update_service_spec.rb
+++ b/spec/services/distribution_update_service_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe DistributionUpdateService, type: :service do
         DistributionUpdateService.new(distribution, new_attributes).call
       end.to change { distribution.storage_location.size }.by(8)
     end
+
+    context "when missing issued_at attribute" do
+      it "preserves validation error and is unsuccessful" do
+        result = DistributionUpdateService.new(distribution, {issued_at: ""}).call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_instance_of(ActiveRecord::RecordInvalid)
+        expect(result.error.message).to include("Distribution date and time can't be blank")
+      end
+    end
   end
 
   describe "resend_notification?" do

--- a/spec/services/donation_create_service_spec.rb
+++ b/spec/services/donation_create_service_spec.rb
@@ -7,5 +7,13 @@ RSpec.describe DonationCreateService do
         .to change { Donation.count }.by(1)
         .and change { DonationEvent.count }.by(1)
     end
+
+    context "when missing issued_at attribute" do
+      before { donation.issued_at = "" }
+
+      it "raises a validation error" do
+        expect { described_class.call(donation) }.to raise_error("Issue date can't be blank")
+      end
+    end
   end
 end

--- a/spec/services/itemizable_update_service_spec.rb
+++ b/spec/services/itemizable_update_service_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe ItemizableUpdateService do
       expect(UpdateExistingEvent.count).to eq(1)
     end
 
+    it "fails with a validation message for donation events with invalid issued_at" do
+      attributes[:issued_at] = ""
+
+      expect { subject }.to raise_error do |e|
+        expect(e).to be_a(ActiveRecord::RecordInvalid)
+        expect(e.message).to eq("Validation failed: Issue date can't be blank")
+      end
+    end
+
     context "when storage location changes" do
       context "when there is no intervening audit" do
         it "should update quantity in different locations" do
@@ -125,6 +134,15 @@ RSpec.describe ItemizableUpdateService do
       expect(storage_location.size).to eq(26)
       expect(new_storage_location.size).to eq(20)
       expect(itemizable.issued_at).to eq(2.days.ago)
+    end
+
+    it "fails with a validation message for distribution events with invalid issued_at" do
+      attributes[:issued_at] = ""
+
+      expect { subject }.to raise_error do |e|
+        expect(e).to be_a(ActiveRecord::RecordInvalid)
+        expect(e.message).to eq("Validation failed: Distribution date and time can't be blank")
+      end
     end
 
     context "when storage location changes" do


### PR DESCRIPTION
Resolves #4313

### Description
Previously we had two callbacks on these models with an `issued_at` field. These `before_save` and `before_create` callbacks set the value for `issued_at` to be based on `created_at` if `issued_at` was missing. This prevented records from being saved with no issue date. But it causes the unexpected behavior mentioned in the issue when creating or updating a donation/purchase/distribution with an empty `issued_at` field, silently changing the `issued_at` date to something potentially incorrect.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Added new request and service specs.

### Screenshots
These date times are still filled in automatically with default values like before. The difference is that if a user manually deletes the date, an error will be shown like our other validation errors. 
![image](https://github.com/user-attachments/assets/fc410b54-4ba3-43b4-9891-621a0b6961b7)

