### PR TITLE
Fix flaky ExportCreateService spec

### DIFF
--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the 3T Diapers request" do
-        expect(subject[1]).to eq([
+        expect(subject).to include([
           request_3t.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Child",
@@ -250,7 +250,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the 2T Diapers request" do
-        expect(subject[2]).to eq([
+        expect(subject).to include([
           request_2t.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Individual",
@@ -263,7 +263,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the request with deleted items" do
-        expect(subject[3]).to eq([
+        expect(subject).to include([
           request_with_deleted_items.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           nil,
@@ -276,7 +276,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the request with multiple items" do
-        expect(subject[4]).to eq([
+        expect(subject).to include([
           request_with_multiple_items.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           nil,
@@ -289,7 +289,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the request with 4T diapers without pack unit" do
-        expect(subject[5]).to eq([
+        expect(subject).to include([
           request_4t.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Quantity",
@@ -302,7 +302,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the request with 4T diapers with pack unit" do
-        expect(subject[6]).to eq([
+        expect(subject).to include([
           request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Quantity",


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
I believe this is one of the more flaky specs we have.

This spec expects the requests in the export to be in a particular order, but no order is applied to the requests passed in and no order is defined in the ExportCreateService itself, hence the flakiness.

Example rspec output:
```

Failures:

  1) Exports::ExportRequestService with custom units feature enabled .generate_csv_data has expected data for the 2T Diapers request
     Failure/Error:
       expect(subject[2]).to eq([
         request_2t.created_at.strftime("%m/%d/%Y").to_s,
         "Howdy Partner",
         "Individual",
         "Fulfilled",
         100, # 2T Diapers
         0,   # 3T Diapers
         0,   # 4T Diapers
         0,   # 4T Diapers - packs
         0    # <DELETED_ITEMS>

       expected: ["12/16/2024", "Howdy Partner", "Individual", "Fulfilled", 100, 0, 0, 0, 0]
            got: ["12/16/2024", "Howdy Partner", "Child", "Started", 0, 150, 0, 0, 0]

       (compared using ==)
     # ./spec/services/exports/export_request_service_spec.rb:130:in `block (4 levels) in <top (required)>'
 ```
Explanation: is expecting the the second line to equal the second request defined in the setup. But since `Request.all` are the arguments, no order is defined, and that request is there but on a different line.




### Type of change
* Internal (test refactor)

### How Has This Been Tested?
It's hard to reproduce this flakiness on command. While I was debugging it, I ran `--bisect` with the seed number, but it wasn't helpful in this case.

It's possible this test is flaky for a different reason. But let's take care of this issue first.


### Screenshots
Example failure in CI: https://github.com/rubyforgood/human-essentials/actions/runs/12353561322/job/34472934783#step:7:1433