### PR TITLE
Data fix mhm and aad request distribution link and fulfilled status

### DIFF
--- a/db/migrate/20241220020009_data_fix_for_mhm_and_aad.rb
+++ b/db/migrate/20241220020009_data_fix_for_mhm_and_aad.rb
@@ -2,6 +2,8 @@ class DataFixForMhmAndAad < ActiveRecord::Migration[7.2]
   def up
     # This is a one-time, one-way data fix for MHM and AAD.  See support ticket starting Sept 9, 2024, 1327
 
+    return unless Rails.env.production?
+
     # This request should be marked fulfilled and associated with distribution 74466.  We have checked that no request is already associated with that distribution
 
     request = Request.find("39408")

--- a/db/migrate/20241220020009_data_fix_for_mhm_and_aad.rb
+++ b/db/migrate/20241220020009_data_fix_for_mhm_and_aad.rb
@@ -1,0 +1,27 @@
+class DataFixForMhmAndAad < ActiveRecord::Migration[7.2]
+  def up
+    # This is a one-time, one-way data fix for MHM and AAD.  See support ticket starting Sept 9, 2024, 1327
+
+    # This request should be marked fulfilled and associated with distribution 74466.  We have checked that no request is already associated with that distribution
+
+    request = Request.find("39408")
+    request.distribution_id = "74466"
+    request.status = 2
+    request.save!
+
+
+    ## these addoitinal 3 requests have been identified as having the status 'started', when they should be 'fulfilled'
+    # They already have distributions associated with them
+
+    ["42063", "37900"].each do |request_id|
+      request = Request.find(request_id)
+      request.status = 2
+      request.save!
+    end
+
+
+  end
+  def down
+    # treating this as irreversible.  Though I suppose technically we could.
+  end
+end


### PR DESCRIPTION

### Description

Data fix for support issue regarding started requests that should be fulfilled

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Checked the view and associated distribution of each of the mentioned requests through the user interface in a copy of prod after migration (of course, I put the "return unless Rails.env.production?"  in after that.

