### PR TITLE
Delete backup file after uploading

### DIFF
--- a/lib/tasks/backup_db_rds.rake
+++ b/lib/tasks/backup_db_rds.rake
@@ -19,4 +19,5 @@ task :backup_db_rds => :environment do
 
   logger.info("Uploading #{backup_filename}")
   blob_client.create_block_blob("backups", backup_filename, File.read(backup_filename))
+  File.delete(backup_filename)
 end


### PR DESCRIPTION
This was causing high disk space usage because we weren't cleaning up these files.