### PR TITLE
Perf: Refactor total items calculations

### DIFF
--- a/app/controllers/manufacturers_controller.rb
+++ b/app/controllers/manufacturers_controller.rb
@@ -1,6 +1,6 @@
 class ManufacturersController < ApplicationController
   def index
-    @manufacturers = current_organization.manufacturers.includes(:donations).all.alphabetized
+    @manufacturers = current_organization.manufacturers.with_volumes.alphabetized
   end
 
   def create

--- a/app/controllers/product_drive_participants_controller.rb
+++ b/app/controllers/product_drive_participants_controller.rb
@@ -6,7 +6,7 @@ class ProductDriveParticipantsController < ApplicationController
   # TODO: Should there be a :destroy action for this?
 
   def index
-    @product_drive_participants = current_organization.product_drive_participants.includes(:donations).all.order(:business_name)
+    @product_drive_participants = current_organization.product_drive_participants.with_volumes.order(:business_name)
 
     respond_to do |format|
       format.html

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -3,7 +3,7 @@ class VendorsController < ApplicationController
   include Importable
 
   def index
-    @vendors = current_organization.vendors.includes(:purchases).all.alphabetized
+    @vendors = current_organization.vendors.with_volumes.alphabetized
 
     respond_to do |format|
       format.html

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -21,10 +21,11 @@ class Manufacturer < ApplicationRecord
 
   scope :alphabetized, -> { order(:name) }
 
-  def volume
-    # returns 0 instead of nil when Manufacturer exists without any donations
-    donations.joins(:line_items).sum(:quantity)
-  end
+  scope :with_volumes, -> {
+    left_joins(donations: :line_items)
+      .select("manufacturers.*, SUM(COALESCE(line_items.quantity, 0)) AS volume")
+      .group(:id)
+  }
 
   def self.by_donation_date(count = 10, date_range = nil)
     # selects manufacturers that have donation qty > 0 in the provided date range

--- a/app/models/product_drive_participant.rb
+++ b/app/models/product_drive_participant.rb
@@ -30,6 +30,11 @@ class ProductDriveParticipant < ApplicationRecord
   validates :comment, length: { maximum: 500 }
 
   scope :alphabetized, -> { order(:contact_name) }
+  scope :with_volumes, -> {
+    left_joins(donations: :line_items)
+      .select("product_drive_participants.*, SUM(COALESCE(line_items.quantity, 0)) AS volume")
+      .group(:id)
+  }
 
   def volume
     donations.map { |d| d.line_items.total }.reduce(:+)

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -27,7 +27,9 @@ class Vendor < ApplicationRecord
 
   scope :alphabetized, -> { order(:business_name) }
 
-  def volume
-    purchases.map { |d| d.line_items.total }.reduce(:+)
-  end
+  scope :with_volumes, -> {
+    left_joins(purchases: :line_items)
+      .select("vendors.*, SUM(COALESCE(line_items.quantity, 0)) AS volume")
+      .group(:id)
+  }
 end

--- a/spec/models/manufacturer_spec.rb
+++ b/spec/models/manufacturer_spec.rb
@@ -23,19 +23,23 @@ RSpec.describe Manufacturer, type: :model do
     end
   end
 
-  context "Methods" do
-    describe "volume" do
+  context "Scopes" do
+    describe "with_volumes" do
+      subject { described_class.with_volumes }
+
       it "retrieves the amount of product that has been donated by manufacturer" do
         mfg = create(:manufacturer)
         create(:donation, :with_items, item_quantity: 15, source: Donation::SOURCES[:manufacturer], manufacturer: mfg)
-        expect(mfg.volume).to eq(15)
+
+        expect(subject.first.volume).to eq(15)
       end
 
       it "retrieves the amount of product that has been donated by manufacturer from multiple donations" do
         mfg = create(:manufacturer)
         create(:donation, :with_items, item_quantity: 15, source: Donation::SOURCES[:manufacturer], manufacturer: mfg)
         create(:donation, :with_items, item_quantity: 10, source: Donation::SOURCES[:manufacturer], manufacturer: mfg)
-        expect(mfg.volume).to eq(25)
+
+        expect(subject.first.volume).to eq(25)
       end
 
       it "ignores the amount of product from other manufacturers" do
@@ -43,10 +47,13 @@ RSpec.describe Manufacturer, type: :model do
         mfg2 = create(:manufacturer)
         create(:donation, :with_items, item_quantity: 5, source: Donation::SOURCES[:manufacturer], manufacturer: mfg)
         create(:donation, :with_items, item_quantity: 10, source: Donation::SOURCES[:manufacturer], manufacturer: mfg2)
-        expect(mfg.volume).to eq(5)
+
+        expect(subject.first.volume).to eq(5)
       end
     end
+  end
 
+  context "Methods" do
     describe "by_donation_date" do
       before do
         # Prepare manufacturers with donations for tests

--- a/spec/models/product_drive_participant_spec.rb
+++ b/spec/models/product_drive_participant_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe ProductDriveParticipant, type: :model do
     end
   end
 
+  context "Scopes" do
+    describe "with_volumes" do
+      subject { described_class.with_volumes }
+      it "retrieves the amount of product that has been donated by participant" do
+        dd = create(:product_drive)
+        ddp = create(:product_drive_participant)
+        create(:donation, :with_items, item_quantity: 10, source: Donation::SOURCES[:product_drive], product_drive: dd, product_drive_participant: ddp)
+
+        expect(subject.first.volume).to eq(10)
+      end
+    end
+  end
+
   context "Methods" do
     describe "volume" do
       it "retrieves the amount of product that has been donated by participant" do

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -26,12 +26,15 @@ RSpec.describe Vendor, type: :model do
     end
   end
 
-  context "Methods" do
-    describe "volume" do
+  context "Scopes" do
+    describe "with_volumes" do
+      subject { described_class.with_volumes }
+
       it "retrieves the amount of product that has been bought from this vendor" do
         vendor = create(:vendor)
         create(:purchase, :with_items, item_quantity: 10, amount_spent_in_cents: 1, vendor: vendor)
-        expect(vendor.volume).to eq(10)
+
+        expect(subject.first.volume).to eq(10)
       end
     end
   end


### PR DESCRIPTION
### Description
Noticed that the `/vendors` page had an N+1. As I fixed that, I realized the same change could be applied to `/manufacturers` and `/product_drive_participants`. While those endpoints don't have N+1's, it reduces the number of queries sent to just calculate the total item count in SQL rather than sending requests to load the `line_items` and calculate the sums afterwards.

### Type of change
* Performance (behavior unaffected)

### How Has This Been Tested?
Refactored the tests from method specs to scope specs.

### Screenshots
(Note the number of fewer SQL queries sent)

Before:
![Screenshot from 2025-01-27 16-58-56](https://github.com/user-attachments/assets/88b19f44-d116-4def-9d63-26185aacbbd0)

After:
![Screenshot from 2025-01-27 16-59-09](https://github.com/user-attachments/assets/49790f75-56d1-4d3a-8e99-ae8ddbd94d1e)

