### PR TITLE
Update Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ inherit_mode:
 
 inherit_gem:
   standard: config/base.yml
+  standard-rails: config/base.yml
+  standard-performance: config/base.yml
 
 inherit_from:
   .rubocop_todo.yml
@@ -12,15 +14,17 @@ require:
   - rubocop-rails
   - rubocop-performance
   - standard
+  - standard-rails
+  - standard-performance
 
 AllCops:
-  TargetRubyVersion: 3.1.2
   Exclude:
     - "vendor/**/*"
     - "db/schema.rb"
     - "db/partners_schema.rb"
     - "db/seeds.rb"
     - "db/migrate/*"
+    - "db/partners_migrate/*"
     - "bin/*"
     - "lib/files/cucumber.rake"
     - "lib/tasks/*"
@@ -29,25 +33,12 @@ AllCops:
     - "Rakefile"
     - "tmp/*"
     - "node_modules/**/*"
-  UseCache: false
 
 Rails:
   Enabled: true
-Rails/Output:
-  Enabled: true
-Rails/Date:
-  Enabled: true
 Rails/FilePath:
   Enabled: false
-Rails/FindBy:
-  Enabled: true
-Rails/FindEach:
-  Enabled: true
 Rails/PluralizationGrammar:
-  Enabled: true
-Rails/ScopeArgs:
-  Enabled: true
-Rails/TimeZone:
   Enabled: true
 Rails/UnknownEnv:
   Environments:
@@ -62,19 +53,13 @@ Rails/AfterCommitOverride:
   Enabled: false
 Rails/FindById:
   Enabled: false
-Rails/Inquiry:
-  Enabled: false
 Rails/MailerName:
   Enabled: false
 Rails/MatchRoute:
   Enabled: false
-Rails/NegateInclude:
-  Enabled: false
 Rails/Pluck:
   Enabled: false
 Rails/PluckInWhere:
-  Enabled: false
-Rails/RenderInline:
   Enabled: false
 Rails/RenderPlainText:
   Enabled: false
@@ -82,12 +67,13 @@ Rails/ShortI18n:
   Enabled: false
 Rails/SquishedSQLHeredocs:
   Enabled: false
-Rails/WhereExists:
-  Enabled: false
-Rails/WhereNot:
-  Enabled: false
 Rails/HasAndBelongsToMany:
   Enabled: false
+Rails/ThreeStateBooleanColumn:
+  Enabled: true
+# FIXME: Fix our ENV variable access and remove the following config.
+Rails/EnvironmentVariableAccess:
+  AllowReads: true
 
 Rails/BulkChangeTable:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -157,9 +157,11 @@ group :development, :test do
   gem "rubocop"
   # Rails add-on for static analysis.
   gem 'rubocop-performance'
-  gem "rubocop-rails", "~> 2.27.0"
+  gem "rubocop-rails", "~> 2.25.1"
   # Default rules for Rubocop.
   gem "standard", "~> 1.40"
+  gem "standard-rails"
+  gem "standard-performance"
   # Erb linter.
   gem "erb_lint"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,7 +445,7 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
-    pdf-core (0.10.0)
+    pdf-core (0.9.0)
     pdf-reader (2.12.0)
       Ascii85 (~> 1.0)
       afm (~> 0.2.1)
@@ -454,13 +454,11 @@ GEM
       ttfunk
     pg (1.5.7)
     popper_js (2.11.8)
-    prawn (2.5.0)
-      matrix (~> 0.4)
-      pdf-core (~> 0.10.0)
-      ttfunk (~> 1.8)
-    prawn-rails (1.5.0)
+    prawn (2.4.0)
+      pdf-core (~> 0.9.0)
+      ttfunk (~> 1.7)
+    prawn-rails (1.4.2)
       actionview (>= 3.1.0)
-      activesupport (>= 3.1.0)
       prawn
       prawn-table
     prawn-table (0.2.2)
@@ -595,10 +593,10 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rails (2.27.0)
+    rubocop-rails (2.25.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 1.52.0, < 2.0)
+      rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-graphviz (1.2.5)
       rexml
@@ -664,6 +662,9 @@ GEM
     standard-performance (1.6.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.23.0)
