### PR TITLE
Remove partner FAQs - Part 3

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -14,9 +14,6 @@ class Question < ApplicationRecord
   validates :title, presence: true
   scope :search_title, ->(query) { where("title ilike ?", "%#{query}%").includes([:rich_text_answer]) }
 
-  # TODO: remove this line once migration `20250104193318_remove_for_banks_and_for_partners_from_questions` has been run in production
-  self.ignored_columns += ["for_banks", "for_partners"]
-
   filterrific(
     available_filters: [
       :search_title


### PR DESCRIPTION
Relates to #4546 

### Description
This is the last step to remove columns from the Question model now #4912 and #4913 have been merged and deployed in production.

### Type of change
n/a

### How Has This Been Tested?
n/a

### Screenshots
n/a
