### PR TITLE
Remove unused date range params from partners csv export link

### DIFF
--- a/app/views/partners/_partners_table.html.erb
+++ b/app/views/partners/_partners_table.html.erb
@@ -11,7 +11,7 @@
         <div class="card-footer">
           <div class="pull-right">
             <%= modal_button_to("#csvImportModal", {text: "Import Partners", icon: "upload", size: "md"}) %>
-            <%= download_button_to(partners_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Partner Agencies", size: "md"}) if @partners.any? %>
+            <%= download_button_to(partners_path(format: :csv), {text: "Export Partner Agencies", size: "md"}) if @partners.any? %>
             <%= new_button_to new_partner_path, {text: "New Partner Agency"} %>
           </div>
         </div>


### PR DESCRIPTION
Doesn't resolve any issue.

### Description
While working on performance of the partners csv export, I notice the request applies some default date range parameters to the csv requests.

Let's remove those date params because we aren't actually doing anything will them (they aren't permitted params in the controller) so as not to confuse users in to thinking the export is only for the time range supplied.

### Type of change
I don't know how to categorize this. It is user-facing in that on hover the link looks different, but it doesn't effect the CSV export in any way.

### How Has This Been Tested?
Test suite

### Screenshot
These are screenshots of me hovering over the export partner agencies button. Note the link in the lower lefthand corner.

Before:

![Screenshot from 2025-02-07 14-39-46](https://github.com/user-attachments/assets/d4cde6d0-682b-4868-995b-a52f256b21aa)

After:

![Screenshot from 2025-02-07 14-40-04](https://github.com/user-attachments/assets/8ba459f3-c2f5-4e04-a6b9-e87b4a01082b)


