### PR TITLE
Fix lingering flash messages

### DIFF
--- a/app/controllers/account_requests_controller.rb
+++ b/app/controllers/account_requests_controller.rb
@@ -25,7 +25,7 @@ class AccountRequestsController < ApplicationController
     @bank_selected = true
 
     if !verify_recaptcha(model: @account_request)
-      flash[:alert] = "Invalid captcha submission"
+      flash.now[:alert] = "Invalid captcha submission"
       render :new
     elsif @account_request.save
       AccountRequestMailer.confirmation(account_request_id: @account_request.id).deliver_later

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -45,7 +45,7 @@ class AdjustmentsController < ApplicationController
       flash[:notice] = "Adjustment was successful."
       redirect_to adjustment_path(@adjustment)
     else
-      flash[:error] = @adjustment.errors.collect { |error| "#{error.attribute}: " + error.message }.join("<br />".html_safe)
+      flash.now[:error] = @adjustment.errors.collect { |error| "#{error.attribute}: " + error.message }.join("<br />".html_safe)
       load_form_collections
       render :new
     end

--- a/app/controllers/admin/barcode_items_controller.rb
+++ b/app/controllers/admin/barcode_items_controller.rb
@@ -10,7 +10,7 @@ class Admin::BarcodeItemsController < AdminController
     if @barcode_item.update(barcode_item_params)
       redirect_to admin_barcode_items_path, notice: "Updated Barcode Item!"
     else
-      flash[:error] = "Failed to update this Barcode Item."
+      flash.now[:error] = "Failed to update this Barcode Item."
       render :edit
     end
   end
@@ -33,7 +33,7 @@ class Admin::BarcodeItemsController < AdminController
       end
     else
       load_base_items
-      flash[:error] = "Failed to create Barcode Item."
+      flash.now[:error] = "Failed to create Barcode Item."
       render :new
     end
   end

--- a/app/controllers/admin/base_items_controller.rb
+++ b/app/controllers/admin/base_items_controller.rb
@@ -12,7 +12,7 @@ class Admin::BaseItemsController < AdminController
     if @base_item.update(base_item_params)
       redirect_to admin_base_items_path, notice: "Updated base item!"
     else
-      flash[:error] = "Failed to update this base item."
+      flash.now[:error] = "Failed to update this base item."
       render :edit
     end
   end
@@ -30,7 +30,7 @@ class Admin::BaseItemsController < AdminController
     if @base_item.save
       redirect_to admin_base_items_path, notice: "Base Item added!"
     else
-      flash[:error] = "Failed to create Base Item."
+      flash.now[:error] = "Failed to create Base Item."
       render :new
     end
   end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -10,7 +10,7 @@ class Admin::OrganizationsController < AdminController
     if OrganizationUpdateService.update(@organization, organization_params)
       redirect_to admin_organizations_path, notice: "Updated organization!"
     else
-      flash[:error] = @organization.errors.full_messages.join("\n")
+      flash.now[:error] = @organization.errors.full_messages.join("\n")
       render :edit
     end
   end
@@ -57,11 +57,11 @@ class Admin::OrganizationsController < AdminController
       SnapshotEvent.publish(@organization) # need one to start with
       redirect_to admin_organizations_path, notice: "Organization added!"
     else
-      flash[:error] = "Failed to create Organization."
+      flash.now[:error] = "Failed to create Organization."
       render :new
     end
   rescue => e
-    flash[:error] = e
+    flash.now[:error] = e
     render :new
   end
 

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -16,7 +16,7 @@ class Admin::PartnersController < AdminController
     if @partner.update(partner_attributes)
       redirect_to admin_partners_path, notice: "#{@partner.name} updated!"
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -12,7 +12,7 @@ class Admin::QuestionsController < AdminController
     if @question.save
       redirect_to admin_questions_path
     else
-      flash[:error] = "Failed to create question. #{@question.punctuate(@question.errors.to_a)}"
+      flash.now[:error] = "Failed to create question. #{@question.punctuate(@question.errors.to_a)}"
       render :new
     end
   end
@@ -26,7 +26,7 @@ class Admin::QuestionsController < AdminController
     if @question.update(question_params)
       redirect_to admin_questions_path
     else
-      flash[:error] = "Failed to update question. #{@question.punctuate(@question.errors.to_a)}"
+      flash.now[:error] = "Failed to update question. #{@question.punctuate(@question.errors.to_a)}"
       render :edit
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -46,7 +46,7 @@ class Admin::UsersController < AdminController
     flash[:notice] = "Created a new user!"
     redirect_to admin_users_path
   rescue => e
