### PR TITLE
Perf: Cache inventory calculation on dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,7 +3,6 @@ class DashboardController < ApplicationController
   respond_to :html, :js
 
   def index
-    inventory = View::Inventory.new(current_organization.id)
     @org_stats = OrganizationStats.new(current_organization, inventory)
     @partners_awaiting_review = current_organization.partners.awaiting_review
     @outstanding_requests = current_organization
@@ -17,5 +16,13 @@ class DashboardController < ApplicationController
 
     # passing nil here filters the announcements that didn't come from an organization
     @broadcast_announcements = BroadcastAnnouncement.filter_announcements(nil)
+  end
+
+  private
+
+  def inventory
+    return @inventory if defined? @inventory
+
+    @inventory = current_organization.nil? ? nil : View::Inventory.new(current_organization.id)
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,7 +3,8 @@ class DashboardController < ApplicationController
   respond_to :html, :js
 
   def index
-    @org_stats = OrganizationStats.new(current_organization)
+    inventory = View::Inventory.new(current_organization.id)
+    @org_stats = OrganizationStats.new(current_organization, inventory)
     @partners_awaiting_review = current_organization.partners.awaiting_review
     @outstanding_requests = current_organization
       .ordered_requests
@@ -12,7 +13,7 @@ class DashboardController < ApplicationController
       .order(:created_at)
       .limit(25)
 
-    @low_inventory_report = LowInventoryQuery.call(current_organization)
+    @low_inventory_report = LowInventoryQuery.call(current_organization, inventory)
 
     # passing nil here filters the announcements that didn't come from an organization
     @broadcast_announcements = BroadcastAnnouncement.filter_announcements(nil)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -21,8 +21,6 @@ class DashboardController < ApplicationController
   private
 
   def inventory
-    return @inventory if defined? @inventory
-
-    @inventory = current_organization.nil? ? nil : View::Inventory.new(current_organization.id)
+    @inventory ||= View::Inventory.new(current_organization.id)
   end
 end

--- a/app/models/organization_stats.rb
+++ b/app/models/organization_stats.rb
@@ -7,8 +7,9 @@ class OrganizationStats
            :donation_sites,
            to: :current_organization, allow_nil: true
 
-  def initialize(organization)
+  def initialize(organization, inventory)
     @current_organization = organization
+    @inventory = inventory
   end
 
   def partners_added
@@ -26,11 +27,10 @@ class OrganizationStats
   def locations_with_inventory
     return [] unless storage_locations
 
-    inventory = View::Inventory.new(current_organization.id)
     storage_locations.select { |loc| inventory.quantity_for(storage_location: loc.id).positive? }
   end
 
   private
 
-  attr_reader :current_organization
+  attr_reader :current_organization, :inventory
 end

--- a/app/models/organization_stats.rb
+++ b/app/models/organization_stats.rb
@@ -24,10 +24,10 @@ class OrganizationStats
     donation_sites&.length || 0
   end
 
-  def locations_with_inventory
-    return [] unless storage_locations
+  def num_locations_with_inventory
+    return 0 unless storage_locations
 
-    storage_locations.select { |loc| inventory.quantity_for(storage_location: loc.id).positive? }
+    storage_locations.count { |loc| inventory.quantity_for(storage_location: loc.id).positive? }
   end
 
   private

--- a/app/queries/low_inventory_query.rb
+++ b/app/queries/low_inventory_query.rb
@@ -1,7 +1,9 @@
 class LowInventoryQuery
   LowInventoryItem = Data.define(:id, :name, :on_hand_minimum_quantity, :on_hand_recommended_quantity, :total_quantity)
 
-  def self.call(organization, inventory)
+  def self.call(organization, inventory = View::Inventory.new(organization.id))
+    return [] if organization.blank?
+
     items = inventory.all_items.uniq(&:item_id)
 
     low_inventory_items = []

--- a/app/queries/low_inventory_query.rb
+++ b/app/queries/low_inventory_query.rb
@@ -1,8 +1,7 @@
 class LowInventoryQuery
   LowInventoryItem = Data.define(:id, :name, :on_hand_minimum_quantity, :on_hand_recommended_quantity, :total_quantity)
 
-  def self.call(organization)
-    inventory = View::Inventory.new(organization.id)
+  def self.call(organization, inventory)
     items = inventory.all_items.uniq(&:item_id)
 
     low_inventory_items = []

