### PR TITLE
Remove duplicate donation system spec

### DIFF
--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -312,20 +312,6 @@ RSpec.describe "Donations", type: :system, js: true do
           end.to change { Donation.count }.by(1)
         end
 
-        it "Allows User to create a donation for Purchased Supplies" do
-          select Donation::SOURCES[:misc], from: "donation_source"
-          expect(page).not_to have_xpath("//select[@id='donation_donation_site_id']")
-          expect(page).not_to have_xpath("//select[@id='donation_product_drive_participant_id']")
-          expect(page).not_to have_xpath("//select[@id='donation_manufacturer_id']")
-          select StorageLocation.first.name, from: "donation_storage_location_id"
-          select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
-          fill_in "donation_line_items_attributes_0_quantity", with: "5"
-
-          expect do
-            click_button "Save"
-          end.to change { Donation.count }.by(1)
-        end
-
         it "Allows User to create a donation with a Miscellaneous source" do
           select Donation::SOURCES[:misc], from: "donation_source"
           expect(page).not_to have_xpath("//select[@id='donation_donation_site_id']")


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
While investigating flaky specs, I noticed what looks like the same spec twice in a row. Look at the spec directly underneath the removed code in this PR (the one titled "Allows User to create a donation with a Miscellaneous source").

I did a `diff` and the only thing different between them is the spec description in double quotes.

The two specs were commited in 17e818c76af1866666c56aed57725530428f9760. I can't figure out what was meant to be tested here so maybe we can just remove it?

### Type of change
* Internal