-    flash[:error] = "Failed to create user: #{e}"
+    flash.now[:error] = "Failed to create user: #{e}"
     render :new
   end
 

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -36,7 +36,7 @@ class AuditsController < ApplicationController
     if @audit.update(audit_params)
       save_audit_status_and_redirect(params)
     else
-      flash[:error] = @audit.errors.full_messages.join("\n")
+      flash.now[:error] = @audit.errors.full_messages.join("\n")
       @storage_locations = [@audit.storage_location]
       set_items
       @audit.line_items.build if @audit.line_items.empty?
@@ -64,7 +64,7 @@ class AuditsController < ApplicationController
       render :new
     end
   rescue Errors::InsufficientAllotment, InventoryError => e
-    flash[:error] = e.message
+    flash.now[:error] = e.message
     render :new
   end
 
@@ -81,7 +81,7 @@ class AuditsController < ApplicationController
       attr = (error.attribute.to_s == 'base') ? '' : error.attribute.capitalize
       "#{attr} ".tr("_", " ") + error.message
     end
-    flash[:error] = error_message.join(", ")
+    flash.now[:error] = error_message.join(", ")
   end
 
   def set_audit

--- a/app/controllers/barcode_items_controller.rb
+++ b/app/controllers/barcode_items_controller.rb
@@ -27,7 +27,7 @@ class BarcodeItemsController < ApplicationController
         format.html { redirect_to barcode_items_path, notice: msg }
       end
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :new
     end
   end
@@ -78,7 +78,7 @@ class BarcodeItemsController < ApplicationController
     if @barcode_item.update(barcode_item_params)
       redirect_to barcode_items_path, notice: "Barcode updated!"
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -207,7 +207,7 @@ class DistributionsController < ApplicationController
       perform_inventory_check
       redirect_to @distribution, notice: "Distribution updated!"
     else
-      flash[:error] = insufficient_error_message(result.error.message)
+      flash.now[:error] = insufficient_error_message(result.error.message)
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @distribution.initialize_request_items
       @items = current_organization.items.active.alphabetized

--- a/app/controllers/donation_sites_controller.rb
+++ b/app/controllers/donation_sites_controller.rb
@@ -22,7 +22,7 @@ class DonationSitesController < ApplicationController
         end
       else
         format.html do
-          flash[:error] = "Something didn't work quite right -- try again?"
+          flash.now[:error] = "Something didn't work quite right -- try again?"
           render action: :new
         end
       end
@@ -47,7 +47,7 @@ class DonationSitesController < ApplicationController
     if @donation_site.update(donation_site_params)
       redirect_to donation_sites_path, notice: "#{@donation_site.name} updated!"
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -63,7 +63,7 @@ class DonationsController < ApplicationController
     rescue => e
       load_form_collections
       @donation.line_items.build if @donation.line_items.count.zero?
-      flash[:error] = "There was an error starting this donation: #{e.message}"
+      flash.now[:error] = "There was an error starting this donation: #{e.message}"
       Rails.logger.error "[!] DonationsController#create Error: #{e.message}"
       render action: :new
     end
@@ -98,7 +98,7 @@ class DonationsController < ApplicationController
     flash[:notice] = "Donation updated!"
     redirect_to donations_path
   rescue => e
-    flash[:alert] = "Error updating donation: #{e.message}"
+    flash.now[:alert] = "Error updating donation: #{e.message}"
     load_form_collections
     # calling new(donation_params) triggers a validation error if line_item quantity is invalid
     @previous_input = Donation.new(donation_params.except(:line_items_attributes))

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,7 @@ class ItemsController < ApplicationController
       # the provided parameters. This is required to render the page again
       # with the error + the invalid parameters
       @item = current_organization.items.new(item_params)
-      flash[:error] = result.error.record.errors.full_messages.to_sentence
+      flash.now[:error] = result.error.record.errors.full_messages.to_sentence
       render action: :new
     end
   end
@@ -77,7 +77,7 @@ class ItemsController < ApplicationController
     deactivated = @item.active_changed? && !@item.active
     if deactivated && !@item.can_deactivate?
       @base_items = BaseItem.without_kit.alphabetized
-      flash[:error] = "Can't deactivate this item - it is currently assigned to either an active kit or a storage location!"
+      flash.now[:error] = "Can't deactivate this item - it is currently assigned to either an active kit or a storage location!"
       render action: :edit
       return
     end
