### PR TITLE
Deleting BarcodeItem works as intended

### DIFF
--- a/app/controllers/barcode_items_controller.rb
+++ b/app/controllers/barcode_items_controller.rb
@@ -92,6 +92,7 @@ class BarcodeItemsController < ApplicationController
     rescue StandardError
       flash[:error] = "Sorry, you don't have permission to delete this barcode."
     end
+    flash[:notice] = "Barcode deleted!"
     redirect_to barcode_items_path
   end
 

--- a/app/controllers/barcode_items_controller.rb
+++ b/app/controllers/barcode_items_controller.rb
@@ -88,7 +88,7 @@ class BarcodeItemsController < ApplicationController
       barcode = current_organization.barcode_items.find(params[:id])
       raise if barcode.nil? || barcode.global?
 
-      barcode.destroy
+      barcode.destroy!
     rescue StandardError
       flash[:error] = "Sorry, you don't have permission to delete this barcode."
     end

--- a/app/models/barcode_item.rb
+++ b/app/models/barcode_item.rb
@@ -15,7 +15,7 @@
 class BarcodeItem < ApplicationRecord
   has_paper_trail
   belongs_to :organization, optional: true
-  belongs_to :barcodeable, polymorphic: true, dependent: :destroy, counter_cache: :barcode_count
+  belongs_to :barcodeable, polymorphic: true, counter_cache: :barcode_count
 
   validates :organization, presence: true, unless: proc { |b| b.barcodeable_type == "BaseItem" }
   validates :value, presence: true
@@ -45,10 +45,8 @@ class BarcodeItem < ApplicationRecord
   scope :global, -> { where(barcodeable_type: "BaseItem") }
 
   # aliases of barcodeable
-  belongs_to :item, polymorphic: true, dependent: :destroy,
-    counter_cache: :barcode_count, foreign_key: :barcodeable_id, foreign_type: :barcodeable_type
-  belongs_to :base_item, polymorphic: true, dependent: :destroy,
-    counter_cache: :barcode_count, foreign_key: :barcodeable_id, foreign_type: :barcodeable_type
+  belongs_to :item, polymorphic: true, counter_cache: :barcode_count, foreign_key: :barcodeable_id, foreign_type: :barcodeable_type
+  belongs_to :base_item, polymorphic: true, counter_cache: :barcode_count, foreign_key: :barcodeable_id, foreign_type: :barcodeable_type
 
   def to_h
     {

--- a/spec/models/barcode_item_spec.rb
+++ b/spec/models/barcode_item_spec.rb
@@ -111,6 +111,18 @@ RSpec.describe BarcodeItem, type: :model do
 
       include_examples "common barcode tests", :global_barcode_item
     end
+
+    describe "#destroy" do
+      before { global_barcode_item } # Ensure barcode and its item are created
+
+      it "deletes the barcode item" do
+        expect { global_barcode_item.destroy }.to change(BarcodeItem, :count).by(-1)
+      end
+
+      it "keeps the associated item" do
+        expect { global_barcode_item.destroy }.to_not change(Item, :count)
+      end
+    end
   end
 
   context "Organization barcodes" do
@@ -193,6 +205,18 @@ RSpec.describe BarcodeItem, type: :model do
     describe "to_h >" do
       it "emits a hash for a line_item" do
         expect(barcode_item.to_h).to eq(barcodeable_id: barcode_item.barcodeable_id, barcodeable_type: barcode_item.barcodeable_type, quantity: barcode_item.quantity)
+      end
+    end
+
+    describe "#destroy" do
+      before { barcode_item } # Ensure barcode and its item are created
+
+      it "deletes the barcode item" do
+        expect { barcode_item.destroy }.to change(BarcodeItem, :count).by(-1)
+      end
+
+      it "keeps the associated item" do
+        expect { barcode_item.destroy }.to_not change(Item, :count)
       end
     end
   end

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Barcode Items Admin", type: :system do
 
       it "deletes a global barcode" do
         expect(accept_confirm { click_on "Delete" }).to include "Are you sure you want to delete"
-        expect(page).to have_no_content "\n#{barcode_item.base_item.name}"
+        expect(page).to have_content("Barcode Item deleted!")
       end
 
       it 'creates a new global barcode item' do


### PR DESCRIPTION
Resolves #4989 

### Description
When trying to delete a BarcodeItem, there was also an attempt to delete the associated Item.
I removed the `dependent: :destroy` option on the `belongs_to` association to fix this. Per [Rails documentation for the `:dependent` option](https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to), this option shouldn't be used anyway if there is a corresponding `has_many` association.

I also ensured that flash messages are being displayed if the BarcodeItem is deleted or if it fails to delete.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added some model tests for BarcodeItem. Modified existing admin system spec for BarcodeItem to be more precise on the expectation.

### Screenshots

https://github.com/user-attachments/assets/e5112a4d-118c-431d-a4fb-35c97995c237


