### PR TITLE
Minor CSS fixes to sign in/up flow

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -108,3 +108,17 @@
   width: 3rem;
   cursor: not-allowed;
 }
+
+// The account request form is placed inside the default devise container which
+// is too narrow for the desired form width, so we have to apply a negative
+// margin to center it (except on mobile where text would get cut off).
+.account-request {
+  $inner-width: 35rem;
+  $outer-width: 360px;
+  width: $inner-width;
+  margin-left: calc((#{$outer-width} - #{$inner-width}) / 2);
+  @media (max-width: 620px) {
+    margin-left: 0;
+    max-width: 100%;
+  }
+}

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -6,7 +6,7 @@
       </div>
 
       <div class="form-check">
-        <%= radio_button_tag(:account, :bank, false, class: 'form-check-input account_type') %>
+        <%= radio_button_tag(:account, :bank, @bank_selected, class: 'form-check-input account_type') %>
         <%= label_tag(:account, "I am an Essentials Bank. I do NOT distribute diapers/period supplies directly to the public, I distribute them to partner agencies who distribute them to the public.", class: 'form-check-label') %>
       </div>
       <div class="form-check">
@@ -14,36 +14,16 @@
         <%= label_tag(:account, "I am a Partner Agency to an Essentials Bank. I distribute the diapers/period supplies that I receive from essentials banks directly to the public.", class: 'form-check-label') %>
       </div>
 
-      <% if @bank_selected %>
-        <script type="module">
-            $(document).ready(function() {
-                const bankRadioButtons = $('.account_type[value="bank"]:not(:checked)');
-
-                if (bankRadioButtons.length > 0) {
-                    bankRadioButtons.eq(0).click();
-                }
-            });
-        </script>
-      <% else %>
-        <script type="module">
-            $(document).ready(function() {
-                $('#create_bank').hide()
-                $('#partner_info').hide()
-            });
-        </script>
-      <% end %>
-
-      <script type="module">
-          $('.account_type').change(function() {
-              if (this.value === 'bank') {
-                  $('#create_bank').show()
-                  $('#partner_info').hide()
-              } else {
-                  $('#create_bank').hide()
-                  $('#partner_info').show()
-              }
-          })
-      </script>
+      <%# Hide #partner_info and #create_bank selections unless radio button selected %>
+      <style>
+        #partner_info, #create_bank {
+          display: none;
+        }
+        .form-check:has(#account_partner:checked)~#partner_info,
+          .form-check:has(#account_bank:checked)~#create_bank {
+          display: block;
+        }
+      </style>
 
       <div class='card-text' id='partner_info'>
         <p class='p-2'>Are you a current partner to diaper and/or period supply banks? If so please go <a href='https://humanessentials.app/users/sign_in'>here</a> to login.</p>

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -1,5 +1,5 @@
 <% unless Rails.env.staging? %>
-  <div class="bg-white" style='width: 35rem'>
+  <div class="bg-white account-request">
     <div class="p-3">
       <div class="mb-10">
         <h1 class='text-3xl text-center'>Essentials Bank Account Request Form</h1>

--- a/app/views/layouts/_devise_shared.html.erb
+++ b/app/views/layouts/_devise_shared.html.erb
@@ -57,8 +57,8 @@
 <body id="devise" class="hold-transition login-page <%= body_class %> <%= Rails.env.staging? ? 'login-page-test' : '' %>">
   <div class="login-box">
     <% if masthead_img_src %>
-      <div class="login-logo text-center">
-        <img id="MastheadLogo" src="<%= masthead_img_src %>" alt="Human Essentials" title="Human Essentials" class="serv_icon">
+      <div class="login-logo">
+        <img id="MastheadLogo" src="<%= masthead_img_src %>" alt="Human Essentials" title="Human Essentials" class="serv_icon mw-100">
       </div>
     <% end %>
 

--- a/app/views/layouts/_devise_shared.html.erb
+++ b/app/views/layouts/_devise_shared.html.erb
@@ -32,9 +32,9 @@
       padding-left: 0px;
     }
   </style>
-  <script type="module">
-    $(document).ready(function() {
-      <% if Rails.env.staging? %>
+  <% if Rails.env.staging? %>
+    <script type="module">
+      $(document).ready(function() {
         // Prevents users from closing the modal by clicking outside of it or pressing the esc key
         new bootstrap.Modal('#warningModal', {
           backdrop: 'static',
@@ -49,9 +49,9 @@
             $('.continue-btn').attr("disabled", true);
           }
         });
-      <% end %>
-    });
-  </script>
+      });
+    </script>
+  <% end %>
 </head>
 
 <body id="devise" class="hold-transition login-page <%= body_class %> <%= Rails.env.staging? ? 'login-page-test' : '' %>">
@@ -73,31 +73,33 @@
   <!-- /.login-box -->
 
   <!-- Modal -->