+    standard-rails (1.1.0)
+      lint_roller (~> 1.0)
+      rubocop-rails (~> 2.25.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.2)
@@ -673,10 +674,9 @@ GEM
       execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     tilt (2.2.0)
-    timeout (0.4.2)
-    ttfunk (1.8.0)
-      bigdecimal (~> 3.1)
-    turbo-rails (2.0.11)
+    timeout (0.4.1)
+    ttfunk (1.7.0)
+    turbo-rails (2.0.10)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     tzinfo (2.0.6)
@@ -792,13 +792,15 @@ DEPENDENCIES
   rspec-rails (~> 7.0.1)
   rubocop
   rubocop-performance
-  rubocop-rails (~> 2.27.0)
+  rubocop-rails (~> 2.25.1)
   sass-rails
   shoulda-matchers (~> 6.2)
   simple_form
   simplecov
   sprockets (~> 4.2.1)
   standard (~> 1.40)
+  standard-performance
+  standard-rails
   stimulus-rails
   strong_migrations (= 1.8.0)
   terser

--- a/app/controllers/partners/dashboards_controller.rb
+++ b/app/controllers/partners/dashboards_controller.rb
@@ -10,9 +10,9 @@ module Partners
       @partner = current_partner
       @partner_requests = @partner.requests.order(created_at: :desc).limit(10)
       @upcoming_distributions = @partner.distributions.order(issued_at: :desc)
-                                        .where('issued_at >= ?', Time.zone.today)
+                                        .where(issued_at: Time.zone.today..)
       @distributions = @partner.distributions.order(issued_at: :desc)
-                               .where('issued_at < ?', Time.zone.today)
+                               .where(issued_at: ...Time.zone.today)
                                .limit(5)
 
       @parent_org = Organization.find(@partner.organization_id)

--- a/app/events/inventory_aggregate.rb
+++ b/app/events/inventory_aggregate.rb
@@ -24,7 +24,7 @@ module InventoryAggregate
       end
 
       if event_time && (!last_snapshot || event_time > last_snapshot.event_time)
-        events = events.where("event_time <= ?", event_time)
+        events = events.where(event_time: ..event_time)
       end
 
       events = events.to_a

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -28,7 +28,6 @@ class Adjustment < ApplicationRecord
   }
   scope :during, ->(range) { where(adjustments: { created_at: range }) }
 
-  validates :storage_location, :organization, presence: true
   validate :storage_locations_belong_to_organization
 
   def self.storage_locations_adjusted_for(organization)

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -27,7 +27,6 @@ class Audit < ApplicationRecord
 
   enum status: { in_progress: 0, confirmed: 1, finalized: 2 }
 
-  validates :storage_location, :organization, presence: true
   validate :line_items_quantity_is_not_negative
   validate :line_items_unique_by_item_id
   validate :user_is_organization_admin_of_the_organization

--- a/app/models/barcode_item.rb
+++ b/app/models/barcode_item.rb
@@ -20,7 +20,7 @@ class BarcodeItem < ApplicationRecord
   validates :organization, presence: true, unless: proc { |b| b.barcodeable_type == "BaseItem" }
   validates :value, presence: true
   validate  :unique_barcode_value
-  validates :quantity, :barcodeable, presence: true
+  validates :quantity, presence: true
   validates :quantity, numericality: { only_integer: true, greater_than: 0 }
 
   include Filterable

--- a/app/models/concerns/issued_at.rb
+++ b/app/models/concerns/issued_at.rb
@@ -5,7 +5,7 @@ module IssuedAt
   extend ActiveSupport::Concern
 
   included do
-    scope :by_issued_at, ->(issued_at) { where(issued_at: issued_at.beginning_of_month..issued_at.end_of_month) }
+    scope :by_issued_at, ->(issued_at) { where(issued_at: issued_at.all_month) }
     scope :for_year, ->(year) { where("extract(year from issued_at) = ?", year) }
     validates :issued_at, presence: true
     validate :issued_at_cannot_be_before_2000

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -38,7 +38,7 @@ class Distribution < ApplicationRecord
   has_one :request, dependent: :nullify
   accepts_nested_attributes_for :request
 
-  validates :storage_location, :partner, :organization, :delivery_method, presence: true
+  validates :delivery_method, presence: true
   validate :line_items_quantity_is_positive
   validates :shipping_cost, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true, if: :shipped?
 
