### PR TITLE
Issue 5069: Add pagination to product drives

### DIFF
--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -11,6 +11,8 @@ class ProductDrivesController < ApplicationController
                      .class_filter(filter_params)
                      .within_date_range(@selected_date_range)
                      .order(start_date: :desc)
+    @paginated_product_drives = @product_drives.page(params[:page])
+
     # to be used in the name filter to sort product drives in alpha order
     @product_drives_alphabetical = @product_drives.sort_by { |pd| pd.name.downcase }
     @item_categories = current_organization.item_categories

--- a/app/views/product_drives/index.html.erb
+++ b/app/views/product_drives/index.html.erb
@@ -102,7 +102,7 @@
               </tr>
               </thead>
               <tbody>
-              <% @product_drives.each do |product_drive| %>
+              <% @paginated_product_drives.each do |product_drive| %>
                 <tr>
                   <td><%= product_drive.name %></td>
                   <td><%= product_drive.start_date.strftime("%m-%d-%Y") %></td>
@@ -119,9 +119,9 @@
             </table>
           </div>
           <!-- /.card-body -->
-          <!--          <div class="card-footer clearfix">-->
-          <%#= paginate @paginated_requests %>
-          <!--          </div>-->
+          <div class="card-footer clearfix">
+            <%= paginate @paginated_product_drives %>
+          </div>
           <!-- /.card-footer-->
         </div>
         <!-- /.card -->

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -159,6 +159,40 @@ RSpec.describe "ProductDrives", type: :request do
           end
         end
       end
+
+      describe "pagination" do
+        around do |ex|
+          Kaminari.config.default_per_page = 2
+          ex.run
+          Kaminari.config.default_per_page = 5
+        end
+
+        before do
+          # Create a list of Product Drives to exceed pagination limit
+          create_list(:product_drive, 10, organization: organization)
+
+          # Fetch Product Drives before assertions
+          get product_drives_path
+        end
+
+        it "displays pagination controls when there are more product drives than default per page" do
+          expect(response).to be_successful
+
+          parsed_html = Nokogiri::HTML(response.body)
+
+          # Select the Product Drives table, which is the only table in the view
+          # and count the rows
+          product_drives_table = parsed_html.at_css("table.table")
+          row_count = product_drives_table.css("tbody tr").size
+
+          # There should be 2 rows on the first page--the default per page configured above
+          expect(row_count).to eq(2)
+
+          # Check that pagination controls (e.g., "Next" button) appear
+          next_button = parsed_html.at_css('a, button') { |el| el.text.strip == 'Next' }
+          expect(next_button).not_to be_nil
+        end
+      end
     end
 
     describe "GET #new" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5069 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
- Added pagination to Product Drives controller and corresponding view
    - Utilizes `Kaminari` pagination Gem already in use in project

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
Test case checks that:
- product drives table will only display the number of rows set in `Kaminari.config.default_per_page`
- pagination controls appear if the per-page limit is exceeded

To test, run `bundle exec rspec spec/requests/product_drives_requests_spec.rb` from project directory