@@ -86,7 +86,7 @@ class ItemsController < ApplicationController
       redirect_to items_path, notice: "#{@item.name} updated!"
     else
       @base_items = BaseItem.without_kit.alphabetized
-      flash[:error] = "Something didn't work quite right -- try again? #{@item.errors.map { |error| "#{error.attribute}: #{error.message}" }}"
+      flash.now[:error] = "Something didn't work quite right -- try again? #{@item.errors.map { |error| "#{error.attribute}: #{error.message}" }}"
       render action: :edit
     end
   end

--- a/app/controllers/kits_controller.rb
+++ b/app/controllers/kits_controller.rb
@@ -23,7 +23,7 @@ class KitsController < ApplicationController
       flash[:notice] = "Kit created successfully"
       redirect_to kits_path
     else
-      flash[:error] = kit_creation.errors
+      flash.now[:error] = kit_creation.errors
         .map { |error| formatted_error_message(error) }
         .join(", ")
 

--- a/app/controllers/manufacturers_controller.rb
+++ b/app/controllers/manufacturers_controller.rb
@@ -10,7 +10,7 @@ class ManufacturersController < ApplicationController
         format.html { redirect_to manufacturers_path, notice: "New Manufacturer added!" }
         format.js
       else
-        flash[:error] = "Something didn't work quite right -- try again?"
+        flash.now[:error] = "Something didn't work quite right -- try again?"
         format.html { render action: :new }
         format.js { render template: "manufacturers/new_modal" }
       end
@@ -40,7 +40,7 @@ class ManufacturersController < ApplicationController
       redirect_to manufacturers_path, notice: "#{@manufacturer.name} updated!"
 
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -18,7 +18,7 @@ class OrganizationsController < ApplicationController
     if OrganizationUpdateService.update(@organization, organization_params)
       redirect_to organization_path, notice: "Updated your organization!"
     else
-      flash[:error] = @organization.errors.full_messages.join("\n")
+      flash.now[:error] = @organization.errors.full_messages.join("\n")
       render :edit
     end
   end

--- a/app/controllers/partner_groups_controller.rb
+++ b/app/controllers/partner_groups_controller.rb
@@ -12,7 +12,7 @@ class PartnerGroupsController < ApplicationController
       # Redirect to groups tab in Partner page.
       redirect_to partners_path + "#nav-partner-groups", notice: "Partner group added!"
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       set_items_categories
       render action: :new
     end
@@ -28,7 +28,7 @@ class PartnerGroupsController < ApplicationController
     if @partner_group.update(partner_group_params)
       redirect_to partners_path + "#nav-partner-groups", notice: "Partner group edited!"
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       set_items_categories
       render action: :edit
     end

--- a/app/controllers/partner_users_controller.rb
+++ b/app/controllers/partner_users_controller.rb
@@ -20,7 +20,7 @@ class PartnerUsersController < ApplicationController
       redirect_back(fallback_location: "/",
         notice: "#{@user.name} has been invited. Invitation email sent to #{@user.email}")
     else
-      flash[:alert] = "Invitation failed. Check the form for errors."
+      flash.now[:alert] = "Invitation failed. Check the form for errors."
       @users = @partner.users
       render :index
     end

--- a/app/controllers/partners/users_controller.rb
+++ b/app/controllers/partners/users_controller.rb
@@ -18,7 +18,7 @@ module Partners
         flash[:success] = "User information was successfully updated!"
         redirect_to edit_partners_user_path(@user)
       else
-        flash[:error] = "Failed to update this user."
+        flash.now[:error] = "Failed to update this user."
         render :edit
       end
     end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -31,7 +31,7 @@ class PartnersController < ApplicationController
     if svc.errors.none?
       redirect_to partners_path, notice: "Partner #{@partner.name} added!"
     else
-      flash[:error] = "Failed to add partner due to: #{svc.errors.full_messages}"
+      flash.now[:error] = "Failed to add partner due to: #{svc.errors.full_messages}"
       render action: :new
     end
   end
@@ -101,7 +101,7 @@ class PartnersController < ApplicationController
     if @partner.update(partner_params)
       redirect_to partner_path(@partner), notice: "#{@partner.name} updated!"
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/product_drive_participants_controller.rb
+++ b/app/controllers/product_drive_participants_controller.rb
@@ -21,7 +21,7 @@ class ProductDriveParticipantsController < ApplicationController
         format.html { redirect_to product_drive_participants_path, notice: "New product drive participant added!" }
         format.js
       else
