### PR TITLE
4672: Fix for alignment of table heading and content

### DIFF
--- a/app/views/adjustments/index.html.erb
+++ b/app/views/adjustments/index.html.erb
@@ -76,24 +76,24 @@
             <table class="table">
               <thead>
               <tr>
-                <th class="text-center">Created</th>
-                <th>Organization</th>
-                <th>Storage location</th>
-                <th>Comment</th>
-                <th>Summary</th>
+                <th class="text-left">Created</th>
+                <th class="text-left">Organization</th>
+                <th class="text-left">Storage location</th>
+                <th class="text-left">Comment</th>
+                <th class="text-left">Summary</th>
                 <th>&nbsp;</th>
               </tr>
               </thead>
               <tbody>
               <% @paginated_adjustments.each do |adjustment| %>
                 <tr>
-                  <td class="date">
+                  <td class="date text-left">
                     <time datetime="<%= adjustment.created_at %>"><%= adjustment.created_at.strftime("%B %e, %Y") %></time>
                   </td>
-                  <td><%= adjustment.organization.name %></td>
-                  <td><%= adjustment.storage_location.name %></td>
-                  <td><%= adjustment.comment %></td>
-                  <td><%= pluralize(adjustment.line_items.count, 'change') %></td>
+                  <td class="text-left"><%= adjustment.organization.name %></td>
+                  <td class="text-left"><%= adjustment.storage_location.name %></td>
+                  <td class="text-left"><%= adjustment.comment %></td>
+                  <td class="text-left"><%= pluralize(adjustment.line_items.count, 'change') %></td>
                   <td class="text-right"><%= view_button_to adjustment %></td>
                 </tr>
               <% end %>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -69,24 +69,24 @@
             <table class="table">
               <thead>
               <tr>
-                <th>Created</th>
-                <th>Organization</th>
-                <th>Storage location</th>
-                <th>Summary</th>
-                <th>Status</th>
+                <th class="text-left">Created</th>
+                <th class="text-left">Organization</th>
+                <th class="text-left">Storage location</th>
+                <th class="text-left">Summary</th>
+                <th class="text-left">Status</th>
                 <th class="text-center">Actions</th>
               </tr>
               </thead>
               <tbody>
               <% @audits.each do |audit| %>
                 <tr class="<%= (audit.finalized?) ? 'positive' : (audit.in_progress?) ? 'negative' : 'highlight' %>">
-                  <td>
+                  <td class="text-left">
                     <time datetime="<%= audit.created_at %>"><%= audit.created_at.strftime("%B %e, %Y") %></time>
                   </td>
-                  <td><%= audit.organization.name %></td>
-                  <td><%= audit.storage_location.name %></td>
-                  <td><%= pluralize(audit.line_items.count, 'item') %></td>
-                  <td><%= audit.status.titleize %></td>
+                  <td class="text-left"><%= audit.organization.name %></td>
+                  <td class="text-left"><%= audit.storage_location.name %></td>
+                  <td class="text-left"><%= pluralize(audit.line_items.count, 'item') %></td>
+                  <td class="text-left"><%= audit.status.titleize %></td>
                   <td class="text-center"><%= view_button_to audit %></td>
                 </tr>
               <% end %>

--- a/app/views/barcode_items/_barcode_item_row.html.erb
+++ b/app/views/barcode_items/_barcode_item_row.html.erb
@@ -1,8 +1,8 @@
 <tr>
-  <td><%= barcode_item_row.barcodeable.name %></td>
-  <td><%= barcode_item_row.quantity %></td>
-  <td><%= barcode_item_row.value %></td>
-  <td class="text-right">
+  <td class="text-left"><%= barcode_item_row.barcodeable.name %></td>
+  <td class="text-left"><%= barcode_item_row.quantity %></td>
+  <td class="text-left"><%= barcode_item_row.value %></td>
+  <td class="text-center">
       <%= view_button_to barcode_item_path(barcode_item_row) %>
       <%= edit_button_to edit_barcode_item_path(barcode_item_row) %>
       <%= delete_button_to barcode_item_path(barcode_item_row), { confirm: confirm_delete_msg(barcode_item_row.item.name) } %>

--- a/app/views/barcode_items/index.html.erb
+++ b/app/views/barcode_items/index.html.erb
@@ -70,9 +70,9 @@
             <table class="table">
               <thead>
               <tr>
