### PR TITLE
Perf: Fix slow selectAll and deselectAll highcharts controller methods

### DIFF
--- a/app/javascript/controllers/highchart_controller.js
+++ b/app/javascript/controllers/highchart_controller.js
@@ -18,14 +18,20 @@ export default class extends Controller {
 
   deselectAll() {
     this.chart.series.forEach((s) => {
-      s.hide();
+      // Change series visibility to hidden (first param) without redrawing (second param)
+      s.setVisible(false, false);
     })
+    // Redraw chart only once at the end for performance reasons.
+    this.chart.redraw();
   }
 
   selectAll() {
     this.chart.series.forEach((s) => {
-      s.show();
+      // Change series visibility to visible (first param) without redrawing (second param)
+      s.setVisible(true, false);
     })
+    // Redraw chart only once at the end for performance reasons.
+    this.chart.redraw();
   }
 
 }

--- a/app/views/shared/_highcharts.html.erb
+++ b/app/views/shared/_highcharts.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="highchart" data-highchart-config-value="<%= config %>">
   <div data-highchart-target="chart"></div>
-  <div>
+  <div class="pl-3">
     <button type="button" class="btn btn-sm btn-secondary" data-action="click->highchart#selectAll">Select All</button>
     <button type="button" class="btn btn-sm btn-info" data-action="click->highchart#deselectAll">Deselect All</button>
   </div>


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
While looking into places we use caching (for the solid_cache task), I noticed the 'Select All' and 'Deselect All' buttons in the historical trends pages were really slow.

Reason for slowness:
From this flame graph, you can see that a `redraw` method was being called over and over again.

![image](https://github.com/user-attachments/assets/604f6db1-d389-404d-923f-d27941d69307)

Apparently the `show` and `hide` methods were redrawing the chart after every item (series) had it's visibility changed.

This PR changes it so that the visibility is set for all items and then the chart is redrawn only once.

### Type of change

* Performance (behavior unaffected)

### How Has This Been Tested?
Manually. I couldn't find any system specs for these pages.

### Screenshots
I also moved added a little padding to buttons.

Before
![image](https://github.com/user-attachments/assets/57a75120-1949-4fe7-8b8b-69186adfcccb)

After
![Screenshot from 2025-01-17 13-13-14](https://github.com/user-attachments/assets/a2e75303-c094-4afd-ad73-454d51bf07e1)

