### PR TITLE
Rename StorageLocation::active_locations scope to active

### DIFF
--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -33,7 +33,7 @@ class AdjustmentsController < ApplicationController
   def new
     @adjustment = current_organization.adjustments.new
     @adjustment.line_items.build
-    @storage_locations = current_organization.storage_locations.active_locations
+    @storage_locations = current_organization.storage_locations.active
     @items = current_organization.items.loose.active.alphabetized
   end
 
@@ -54,7 +54,7 @@ class AdjustmentsController < ApplicationController
   private
 
   def load_form_collections
-    @storage_locations = current_organization.storage_locations.active_locations
+    @storage_locations = current_organization.storage_locations.active
     @items = current_organization.items.loose.alphabetized
   end
 

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -89,7 +89,7 @@ class AuditsController < ApplicationController
   end
 
   def set_storage_locations
-    @storage_locations = current_organization.storage_locations.active_locations
+    @storage_locations = current_organization.storage_locations.active
   end
 
   def set_items

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -49,7 +49,7 @@ class DistributionsController < ApplicationController
     @paginated_distributions = @distributions.page(params[:page])
     @items = current_organization.items.alphabetized.select(:id, :name)
     @item_categories = current_organization.item_categories.select(:id, :name)
-    @storage_locations = current_organization.storage_locations.active_locations.alphabetized.select(:id, :name)
+    @storage_locations = current_organization.storage_locations.active.alphabetized.select(:id, :name)
     @partners = current_organization.partners.active.alphabetized.select(:id, :name)
     @selected_item = filter_params[:by_item_id].presence
     @distribution_totals = DistributionTotalsService.new(current_organization.distributions, scope_filters)
@@ -122,7 +122,7 @@ class DistributionsController < ApplicationController
       @partner_list = current_organization.partners.where.not(status: 'deactivated').alphabetized
 
       inventory = View::Inventory.new(@distribution.organization_id)
-      @storage_locations = current_organization.storage_locations.active_locations.alphabetized.select do |storage_loc|
+      @storage_locations = current_organization.storage_locations.active.alphabetized.select do |storage_loc|
         inventory.quantity_for(storage_location: storage_loc.id).positive?
       end
       if @distribution.storage_location.present?
@@ -157,7 +157,7 @@ class DistributionsController < ApplicationController
     @partner_list = current_organization.partners.where.not(status: 'deactivated').alphabetized
 
     inventory = View::Inventory.new(current_organization.id)
-    @storage_locations = current_organization.storage_locations.active_locations.alphabetized.select do |storage_loc|
+    @storage_locations = current_organization.storage_locations.active.alphabetized.select do |storage_loc|
       inventory.quantity_for(storage_location: storage_loc.id).positive?
     end
   end
@@ -185,7 +185,7 @@ class DistributionsController < ApplicationController
         .where(storage_location_id: @distribution.storage_location_id)
         .where("updated_at > ?", @distribution.created_at).any?
       inventory = View::Inventory.new(@distribution.organization_id)
-      @storage_locations = current_organization.storage_locations.active_locations.alphabetized.select do |storage_loc|
+      @storage_locations = current_organization.storage_locations.active.alphabetized.select do |storage_loc|
         !inventory.quantity_for(storage_location: storage_loc.id).negative?
       end
     else
@@ -212,7 +212,7 @@ class DistributionsController < ApplicationController
       @distribution.initialize_request_items
       @items = current_organization.items.active.alphabetized
       @partner_list = current_organization.partners.alphabetized
-      @storage_locations = current_organization.storage_locations.active_locations.alphabetized
+      @storage_locations = current_organization.storage_locations.active.alphabetized
       render :edit
     end
   end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -123,7 +123,7 @@ class DonationsController < ApplicationController
   private
 
   def load_form_collections
-    @storage_locations = current_organization.storage_locations.active_locations.alphabetized
+    @storage_locations = current_organization.storage_locations.active.alphabetized
     @donation_sites = current_organization.donation_sites.active.alphabetized
     @product_drives = current_organization.product_drives.alphabetized
     @product_drive_participants = current_organization.product_drive_participants.alphabetized

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,7 @@ class ItemsController < ApplicationController
 
     @item_categories = current_organization.item_categories.includes(:items).order('name ASC')
     @kits = current_organization.kits.includes(line_items: :item)
-    @storages = current_organization.storage_locations.active_locations.order(id: :asc)
+    @storages = current_organization.storage_locations.active.order(id: :asc)
 
     @include_inactive_items = params[:include_inactive_items]
     @selected_base_item = filter_params[:by_base_item]