@@ -59,7 +59,7 @@ class Distribution < ApplicationRecord
   # state scope to allow filtering by state
   scope :by_state, ->(state) { where(state: state) }
   scope :recent, ->(count = 3) { order(issued_at: :desc).limit(count) }
-  scope :future, -> { where("issued_at >= :tomorrow", tomorrow: Time.zone.tomorrow) }
+  scope :future, -> { where(issued_at: Time.zone.tomorrow..) }
   scope :during, ->(range) { where(distributions: { issued_at: range }) }
   scope :for_csv_export, ->(organization, filters = {}, date_range = nil) {
     where(organization: organization)

--- a/app/models/donation_site.rb
+++ b/app/models/donation_site.rb
@@ -22,7 +22,7 @@ class DonationSite < ApplicationRecord
 
   belongs_to :organization
 
-  validates :name, :address, :organization, presence: true
+  validates :name, :address, presence: true
   validates :contact_name, length: {minimum: 3}, allow_blank: true
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email format"}, allow_blank: true
 

--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -20,8 +20,6 @@ class InventoryItem < ApplicationRecord
   belongs_to :item
 
   validates :quantity, presence: true
-  validates :storage_location_id, presence: true
-  validates :item_id, presence: true
 
   scope :by_partner_key, ->(partner_key) { joins(:item).merge(Item.by_partner_key(partner_key)) }
   scope :active, -> { joins(:item).where(items: {active: true}) }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -36,7 +36,6 @@ class Item < ApplicationRecord
 
   validates :name, uniqueness: { scope: :organization, case_sensitive: false, message: "- An item with that name already exists (could be an inactive item)" }
   validates :name, presence: true
-  validates :organization, presence: true
   validates :distribution_quantity, numericality: { greater_than: 0 }, allow_blank: true
   validates :on_hand_recommended_quantity, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
   validates :on_hand_minimum_quantity, numericality: { greater_than_or_equal_to: 0 }
@@ -115,7 +114,7 @@ class Item < ApplicationRecord
   end
 
   def self.barcodes_for(item)
-    BarcodeItem.where("barcodeable_id = ?", item.id)
+    BarcodeItem.where(barcodeable_id: item.id)
   end
 
   def self.reactivate(item_ids)

--- a/app/models/item_category.rb
+++ b/app/models/item_category.rb
@@ -12,7 +12,6 @@
 class ItemCategory < ApplicationRecord
   has_paper_trail
   validates :name, presence: true, uniqueness: { scope: :organization_id }
-  validates :organization, presence: true
   validates :description, length: { maximum: 250 }
 
   belongs_to :organization

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -20,7 +20,6 @@ class LineItem < ApplicationRecord
   belongs_to :itemizable, polymorphic: true, inverse_of: :line_items, optional: false
   belongs_to :item
 
-  validates :item_id, presence: true
   validates :quantity, numericality: { only_integer: true, message: "is not a number. Note: commas are not allowed" }
   validate :quantity_must_be_a_number_within_range
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -39,7 +39,7 @@ class Organization < ApplicationRecord
   has_paper_trail
   resourcify
 
-  DIAPER_APP_LOGO = Rails.root.join("public", "img", "humanessentials_logo.png")
+  DIAPER_APP_LOGO = Rails.public_path.join("img", "humanessentials_logo.png")
 
   include Deadlinable
 
@@ -106,7 +106,7 @@ class Organization < ApplicationRecord
   end
   has_many :distributions, dependent: :destroy do
     def upcoming
-      this_week.scheduled.where('issued_at >= ?', Time.zone.today)
+      this_week.scheduled.where(issued_at: Time.zone.today..)
     end
   end
 
@@ -293,6 +293,6 @@ class Organization < ApplicationRecord
   end
 
   def logo_size_check
-    errors.add(:logo, 'File size is greater than 1 MB') if logo.byte_size > 1.megabyte
+    errors.add(:logo, 'File size is greater than 1 MB') if logo.byte_size > 1.megabytes
   end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -45,7 +45,6 @@ class Partner < ApplicationRecord
 
   has_many_attached :documents
 
-  validates :organization, presence: true
   validates :name, presence: true, uniqueness: { scope: :organization }
 
   validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP }
