### PR TITLE
Fix flaky family requests system spec

### DIFF
--- a/spec/system/partners/children_system_spec.rb
+++ b/spec/system/partners/children_system_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Creating a parner child", type: :system, js: true do
       expect(page).to have_text("Child Last Name")
       expect(page).to have_text("01234")
       expect(page).to have_text("Some Comment")
-      expect(page).to have_text("Item 1, Item 2")
+      expect(page).to have_text(/Item 1, Item 2|Item 2, Item 1/) # order of items requested not guaranteed
     end
   end
 end

--- a/spec/system/partners/family_requests_system_spec.rb
+++ b/spec/system/partners/family_requests_system_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe "Family requests", type: :system, js: true do
       within("table tbody tr", text: "Main Items1") do |row|
         expect(row).to have_css("td", text: "Main Family")
         expect(row).to have_css("td", text: "Main Items1")
-        expect(row).to have_css("td", text: "Item 1, Item 2")
+        expect(row).to have_css("td", text: /Item 1, Item 2|Item 2, Item 1/) # order of items requested not guaranteed
       end
 
       within("table tbody tr", text: "Main Items2") do |row|
         expect(row).to have_css("td", text: "Main Family")
         expect(row).to have_css("td", text: "Main Items2")
-        expect(row).to have_css("td", text: "Item 2, Item 3")
+        expect(row).to have_css("td", text: /Item 2, Item 3|Item 3, Item 2/) # order of items requested not guaranteed
       end
 
       within("table tbody tr", text: "Main No Items") do |row|
@@ -47,7 +47,7 @@ RSpec.describe "Family requests", type: :system, js: true do
       within("table tbody tr", text: "Other Items") do |row|
         expect(row).to have_css("td", text: "Other Family")
         expect(row).to have_css("td", text: "Other Items")
-        expect(row).to have_css("td", text: "Item 1, Item 2")
+        expect(row).to have_css("td", text: /Item 1, Item 2|Item 2, Item 1/) # order of items requested not guaranteed
       end
 
       within("table tbody tr", text: "Other No Items") do |row|


### PR DESCRIPTION
Doesn't resolve any issue, although related to https://github.com/rubyforgood/human-essentials/issues/4557.

### Description
This system spec is known to be flaky. See this [comment](https://github.com/rubyforgood/human-essentials/issues/4557#issuecomment-2316498535). 

Example failure: https://github.com/rubyforgood/human-essentials/actions/runs/12392348304/job/34591567923#step:7:552

Example output:
```
Failures:

  1) Family requests for children with different items, from different families it creates family requests
     Failure/Error: expect(row).to have_css("td", text: "Item 2, Item 3")
       expected to find visible css "td" with text "Item 2, Item 3" within #<Capybara::Node::Element tag="tr" path="//HTML[1]/BODY[1]/DIV[1]/DIV[1]/SECTION[2]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/FORM[1]/DIV[1]/TABLE[1]/TBODY[1]/TR[3]"> but there were no matches. Also found "Main Family", "Main Items2", "Item 3, Item 2", "Include This Child?", which matched the selector but not all filters. 

     [Screenshot Image]: /home/runner/work/human-essentials/human-essentials/tmp/capybara/failures_r_spec_example_groups_family_requests_for_children_with_different_items_from_different_families_it_creates_family_requests_611.png


     # ./spec/system/partners/family_requests_system_spec.rb:38:in `block (4 levels) in <top (required)>'
     # ./spec/system/partners/family_requests_system_spec.rb:35:in `block (3 levels) in <top (required)>'
```

Proposed reason behind flakiness:
We are expecting the requested items (Items Needed column) for each child to be in a certain order.
But in the view we are calling `child.requested_item_ids` to fetch the items which doesn't specify an `ORDER BY` clause (nor do we sort the items in Ruby), as you can see from development logs:

![image](https://github.com/user-attachments/assets/5984c4ff-fbca-4719-ada6-224337d537db)
or from Rails console:

![Screenshot from 2024-12-18 14-02-38](https://github.com/user-attachments/assets/f31dc978-dff6-41c2-871f-4c005cdc13a5)


### Type of change
* Internal

### How Has This Been Tested?
I retried this spec 10+ times locally and wasn't and wasn't able to reproduce the failure.
But I changed the order of the `requested_item_ids` for the `partners_child` factories and the test still passes afterwards, so I think this will fix the issue. 

### Screenshots
Which page we are testing for reference:
![Screenshot from 2024-12-18 14-21-22](https://github.com/user-attachments/assets/f49e9203-dd26-4e1b-8c52-0aa2a8a40f26)