--- a/app/controllers/kits_controller.rb
+++ b/app/controllers/kits_controller.rb
@@ -53,7 +53,7 @@ class KitsController < ApplicationController
 
   def allocations
     @kit = Kit.find(params[:id])
-    @storage_locations = current_organization.storage_locations.active_locations
+    @storage_locations = current_organization.storage_locations.active
     @inventory = View::Inventory.new(current_organization.id)
 
     load_form_collections
@@ -61,7 +61,7 @@ class KitsController < ApplicationController
 
   def allocate
     @kit = Kit.find(params[:id])
-    @storage_location = current_organization.storage_locations.active_locations.find(kit_adjustment_params[:storage_location_id])
+    @storage_location = current_organization.storage_locations.active.find(kit_adjustment_params[:storage_location_id])
     @change_by = kit_adjustment_params[:change_by].to_i
     begin
       if @change_by.positive?

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -23,7 +23,7 @@ class PurchasesController < ApplicationController
     @total_fair_market_values = @purchases.sum(&:value_per_itemizable)
     @paginated_fair_market_values = @paginated_purchases.collect(&:value_per_itemizable).sum
     # Storage and Vendor
-    @storage_locations = current_organization.storage_locations.active_locations
+    @storage_locations = current_organization.storage_locations.active
     @selected_storage_location = filter_params[:at_storage_location]
     @vendors = current_organization.vendors.sort_by { |vendor| vendor.business_name.downcase }
     @selected_vendor = filter_params[:from_vendor]
@@ -99,7 +99,7 @@ class PurchasesController < ApplicationController
   private
 
   def load_form_collections
-    @storage_locations = current_organization.storage_locations.active_locations.alphabetized
+    @storage_locations = current_organization.storage_locations.active.alphabetized
     @items = current_organization.items.active.alphabetized
     @vendors = current_organization.vendors.alphabetized
   end

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -34,7 +34,7 @@ class TransfersController < ApplicationController
   def new
     @transfer = current_organization.transfers.new
     @transfer.line_items.build
-    @storage_locations = current_organization.storage_locations.active_locations.alphabetized
+    @storage_locations = current_organization.storage_locations.active.alphabetized
     @items = current_organization.items.active.alphabetized
   end
 
@@ -60,7 +60,7 @@ class TransfersController < ApplicationController
   private
 
   def load_form_collections
-    @storage_locations = current_organization.storage_locations.active_locations.alphabetized
+    @storage_locations = current_organization.storage_locations.active.alphabetized
     @items = current_organization.items.alphabetized
   end
 

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -54,7 +54,7 @@ class StorageLocation < ApplicationRecord
 
   scope :alphabetized, -> { order(:name) }
   scope :for_csv_export, ->(organization, *) { where(organization: organization) }
-  scope :active_locations, -> { where(discarded_at: nil) }
+  scope :active, -> { where(discarded_at: nil) }
   scope :with_transfers_to, ->(organization) {
     joins(:transfers_to).where(organization_id: organization.id).distinct.order(:name)
   }

--- a/app/models/view/inventory.rb
+++ b/app/models/view/inventory.rb
@@ -53,7 +53,7 @@ module View
     def reload(event_time = nil)
       @inventory = InventoryAggregate.inventory_for(organization_id, event_time: event_time)
       @items = Item.where(organization_id: organization_id).active
-      @db_storage_locations = StorageLocation.where(organization_id: organization_id).active_locations
+      @db_storage_locations = StorageLocation.where(organization_id: organization_id).active
       load_item_details
     end
 

--- a/app/views/admin/organizations/edit.html.erb
+++ b/app/views/admin/organizations/edit.html.erb
@@ -69,7 +69,7 @@
 
                 <%= render 'shared/deadline_day_fields', f: f %>
 
-                <%= f.input :intake_location, :collection => @organization.storage_locations.active_locations.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Intake Location", :include_blank => true, wrapper: :input_group %>
+                <%= f.input :intake_location, :collection => @organization.storage_locations.active.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Intake Location", :include_blank => true, wrapper: :input_group %>
 
                 <%= f.input :invitation_text, label: "Custom Partner Invitation Message", wrapper: :input_group do %>
                   <%= f.text_area :invitation_text, class: "form-control" %>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -87,14 +87,14 @@
 
                 <%= render 'shared/deadline_day_fields', f: f %>
 
