### PR TITLE
Fix flaky export service spec

### DIFF
--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the 3T Diapers request" do
-        expect(subject[1]).to eq([
+        expect(subject).to include([
           request_3t.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Child",
@@ -127,7 +127,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the 2T Diapers request" do
-        expect(subject[2]).to eq([
+        expect(subject).to include([
           request_2t.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Individual",
@@ -141,7 +141,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the request with deleted items" do
-        expect(subject[3]).to eq([
+        expect(subject).to include([
           request_with_deleted_items.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           nil,
@@ -155,7 +155,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the request with multiple items" do
-        expect(subject[4]).to eq([
+        expect(subject).to include([
           request_with_multiple_items.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           nil,
@@ -169,7 +169,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the request with 4T diapers without pack unit" do
-        expect(subject[5]).to eq([
+        expect(subject).to include([
           request_4t.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Quantity",
@@ -183,7 +183,7 @@ RSpec.describe Exports::ExportRequestService do
       end
 
       it "has expected data for the request with 4T diapers with pack unit" do
-        expect(subject[6]).to eq([
+        expect(subject).to include([
           request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Quantity",
@@ -198,7 +198,7 @@ RSpec.describe Exports::ExportRequestService do
 
       it "has expected data even when the unit was deleted" do
         item_4t.request_units.destroy_all
-        expect(subject[6]).to eq([
+        expect(subject).to include([
           request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
           "Howdy Partner",
           "Quantity",


### PR DESCRIPTION
Doesn't resolve any issue, but related to #4557 

### Description
This is the same fix for a previously flaky test fix #4862. All the tests for this service are duplicated (with and without a feature flag enabled), so when I made that PR I accidentally only applied the fix to half the tests so this PR is needed for the other half.

See example failure here: https://github.com/rubyforgood/human-essentials/actions/runs/12622483605/job/35170445844

### Type of change

* Internal (Test refactor)

### How Has This Been Tested?
Hard to replicate the failure because it depends on Postgres returning records from a `Request.all` query not in the order of creation (id) which it tends to do when there are only a few records in the table. But it should fix the issue.
