### PR TITLE
Refactor out for_families attribute from FamilyRequestCreateService

### DIFF
--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -19,7 +19,7 @@ module Partners
       create_service = Partners::FamilyRequestCreateService.new(
         partner_user_id: current_user.id,
         family_requests_attributes: family_requests_attributes,
-        for_families: true
+        request_type: "child"
       )
 
       create_service.call
@@ -37,7 +37,7 @@ module Partners
       @partner_request = Partners::FamilyRequestCreateService.new(
         partner_user_id: current_user.id,
         family_requests_attributes: family_requests_attributes,
-        for_families: true
+        request_type: "child"
       ).initialize_only
       if @partner_request.valid?
         @total_items = @partner_request.total_items

--- a/app/controllers/partners/individuals_requests_controller.rb
+++ b/app/controllers/partners/individuals_requests_controller.rb
@@ -12,7 +12,8 @@ module Partners
       create_service = Partners::FamilyRequestCreateService.new(
         partner_user_id: current_user.id,
         comments: individuals_request_params[:comments],
-        family_requests_attributes: individuals_request_params[:items_attributes]&.values
+        family_requests_attributes: individuals_request_params[:items_attributes]&.values,
+        request_type: "individual"
       )
 
       create_service.call
@@ -36,7 +37,8 @@ module Partners
       @partner_request = Partners::FamilyRequestCreateService.new(
         partner_user_id: current_user.id,
         comments: individuals_request_params[:comments],
-        family_requests_attributes: individuals_request_params[:items_attributes]&.values
+        family_requests_attributes: individuals_request_params[:items_attributes]&.values,
+        request_type: "individual"
       ).initialize_only
       if @partner_request.valid?
         @total_items = @partner_request.total_items

--- a/app/services/partners/family_request_create_service.rb
+++ b/app/services/partners/family_request_create_service.rb
@@ -6,13 +6,13 @@ module Partners
   class FamilyRequestCreateService
     include ServiceObjectErrorsMixin
 
-    attr_reader :partner_user_id, :comments, :family_requests_attributes, :partner_request
+    attr_reader :partner_user_id, :comments, :family_requests_attributes, :partner_request, :request_type
 
-    def initialize(partner_user_id:, family_requests_attributes:, comments: nil, for_families: false)
+    def initialize(partner_user_id:, family_requests_attributes:, request_type:, comments: nil)
       @partner_user_id = partner_user_id
       @comments = comments
       @family_requests_attributes = family_requests_attributes.presence || []
-      @for_families = for_families
+      @request_type = request_type
     end
 
     def call
@@ -80,10 +80,6 @@ module Partners
 
     def included_items_by_id
       @included_items_by_id ||= Item.where(id: family_requests_attributes.pluck(:item_id)).index_by(&:id)
-    end
-
-    def request_type
-      @for_families ? "child" : "individual"
     end
   end
 end

--- a/spec/services/partners/family_request_create_service_spec.rb
+++ b/spec/services/partners/family_request_create_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Partners::FamilyRequestCreateService do
       {
         partner_user_id: partner_user.id,
         comments: comments,
-        for_families: for_families,
+        request_type: request_type,
         family_requests_attributes: family_requests_attributes
       }
     end
@@ -13,7 +13,7 @@ RSpec.describe Partners::FamilyRequestCreateService do
     let(:partner) { create(:partner, organization: organization) }
     let(:partner_user) { partner.primary_user }
     let(:comments) { Faker::Lorem.paragraph }
-    let(:for_families) { false }
+    let(:request_type) { "individual" }
 
     context 'when the arguments are incorrect' do
       context 'because no family_requests_attributes or comments were defined' do
@@ -97,8 +97,8 @@ RSpec.describe Partners::FamilyRequestCreateService do
           expect(second_item_request.quantity.to_i).to eq(second_item_request.item.default_quantity * 4)
         end
 
-        context "with for_families false" do
-          let(:for_families) { false }
+        context "with request_type as individual" do
+          let(:request_type) { "individual" }
 
           it "creates a request of type individual" do
             expect { subject }.to change { Request.count }.by(1)
@@ -108,8 +108,8 @@ RSpec.describe Partners::FamilyRequestCreateService do
           end
         end
 
-        context "with for_families true" do
-          let(:for_families) { true }
+        context "with request_type as child" do
+          let(:request_type) { "child" }
 
           it "creates a request of type child" do
             expect { subject }.to change { Request.count }.by(1)


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
This `for_families` attribute is a funny one. I removed it from `RequestCreateService` in PR #4827, because it was being passed in but then not used.

Let's go ahead and remove it from `FamilyCreateService` as I think it isn't necessary there either.

It also appears to be a column on the `partner_requests` table which as far as I can tell is currently not being used. Not sure if it was ever used. 

A side topic is what to do about the `partner_requests` table. Can we drop it or does it have records in production?

### Type of change

<!-- Please delete options that are not relevant. -->

* Internal refactor

### How Has This Been Tested?
Fixed related tests that references `for_families`.