### PR TITLE
Fix distribution export performance regression

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -69,7 +69,7 @@ class DistributionsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportDistributionsCSVService.new(distributions: @distributions, organization: current_organization, filters: scope_filters).generate_csv, filename: "Distributions-#{Time.zone.today}.csv"
+        send_data Exports::ExportDistributionsCSVService.new(distributions: @distributions.includes(line_items: :item), organization: current_organization, filters: scope_filters).generate_csv, filename: "Distributions-#{Time.zone.today}.csv"
       end
     end
   end


### PR DESCRIPTION
### Description
I introduced an N+1 into the distributions export accidentally by removing included association that was no longer needed for the distribution index page. But it the included association was needed for the CSV export.  

### Type of change

<!-- Please delete options that are not relevant. -->

* Performance fix (could be called a bug I guess?)

### How Has This Been Tested?
Automated test suite.

### Screenshots
Note the warnings from Bullet and the query count going from 76 to 14.

Before:
![Screenshot from 2025-01-29 23-42-23](https://github.com/user-attachments/assets/8b3e0468-8b25-4f49-a784-6fd0e0f1be22)

After:
![Screenshot from 2025-01-29 23-42-50](https://github.com/user-attachments/assets/54576d00-0d8d-4f6a-a55e-10e6e6b5cbb4)

