### PR TITLE
Fix partner disabling for distributions from requests

### DIFF
--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -11,8 +11,14 @@
     <%= f.association :partner,
       collection: @partner_list,
       label: "Partner",
-      readonly: !!@request,
+      disabled: !!@request,
       error: "Which partner is this distribution going to?" %>
+
+    <%# If the distribution is from a request, the partner has been set already. %>
+    <%# We send it via hidden_field because params aren't sent for disabled fields.  %>
+    <% if @request %>
+      <%= f.hidden_field :partner_id, value: distribution.partner_id %>
+    <% end %>
 
     <div class='w-72'>
       <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date and time", html5: true, :input_html => { :value => date_place_holder&.strftime("%Y-%m-%dT%0k:%M")} %>

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe "Distributions", type: :request do
         get new_distribution_path(default_params)
         page = Nokogiri::HTML(response.body)
 
-        expect(page.at_css("select#distribution_partner_id").classes).to include("readonly")
+        expect(page.at_css("select#distribution_partner_id").classes).to include("disabled")
       end
 
       context "with org default but no partner default" do
@@ -404,7 +404,7 @@ RSpec.describe "Distributions", type: :request do
             get new_distribution_path({})
             page = Nokogiri::HTML(response.body)
 
-            expect(page.at_css("select#distribution_partner_id").classes).not_to include("readonly")
+            expect(page.at_css("select#distribution_partner_id").classes).not_to include("disabled")
           end
         end
       end
@@ -680,7 +680,7 @@ RSpec.describe "Distributions", type: :request do
         get edit_distribution_path(id: distribution.id)
         page = Nokogiri::HTML(response.body)
 
-        expect(page.at_css("select#distribution_partner_id").classes).not_to include("readonly")
+        expect(page.at_css("select#distribution_partner_id").classes).not_to include("disabled")
       end
 
       context 'with units' do
@@ -740,7 +740,7 @@ RSpec.describe "Distributions", type: :request do
           get edit_distribution_path(id: distribution.id)
           page = Nokogiri::HTML(response.body)
 
-          expect(page.at_css("select#distribution_partner_id").classes).to include("readonly")
+          expect(page.at_css("select#distribution_partner_id").classes).to include("disabled")
         end
 
         context 'with no request' do


### PR DESCRIPTION
Related to issue #4983. 

### Description
My PR #5029 set the partner field to `readonly` when the distribution is from a request. Apparently, that just makes the field look disabled, but it can still be changed. This PR changes the field from `readonly` to `disabled`.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually checked the field is now disabled.