### PR TITLE
Fix partner view to display distribution scheduled date

### DIFF
--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -238,7 +238,7 @@
                 <tbody>
                 <% @partner_distributions.each do |dist| %>
                   <tr>
-                    <td><%= dist.created_at.strftime("%m/%d/%Y") %></td>
+                    <td><%= dist.issued_at.strftime("%m/%d/%Y") %></td>
                     <td><%= dist.storage_location.name %></td>
                     <td><%= dist.line_items.total %></td>
                     <td class="text-right">

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -317,6 +317,21 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           end
         end
       end
+
+      context "when viewing prior distributions" do
+        let(:partner) do
+          partner = create(:partner, :approved)
+          partner.distributions << create(:distribution, :with_items, :past, item_quantity: 1231)
+          partner
+        end
+        it "displays distribution scheduled date" do
+          visit partner_path(partner.id)
+          partner.distributions.each do |distribution|
+            expect(page).to have_content(distribution.issued_at.strftime("%m/%d/%Y"))
+            expect(page).to_not have_content(distribution.created_at.strftime("%m/%d/%Y"))
+          end
+        end
+      end
     end
 
     describe "#new" do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -317,21 +317,6 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           end
         end
       end
-
-      context "when viewing prior distributions" do
-        let(:partner) do
-          partner = create(:partner, :approved)
-          partner.distributions << create(:distribution, :with_items, :past, item_quantity: 1231)
-          partner
-        end
-        it "displays distribution scheduled date" do
-          visit partner_path(partner.id)
-          partner.distributions.each do |distribution|
-            expect(page).to have_content(distribution.issued_at.strftime("%m/%d/%Y"))
-            expect(page).to_not have_content(distribution.created_at.strftime("%m/%d/%Y"))
-          end
-        end
-      end
     end
 
     describe "#new" do


### PR DESCRIPTION
Resolves #4856

### Description
Previously, the partner view's "prior distributions" section included the date when distributions were entered into the system.  Now, the "prior distributions" section will instead include the distribution scheduled date.


### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
- I followed steps to reproduce in issue #4856 and confirmed that the bug was fixed.  I also wrote a new system spec that confirms the fix worked.  Lastly, I confirmed that this change doesn't break any existing specs.

### Screenshots
<details>
<Summary>Before</summary>

![4856Before](https://github.com/user-attachments/assets/33251670-8f7b-49a3-8421-f8f60ffe1029)

</details>

<details>
<Summary>After</summary>

![4856After](https://github.com/user-attachments/assets/0c90932d-b34f-47f5-a385-6d3cd5d3df7b)

</details>