### PR TITLE
 resolve #4998 Package size on item must be non-negative

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -39,6 +39,7 @@ class Item < ApplicationRecord
   validates :distribution_quantity, numericality: { greater_than: 0 }, allow_blank: true
   validates :on_hand_recommended_quantity, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
   validates :on_hand_minimum_quantity, numericality: { greater_than_or_equal_to: 0 }
+  validates :package_size, numericality: { greater_than_or_equal_to: 0 }
 
   has_many :line_items, dependent: :destroy
   has_many :inventory_items, dependent: :destroy


### PR DESCRIPTION


Resolves #4998

added additional model validation to ensure package size should not be negative, but it still can be 0, if not then additional change is required as:
<i>validates :package_size, numericality: { greater_than: 0 } </i>

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

require 'test_helper'
<i>
class ItemTest < ActiveSupport::TestCase
  test "should not allow negative package_size" do
    item = Item.new(name: "Test Item", package_size: -1)
    assert_not item.valid?
    assert_includes item.errors[:package_size], "must be greater than or equal to 0"
  end

  test "should allow zero and positive package_size" do
    item = Item.new(name: "Test Item", package_size: 0)
    assert item.valid?
    item.package_size = 10
    assert item.valid?
  end
end
</i>