@@ -258,7 +257,7 @@ class Partner < ApplicationRecord
   def quantity_year_to_date
     distributions
       .includes(:line_items)
-      .where('distributions.issued_at >= ?', Time.zone.today.beginning_of_year)
+      .where(distributions: { issued_at: Time.zone.today.beginning_of_year.. })
       .references(:line_items).map(&:line_items).flatten.sum(&:quantity)
   end
 

--- a/app/models/partner_group.rb
+++ b/app/models/partner_group.rb
@@ -19,7 +19,6 @@ class PartnerGroup < ApplicationRecord
   has_many :partners, dependent: :nullify
   has_and_belongs_to_many :item_categories
 
-  validates :organization, presence: true
   validates :name, presence: true, uniqueness: { scope: :organization }
   validates :deadline_day, :reminder_day, presence: true, if: :send_reminders?
 end

--- a/app/models/partners/profile.rb
+++ b/app/models/partners/profile.rb
@@ -101,7 +101,7 @@ module Partners
     validate :has_at_least_one_request_setting
     validate :pick_up_email_addresses
 
-    self.ignored_columns = %w[
+    self.ignored_columns += %w[
       evidence_based_description
       program_client_improvement
       incorporate_plan

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -42,7 +42,7 @@ class StorageLocation < ApplicationRecord
                           dependent: :destroy
   has_many :kit_allocations, dependent: :destroy
 
-  validates :name, :address, :organization, presence: true
+  validates :name, :address, presence: true
   validates :warehouse_type, inclusion: { in: WAREHOUSE_TYPES },
                              allow_blank: true
   before_destroy :validate_empty_inventory, prepend: true

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -30,7 +30,6 @@ class Transfer < ApplicationRecord
   }
   scope :during, ->(range) { where(created_at: range) }
 
-  validates :from, :to, :organization, presence: true
   validate :storage_locations_belong_to_organization
   validate :storage_locations_must_be_different
   validate :from_storage_quantities

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -15,12 +15,12 @@ class OrganizationUpdateService
       org_params = params.dup
 
       if org_params.has_key?("partner_form_fields")
-        org_params["partner_form_fields"] = org_params["partner_form_fields"].reject(&:blank?)
+        org_params["partner_form_fields"] = org_params["partner_form_fields"].compact_blank
       end
 
       if Flipper.enabled?(:enable_packs) && org_params[:request_unit_names]
         # Find or create units for the organization
-        request_unit_ids = org_params[:request_unit_names].reject(&:blank?).map do |request_unit_name|
+        request_unit_ids = org_params[:request_unit_names].compact_blank.map do |request_unit_name|
           Unit.find_or_create_by(organization: organization, name: request_unit_name).id
         end
         org_params.delete(:request_unit_names)

--- a/config/initializers/action_view.rb
+++ b/config/initializers/action_view.rb
@@ -1,2 +1,0 @@
-# this is to enable the MoneyRails::ActionViewExtension in the helper files as they load
-require "action_view/base"

--- a/lib/seeds.rb
+++ b/lib/seeds.rb
@@ -1,7 +1,7 @@
 module Seeds
   def self.seed_base_items
     # Initial starting qty for our test organizations
-    base_items = File.read(Rails.root.join("db", "base_items.json"))
+    base_items = Rails.root.join("db", "base_items.json").read
     items_by_category = JSON.parse(base_items)
 
     items_by_category.each do |category, entries|

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe TransfersController, type: :controller do
 
         context 'when date parameters are supplied' do
           it 'only returns the correct obejects' do
-            start_date = 3.days.ago.to_formatted_s(:date_picker)
-            end_date = Time.zone.today.to_formatted_s(:date_picker)
+            start_date = 3.days.ago.to_fs(:date_picker)
+            end_date = Time.zone.today.to_fs(:date_picker)
             get :index, params: { filters: { date_range: "#{start_date} - #{end_date}" } }
             expect(assigns(:transfers)).to eq([new_transfer])
           end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
       sequence(:email) { |n| "partner_user_#{n}@example.com" }
       password { "password!" }
       password_confirmation { "password!" }
-      invitation_sent_at { Time.current - 1.day }
+      invitation_sent_at { 1.day.ago }
       last_sign_in_at { Time.current }
       organization { nil }
       transient do

--- a/spec/jobs/partner_mailer_job_spec.rb
+++ b/spec/jobs/partner_mailer_job_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe PartnerMailerJob, type: :job do
     let(:mailer_subject) { 'PartnerMailerJob subject' }
     let(:distribution) { create :distribution }
 
-    let(:past_distribution) { create(:distribution, issued_at: Time.zone.now - 1.week) }
-    let(:future_distribution) { create(:distribution, issued_at: Time.zone.now + 1.week) }
+    let(:past_distribution) { create(:distribution, issued_at: 1.week.ago) }
+    let(:future_distribution) { create(:distribution, issued_at: 1.week.from_now) }
     let(:distribution_changes) { {} }
 
     it "does not send mail for past distributions" do

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe Distribution, type: :model do
   it_behaves_like "itemizable"
 
   context "Validations >" do
-    it { should validate_presence_of(:organization) }
-    it { should validate_presence_of(:partner) }
-    it { should validate_presence_of(:storage_location) }
-
     it "ensures the associated line_items are valid" do
       organization = create(:organization)
       storage_location = create(:storage_location, organization: organization)
@@ -95,7 +91,7 @@ RSpec.describe Distribution, type: :model do
         create(:distribution, issued_at: Date.yesterday)
         # and one outside the range
         create(:distribution, issued_at: 1.year.ago)
-        expect(Distribution.during(Time.zone.now - 1.week..Time.zone.now + 2.days).size).to eq(2)
+        expect(Distribution.during(1.week.ago..2.days.from_now).size).to eq(2)
       end
     end
 
@@ -103,10 +99,6 @@ RSpec.describe Distribution, type: :model do
       context "When it's Sunday (end of the week)" do
         before do
           travel_to Time.zone.local(2019, 6, 30)
-        end
-
-        after do
-          travel_back
         end
 
         it "doesn't include distributions past Sunday" do
@@ -121,10 +113,6 @@ RSpec.describe Distribution, type: :model do
       context "When it's Tuesday (mid-week)" do
         before do
           travel_to Time.zone.local(2019, 7, 2)
-        end
-
-        after do
-          travel_back
         end
 
         it "includes distributions as early as Monday and as late as upcoming Sunday" do
@@ -143,10 +131,6 @@ RSpec.describe Distribution, type: :model do
       context "when the current date is December 31, 2023" do
         before do
           travel_to Time.zone.local(2023, 12, 31)
-        end
-
-        after do
-          travel_back
         end
 
         it "includes distributions issued within the last 12 months" do

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Donation, type: :model do
         create(:donation, issued_at: Date.yesterday)
         # and one outside the range
         create(:donation, issued_at: 1.year.ago)
-        expect(Donation.during(1.month.ago..Time.zone.now + 2.days).size).to eq(2)
+        expect(Donation.during(1.month.ago..2.days.from_now).size).to eq(2)
       end
     end
 

--- a/spec/models/item_category_spec.rb
+++ b/spec/models/item_category_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe ItemCategory, type: :model do
 
     it { should validate_presence_of(:name) }
     it { should validate_uniqueness_of(:name).scoped_to(:organization_id) }
-    it { should validate_presence_of(:organization) }
     it { should validate_length_of(:description).is_at_most(250) }
   end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Organization, type: :model do
     end
 
     it "validates that attachment file size is not higher than 1 MB" do
-      fixture_path = File.join(Rails.root, 'spec', 'fixtures', 'files', 'logo.jpg')
+      fixture_path = Rails.root.join('spec', 'fixtures', 'files', 'logo.jpg')
       fixture_file = File.open(fixture_path)
       organization = build(:organization)
 
@@ -129,10 +129,6 @@ RSpec.describe Organization, type: :model do
       describe "upcoming" do
         before do
           travel_to Time.zone.local(2019, 7, 3) # Wednesday
-        end
-
-        after do
-          travel_back
         end
 
         it "retrieves the distributions scheduled for this week that have not yet happened" do

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Purchase, type: :model do
         # and one outside the range
         create(:purchase, issued_at: 1.year.ago)
 
-        expect(Purchase.during(1.month.ago..Time.zone.now + 2.days).size).to eq(2)
+        expect(Purchase.during(1.month.ago..2.days.from_now).size).to eq(2)
       end
     end
   end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe StorageLocation, type: :model do
   context "Validations >" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:address) }