-                <th>Item Type</th>
-                <th>Quantity in the Box</th>
-                <th>Barcode</th>
+                <th class="text-left">Item Type</th>
+                <th class="text-left">Quantity in the Box</th>
+                <th class="text-left">Barcode</th>
                 <th class="text-center">Actions</th>
               </tr>
               </thead>

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -1,19 +1,19 @@
 <tr <%= 'class="highlight"' if distribution_row.id == @highlight_id %>>
-  <td><%= distribution_row.id %></td>
-  <td><%= distribution_row.partner.name %></td>
-  <td class="date"><%= distribution_row.created_at.strftime("%m/%d/%Y") %></td>
-  <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %></td>
-  <td><%= distribution_row.storage_location.name %></td>
+  <td class="text-left"><%= distribution_row.id %></td>
+  <td class="text-left"><%= distribution_row.partner.name %></td>
+  <td class="date text-left"><%= distribution_row.created_at.strftime("%m/%d/%Y") %></td>
+  <td class="date text-left"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %></td>
+  <td class="text-left"><%= distribution_row.storage_location.name %></td>
 
-  <td class="numeric"><%= @distribution_totals.fetch_quantity(distribution_row.id) %></td>
-  <td class="numeric"><%= dollar_value(@distribution_totals.fetch_value(distribution_row.id)) %></td>
-  <td><%= distribution_row.delivery_method.humanize %></td>
-  <td><%= distribution_shipping_cost(distribution_row.shipping_cost) %></td>
-  <td><%= distribution_row.comment %></td>
-  <td><%= distribution_row.state&.humanize %></td>
+  <td class="numeric text-left"><%= @distribution_totals.fetch_quantity(distribution_row.id) %></td>
+  <td class="numeric text-left"><%= dollar_value(@distribution_totals.fetch_value(distribution_row.id)) %></td>
+  <td class="text-left"><%= distribution_row.delivery_method.humanize %></td>
+  <td class="text-left"><%= distribution_shipping_cost(distribution_row.shipping_cost) %></td>
+  <td class="text-left"><%= distribution_row.comment %></td>
+  <td class="text-left"><%= distribution_row.state&.humanize %></td>
 
   <% distribution_has_inactive_item = @distributions_with_inactive_items.include?(distribution_row.id) %>
-  <td class="text-right">
+  <td class="text-center">
     <%= view_button_to distribution_path(distribution_row) %>
     <% if (!distribution_row.complete? && !distribution_row.future?) || current_user.has_cached_role?(Role::ORG_ADMIN, current_organization) %>
       <%= edit_button_to edit_distribution_path(distribution_row), enabled: !distribution_has_inactive_item %>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -97,29 +97,29 @@
             <table class="table table-hover">
               <thead>
               <tr>
-                <th>ID</th>
-                <th>Partner</th>
-                <th class="date">Initial Allocation</th>
-                <th class="date">Date of Distribution</th>
-                <th>Source Inventory</th>
+                <th class="text-left">ID</th>
+                <th class="text-left">Partner</th>
+                <th class="date text-left">Initial Allocation</th>
+                <th class="date text-left">Date of Distribution</th>
+                <th class="text-left">Source Inventory</th>
 
                 <!-- Quantity -->
                 <% if filter_params[:by_item_id].present? %>
-                  <th class="numeric">Total <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
+                  <th class="numeric text-left">Total <%= @items.find { |i| i.id == filter_params[:by_item_id].to_i }&.name %></th>
                 <% elsif filter_params[:by_item_category_id].present? %>
-                  <th class="numeric">Total in <%= @item_categories.find { |ic| ic.id == filter_params[:by_item_category_id].to_i }&.name %></th>
+                  <th class="numeric text-left">Total in <%= @item_categories.find { |ic| ic.id == filter_params[:by_item_category_id].to_i }&.name %></th>
                 <% else %>
-                  <th class="numeric">Total Items</th>
+                  <th class="numeric text-left">Total Items</th>
                 <% end %>
                 <!-- End Quantity -->
 
-                <th class="numeric">Total Value</th>
+                <th class="numeric text-left">Total Value</th>
 
-                <th>Delivery Method</th>
-                <th>Shipping Cost</th>
-                <th>Comments</th>
-                <th>Status</th>
-                <th class="text-right" style="width: 400px">Actions</th>
+                <th class="text-left">Delivery Method</th>
+                <th class="text-left">Shipping Cost</th>
+                <th class="text-left">Comments</th>
+                <th class="text-left">Status</th>
+                <th class="text-center" style="width: 400px">Actions</th>
               </tr>
               </thead>
               <tbody>