-        flash[:error] = "Something didn't work quite right -- try again?"
+        flash.now[:error] = "Something didn't work quite right -- try again?"
         format.html { render action: :new }
         format.js { render template: "product_drive_participants/new_modal" }
       end
@@ -51,7 +51,7 @@ class ProductDriveParticipantsController < ApplicationController
       redirect_to product_drive_participants_path, notice: "#{@product_drive_participant.contact_name} updated!"
 
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -38,7 +38,7 @@ class ProductDrivesController < ApplicationController
         format.html { redirect_to product_drives_path, notice: "New product drive added!" }
         format.js
       else
-        flash[:error] = "Something didn't work quite right -- try again?"
+        flash.now[:error] = "Something didn't work quite right -- try again?"
         format.html { render action: :new }
         format.js { render template: "product_drives/new_modal" }
       end
@@ -70,7 +70,7 @@ class ProductDrivesController < ApplicationController
       redirect_to product_drives_path, notice: "#{@product_drive.name} updated!"
 
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -46,7 +46,7 @@ class PurchasesController < ApplicationController
     rescue => e
       load_form_collections
       @purchase.line_items.build if @purchase.line_items.count.zero?
-      flash[:error] = "Failed to create purchase due to:\n#{e.message}"
+      flash.now[:error] = "Failed to create purchase due to:\n#{e.message}"
       Rails.logger.error "[!] PurchasesController#create ERROR: #{e.message}"
       render action: :new
     end
@@ -79,7 +79,7 @@ class PurchasesController < ApplicationController
     redirect_to purchases_path
   rescue => e
     load_form_collections
-    flash[:alert] = "Error updating purchase: #{e.message}"
+    flash.now[:alert] = "Error updating purchase: #{e.message}"
     render "edit"
   end
 

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -40,7 +40,7 @@ class StorageLocationsController < ApplicationController
     if @storage_location.save
       redirect_to storage_locations_path, notice: "New storage location added!"
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :new
     end
   end
@@ -98,7 +98,7 @@ class StorageLocationsController < ApplicationController
     if @storage_location.update(storage_location_params)
       redirect_to storage_locations_path, notice: "#{@storage_location.name} updated!"
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -25,7 +25,7 @@ class TransfersController < ApplicationController
     TransferCreateService.call(@transfer)
     redirect_to transfers_path, notice: "#{@transfer.line_items.total} items have been transferred from #{@transfer.from.name} to #{@transfer.to.name}!"
   rescue StandardError => e
-    flash[:error] = e.message
+    flash.now[:error] = e.message
     load_form_collections
     @transfer.line_items.build if @transfer.line_items.empty?
     render :new

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -18,7 +18,7 @@ class VendorsController < ApplicationController
         format.html { redirect_to vendors_path, notice: "New vendor added!" }
         format.js
       else
-        flash[:error] = "Something didn't work quite right -- try again?"
+        flash.now[:error] = "Something didn't work quite right -- try again?"
         format.html { render action: :new }
         format.js { render template: "vendors/new_modal" }
       end
@@ -48,7 +48,7 @@ class VendorsController < ApplicationController
       redirect_to vendors_path, notice: "#{@vendor.contact_name} updated!"
 
     else
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash.now[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
I've noticed an issue with lingering flash messages throughout the app, where I get an error/notice flash message but then it seems to stick around for an extra request.

Example with lingering flash message:
Attempt to create a purchase that is invalid (set the date to 3000 or something), and click save. The validation error flash message appears at the top of the page. Then click another link (for example to the dashboard), you will see the validation error is still there. Until you refresh or click another link, and then it will disappear.

Example without this issue:
Attempt to create a distribution that is invalid (set the date to the year 3000 for example), and click save. The validation error flash message appears. But if you click any other link, the message disappears. (Which I think is the correct behavior).

This PR fixes this issue by only rendering the flash message once. (In controller actions when we are rendering a template, we should be using `flash.now` instead of `flash` as per the [Rails docs](https://guides.rubyonrails.org/action_controller_overview.html#flash-keep-and-flash-now).)

### Type of change

* Bug fix (non-breaking change which fixes an issue)
I'm assuming this isn't intended behavior so I guess it would be categorized as a bug.

### How Has This Been Tested?

Running the test quite and some light manual testing. (Although there are many instances of this behavior and I did not manually test all of them.)

### Screenshots
Screenshot of seeing an unrelated flash message for the given page (purchase creation error after going to the requests page):
![image](https://github.com/user-attachments/assets/49390bb9-8cf4-435a-853d-bfee3af90c83)

