### PR TITLE
4821-part1-partner-profile-support-multiple-attached-docs

### DIFF
--- a/app/views/partners/profiles/step/_attached_documents_form.html.erb
+++ b/app/views/partners/profiles/step/_attached_documents_form.html.erb
@@ -4,7 +4,10 @@
       <strong>Attached files:</strong>
       <ul>
         <% profile.documents.each do |doc| %>
-          <li><%= link_to doc.blob['filename'], rails_blob_path(doc), class: "font-weight-bold" %></li>
+          <% if doc.persisted? %>
+            <li><%= link_to doc.blob['filename'], rails_blob_path(doc), class: "font-weight-bold" %></li>
+            <%= pf.hidden_field :documents, multiple: true, value: doc.signed_id %>
+          <% end %>
         <% end %>
       </ul>
       <%= pf.file_field :documents, multiple: true, class: "form-control-file" %>

--- a/spec/fixtures/files/document1.md
+++ b/spec/fixtures/files/document1.md
@@ -1,0 +1,13 @@
+# Food Pantry Program Overview
+
+Our food pantry serves families in need within the community.
+
+## Services Provided
+
+- Weekly food distribution
+- Emergency food assistance
+
+## Contact Information
+
+Email: info@foodpantry.org
+Phone: (555) 123-4567

--- a/spec/fixtures/files/document2.md
+++ b/spec/fixtures/files/document2.md
@@ -1,0 +1,9 @@
+# Delivery Guidelines
+
+Please follow these guidelines when delivering goods:
+
+1. Ensure all packages are labeled.
+2. Deliveries must be completed by 5 PM.
+3. Contact us immediately if there are delays.
+
+Thank you for your cooperation!

--- a/spec/system/partners/profile_edit_system_spec.rb
+++ b/spec/system/partners/profile_edit_system_spec.rb
@@ -99,6 +99,44 @@ RSpec.describe "Partners profile edit", type: :system, js: true do
       expect(page).to have_css("#partner_settings.accordion-collapse.collapse.show", visible: true)
     end
 
+    it "preserves previously uploaded documents when adding new attachments" do
+      # Upload the first document
+      find("button[data-bs-target='#attached_documents']").click
+      expect(page).to have_css("#attached_documents.accordion-collapse.collapse.show", visible: true)
+
+      within "#attached_documents" do
+        attach_file("partner_profile_documents", Rails.root.join("spec/fixtures/files/document1.md"), make_visible: true)
+      end
+
+      # Save Progress
+      all("input[type='submit'][value='Save Progress']").last.click
+      expect(page).to have_css(".alert-success", text: "Details were successfully updated.")
+
+      # Verify the document is listed
+      visit edit_partners_profile_path
+      find("button[data-bs-target='#attached_documents']").click
+      within "#attached_documents" do
+        expect(page).to have_link("document1.md")
+      end
+
+      # Upload a second document
+      within "#attached_documents" do
+        attach_file("partner_profile_documents", Rails.root.join("spec/fixtures/files/document2.md"), make_visible: true)
+      end
+
+      # Save Progress
+      all("input[type='submit'][value='Save Progress']").last.click
+      expect(page).to have_css(".alert-success", text: "Details were successfully updated.")
+
+      # Verify both documents are listed
+      visit edit_partners_profile_path
+      find("button[data-bs-target='#attached_documents']").click
+      within "#attached_documents" do
+        expect(page).to have_link("document1.md")
+        expect(page).to have_link("document2.md")
+      end
+    end
+
     it "persists file upload when there are validation errors" do
       # Open up Agency Information section and upload proof-of-status letter
       find("button[data-bs-target='#agency_information']").click


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Partial solution for #4821

### Description

This is the first part in a series of [planned improvements](https://github.com/rubyforgood/human-essentials/issues/4821#issuecomment-2676150125) for the "Additional Documents" section of Partner Profile editing.

Currently, even though the field is named in the plural "Additional Documents" and is using the `has_many_attached` association, in practice, the partner can only ever have one document at a time. Any time they upload a new one, it removes whatever was there previously.

What this fixes is to maintain the existing document(s), when a new one is uploaded, by including a hidden `signed_id` field for every document that is already attached. This solution is explained in the [Rails Guide on Active Storage](https://guides.rubyonrails.org/v7.2/active_storage_overview.html#replacing-vs-adding-attachments).

> [!NOTE]
> This is only implemented in the step-wise version of the Partner Profile edit form as the legacy "all-in-one" version is no longer in use (and should eventually be retired - future ticket).

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

For automated testing, see new system test `spec/system/partners/profile_edit_system_spec.rb` "preserves previously uploaded documents when adding new attachments".

For manual testing:

* Login as an invited partner `invited@pawneehomeless.com`
* Click on "Edit Profile" from the left hand side navigation
* Open the "Attached Documents" accordion section
* Upload a document and Save Progress
* Open the "Attached Documents" accordion section again and upload another document, and Save Progress
* Open the section and this time you should see both documents listed (previously only the newest one uploaded would be preserved)
* Optionally, you can also select multiple files at a time, they should all be saved, then if you come back to add more, originals plus anything new you added should all remain

### Screenshots

![image](https://github.com/user-attachments/assets/2a4ce5cd-9a46-48db-8c0d-b65823053018)
