### PR TITLE
Add rack-mini-profiler gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -182,6 +182,12 @@ group :development do
   gem "rails-erd"
   # Allows to create a console in the browser.
   gem "web-console"
+  # Middleware that displays speed badge for every HTML page
+  gem "rack-mini-profiler"
+  # Adds memory profiling to rack-mini-profiler
+  gem "memory_profiler"
+  # Adds call-stack profiling flamegraphs to rack-mini-profiler
+  gem "stackprof"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    memory_profiler (1.1.0)
     method_source (1.1.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
@@ -494,6 +495,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-mini-profiler (3.3.1)
+      rack (>= 1.2.0)
     rack-protection (4.0.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0, < 4)
@@ -657,6 +660,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    stackprof (0.2.27)
     standard (1.43.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -775,6 +779,7 @@ DEPENDENCIES
   lograge
   magic_test
   matrix
+  memory_profiler
   money-rails
   newrelic_rpm
   nokogiri (>= 1.10.4)
@@ -791,6 +796,7 @@ DEPENDENCIES
   pry-rails
   pry-remote
   puma
+  rack-mini-profiler
   rails (= 7.2.2)
   rails-controller-testing
   rails-erd
@@ -806,6 +812,7 @@ DEPENDENCIES
   simplecov
   solid_cache (~> 1.0)
   sprockets (~> 4.2.1)
+  stackprof
   standard (~> 1.40)
   standard-performance
   standard-rails


### PR DESCRIPTION
### Description
We have some pages that are known to be slow. Adding this gem might make slow performance somewhat more obvious for contributors and potentially easier to debug.

For example, in one issue I remember a contributor asking for a flamegraph to triage a slow request. Adding this gem lowers the bar for contributors to work on performance-related issues. 

I also thing it might help when testing PRs or features, to see if a PR is adding a N+1 or something that will cause a performance degradation.

Documentation on the gem can be found here: https://github.com/MiniProfiler/rack-mini-profiler

If someone find the badge annoying, it can be hidden by pressing alt+p.

### Type of change
* Internal (gem only added to development env)

### How Has This Been Tested?
I don't think testing is necessary

### Screenshots
Some example screens:
![Screenshot from 2025-01-28 10-58-14](https://github.com/user-attachments/assets/8ce4458b-8193-429b-9c04-b7a77391a921)
![Screenshot from 2025-01-28 11-15-35](https://github.com/user-attachments/assets/ff6b247c-c5ac-438e-8563-fed66dfe9a08)
![image](https://github.com/user-attachments/assets/603597d9-d68d-4a5d-816c-8b1050ffc908)
