### PR TITLE
Data Fix re started request has been fulfilled

### DIFF
--- a/db/migrate/20250121200831_fix_for20250120_request_problem.rb
+++ b/db/migrate/20250121200831_fix_for20250120_request_problem.rb
@@ -1,0 +1,10 @@
+class FixFor20250120RequestProblem < ActiveRecord::Migration[7.2]
+  def up
+    # Merely marking request 44040 fulfilled.
+    # It already has a distribution associated with it, so we don't have to fix that
+    return unless Rails.env.production?
+    request = Request.find("44040")
+    request.status = 2
+    request.save!
+  end
+end


### PR DESCRIPTION
See support thread starting   20250119 2223  

This fixes one instance of the "request is started when it should be fulfilled" problem.

### Type of change
* data fix 
### How Has This Been Tested?
* confirmed on a local copy of production before adding in the statement limiting it to production