### PR TITLE
Remove old/unused #for_csv_export methods

### DIFF
--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -22,10 +22,6 @@ class Adjustment < ApplicationRecord
   include Filterable
   scope :at_location, ->(location_id) { where(storage_location_id: location_id) }
   scope :by_user, ->(user_id) { where(user_id: user_id) }
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .includes(:storage_location, :line_items)
-  }
   scope :during, ->(range) { where(adjustments: { created_at: range }) }
 
   validate :storage_locations_belong_to_organization

--- a/app/models/barcode_item.rb
+++ b/app/models/barcode_item.rb
@@ -42,11 +42,6 @@ class BarcodeItem < ApplicationRecord
 
   scope :by_value, ->(value) { where(value: value) }
 
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .includes(:barcodeable)
-  }
-
   scope :global, -> { where(barcodeable_type: "BaseItem") }
 
   # aliases of barcodeable

--- a/app/models/concerns/provideable.rb
+++ b/app/models/concerns/provideable.rb
@@ -8,10 +8,6 @@ module Provideable
   included do
     belongs_to :organization # Automatically validates presence as of Rails 5
 
-    scope :for_csv_export, ->(organization, *) {
-      where(organization: organization).order(:business_name)
-    }
-
     def self.import_csv(csv, organization)
       csv.each do |row|
         loc = new(row.to_hash)

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -61,11 +61,6 @@ class Distribution < ApplicationRecord
   scope :recent, ->(count = 3) { order(issued_at: :desc).limit(count) }
   scope :future, -> { where(issued_at: Time.zone.tomorrow..) }
   scope :during, ->(range) { where(distributions: { issued_at: range }) }
-  scope :for_csv_export, ->(organization, filters = {}, date_range = nil) {
-    where(organization: organization)
-      .includes(:partner, :storage_location, :line_items)
-      .apply_filters(filters, date_range)
-  }
   scope :apply_filters, ->(filters, date_range) {
     class_filter(filters.merge(during: date_range))
   }

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -51,11 +51,6 @@ class Donation < ApplicationRecord
   scope :from_manufacturer, ->(manufacturer_id) {
     where(manufacturer_id: manufacturer_id)
   }
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .includes(:line_items, :storage_location, :donation_site)
-      .order(created_at: :desc)
-  }
 
   before_create :combine_duplicates
 

--- a/app/models/donation_site.rb
+++ b/app/models/donation_site.rb
@@ -31,11 +31,6 @@ class DonationSite < ApplicationRecord
   include Geocodable
   include Exportable
 
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .order(:name)
-  }
-
   scope :active, -> { where(active: true) }
 
   scope :alphabetized, -> { order(:name) }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -60,11 +60,6 @@ class Item < ApplicationRecord
   scope :by_partner_key, ->(partner_key) { where(partner_key: partner_key) }
 
   scope :by_size, ->(size) { joins(:base_item).where(base_items: { size: size }) }
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .includes(:base_item)
-      .alphabetized
-  }
 
   # Scopes - explanation of business rules for filtering scopes as of 20240527.  This was a mess, but is much better now.
   # 1/  Disposable.   Disposables are only the disposable diapers for children.  So we deliberately exclude adult and cloth

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -57,11 +57,6 @@ class Partner < ApplicationRecord
   before_save { email&.downcase! }
   before_update :invite_new_partner, if: :should_invite_because_email_changed?
 
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .order(:name)
-  }
-
   scope :alphabetized, -> { order(:name) }
   scope :active, -> { where.not(status: :deactivated) }
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -48,11 +48,6 @@ class Purchase < ApplicationRecord
   scope :purchased_from, ->(purchased_from) { where(purchased_from: purchased_from) }
   scope :during, ->(range) { where(purchases: { issued_at: range }) }
   scope :recent, ->(count = 3) { order(issued_at: :desc).limit(count) }
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .includes(:line_items, :storage_location)
-      .order(created_at: :desc)
-  }
 
   scope :active, -> { joins(:line_items).joins(:items).where(items: { active: true }) }
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -49,11 +49,6 @@ class Request < ApplicationRecord
   scope :by_status, ->(status) { where(status: status) }
   scope :by_request_type, ->(request_type) { where(request_type: request_type) }
   scope :during, ->(range) { where(created_at: range) }
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .includes(:partner)
-      .order(created_at: :desc)
-  }
 
   def total_items
     request_items.sum { |item| item["quantity"] }

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -53,7 +53,6 @@ class StorageLocation < ApplicationRecord
   include Exportable
 
   scope :alphabetized, -> { order(:name) }