-  <div class="modal fade" id="warningModal" tabindex="-1" role="dialog" aria-labelledby="warningModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3 class="modal-title" id="warningModalLabel"><b>This site is for TEST purposes only!</b></h3>
-        </div>
-        <div class="modal-body">
-          You're visiting staging.humanessentials.app, a demo/test site for the full site at <a href="https://humanessentials.app">humanessentials.app</a>.<br>
-          It is not safe to upload, enter or save any sensitive data here.<br>
-          <div class="modal-body-warning-text">
-            If you meant to login to your live account, go to <a href="https://humanessentials.app/users/sign_in">humanessentials.app</a>
+  <% if Rails.env.staging? %>
+    <div class="modal fade" id="warningModal" tabindex="-1" role="dialog" aria-labelledby="warningModalLabel" aria-hidden="true">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h3 class="modal-title" id="warningModalLabel"><b>This site is for TEST purposes only!</b></h3>
           </div>
-          <br>
-          <div class="form-check">
-            <input class="form-check-input" type="checkbox" value="" id="defaultCheck1">
-            <label class="form-check-label" for="defaultCheck1">
-              I Understand
-            </label>
+          <div class="modal-body">
+            You're visiting staging.humanessentials.app, a demo/test site for the full site at <a href="https://humanessentials.app">humanessentials.app</a>.<br>
+            It is not safe to upload, enter or save any sensitive data here.<br>
+            <div class="modal-body-warning-text">
+              If you meant to login to your live account, go to <a href="https://humanessentials.app/users/sign_in">humanessentials.app</a>
+            </div>
+            <br>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" value="" id="defaultCheck1">
+              <label class="form-check-label" for="defaultCheck1">
+                I Understand
+              </label>
+            </div>
           </div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-warning continue-btn" data-bs-dismiss="modal" disabled>Continue To The Test Site</button>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-warning continue-btn" data-bs-dismiss="modal" disabled>Continue To The Test Site</button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </body>
 </html>

--- a/app/views/layouts/_devise_shared.html.erb
+++ b/app/views/layouts/_devise_shared.html.erb
@@ -1,4 +1,5 @@
 <%# required params: title, body_class, masthead_img_src   %>
+<!doctype html>
 <html>
 <head>
   <meta charset="utf-8">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -27,7 +27,7 @@
         </div>
         <div class="form-inputs" data-controller="password-visibility">
           <div class="password-input-wrapper">
-            <%= f.input :password, autofocus: true, input_html: { data: { password_visibility_target: 'password' } } %>
+            <%= f.input :password, autofocus: true, required: true, input_html: { data: { password_visibility_target: 'password' } } %>
             <span class="toggle-password">
               <i class="fas fa-eye-slash" data-action="click->password-visibility#toggle" data-password-visibility-target="icon"></i>
             </span>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -14,7 +14,7 @@
 </style>
 <%= render partial: "shared/flash" %>
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="login-box">
+  <div class="login-box w-100">
     <!-- /.login-logo -->
     <div class="card">
       <div class="card-body login-card-body">
@@ -53,6 +53,6 @@
   </div>
 <% end %>
 
-<%= link_to user_google_oauth2_omniauth_authorize_path, method: :post do %>
-  <img src="../img/btn_google_signin_dark_focus_web@2x.png" alt="Sign in with Google">
+<%= link_to user_google_oauth2_omniauth_authorize_path, method: :post, class: "d-block" do %>
+  <img src="../img/btn_google_signin_dark_focus_web@2x.png" alt="Sign in with Google" class="d-block w-100">
 <% end %>


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
Minor CSS improvements. See screenshots below.

### Type of change

- UI related changes

(Not sure how to categorize this)

### How Has This Been Tested?
Just manually (as they're almost entirely UI-only changes)

### Screenshots
- Fixed alignment of Human Essentials Logo and Google SSO button. Added asterisk to password field.
Before
![Screenshot from 2025-01-23 13-04-23](https://github.com/user-attachments/assets/d3c7e44d-f981-4a2b-a98d-4ed30571c3c0)
After
![Screenshot from 2025-01-23 13-04-39](https://github.com/user-attachments/assets/65815592-ff86-4a02-addc-9f0a3e5155a9)

- Centered account request form
Before:
![Screenshot from 2025-01-23 13-05-07](https://github.com/user-attachments/assets/5667975c-a209-4a52-b3d5-3183ad26d27b)
After: (Ignore my mouse being in the way of the screenshot)
![Screenshot from 2025-01-23 13-04-51](https://github.com/user-attachments/assets/03f127d8-800e-48b4-8d5d-107dcabb8a0a)

- Don't send modal HTML for staging warning when environment is dev or prod
Before:
![Screenshot from 2025-01-23 13-07-46](https://github.com/user-attachments/assets/bbd43681-e248-4641-bf58-b047afed62f1)
After:
![Screenshot from 2025-01-23 13-08-14](https://github.com/user-attachments/assets/bd62faaa-ae59-456e-bbc0-e164b80b51f7)

- I also fixed a flash of text that occurs on the `/account_requests/new` page, but didn't take a video of it. If you go to this page in production, you should see the flash I'm talking about though -> https://humanessentials.app/account_requests/new.