--- a/app/views/dashboard/_getting_started_prompt.html.erb
+++ b/app/views/dashboard/_getting_started_prompt.html.erb
@@ -2,7 +2,7 @@
 <% partner_criteria_met = org_stats.partners_added > 0 %>
 <% location_criteria_met = org_stats.storage_locations_added > 0 %>
 <% donation_criteria_met = org_stats.donation_sites_added > 0 %>
-<% inventory_criteria_met = org_stats.locations_with_inventory.length > 0 %>
+<% inventory_criteria_met = org_stats.num_locations_with_inventory > 0 %>
 <% criterias = [ location_criteria_met, partner_criteria_met, donation_criteria_met, inventory_criteria_met ] %>
 <% current_step = criterias.find_index(false) %>
 
@@ -116,7 +116,7 @@
                     <% else %>
                       <i class="fa fa-pie-chart fa-2x" aria-hidden="true"></i>
                     <% end %>
-                    <h4><%= pluralize(org_stats.locations_with_inventory.length, 'Storage Location') %> with Inventory</h4>
+                    <h4><%= pluralize(org_stats.num_locations_with_inventory, 'Storage Location') %> with Inventory</h4>
                   </div>
 
                   <div class="org-stats-desc">

--- a/spec/models/organization_stats_spec.rb
+++ b/spec/models/organization_stats_spec.rb
@@ -2,12 +2,14 @@
 #
 RSpec.describe OrganizationStats, type: :model do
   let(:current_org) { create(:organization) }
+  let(:inventory) { View::Inventory.new(current_org.id) }
 
-  subject { described_class.new(current_org) }
+  subject { described_class.new(current_org, inventory) }
 
   describe "partners_added method >" do
     context "current org is nil >" do
       let(:current_org) { nil }
+      let(:inventory) { nil }
 
       it "should return 0" do
         expect(subject.partners_added).to eq(0)
@@ -28,6 +30,7 @@ RSpec.describe OrganizationStats, type: :model do
   describe "storage_locations_added method >" do
     context "current org is nil >" do
       let(:current_org) { nil }
+      let(:inventory) { nil }
 
       it "should return 0" do
         expect(subject.storage_locations_added).to eq(0)
@@ -48,6 +51,7 @@ RSpec.describe OrganizationStats, type: :model do
   describe "donation_sites_added method >" do
     context "current org is nil >" do
       let(:current_org) { nil }
+      let(:inventory) { nil }
 
       it "should return 0" do
         expect(subject.donation_sites_added).to eq(0)
@@ -65,12 +69,13 @@ RSpec.describe OrganizationStats, type: :model do
     end
   end
 
-  describe "locations_with_inventory method >" do
+  describe "num_locations_with_inventory method >" do
     context "current org is nil >" do
       let(:current_org) { nil }
+      let(:inventory) { nil }
 
       it "should return an empty array" do
-        expect(subject.locations_with_inventory).to eq([])
+        expect(subject.num_locations_with_inventory).to eq(0)
       end
     end
 
@@ -87,7 +92,7 @@ RSpec.describe OrganizationStats, type: :model do
       end
 
       it "should return storage location" do
-        expect(subject.locations_with_inventory).to include(storage_location_1)
+        expect(subject.num_locations_with_inventory).to eq(1)
       end
     end
 
@@ -96,7 +101,7 @@ RSpec.describe OrganizationStats, type: :model do
       let(:storage_locations) { [storage_location_1] }
 
       it "should return an empty array" do
-        expect(subject.locations_with_inventory).to eq([])
+        expect(subject.num_locations_with_inventory).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
Noticed a number of duplicate queries in the dashboard, so here's a PR to remove them.

### Type of change

<!-- Please delete options that are not relevant. -->

* Internal (code refactor)

### How Has This Been Tested?
Test suite and some manually testing locally.

### Screenshots
These are just on my local machine with the seed database so YMMV

Before:
 ~70 ms response time
32 queries (11 cached)
![Screenshot from 2025-01-21 17-00-31](https://github.com/user-attachments/assets/2357e50e-b524-4927-8984-ea8886bb4786)

After:
~56 ms response time
27 queries (6 cached)
![Screenshot from 2025-01-21 17-00-41](https://github.com/user-attachments/assets/809f1d00-84bf-4c48-ae77-d967f4eab7a4)


