### PR TITLE
Fix N plus ones for partners

### DIFF
--- a/app/controllers/partners/dashboards_controller.rb
+++ b/app/controllers/partners/dashboards_controller.rb
@@ -11,7 +11,9 @@ module Partners
       @partner_requests = @partner.requests.order(created_at: :desc).limit(10)
       @upcoming_distributions = @partner.distributions.order(issued_at: :desc)
                                         .where(issued_at: Time.zone.today..)
-      @distributions = @partner.distributions.order(issued_at: :desc)
+      @distributions = @partner.distributions
+                               .includes(line_items: :item)
+                               .order(issued_at: :desc)
                                .where(issued_at: ...Time.zone.today)
                                .limit(5)
 
@@ -19,6 +21,7 @@ module Partners
 
       @requests_in_progress = @parent_org
                               .ordered_requests
+                              .includes(item_requests: :item)
                               .where(partner: @partner.id)
                               .where(status: 0)
 

--- a/app/controllers/partners/distributions_controller.rb
+++ b/app/controllers/partners/distributions_controller.rb
@@ -7,7 +7,7 @@ module Partners
 
     def index
       @partner = current_partner
-      @distributions = @partner.distributions.order(issued_at: :desc)
+      @distributions = @partner.distributions.includes(:items).order(issued_at: :desc)
 
       @parent_org = Organization.find(@partner.organization_id)
     end

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -1,6 +1,8 @@
 module Partners
   class ProfilesController < BaseController
-    def show; end
+    def show
+      @profile = Partners::Profile.includes(:counties).find_by(partner_id: current_partner.id)
+    end
 
     def edit
       @counties = County.in_category_name_order

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -4,7 +4,7 @@ module Partners
 
     def index
       @partner = current_partner
-      @partner_requests = @partner.requests.order(created_at: :desc).limit(10)
+      @partner_requests = @partner.requests.includes(:item_requests).order(created_at: :desc).limit(10)
     end
 
     def new

--- a/app/views/partners/profiles/show.html.erb
+++ b/app/views/partners/profiles/show.html.erb
@@ -29,15 +29,15 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-6">
-            <%= render partial: "partners/profiles/show/agency_information", locals: { profile: current_partner.profile } %>
+            <%= render partial: "partners/profiles/show/agency_information", locals: { profile: @profile } %>
           </div>
           <% current_partner.partials_to_show.each do |partial| %>
             <div class="col-6">
-              <%= render partial: "partners/profiles/show/#{partial}", locals: { profile: current_partner.profile } %>
+              <%= render partial: "partners/profiles/show/#{partial}", locals: { profile: @profile } %>
             </div>
           <% end %>
           <div class="col-6">
-            <%= render partial: "partners/profiles/show/partner_settings", locals: { profile: current_partner.profile } %>
+            <%= render partial: "partners/profiles/show/partner_settings", locals: { profile: @profile } %>
           </div>
         </div>
       </div>

--- a/app/views/partners/profiles/show/_area_served.html.erb
+++ b/app/views/partners/profiles/show/_area_served.html.erb
@@ -5,9 +5,8 @@
     <table>
       <th class="county-heading">County</th><th class="county-heading percent">% of Clients in county</th>
 
-      <% served_area_col = Partners::ServedArea.where(partner_profile: profile) %>
-      <% if served_area_col.any? %>
-        <%= render partial: "partners/profiles/show/served_area_row", collection: served_area_col %>
+      <% if profile.served_areas.load.any? %>
+        <%= render partial: "partners/profiles/show/served_area_row", collection: profile.served_areas %>
       <% else %>
         <tr><td class="county-name"><%= "No County Specified" %></td><td class="client-share percent">100 %</td></tr>
       <% end %>


### PR DESCRIPTION
### Description
Fixing a few N+1's in the partners portal.

### Type of change

<!-- Please delete options that are not relevant. -->

* Performance (behavior unaffected)

### How Has This Been Tested?
Manually to ensure that fewer queries occurred.

### Screenshots
Biggest offender was the partner dashboard

Before:
![Screenshot from 2025-01-27 14-32-45](https://github.com/user-attachments/assets/4760b2c2-689c-48d9-9fdd-f3259ed61249)

After:
![Screenshot from 2025-01-27 14-33-26](https://github.com/user-attachments/assets/543c9447-70aa-45a1-ba3d-06c87c234c69)
