### PR TITLE
Fix: Remove deprecation warning in Audit and Partner status enum (#4975)

### DIFF
--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -25,7 +25,7 @@ class Audit < ApplicationRecord
 
   accepts_nested_attributes_for :adjustment
 
-  enum status: { in_progress: 0, confirmed: 1, finalized: 2 }
+  enum :status, { in_progress: 0, confirmed: 1, finalized: 2 }
 
   validate :line_items_quantity_is_not_negative
   validate :line_items_unique_by_item_id

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -28,7 +28,7 @@ class Partner < ApplicationRecord
   ].freeze
 
   # Status `4` (error) was removed for being obsolete but is intentionally skipped to preserve existing enum values.
-  enum status: { uninvited: 0, invited: 1, awaiting_review: 2, approved: 3, recertification_required: 5, deactivated: 6 }
+  enum :status, { uninvited: 0, invited: 1, awaiting_review: 2, approved: 3, recertification_required: 5, deactivated: 6 }
 
   belongs_to :organization
   belongs_to :partner_group, optional: true


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #4975 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
This PR addresses a **deprecation warning** that occurs when calling `Partner.all` and `Audit.count` in the Rails console.


### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

You can test this fix typing `Partner.count` or `Partner.all`.
All tests relating to Partner and Audit models still pass.