-  scope :for_csv_export, ->(organization, *) { where(organization: organization) }
   scope :active, -> { where(discarded_at: nil) }
   scope :with_transfers_to, ->(organization) {
     joins(:transfers_to).where(organization_id: organization.id).distinct.order(:name)

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -24,10 +24,6 @@ class Transfer < ApplicationRecord
   belongs_to :storage_location, class_name: "StorageLocation", inverse_of: :transfers_from, foreign_key: :from_id
   scope :from_location, ->(location_id) { where(from_id: location_id) }
   scope :to_location, ->(location_id) { where(to_id: location_id) }
-  scope :for_csv_export, ->(organization, *) {
-    where(organization: organization)
-      .includes(:line_items, :from, :to)
-  }
   scope :during, ->(range) { where(created_at: range) }
 
   validate :storage_locations_belong_to_organization

--- a/spec/models/barcode_item_spec.rb
+++ b/spec/models/barcode_item_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe BarcodeItem, type: :model do
       describe "by_item_partner_key" # TODO: Write test
       describe "by_base_item_partner_key" # TODO: Write test
       describe "by_value" # TODO: Write test
-      describe "for_csv_export" # TODO: Write test
       describe "global" do
         it "includes all barcodes, for both base items and regular items" do
           create(:global_barcode_item)
@@ -133,13 +132,6 @@ RSpec.describe BarcodeItem, type: :model do
     end
 
     context "scopes >" do
-      it "->for_csv_export will accept an organization and provide all barcodes for that org" do
-        barcode_item
-        create(:barcode_item, organization: create(:organization))
-        results = BarcodeItem.for_csv_export(barcode_item.organization)
-        expect(results).to eq([barcode_item])
-      end
-
       it "#by_item_partner_key returns barcodes that match the partner key" do
         bases = create_list(:base_item, 2)
         i1 = create(:item, name: "Item 1", base_item: bases.first)

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -315,27 +315,6 @@ RSpec.describe Distribution, type: :model do
   end
 
   context "CSV export >" do
-    let(:organization_2) { create(:organization) }
-    let(:item1) { create(:item, organization: organization) }
-    let(:item2) { create(:item, organization: organization) }
-    let!(:distribution_1) { create(:distribution, :with_items, item: item1, organization: organization, issued_at: 3.days.ago) }
-    let!(:distribution_2) { create(:distribution, :with_items, item: item2, organization: organization, issued_at: 1.day.ago) }
-    let!(:distribution_3) { create(:distribution, organization: organization_2, issued_at: Time.zone.today) }
-
-    describe "for_csv_export >" do
-      it "filters only to the given organization" do
-        expect(Distribution.for_csv_export(organization)).to match_array [distribution_1, distribution_2]
-      end
-
-      it "filters only to the given filter" do
-        expect(Distribution.for_csv_export(organization, { by_item_id: item1.id })).to match_array [distribution_1]
-      end
-
-      it "filters only to the given issue time range" do
-        expect(Distribution.for_csv_export(organization, {}, 4.days.ago..2.days.ago)).to match_array [distribution_1]
-      end
-    end
-
     describe "csv_export_attributes" do
       let(:item) { create(:item, organization: organization) }
       let!(:distribution) { create(:distribution, :with_items, item: item, organization: organization, issued_at: 3.days.ago) }


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
While working on the partners export, I noticed that these `for_csv_export` methods are from a previous implementation and no longer used.

### Type of change
* Internal 

### How Has This Been Tested?
Test suite