### PR TITLE
Fix the transfer line item quantity can be negative.

### DIFF
--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -33,6 +33,7 @@ class Transfer < ApplicationRecord
   validate :storage_locations_belong_to_organization
   validate :storage_locations_must_be_different
   validate :from_storage_quantities
+  validate :line_items_quantity_is_positive
 
   def self.csv_export_headers
     ["From", "To", "Comment", "Total Moved"]
@@ -82,5 +83,9 @@ class Transfer < ApplicationRecord
   def insufficient_items
     inventory = View::Inventory.new(organization_id)
     line_items.select { |i| i.quantity > inventory.quantity_for(item_id: i.item_id) }
+  end
+
+  def line_items_quantity_is_positive
+    line_items_quantity_is_at_least(1)
   end
 end

--- a/spec/models/transfer_spec.rb
+++ b/spec/models/transfer_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe Transfer, type: :model do
       })
       expect(transfer).not_to be_valid
     end
+
+    it "requires that the quantity must be positive" do
+      item = create(:item)
+      transfer = build(:transfer, :with_items, item: item, item_quantity: -1)
+      expect(transfer).not_to be_valid
+    end
   end
 
   context "Scopes >" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #4487 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
Only transfers are able to save negative value.
### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
```bash
bundle exec rspec spec/controllers/transfers_controller_spec.rb:64
```
### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