-    it { is_expected.to validate_presence_of(:organization) }
   end
 
   context "Callbacks >" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -122,9 +122,9 @@ RSpec.describe User, type: :model do
     end
 
     it "#reinvitable?" do
-      expect(build(:user, invitation_sent_at: Time.current - 7.days).reinvitable?).to be true
-      expect(build(:user, invitation_sent_at: Time.current - 6.days).reinvitable?).to be false
-      expect(build(:user, invitation_sent_at: Time.current - 7.days, invitation_accepted_at: Time.current - 7.days).reinvitable?).to be false
+      expect(build(:user, invitation_sent_at: 7.days.ago).reinvitable?).to be true
+      expect(build(:user, invitation_sent_at: 6.days.ago).reinvitable?).to be false
+      expect(build(:user, invitation_sent_at: 7.days.ago, invitation_accepted_at: 7.days.ago).reinvitable?).to be false
     end
 
     it "discarded?" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -174,9 +174,11 @@ RSpec.configure do |config|
     Faker::UniqueGenerator.clear # Clears used values to avoid retry limit exceeded error
   end
 
+  # rubocop:disable Rails/RedundantTravelBack
   config.after(:each) do
     travel_back
   end
+  # rubocop:enable Rails/RedundantTravelBack
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Organizations", type: :request do
       end
 
       it "can re-invite a user to an organization after 7 days" do
