### PR TITLE
Add bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,8 @@ gem "jwt"
 gem "newrelic_rpm"
 # Used to manage periodic cron-like jobs
 gem "clockwork"
+# Speed up app boot time by caching expensive operations
+gem 'bootsnap', require: false
 
 ##### DEPENDENCY PINS ######
 # These are gems that aren't used directly, only as dependencies for other gems.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
+    bootsnap (1.18.4)
+      msgpack (~> 1.2)
     bootstrap (5.2.3)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 2.11.6, < 3)
@@ -383,6 +385,7 @@ GEM
       monetize (~> 1.9)
       money (~> 6.13)
       railties (>= 3.0)
+    msgpack (1.7.5)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     multipart-post (2.4.1)
@@ -717,6 +720,7 @@ DEPENDENCIES
   azure-storage-blob
   better_errors
   binding_of_caller
+  bootsnap
   bootstrap (~> 5.2)
   brakeman
   bugsnag

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
-# require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
The app boots up pretty slowly, takes me ~9 seconds in developent mode. This cuts bootup time by half for me locally.
This will be a nice improvement for development, because I often have to wait those ~10 seconds for the application to load just to run a test that takes a fraction of a second.

### Type of change
* Internal/dependencies

### How Has This Been Tested?
Tested it locally. I'm not sure if there will be any issues with this in production or CI or codespaces.
But it not working will probably just mean that the boot time for the app is the same as it was before, so I don't think it's too risky.

### Screenshots
Before and then after
![image](https://github.com/user-attachments/assets/69d92068-c4d9-4221-b4bf-34e0fc310514)