### PR TITLE
Update Item Request Names where needful

### DIFF
--- a/db/migrate/20250211172314_update_item_request_name_for_all.rb
+++ b/db/migrate/20250211172314_update_item_request_name_for_all.rb
@@ -1,0 +1,15 @@
+class UpdateItemRequestNameForAll < ActiveRecord::Migration[7.2]
+  def change
+    return unless Rails.env.production?
+    Item.all.each do |item|
+      # Some very old item requests have nil partner keys.   We are not going to fix them with this.
+      item_requests = Partners::ItemRequest.where(item_id: item.id).where.not(partner_key: nil).where.not(name: item.name)
+      item_requests.each do |item_request|
+        if(item_request.request)
+          item_request.name = item.name
+          item_request.save!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Migration to update names on ItemRequest where they do not match the corresponding item.

This happens when Item names are updated.
Prompted because Request export fails if the item names do not match the item request names.   
We had fixed this for one bank,  but it has recurred.  See bugsnag Feb 7 ~10:07 EST
******************************************************************************
*** This migration is kind of slow -- 5-10 minutes (I wandered off) -- on local **  
*******************************************************************************
#### NOTE
This is still a band-aid -- there are two things to be done to further address the problem.
1/ Reconcile Item Request  and Request Item 
2/ Rework the Request Export so it isn't dependent on the name in the ItemRequest, se we can then remove it.

These are in the "queue".



### Type of change


* Bug fix (non-breaking change which (partially) fixes an issue)
### How Has This Been Tested?

Tested by running request export before (failing) and after (working, and looks reasonable) for someone we know had the problem on a local copy of prod data.

