### PR TITLE
Fix for production issue,  Remove www from email links

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   routes.default_url_options[:host] = 'humanessentials.app'
-  config.action_mailer.default_url_options = { host: "www.humanessentials.app" }
+  config.action_mailer.default_url_options = { host: "humanessentials.app" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: 'smtp.sendgrid.net',


### PR DESCRIPTION
### Description

Removes www from the default url options for production.
In response to links not working after last night's reconfiguration of production

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Not tested