### PR TITLE
Fix flaky admin users system spec

### DIFF
--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -47,10 +47,7 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       expect(page).to have_content('User 123')
       select "Partner", from: "resource_type"
       find("div.input-group:has(.select2-container)").click
-      find('.select2-search__field', wait: 5).set("Partner ABC")
-      find(:xpath,
-        "//li[contains(@class, 'select2-results__option') and contains(., 'Partner ABC')]",
-        wait: 5).click
+      find("li.select2-results__option", text: "Partner ABC").click
       click_on 'Add Role'
 
       expect(page.find('.alert')).to have_content('Role added')


### PR DESCRIPTION
Doesn't resolve any issue. Relate to flaky specs issue (#4557).

### Description
Example build failure: https://github.com/rubyforgood/human-essentials/actions/runs/12431427850/job/34708824591

Example output:
```
Failures:

  1) Admin Users Management While signed in as an Administrative User (super admin) adds a role
     Failure/Error: expect(page.find('.alert')).to have_content('Role added')
       expected to find text "Role added" in "Couldn't find Partner without an ID"

     [Screenshot Image]: /home/runner/work/human-essentials/human-essentials/tmp/capybara/failures_r_spec_example_groups_admin_users_management_while_signed_in_as_an_administrative_user_super_admin_adds_a_role_214.png


     # ./spec/system/admin/users_system_spec.rb:56:in `block (3 levels) in <top (required)>'
```

Theory behind flakiness, this line in the test:
```ruby
find('.select2-search__field', wait: 5).set("Partner ABC")
```
is filling in the select2 input field as if a human would (letter by letter). Every time you input a letter, another request is sent to filter those resources (which could be done locally instead of over a request but that's another topic).
This ends up sending a bunch of requests as seen in the test logs:

```
Started GET "/admin/users/resource_ids?resource_type=partner&_type=query" for 127.0.0.1 at 2024-12-20 05:36:09 -0800
Processing by Admin::UsersController#resource_ids as JSON
  Parameters: {"resource_type"=>"partner", "_type"=>"query"}
Started GET "/admin/users/resource_ids?resource_type=partner&term=P&_type=query&q=P" for 127.0.0.1 at 2024-12-20 05:36:09 -0800
Processing by Admin::UsersController#resource_ids as JSON
  Parameters: {"resource_type"=>"partner", "term"=>"P", "_type"=>"query", "q"=>"P"}
Started GET "/admin/users/resource_ids?resource_type=partner&term=Pa&_type=query&q=Pa" for 127.0.0.1 at 2024-12-20 05:36:09 -0800
Processing by Admin::UsersController#resource_ids as JSON
  Parameters: {"resource_type"=>"partner", "term"=>"Pa", "_type"=>"query", "q"=>"Pa"}
Started GET "/admin/users/resource_ids?resource_type=partner&term=Par&_type=query&q=Par" for 127.0.0.1 at 2024-12-20 05:36:09 -0800
Processing by Admin::UsersController#resource_ids as JSON
  Parameters: {"resource_type"=>"partner", "term"=>"Par", "_type"=>"query", "q"=>"Par"}
Started GET "/admin/users/resource_ids?resource_type=partner&term=Part&_type=query&q=Part" for 127.0.0.1 at 2024-12-20 05:36:09 -0800
Processing by Admin::UsersController#resource_ids as JSON
  Parameters: {"resource_type"=>"partner", "term"=>"Part", "_type"=>"query", "q"=>"Part"}
Started GET "/admin/users/resource_ids?resource_type=partner&term=Partn&_type=query&q=Partn" for 127.0.0.1 at 2024-12-20 05:36:09 -0800
Processing by Admin::UsersController#resource_ids as JSON
  Parameters: {"resource_type"=>"partner", "term"=>"Partn", "_type"=>"query", "q"=>"Partn"}
Started GET "/admin/users/resource_ids?resource_type=partner&term=Partne&_type=query&q=Partne" for 127.0.0.1 at 2024-12-20 05:36:09 -0800
Processing by Admin::UsersController#resource_ids as JSON
  Parameters: {"resource_type"=>"partner", "term"=>"Partne", "_type"=>"query", "q"=>"Partne"}
Started GET "/admin/users/resource_ids?resource_type=partner&term=Partner%20ABC&_type=query&q=Partner%20ABC" for 127.0.0.1 at 2024-12-20 05:36:09 -0800
Processing by Admin::UsersController#resource_ids as JSON
  Parameters: {"resource_type"=>"partner", "term"=>"Partner ABC", "_type"=>"query", "q"=>"Partner ABC"}
```

I think these requests create a race condition.

So instead of inputting the text, we just select the option. And it seems to fix the flakiness.


### Type of change
* Internal

### How Has This Been Tested?
I ran this test locally 20 times before and after the changes. Before it failed 4 times, after it failed 0 times.