-        create(:user, name: "Ye Olde Invited User", invitation_sent_at: Time.current - 7.days)
+        create(:user, name: "Ye Olde Invited User", invitation_sent_at: 7.days.ago)
         get organization_path
         expect(response.body).to include("Re-send invitation")
       end

--- a/spec/requests/reports/distributions_summary_requests_spec.rb
+++ b/spec/requests/reports/distributions_summary_requests_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Distributions", type: :request do
           create :distribution, :with_items, item_quantity: 17, issued_at: 30.days.ago, organization: organization
         end
 
-        let(:formatted_date_range) { date_range.map { _1.to_formatted_s(:date_picker) }.join(" - ") }
+        let(:formatted_date_range) { date_range.map { _1.to_fs(:date_picker) }.join(" - ") }
 
         before do
           get reports_distributions_summary_path, params: {filters: {date_range: formatted_date_range}}

--- a/spec/requests/reports/donations_summary_spec.rb
+++ b/spec/requests/reports/donations_summary_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Reports::DonationsSummary", type: :request do
           create :donation, :with_items, item_quantity: 17, issued_at: 30.days.ago, organization: organization
         end
 
-        let(:formatted_date_range) { date_range.map { _1.to_formatted_s(:date_picker) }.join(" - ") }
+        let(:formatted_date_range) { date_range.map { _1.to_fs(:date_picker) }.join(" - ") }
 
         before do
           get reports_donations_summary_path(user.organization), params: {filters: {date_range: formatted_date_range}}

--- a/spec/requests/reports/manufacturer_donations_summary_spec.rb
+++ b/spec/requests/reports/manufacturer_donations_summary_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Reports::ManufacturerDonationsSummary", type: :request do
       end
 
       context "with manufacturer donations in the last year" do
