### PR TITLE
Remove unused methods from Organization model

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -167,10 +167,6 @@ class Organization < ApplicationRecord
     street_changed? || city_changed? || state_changed? || zipcode_changed?
   end
 
-  def total_inventory
-    View::Inventory.total_inventory(id)
-  end
-
   def self.seed_items(organization = Organization.all)
     base_items = BaseItem.without_kit.map(&:to_h)
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -62,6 +62,8 @@ class Organization < ApplicationRecord
     has_many :product_drives
     has_many :donation_sites
     has_many :donations
+    has_many :items
+    has_many :item_categories
     has_many :manufacturers
     has_many :partners
     has_many :partner_groups
@@ -76,29 +78,6 @@ class Organization < ApplicationRecord
     has_many :request_units, class_name: 'Unit'
   end
 
-  has_many :items, dependent: :destroy do
-    def other
-      where(partner_key: "other")
-    end
-
-    def during(date_start, date_end = Time.zone.now.strftime("%Y-%m-%d"))
-      select("COUNT(line_items.id) as amount, name")
-        .joins(:line_items)
-        .where("line_items.created_at BETWEEN ? and ?", date_start, date_end)
-        .group(:name)
-    end
-
-    def top(limit = 5)
-      order('count(line_items.id) DESC')
-        .limit(limit)
-    end
-
-    def bottom(limit = 5)
-      order('count(line_items.id) ASC')
-        .limit(limit)
-    end
-  end
-  has_many :item_categories, dependent: :destroy
   has_many :barcode_items, dependent: :destroy do
     def all
       unscope(where: :organization_id).where("barcode_items.organization_id = ? OR barcode_items.barcodeable_type = ?", proxy_association.owner.id, "BaseItem")
@@ -188,10 +167,6 @@ class Organization < ApplicationRecord
     street_changed? || city_changed? || state_changed? || zipcode_changed?
   end
 
-  def address_inline
-    address.split("\n").map(&:strip).join(", ")
-  end
-
   def total_inventory
     View::Inventory.total_inventory(id)
   end
@@ -237,10 +212,6 @@ class Organization < ApplicationRecord
     valid_items.each_with_object({}) do |item, hash|
       hash[item[:id].to_i] = item[:name]
     end
-  end
-
-  def valid_items_for_select
-    valid_items.map { |item| [item[:name], item[:id]] }.sort
   end
 
   def from_email

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -149,10 +149,6 @@ class Organization < ApplicationRecord
     short_name
   end
 
-  def display_users
-    users.map(&:email).join(", ")
-  end
-
   def ordered_requests
     requests.order(status: :asc, updated_at: :desc)
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -140,68 +140,6 @@ RSpec.describe Organization, type: :model do
         end
       end
     end
-
-    describe "items" do
-      let(:organization) { create(:organization, :with_items) }
-
-      before do
-        organization.items.each_with_index do |item, index|
-          (index + 1).times { LineItem.create!(quantity: rand(250..500), item: item, itemizable: Distribution.new) }
-        end
-      end
-
-      describe ".other" do
-        it "returns all items for this organization designated 'other'" do
-          create(:item, name: "SOMETHING", partner_key: "other", organization: organization)
-          expect(organization.items.other.size).to eq(2)
-        end
-      end
-
-      describe ".during" do
-        it "return ranking of all items" do
-          ranking_items = organization.items.during('1950-01-01', '3000-01-01')
-          expect(ranking_items.length).to eq(organization.items.length)
-        end
-      end
-
-      describe ".during.top" do
-        it "return just 3 elements" do
-          ranking_items = organization.items.during('1950-01-01', '3000-01-01').top(3)
-          expect(ranking_items.length).to eq(3)
-        end
-        it "return 3 most used items" do
-          ranking_items = organization.items.during('1950-01-01', '3000-01-01').top(3)
-
-          expect(ranking_items[0].amount).to eq(organization.items.length)
-          expect(ranking_items[0].name).to eq(organization.items[organization.items.length - 1].name)
-
-          expect(ranking_items[1].amount).to eq(organization.items.length - 1)
-          expect(ranking_items[1].name).to eq(organization.items[organization.items.length - 2].name)
-
-          expect(ranking_items[2].amount).to eq(organization.items.length - 2)
-          expect(ranking_items[2].name).to eq(organization.items[organization.items.length - 3].name)
-        end
-      end
-
-      describe ".during.bottom" do
-        it "return just 3 elements" do
-          ranking_items = organization.items.during('1950-01-01', '3000-01-01').bottom(3)
-          expect(ranking_items.length).to eq(3)
-        end
-        it "return 3 least used items" do
-          ranking_items = organization.items.during('1950-01-01', '3000-01-01').bottom(3)
-
-          expect(ranking_items[0].amount).to eq(1)
-          expect(ranking_items[0].name).to eq(organization.items[0].name)
-
-          expect(ranking_items[1].amount).to eq(2)
-          expect(ranking_items[1].name).to eq(organization.items[1].name)
-
-          expect(ranking_items[2].amount).to eq(3)
-          expect(ranking_items[2].name).to eq(organization.items[2].name)
-        end
-      end
-    end
   end
 
   describe '#assign_attributes_from_account_request' do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -283,18 +283,6 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  describe "total_inventory" do
-    it "returns a sum total of all inventory at all storage locations" do
-      item = create(:item, organization: organization)
-      create(:storage_location, :with_items, item: item, item_quantity: 100, organization: organization)
-      create(:storage_location, :with_items, item: item, item_quantity: 150, organization: organization)
-      expect(organization.total_inventory).to eq(250)
-    end
-    it "returns 0 if there is nothing" do
-      expect(organization.total_inventory).to eq(0)
-    end
-  end
-
   describe "geocode" do
     it "adds coordinates to the database" do
       expect(organization.latitude).to be_a(Float)


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
When I run model specs, I notice the Organization specs take particularly long. At first I was going to refactor them, but then I realized the methods being tested aren't used anywhere.

Removing the offending methods/specs makes `bundle exec rspec spec/models/organization_spec.rb` execution time drop from ~27 seconds to ~7 seconds locally.

Also noticed a few other methods not being used anymore.

### Type of change

* Internal only

### How Has This Been Tested?
Automated test suite.