### PR TITLE
Fix flaky distributions by county system spec

### DIFF
--- a/app/controllers/distributions_by_county_controller.rb
+++ b/app/controllers/distributions_by_county_controller.rb
@@ -4,8 +4,9 @@ class DistributionsByCountyController < ApplicationController
 
   def report
     setup_date_range_picker
-    start_date = helpers.selected_range.first.iso8601
-    end_date = helpers.selected_range.last.iso8601
+    start_date = helpers.selected_range.first.utc.iso8601
+    end_date = helpers.selected_range.last.utc.iso8601
+
     @breakdown = DistributionSummaryByCountyQuery.call(
       organization_id: current_organization.id,
       start_date: start_date,

--- a/app/queries/distribution_summary_by_county_query.rb
+++ b/app/queries/distribution_summary_by_county_query.rb
@@ -56,6 +56,8 @@ class DistributionSummaryByCountyQuery
   SQL
 
   class << self
+    # Timestamps are stored in Postgres without timezones so
+    # start_date and end_date must be strings in UTC.
     def call(organization_id:, start_date: nil, end_date: nil)
       params = {
         organization_id: organization_id,


### PR DESCRIPTION
Doesn't resolve any issue. Related to #4557 

### Description
I noticed these distributions by county system specs are still flaky. See this CI failure: https://github.com/rubyforgood/human-essentials/actions/runs/12568036610/job/35035172689?pr=4908

Example rspec output:
```
   1) Distributions by County handles time ranges properly works for last 12 months
     Failure/Error: expect(page).to have_text(served_area.county.name)
       expected to find text "County 5" in "Need Help?\n2\nDiaper McDiaperface\n \nDashboard\n \nDonations\n \nPurchases\n \nRequests\n \nDistributions\n \nPick Ups & Deliveries\n \nPartner Agencies\n \nInventory\n \nCommunity\n \nReports\n Activity Graph\n Annual Survey\n History\n Distributions - Summary\n Distributions - By County\n Distributions - Itemized\n Distributions - Trends\n Donations - Summary\n Donations - Itemized\n Donations - Manufacturer\n Donations - Trends\n Product Drives - Summary\n Purchases - Summary\n Purchases - Trends\nEstimated Distributions by County for Some Unique Name\n Home\nDistributions\n Filter\nCounty\tEstimated total items\tEstimated total market value\nUnspecified\t0\t$0.00\nHuman Essentials was built with  by Ruby for Good."

     [Screenshot Image]: /home/runner/work/human-essentials/human-essentials/tmp/capybara/failures_r_spec_example_groups_distributions_by_county_handles_time_ranges_properly_works_for_last_12_months_717.png


     # ./spec/system/distributions_by_county_system_spec.rb:78:in `block (4 levels) in <top (required)>'
     # ./spec/system/distributions_by_county_system_spec.rb:77:in `block (3 levels) in <top (required)>'

  2) Distributions by County handles time ranges properly works for prior year
     Failure/Error: expect(page).to have_text(served_area.county.name)
       expected to find text "County 9" in "Need Help?\nDiaper McDiaperface\n \nDashboard\n \nDonations\n \nPurchases\n \nRequests\n \nDistributions\n \nPick Ups & Deliveries\n \nPartner Agencies\n \nInventory\n \nCommunity\n \nReports\n Activity Graph\n Annual Survey\n History\n Distributions - Summary\n Distributions - By County\n Distributions - Itemized\n Distributions - Trends\n Donations - Summary\n Donations - Itemized\n Donations - Manufacturer\n Donations - Trends\n Product Drives - Summary\n Purchases - Summary\n Purchases - Trends\nEstimated Distributions by County for Some Unique Name\n Home\nDistributions\n Filter\nCounty\tEstimated total items\tEstimated total market value\nUnspecified\t0\t$0.00\nHuman Essentials was built with  by Ruby for Good."

     [Screenshot Image]: /home/runner/work/human-essentials/human-essentials/tmp/screenshots/failures_r_spec_example_groups_distributions_by_county_handles_time_ranges_properly_works_for_prior_year_120.png


     # ./spec/system/distributions_by_county_system_spec.rb:56:in `block (4 levels) in <top (required)>'
     # ./spec/system/distributions_by_county_system_spec.rb:55:in `block (3 levels) in <top (required)>'
```

Reason for flakiness:
We should be returning counties for the valid distribution, but no distribution is found. The test seems to be only flaky during certain times of day, specifically at times when the time difference between PST and UTC results in different days.

The system time zone (for Capybara) and server time zone (Rails) are in PST. But timestamps are stored in the database in UTC time. Normally this isn't an issue because Active Record will convert to UTC for queries. But since this is a raw SQL query we need to convert to UTC. Otherwise the timezone provided is silently ignored. From [Postgres docs](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-INPUT-TIMES):
> If a time zone is specified in the input for time without time zone, it is silently ignored.

Note this is not an issue for production though, because the timezone in production is the default (UTC).

Another solution would be to change the timezone for the test environment to UTC, but there might be a reason for it being Los Angeles time.

### Type of change

<!-- Please delete options that are not relevant. -->

* Flaky test fix

### How Has This Been Tested?
In order add a test for this that reliably fails, we would need to add a JS package to mock the time in the browser (because `travel_to` only sets the time for Rails server, but the headless chrome browser for Capybara will still have the regular time).

Instead to reliably reproduce the failure, I manually set the time to the time at which the CI test failed and indeed this change fixes the issue).

```diff
diff --git a/app/javascript/application.js b/app/javascript/application.js
index bb8df687..ab6629c1 100644
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -78,7 +78,7 @@ $(document).ready(function(){
     if (!rangeElement) {
       return;
     }
-    const today = DateTime.now();
+    const today = DateTime.now(2025, 1, 2, 22, 34, 19);
     const startDate = new Date(rangeElement.dataset["initialStartDate"]);
     const endDate = new Date(rangeElement.dataset["initialEndDate"]);

diff --git a/spec/system/distributions_by_county_system_spec.rb b/spec/system/distributions_by_county_system_spec.rb
index 808e7fa2..b48fe52f 100644
--- a/spec/system/distributions_by_county_system_spec.rb
+++ b/spec/system/distributions_by_county_system_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Distributions by County", type: :system do
   let(:issued_at_last_year) { Time.current.change(year: current_year - 1).to_datetime }

   before do
+    travel_to Time.zone.utc(2025, 1, 2, 22, 34, 19)
     sign_in(user)
     @storage_location = create(:storage_location, organization: organization)
     setup_storage_location(@storage_location)
```