-        let(:formatted_date_range) { date_range.map { _1.to_formatted_s(:date_picker) }.join(" - ") }
+        let(:formatted_date_range) { date_range.map { _1.to_fs(:date_picker) }.join(" - ") }
         let(:date_range) { [1.year.ago, 0.days.ago] }
         let!(:donations) do
           [

--- a/spec/requests/reports/product_drives_summary_spec.rb
+++ b/spec/requests/reports/product_drives_summary_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Reports::ProductDrivesSummary", type: :request do
         create :product_drive_donation, :with_items, item_quantity: 117, money_raised: 1700, issued_at: 30.days.ago, organization: organization
       end
 
-      let(:formatted_date_range) { date_range.map { _1.to_formatted_s(:date_picker) }.join(" - ") }
+      let(:formatted_date_range) { date_range.map { _1.to_fs(:date_picker) }.join(" - ") }
 
       before do
         get reports_product_drives_summary_path(user.organization), params: {filters: {date_range: formatted_date_range}}

--- a/spec/requests/reports/purchases_summary_requests_spec.rb
+++ b/spec/requests/reports/purchases_summary_requests_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Purchases", type: :request do
         create :purchase, :with_items, item_quantity: 17, issued_at: 30.days.ago, organization: organization
       end
 
-      let(:formatted_date_range) { date_range.map { _1.to_formatted_s(:date_picker) }.join(" - ") }
+      let(:formatted_date_range) { date_range.map { _1.to_fs(:date_picker) }.join(" - ") }
 
       before do
         get reports_purchases_summary_path, params: {filters: {date_range: formatted_date_range}}

--- a/spec/requests/transfers_requests_spec.rb
+++ b/spec/requests/transfers_requests_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "Transfers", type: :request do
 
           context 'when date parameters are supplied' do
             it 'only returns the correct obejects' do
-              start_date = 3.days.ago.to_formatted_s(:date_picker)
-              end_date = Time.zone.today.to_formatted_s(:date_picker)
+              start_date = 3.days.ago.to_fs(:date_picker)
+              end_date = Time.zone.today.to_fs(:date_picker)
               get transfers_path(filters: { date_range: "#{start_date} - #{end_date}" })
               expect(assigns(:transfers)).to eq([new_transfer])
             end

--- a/spec/services/distribution_reminder_spec.rb
+++ b/spec/services/distribution_reminder_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe DistributionReminder do
   describe "conditionally sending the emails" do
     let(:organization) { create :organization }
 
-    let(:past_distribution) { create(:distribution, issued_at: Time.zone.now - 1.week) }
-    let(:future_distribution) { create(:distribution, issued_at: Time.zone.now + 1.week) }
+    let(:past_distribution) { create(:distribution, issued_at: 1.week.ago) }
+    let(:future_distribution) { create(:distribution, issued_at: 1.week.from_now) }
 
     let(:partner_with_no_reminders) { create :partner, send_reminders: false }
     let(:partner_with_reminders) { create :partner, send_reminders: true }

--- a/spec/services/partners/fetch_partners_to_remind_now_service_spec.rb
+++ b/spec/services/partners/fetch_partners_to_remind_now_service_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe Partners::FetchPartnersToRemindNowService do
     subject { described_class.new.fetch }
     let(:current_day) { 14 }
     before { travel_to(Time.zone.local(2022, 6, current_day, 1, 1, 1)) }
-    after { travel_back }
 
     context "when there is a partner" do
       let!(:partner) { create(:partner) }

--- a/spec/services/sync_ndbn_members_spec.rb
+++ b/spec/services/sync_ndbn_members_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe SyncNDBNMembers do
-  let(:small_input) { File.open(Rails.root.join("spec", "fixtures", "ndbn-small-import.csv")) }
-  let(:invalid_input) { File.open(Rails.root.join("spec", "fixtures", "ndbn-invalid-import.csv")) }
-  let(:invalid_headers) { File.open(Rails.root.join("spec", "fixtures", "ndbn-invalid-header-import.csv")) }
-  let(:non_csv) { File.open(Rails.root.join("spec", "fixtures", "files", "logo.jpg")) }
+  let(:small_input) { Rails.root.join("spec", "fixtures", "ndbn-small-import.csv").open }
+  let(:invalid_input) { Rails.root.join("spec", "fixtures", "ndbn-invalid-import.csv").open }
+  let(:invalid_headers) { Rails.root.join("spec", "fixtures", "ndbn-invalid-header-import.csv").open }
+  let(:non_csv) { Rails.root.join("spec", "fixtures", "files", "logo.jpg").open }
 
   describe "#upload" do
     # NDBN Member Number,Member Name

--- a/spec/support/date_range_picker_shared_example.rb
+++ b/spec/support/date_range_picker_shared_example.rb
@@ -1,5 +1,5 @@
 def date_range_picker_params(start_date, end_date)
-  "#{start_date.to_formatted_s(:date_picker)} - #{end_date.to_formatted_s(:date_picker)}"
+  "#{start_date.to_fs(:date_picker)} - #{end_date.to_fs(:date_picker)}"
 end
 
 def date_range_picker_select_range(range_name)
@@ -34,10 +34,6 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
       sign_in user
     end
 
-    after do
-      travel_back
-    end
-
     it "shows only 4 records" do
       visit subject
       expect(page).to have_css("table tbody tr", count: 4)
@@ -51,13 +47,9 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
       sign_in user
     end
 
-    after do
-      travel_back
-    end
-
     it "shows all the records" do
       visit subject
-      date_range = "#{Time.zone.local(1919, 7, 1).to_formatted_s(:date_picker)} - #{Time.zone.local(2020, 7, 31).to_formatted_s(:date_picker)}"
+      date_range = "#{Time.zone.local(1919, 7, 1).to_fs(:date_picker)} - #{Time.zone.local(2020, 7, 31).to_fs(:date_picker)}"
       fill_in "filters_date_range", with: date_range
       find(:id, 'filters_date_range').native.send_keys(:enter)
       expect(page).to have_css("table tbody tr", count: 6)
@@ -71,15 +63,11 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
       sign_in user
     end
 
-    after do
-      travel_back
-    end
-
     # NOTE: This spec MIGHT be flaky depending on the day of the month.
     # The dates being set may or may not respect the time travelling.
     it "shows only 2 of the records" do
       visit subject
-      date_range = "#{Time.zone.local(2019, 7, 1).to_formatted_s(:date_picker)} - #{Time.zone.local(2019, 7, 31).to_formatted_s(:date_picker)}"
+      date_range = "#{Time.zone.local(2019, 7, 1).to_fs(:date_picker)} - #{Time.zone.local(2019, 7, 31).to_fs(:date_picker)}"
       fill_in "filters_date_range", with: date_range
       find(:id, 'filters_date_range').native.send_keys(:enter)
       expect(page).to have_css("table tbody tr", count: 2)
@@ -89,7 +77,7 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
   context "when choosing a date range that only includes the previous week" do
     it "shows only 1 record" do
       visit subject
-      date_range = "#{Time.zone.local(2019, 7, 22).to_formatted_s(:date_picker)} - #{Time.zone.local(2019, 7, 28).to_formatted_s(:date_picker)}"
+      date_range = "#{Time.zone.local(2019, 7, 22).to_fs(:date_picker)} - #{Time.zone.local(2019, 7, 28).to_fs(:date_picker)}"
       fill_in "filters_date_range", with: date_range
       find(:id, 'filters_date_range').native.send_keys(:enter)
       expect(page).to have_css("table tbody tr", count: 1)

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -497,8 +497,8 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         subject { partner_users_path(partner) }
         let(:partner) { create(:partner, name: "Partner") }
         let(:partner_user) { partner.users.first }
-        let(:invitation_sent_at) { partner_user.invitation_sent_at.to_formatted_s(:date_picker) }
-        let(:last_sign_in_at) { partner_user.last_sign_in_at.to_formatted_s(:date_picker) }
+        let(:invitation_sent_at) { partner_user.invitation_sent_at.to_fs(:date_picker) }
+        let(:last_sign_in_at) { partner_user.last_sign_in_at.to_fs(:date_picker) }
 
         it 'can show users of a partner' do
           visit subject

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe "Purchases", type: :system, js: true do
           visit subject
         end
 
-        after do
-          travel_back
-        end
-
         it "User can click to the new purchase form" do
           find(".fa-plus").click
 

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe "Requests", type: :system, js: true do
     })
   end
 
-  after { travel_back }
-
   context "#index" do
     subject { requests_path }
 


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
Whenever you run `bin/lint` you get this long list of cops that have been added but not configured by our Rubocop config:

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that you can opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Rails/ActionControllerFlashBeforeRender: # new in 2.16
  Enabled: true
Rails/ActionControllerTestCase: # new in 2.14
  Enabled: true
Rails/ActionOrder: # new in 2.17
  Enabled: true
Rails/ActiveSupportOnLoad: # new in 2.16
  Enabled: true
...
```
. Let's use standard-rails and standard-performance to apply those cops.
  
Also let's turn on caching so that linting is faster.

### Type of change
* Developer experience
* Linting

### How Has This Been Tested?
Test suite
