### PR TITLE
Fix flaky distribution system specs

### DIFF
--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -558,9 +558,9 @@ RSpec.feature "Distributions", type: :system do
 
     context "when editing that distribution" do
       before do
-        click_on "Distributions", match: :first
-        click_on "Edit", match: :first
         @distribution = Distribution.last
+        expect(page).to have_current_path(distribution_path(@distribution.id))
+        click_on "Make a Correction"
       end
 
       it "User creates a distribution from a donation then edits it" do


### PR DESCRIPTION
Resolves #4381  <!--fill issue number-->

### Description
We were saving a new distribution (which causes a redirect to that distribution's show page) and then immediately clicking on the distributions index page (which redirects as well). This introduced a race condition that was flaky when we tried to click a link that didn't exist on the page we were on.

### Type of change
* Internal (only related to tests)

### How Has This Been Tested?
I was actually able to reproduce this failure locally, so it was a little easier to test. I ran the three specs that use the faulty `before` block multiple times before and after this change. (Using a simple bash script to run the test multiple times: `for i in {1..20}; do ber spec/system/distribution_system_spec.rb:559; done;`)

Before the change:
5 failing specs out of 60.

After the change:
0 failing specs out of 60.
