### PR TITLE
validates the item purchase fields for diapers,

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -56,6 +56,11 @@ class Purchase < ApplicationRecord
   validates :amount_spent_in_cents, numericality: { greater_than: 0 }
   validate :total_equal_to_all_categories
 
+  validates :amount_spent_on_diapers_cents, numericality: { greater_than_or_equal_to: 0 }
+  validates :amount_spent_on_adult_incontinence_cents, numericality: { greater_than_or_equal_to: 0 }
+  validates :amount_spent_on_period_supplies_cents, numericality: { greater_than_or_equal_to: 0 }
+  validates :amount_spent_on_other_cents, numericality: { greater_than_or_equal_to: 0 }
+
   SummaryByDates = Data.define(
     :amount_spent,
     :recent_purchases,

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -54,6 +54,29 @@ RSpec.describe Purchase, type: :model do
       expect(d).to be_valid
     end
 
+    # re 5059-non-negative-purchase_value, adding in amount_spent_on_period_supplies_cents to test.
+    # also adding in amount_spend_on_incontinence_cents because it was missing.
+
+    it "is not valid if any category negative" do
+      d = build(:purchase, amount_spent_on_diapers_cents: -1)
+      expect(d).not_to be_valid
+      d = build(:purchase, amount_spent_on_adult_incontinence_cents: -2)
+      expect(d).not_to be_valid
+      d = build(:purchase, amount_spent_on_period_supplies_cents: -3)
+      expect(d).not_to be_valid
+      d = build(:purchase, amount_spent_on_other_cents: -4)
+      expect(d).not_to be_valid
+    end
+
+    it "is valid if all categories are positive" do
+      d = build(:purchase, amount_spent_in_cents: 1150,
+        amount_spent_on_diapers_cents: 200,
+        amount_spent_on_adult_incontinence_cents: 300,
+        amount_spent_on_period_supplies_cents: 400,
+        amount_spent_on_other_cents: 250)
+      expect(d).to be_valid
+    end
+
     # 2813 update annual reports -- this covers off making sure it's checking the case of period supplies only (which it won't be before we make it so)
 
     it "is not valid if period supplies is non-zero but no other category is " do


### PR DESCRIPTION

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5059 <!--fill issue number-->

### Description
Before the change, a user could a new purchase with negative dollar values for the respective items (other, incontinence, etc.) and it would be valid so long as the total sum was correct and greater than zero.

A validation was added such that each purchase item must be greater than or equal to zero, and a respective rspec test was added to check.


### Type of change


* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Create a new purchase, and set the following values respectively: 1, -1, 2, 0, 0. This will submit successfully, which is incorrect.

Following the change, this will produce an error and not submit.


