### PR TITLE
feat: add ability to add and show partner-specific information

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -182,7 +182,7 @@ class PartnersController < ApplicationController
 
   def partner_params
     params.require(:partner).permit(:name, :email, :send_reminders, :quota,
-      :notes, :partner_group_id, :default_storage_location_id, documents: [])
+      :notes, :partner_group_id, :default_storage_location_id, :info_for_partner, documents: [])
   end
 
   helper_method \

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -4,6 +4,7 @@
 #
 #  id                          :integer          not null, primary key
 #  email                       :string
+#  info_for_partner            :text
 #  name                        :string
 #  notes                       :text
 #  quota                       :integer

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -46,8 +46,8 @@
               <%= f.input :notes, label: "Notes", wrapper: :input_group do %>
                 <%= f.input_field :notes, class: "form-control" %>
               <% end %>
-              <%= f.input :info_for_partner, label: "Information for partner", wrapper: :input_group do %>
-                <%= f.input_field :info_for_partner, class: "form-control", "aria-describedby": "info-for-partner-note" %>
+              <%= f.input :info_for_partner, label: "Partner specific information (500 characters)", wrapper: :input_group do %>
+                <%= f.input_field :info_for_partner, class: "form-control", "aria-describedby": "info-for-partner-note", maxlength: 500 %>
               <% end %>
                 <p class="form-text" id="info-for-partner-note">Note: The partner can see, but cannot change this information.</p>
               <%= f.input :documents, label: "Documents", wrapper: :input_group do %>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -46,6 +46,10 @@
               <%= f.input :notes, label: "Notes", wrapper: :input_group do %>
                 <%= f.input_field :notes, class: "form-control" %>
               <% end %>
+              <%= f.input :info_for_partner, label: "Information for partner", wrapper: :input_group do %>
+                <%= f.input_field :info_for_partner, class: "form-control", "aria-describedby": "info-for-partner-note" %>
+              <% end %>
+                <p class="form-text" id="info-for-partner-note">Note: The partner can see, but cannot change this information.</p>
               <%= f.input :documents, label: "Documents", wrapper: :input_group do %>
                 <% if @partner.documents.present? %>
                   <ul class="list-unstyled w-100">

--- a/app/views/partners/dashboards/_info_for_partner.html.erb
+++ b/app/views/partners/dashboards/_info_for_partner.html.erb
@@ -1,0 +1,4 @@
+<section class="container mx-auto">
+  <h2 class="font-weight-bold">Info</h2>
+  <p><%= info_for_partner %></p>
+</section>

--- a/app/views/partners/dashboards/show.html.erb
+++ b/app/views/partners/dashboards/show.html.erb
@@ -6,6 +6,10 @@
 </header>
 
 <main>
+  <% if @partner.info_for_partner %>
+    <%= render partial: 'info_for_partner', locals: { info_for_partner: @partner.info_for_partner}  %>
+  <% end %>
+
   <%= render partial: '/partners/requests/request_options_card' if @partner.approved? %>
 
   <section class="container mx-auto my-5">

--- a/app/views/partners/dashboards/show.html.erb
+++ b/app/views/partners/dashboards/show.html.erb
@@ -7,7 +7,7 @@
 
 <main>
   <% if @partner.info_for_partner %>
-    <%= render partial: 'info_for_partner', locals: { info_for_partner: @partner.info_for_partner}  %>
+    <%= render partial: 'info_for_partner', locals: { info_for_partner: @partner.info_for_partner} %>
   <% end %>
 
   <%= render partial: '/partners/requests/request_options_card' if @partner.approved? %>

--- a/db/migrate/20250409014424_add_info_for_partner_to_partner.rb
+++ b/db/migrate/20250409014424_add_info_for_partner_to_partner.rb
@@ -1,0 +1,5 @@
+class AddInfoForPartnerToPartner < ActiveRecord::Migration[8.0]
+  def change
+    add_column :partners, :info_for_partner, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_02_154355) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_09_014424) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -645,6 +645,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_02_154355) do
     t.integer "quota"
     t.bigint "partner_group_id"
     t.bigint "default_storage_location_id"
+    t.text "info_for_partner"
     t.index ["default_storage_location_id"], name: "index_partners_on_default_storage_location_id"
     t.index ["organization_id"], name: "index_partners_on_organization_id"
     t.index ["partner_group_id"], name: "index_partners_on_partner_group_id"

--- a/spec/factories/kits.rb
+++ b/spec/factories/kits.rb
@@ -10,6 +10,15 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  organization_id     :integer          not null
+#
+#  id                  :bigint           not null, primary key
+#  active              :boolean          default(TRUE)
+#  name                :string           not null
+#  value_in_cents      :integer          default(0)
+#  visible_to_partners :boolean          default(TRUE), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  organization_id     :integer          not null
 
 FactoryBot.define do
   factory :kit do

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -4,6 +4,7 @@
 #
 #  id                          :integer          not null, primary key
 #  email                       :string
+#  info_for_partner            :text
 #  name                        :string
 #  notes                       :text
 #  quota                       :integer

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                          :integer          not null, primary key
 #  email                       :string
+#  info_for_partner            :text
 #  name                        :string
 #  notes                       :text
 #  quota                       :integer

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -61,7 +61,8 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
             name: Faker::Name.name,
             email: Faker::Internet.email,
             quota: Faker::Number.within(range: 5..100),
-            notes: Faker::Lorem.paragraph
+            notes: Faker::Lorem.paragraph,
+            info_for_partner: Faker::Lorem.paragraph
           }
         end
         before do
@@ -74,6 +75,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           fill_in 'E-mail *', with: partner_attributes[:email]
           fill_in 'Quota', with: partner_attributes[:quota]
           fill_in 'Notes', with: partner_attributes[:notes]
+          fill_in 'Partner specific information', with: partner_attributes[:info_for_partner]
           find('button', text: 'Add Partner Agency').click
 
           assert page.has_content? "Partner #{partner_attributes[:name]} added!"


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->


Partial:  #5020 

### Description

* [x] Database migration to add new `info_for_partner` field to the `partner.rb` model. 
* [x] Update the create/edit partner information frontend with a new textarea. (for partner)
* [x] Update the `partners_controller.rb` to accept new field params.
* [x] Update the dashboard page for partner to add information.
* [x] Added a test


### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I updated the `spec/system/partner_system_spec.rb` spec.

### Screenshots

<img width="517" alt="New form field with the label 'Partner specific information (500 characters)" src="https://github.com/user-attachments/assets/6e1240d6-43a0-489e-8d1d-8412c5ddcd02" />

<img width="1054" alt="Partner specific information is shown on the partner dashboard under the heading 'Info'" src="https://github.com/user-attachments/assets/ea53fc69-cffb-4ea8-b653-279ffbba66c2" />


