### PR TITLE
Data fix for MHM -- item requests for items whose name changed.

### DIFF
--- a/db/migrate/20250129015253_item_request_fix_for_mhm.rb
+++ b/db/migrate/20250129015253_item_request_fix_for_mhm.rb
@@ -1,0 +1,17 @@
+class ItemRequestFixForMhm < ActiveRecord::Migration[7.2]
+  def change
+    item_ids = [302, 14372]
+    item_ids.each do |item_id|
+      item = Item.find(item_id)
+      item_requests = Partners::ItemRequest.where(item_id: item_id)
+      puts item_requests
+      item_requests.each do |item_request|
+        if(item_request.request)
+          item_request.name = item.name
+          item_request.save!
+        end
+      end
+    end
+  end
+
+end

--- a/db/migrate/20250129015253_item_request_fix_for_mhm.rb
+++ b/db/migrate/20250129015253_item_request_fix_for_mhm.rb
@@ -1,5 +1,6 @@
 class ItemRequestFixForMhm < ActiveRecord::Migration[7.2]
   def change
+    return unless Rails.env.production?
     item_ids = [302, 14372]
     item_ids.each do |item_id|
       item = Item.find(item_id)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_04_193318) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_29_015253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -513,8 +513,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_04_193318) do
     t.integer "deadline_day"
     t.index ["name", "organization_id"], name: "index_partner_groups_on_name_and_organization_id", unique: true
     t.index ["organization_id"], name: "index_partner_groups_on_organization_id"
-    t.check_constraint "deadline_day <= 28", name: "deadline_day_of_month_check"
-    t.check_constraint "reminder_day <= 28", name: "reminder_day_of_month_check"
+    t.check_constraint "deadline_day <= 28", name: "deadline_day_of_month_check", validate: false
+    t.check_constraint "reminder_day <= 28", name: "reminder_day_of_month_check", validate: false
   end
 
   create_table "partner_profiles", force: :cascade do |t|
@@ -728,6 +728,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_04_193318) do
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
   end
 
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.binary "key", null: false
+    t.binary "value", null: false
+    t.datetime "created_at", null: false
+    t.bigint "key_hash", null: false
+    t.integer "byte_size", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+
   create_table "storage_locations", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "address"
@@ -838,7 +849,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_04_193318) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  add_foreign_key "account_requests", "ndbn_members", primary_key: "ndbn_member_id"
+  add_foreign_key "account_requests", "ndbn_members", primary_key: "ndbn_member_id", validate: false
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "adjustments", "organizations"
   add_foreign_key "adjustments", "storage_locations"
@@ -872,7 +883,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_04_193318) do
   add_foreign_key "partner_requests", "users", column: "partner_user_id"
   add_foreign_key "partner_served_areas", "counties"
   add_foreign_key "partner_served_areas", "partner_profiles"
-  add_foreign_key "partners", "storage_locations", column: "default_storage_location_id"
+  add_foreign_key "partners", "storage_locations", column: "default_storage_location_id", validate: false
   add_foreign_key "product_drives", "organizations"
   add_foreign_key "requests", "distributions"
   add_foreign_key "requests", "organizations"


### PR DESCRIPTION
### Description

Data fix - some changes to item names in April 2024 did not propagate into item requests, which causes a problem on exporting requests  (in bugsnag, it shows up as "TypeError requests#index
no implicit conversion from nil to integer row[item_column_idx] ||= 0 ^^^^^^^^^^^^^^^^^^^^^^")    

 This is a fix for one bank who had the problem.  This is only a bandaid.    

Further notes:
1/ I do not know if anyone else has the same situation.  Name changes on items are uncommon. 
2/  We'll need to do a followup to forestall the issue happening again, which may be part of a larger conversation on how we use ItemRequest and RequestItem.
3/ It is possible this will not be a problem with new item changes.  I haven't confirmed, but I doubt that the base cause has been addressed.

I have put further investigation and fixes into the "in box"

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Manually checked against a copy of production data.