-                <%= f.input :intake_location, :collection => current_organization.storage_locations.active_locations.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Intake Location", :include_blank => true, wrapper: :input_group %>
+                <%= f.input :intake_location, :collection => current_organization.storage_locations.active.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Intake Location", :include_blank => true, wrapper: :input_group %>
 
                 <%= f.label :partner_form_fields, 'Partner Profile Sections' %>
 
                 <%= f.select(:partner_form_fields, Organization::ALL_PARTIALS, { include_hidden: true }, { multiple: true, class: 'form-control custom-select', 'data-controller': 'select2', 'data-select2-config-value': '{}'}) %>
 
                 <br>
-                <%= f.input :default_storage_location, :collection => current_organization.storage_locations.active_locations.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Storage Location", :include_blank => true, wrapper: :input_group %>
+                <%= f.input :default_storage_location, :collection => current_organization.storage_locations.active.alphabetized, :label_method => :name, :value_method => :id, :label => "Default Storage Location", :include_blank => true, wrapper: :input_group %>
 
                 <%= f.input :invitation_text, label: "Custom Partner Invitation Message", wrapper: :input_group do %>
                   <%= f.text_area :invitation_text, class: "form-control" %>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -17,7 +17,7 @@
                 <span class="input-group-text"><i class="fa fa-envelope"></i></span>
                 <%= f.input_field :email, class: "form-control" %>
               <% end %>
-              <%= f.input :default_storage_location_id, :collection => current_organization.storage_locations.active_locations.alphabetized,
+              <%= f.input :default_storage_location_id, :collection => current_organization.storage_locations.active.alphabetized,
                           :label_method => :name,
                           :value_method => :id,
                           :label => "Default Storage Location",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -516,7 +516,7 @@ inactive_storage.discard
 #
 # Define all the InventoryItem for each of the StorageLocation
 #
-StorageLocation.active_locations.each do |sl|
+StorageLocation.active.each do |sl|
   sl.organization.items.active.each do |item|
     InventoryItem.create!(
       storage_location: sl,
@@ -664,7 +664,7 @@ complete_orgs.each do |org|
     # Depending on which source it uses, additional data may need to be provided.
     donation = Donation.new(
       source: source,
-      storage_location: org.storage_locations.active_locations.sample,
+      storage_location: org.storage_locations.active.sample,
       organization: org,
       issued_at: dates_generator.next
     )
@@ -699,7 +699,7 @@ complete_orgs.each do |org|
   20.times.each do |index|
     issued_at = dates_generator.next
 
-    storage_location = org.storage_locations.active_locations.sample
+    storage_location = org.storage_locations.active.sample
     stored_inventory_items_sample = inventory.storage_locations[storage_location.id].items.values.sample(20)
     delivery_method = Distribution.delivery_methods.keys.sample
     shipping_cost = (delivery_method == "shipped") ? rand(20.0..100.0).round(2).to_s : nil
@@ -811,7 +811,7 @@ dates_generator = DispersedPastDatesGenerator.new
 complete_orgs.each do |org|
   25.times do |index|
     purchase_date = dates_generator.next
-    storage_location = org.storage_locations.active_locations.sample
+    storage_location = org.storage_locations.active.sample
     vendor = random_record_for_org(org, Vendor)
     purchase = Purchase.new(
       purchased_from: suppliers.sample,
@@ -952,7 +952,7 @@ end
 # ----------------------------------------------------------------------------
 # Transfers
 # ----------------------------------------------------------------------------
-from_id, to_id = pdx_org.storage_locations.active_locations.limit(2).pluck(:id)
+from_id, to_id = pdx_org.storage_locations.active.limit(2).pluck(:id)
 quantity = 5
 inventory = View::Inventory.new(pdx_org.id)
 # Ensure storage location has enough of item for transfer to succeed

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe StorageLocation, type: :model do
   end
 
   context "Filtering >" do
-    it "->active_locations yields only storage locations that haven't been discarded" do
+    it "->active yields only storage locations that haven't been discarded" do
       create(:storage_location, name: "Active Location")
       create(:storage_location, name: "Inactive Location", discarded_at: Time.zone.now)
-      results = StorageLocation.active_locations
+      results = StorageLocation.active
       expect(results.length).to eq(1)
       expect(results.first.discarded_at).to be_nil
     end


### PR DESCRIPTION
### Description
Kind of a nit PR, but many other classes have a scope named `active` except for `StorageLocation` where it is named `active_locations`. I think renaming it improves consistency and clarity.  

### Type of change

<!-- Please delete options that are not relevant. -->

* Internal

### How Has This Been Tested?
Test suite
