### PR TITLE
Fix flaky partners requests request spec

### DIFF
--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Partners", type: :request do
         families_served: 3,
         children_served: 4,
         family_zipcodes: 2,
-        family_zipcodes_list: %w(45612-123 45612-126)
+        family_zipcodes_list: contain_exactly("45612-126", "45612-123") # order of zipcodes not guaranteed
       }
     end
 
@@ -127,7 +127,7 @@ RSpec.describe "Partners", type: :request do
       context "when the partner is invited" do
         it "includes impact metrics" do
           subject
-          expect(assigns[:impact_metrics]).to eq(expected_impact_metrics)
+          expect(assigns[:impact_metrics]).to match(expected_impact_metrics)
         end
       end
 


### PR DESCRIPTION
Doesn't resolve any issue. But it is one of the specs mentioned in this [flaky specs issue](https://github.com/rubyforgood/human-essentials/issues/4557).

### Description
In the spec we are expecting the `family_zipcodes_list` to have a certain order but no order is guaranteed in the request. This changes our expectation to match current behavior (order of zip codes doesn't matter).

Example backtrace:
```

  2) Partners GET #show html when the partner is invited includes impact metrics
     Failure/Error: expect(assigns[:impact_metrics]).to eq(expected_impact_metrics)

       expected: {:children_served=>4, :families_served=>3, :family_zipcodes=>2, :family_zipcodes_list=>["45612-123", "45612-126"]}
            got: {:children_served=>4, :families_served=>3, :family_zipcodes=>2, :family_zipcodes_list=>["45612-126", "45612-123"]}

       (compared using ==)

       Diff:
       @@ -1,5 +1,5 @@
        :children_served => 4,
        :families_served => 3,
        :family_zipcodes => 2,
       -:family_zipcodes_list => ["45612-123", "45612-126"],
       +:family_zipcodes_list => ["45612-126", "45612-123"],

     # ./spec/requests/partners_requests_spec.rb:130:in `block (5 levels) in <top (required)>'
```
(found in this [comment](https://github.com/rubyforgood/human-essentials/issues/4557#issue-2436060928))

### Type of change
* Internal (only related to tests)

### How Has This Been Tested?
I wasn't able to reproduce this failure locally. But changing the order of the zipcodes in the setup didn't break the spec so this should in theory fix the issue.