### PR TITLE
Fix devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # Installs Ruby 3.2.2. When human-essentials moves to a newer version of ruby,
 # it will be more efficient to change the image.
 # See https://github.com/devcontainers/images/blob/main/src/ruby/history/
-FROM mcr.microsoft.com/devcontainers/ruby:dev-3.2-buster
+FROM mcr.microsoft.com/devcontainers/ruby:dev-3.2
 RUN export DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install vim curl gpg postgresql postgresql-contrib
 RUN cd /tmp

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,19 +1,28 @@
 RUBY_VERSION="$(cat .ruby-version | tr -d '\n')"
 
 # copy the file only if it doesn't already exist
+echo "*** Creating initial .env and vscode settings, if needed"
 cp -n .devcontainer/.env.codespaces .env
 mkdir -p .vscode && cp -n .devcontainer/launch.json.codespaces .vscode/launch.json
 
 # If the project's required ruby version changes from 3.2.2, this command
 # will download and compile the correct version, but it will take a long time.
 if [ "$RUBY_VERSION" != "3.2.2" ]; then
+  echo "*** Installing Ruby $RUBY_VERSION (this may take a while)"
   rvm install $RUBY_VERSION
   rvm use $RUBY_VERSION
   echo "Ruby $RUBY_VERSION installed"
 fi
 
+echo "*** Setting up node"
 nvm install node
+
+echo "*** Setting up ruby environment"
 rbenv init bash
 rbenv init zsh
 
+# echo "*** Forcing platform version of nokogiri"
+# gem install nokogiri -v 1.18.1 --platform=ruby -- --use-system-libraries
+
+echo "*** Running project bin/setup"
 bin/setup

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -826,4 +826,4 @@ DEPENDENCIES
   webmock (~> 3.24)
 
 BUNDLED WITH
-   2.6.2
+   2.6.5

--- a/bin/setup
+++ b/bin/setup
@@ -40,7 +40,7 @@ FileUtils.chdir APP_ROOT do
   #
   # Validate that the ruby version requirement is met.
   #
-  expected_ruby_version = `cat .ruby-version`.chomp
+  expected_ruby_version = `cat .ruby-version`.chomp.gsub(/\.\d+\z/, "")
   current_ruby_version = `ruby -v`.chomp
   unless current_ruby_version.include?(expected_ruby_version)
     log "Ruby version must be #{expected_ruby_version}. You are on #{current_ruby_version}", color: :red

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_21_143640) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_02_154355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
* Updates devcontainer base image
* Loosens the bin/setup ruby version check
* Adds some more logging
* Updates db schema so that bin/setup will finish cleanly (no pending migrations)

The underlying issue was .... drumroll ... nokogiri. Updating the base docker image fixed it, but then the bin/setup needed to be more tolerant of the minor version mismatch (unless we want to upgrade everything to 3.2.7, but that sounds worse).