### PR TITLE
Fix the issue where the kit should be excluded when the organization is created.

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -197,7 +197,7 @@ class Organization < ApplicationRecord
   end
 
   def self.seed_items(organization = Organization.all)
-    base_items = BaseItem.all.map(&:to_h)
+    base_items = BaseItem.without_kit.map(&:to_h)
 
     Array.wrap(organization).each do |org|
       Rails.logger.info "\n\nSeeding #{org.name}'s items...\n"

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -238,6 +238,14 @@ RSpec.describe Organization, type: :model do
 
         expect(organization.items.count).to eq(1)
       end
+
+      it "should exclude kit" do
+        create(:base_item, name: "Kit", partner_key: "foo")
+
+        Organization.seed_items(organization)
+
+        expect(organization.items.count).to eq(0)
+      end
     end
 
     context "when no organization is provided" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #4887 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
```bash
bundle exec rspec spec/models/organization_spec.rb:232
```
### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
