### PR TITLE
fix number of purchases appearing on paginated purchases

### DIFF
--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -89,7 +89,7 @@
               </tr>
               </thead>
               <tbody>
-              <%= render partial: "purchase_row", collection: @purchases %>
+              <%= render partial: "purchase_row", collection: @paginated_purchases %>
               </tbody>
               <tfoot>
               <tr>

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -37,6 +37,27 @@ RSpec.describe "Purchases", type: :request do
           expect(subject.body).to include("Comments")
           expect(subject.body).to include("Purchase Comment")
         end
+
+        describe "pagination" do
+          around do |ex|
+            Kaminari.config.default_per_page = 2
+            ex.run
+            Kaminari.config.default_per_page = 50
+          end
+          before do
+            item = create(:item, organization: organization)
+            purchase_1 = create(:purchase, organization: organization, comment: "Singleton", issued_at: 1.day.ago)
+            create(:line_item, item: item, itemizable: purchase_1, quantity: 2)
+            purchase_2 = create(:purchase, organization: organization, comment: "Twins", issued_at: 2.days.ago)
+            create(:line_item, item: item, itemizable: purchase_2, quantity: 2)
+            purchase_3 = create(:purchase, organization: organization, comment: "Fates", issued_at: 3.days.ago)
+            create(:line_item, item: item, itemizable: purchase_3, quantity: 2)
+          end
+
+          it "puts the right number of purchases on the page" do
+            expect(subject.body).to include(" View").twice
+          end
+        end
       end
 
       context "csv" do


### PR DESCRIPTION

### Description

Fixes an issue found while testing #4847   -- the number of purchases actually appearing in the purchase index was the number of filtered purchases, not the number of paginated filtered purchases

Most banks don't make 50 purchases a year,  so this hasn't had a large impact.

Very simple fix (one variable name change), plus tests.
   
### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- automated tests
- also  temporarily reduced   config.default_per_page  in config/initializers/kaminari.rb to 3  to manually test on local.


