### PR TITLE
Modify category names in seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,7 +125,7 @@ end
 # ----------------------------------------------------------------------------
 
 Organization.all.find_each do |org|
-  ["Diapers", "Period Supplies", "Adult Incontinence"].each do |letter|
+  ["One", "Two", "Three"].each do |letter|
     FactoryBot.create(:item_category, organization: org, name: "Category #{letter}")
   end
 end


### PR DESCRIPTION
Resolves #5005

### Description
- I updated `seeds.rb` to use more generic category names.
- When I ran local tests, the change didn't cause any tests to break.  
- I did notice that the `CalendarService#time_zones` test was failing on both my branch and main.  I did not see this spec mentioned in issue #4557 or any other issues.  Please let me know if I should make an issue to fix this failing spec.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
- I ran automated tests to ensure that tests passed.
- I ensured that the "Filter by item category" functionality for distributions reflected the change.

### Screenshots
<details>
<summary>Screenshot of change</summary>

![5005CategoriesChanged](https://github.com/user-attachments/assets/842cfe56-7a67-4db5-a872-19792d4e7bc2)

</details>