--- a/app/views/purchases/_purchase_row.html.erb
+++ b/app/views/purchases/_purchase_row.html.erb
@@ -1,12 +1,12 @@
 <tr>
-  <td><%= purchase_row.purchased_from_view %></td>
-  <td><%= purchase_row.storage_location.name %></td>
-  <td><%= purchase_row.comment %></td>
-  <td class="numeric"><%= purchase_row.line_items.total %></td>
-  <td class="numeric"><%= purchase_row.line_items.size %></td>
-  <td class="numeric"><%= dollar_value(purchase_row.amount_spent_in_cents) %></td>
-  <td class="numeric"><%= dollar_value(purchase_row.value_per_itemizable) %></td>
-  <td class="date"><%= purchase_row.issued_at.strftime("%F") %></td>
+  <td class="text-left"><%= purchase_row.purchased_from_view %></td>
+  <td class="text-left"><%= purchase_row.storage_location.name %></td>
+  <td class="text-left"><%= purchase_row.comment %></td>
+  <td class="numeric text-left"><%= purchase_row.line_items.total %></td>
+  <td class="numeric text-left"><%= purchase_row.line_items.size %></td>
+  <td class="numeric text-left"><%= dollar_value(purchase_row.amount_spent_in_cents) %></td>
+  <td class="numeric text-left"><%= dollar_value(purchase_row.value_per_itemizable) %></td>
+  <td class="date text-left"><%= purchase_row.issued_at.strftime("%F") %></td>
   <td class="text-right">
     <%= view_button_to purchase_path(purchase_row) %>
   </td>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -77,14 +77,14 @@
             <table class="table">
               <thead>
               <tr>
-                <th>Purchases from</th>
-                <th>Storage Location</th>
-                <th>Comments</th>
-                <th class="text-right">Quantity of Items</th>
-                <th class="text-right">Variety of Items</th>
-                <th class="text-right">Amount spent</th>
-                <th class="text-right">FMV</th>
-                <th class="text-right">Purchased Date</th>
+                <th class="text-left">Purchases from</th>
+                <th class="text-left">Storage Location</th>
+                <th class="text-left">Comments</th>
+                <th class="text-left">Quantity of Items</th>
+                <th class="text-left">Variety of Items</th>
+                <th class="text-left">Amount spent</th>
+                <th class="text-left">FMV</th>
+                <th class="text-left">Purchased Date</th>
                 <th class="text-right">Actions</th>
               </tr>
               </thead>
@@ -93,7 +93,7 @@
               </tbody>
               <tfoot>
               <tr>
-                <td colspan="2" style="text-align: left"><strong>Total</strong></td>
+                <td colspan="2" style="text-align: left" ><strong>Total</strong></td>
                 <td class="numeric">
                   <strong id="purchase_quantity">
                     <%= @purchases_quantity %> (Total)

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -93,7 +93,7 @@
               </tbody>
               <tfoot>
               <tr>
-                <td colspan="2" style="text-align: left" ><strong>Total</strong></td>
+                <td colspan="2" style="text-align: left"><strong>Total</strong></td>
                 <td class="numeric">
                   <strong id="purchase_quantity">
                     <%= @purchases_quantity %> (Total)


### PR DESCRIPTION
Resolves #4672 

### Description
Fix to Match header alignment to the contents on all tables to improve UI and readability.
Fixed the following pages:
1.  Adjustments Listing
2. Aduit Listing
3. Barcode Item Listing
4. Distribution Listing
5. Purchase Listing
   

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Checked the UI manually 

### Screenshots
![Screenshot 2025-01-01 at 3 45 38 PM](https://github.com/user-attachments/assets/b0cce5ad-de4d-456f-9d83-6bb5ce98424d)
![Screenshot 2025-01-01 at 3 45 47 PM](https://github.com/user-attachments/assets/9f5b16f6-2dc4-4038-be46-da20893d85e3)
![Screenshot 2025-01-01 at 3 46 01 PM](https://github.com/user-attachments/assets/01a1919e-ec52-43b9-b951-4685a06aa249)
![Screenshot 2025-01-01 at 3 46 10 PM](https://github.com/user-attachments/assets/0b67fc43-b55a-4d8d-b0d4-b1121a4cf35b)

