### PR TITLE
Fix questions table annotations after PR #4912

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,12 +2,10 @@
 #
 # Table name: questions
 #
-#  id           :bigint           not null, primary key
-#  for_banks    :boolean          default(TRUE), not null
-#  for_partners :boolean          default(TRUE), not null
-#  title        :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id         :bigint           not null, primary key
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 class Question < ApplicationRecord
   has_paper_trail

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -2,12 +2,10 @@
 #
 # Table name: questions
 #
-#  id           :bigint           not null, primary key
-#  for_banks    :boolean          default(TRUE), not null
-#  for_partners :boolean          default(TRUE), not null
-#  title        :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id         :bigint           not null, primary key
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 FactoryBot.define do
   factory :question do

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -2,12 +2,10 @@
 #
 # Table name: questions
 #
-#  id           :bigint           not null, primary key
-#  for_banks    :boolean          default(TRUE), not null
-#  for_partners :boolean          default(TRUE), not null
-#  title        :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id         :bigint           not null, primary key
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 RSpec.describe Question, type: :model do


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
Running `db:migrate` on the `main` branch after #4912, causes these annotations to be updated.

### Type of change

<!-- Please delete options that are not relevant. -->

* Internal code documentation