### PR TITLE
Rename fixture_path to fixtures_path to fix deprecation warning

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -107,7 +107,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   # Location for fixtures (logo, etc)
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 
   # Persistence for failures
   config.example_status_persistence_file_path = "spec/example_failures.txt"


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
Removes the following deprecation warning:
![Screenshot from 2024-12-18 12-28-29](https://github.com/user-attachments/assets/dbe79e85-f0e3-4e82-9d7c-156a8f91dace)

For additional context: This change was introduced in this [Rails PR](https://github.com/rails/rails/pull/47675).

### Type of change
* Internal

### How Has This Been Tested?
Just by running the test suite.