### PR TITLE
Fix missing partner dropdown options on distribution update fail

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -205,6 +205,7 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @distribution.initialize_request_items
       @items = current_organization.items.active.alphabetized
+      @partner_list = current_organization.partners.alphabetized
       @storage_locations = current_organization.storage_locations.active_locations.alphabetized
       render :edit
     end

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -504,9 +504,10 @@ RSpec.describe "Distributions", type: :request do
       include_examples "requiring authorization"
     end
 
-    describe "POST #update" do
+    describe "PATCH #update" do
+      let(:partner_name) { "Patrick" }
       let(:location) { create(:storage_location, organization: organization) }
-      let(:partner) { create(:partner, organization: organization) }
+      let(:partner) { create(:partner, name: partner_name, organization: organization) }
 
       let(:distribution) { create(:distribution, partner: partner, organization: organization) }
       let(:issued_at) { distribution.issued_at }
@@ -543,6 +544,15 @@ RSpec.describe "Distributions", type: :request do
 
           expect(flash[:error]).to include("Distribution date and time can't be blank")
           expect(response).not_to redirect_to(anything)
+        end
+
+        it "renders storage location dropdowns" do
+          patch distribution_path(distribution_params)
+
+          page = Nokogiri::HTML(response.body)
+          selectable_partners = page.at_css("select#distribution_partner_id").text.split("\n")
+
+          expect(selectable_partners).to include("Patrick")
         end
       end
 


### PR DESCRIPTION
Doesn't resolve any issue. 

### Description
This bug was discovered while I was working on #4849.

Steps to reproduce:
1. Log in as an org_admin.
2. Find a distribution and click edit.
3. Change something on the page to create a validation error. (For example, set the issue date year to be 1000.)
4. Click save/update.
5. The update should fail, and now the dropdown for partners will be messed up. Instead of valid partner names, you see something like the screenshot below.


Expected behavior: You should see the same partner names as before the failed update.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Locally and I added a new request spec.

### Screenshots
![image](https://github.com/user-attachments/assets/f30bb9dd-88aa-42cc-a005-26f8f7b89548)