### PR TITLE
Hide unneeded "Attach Files" button when creating a new FAQ question - Resolves #5070

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,7 @@
 @import 'modal-dialog';
 @import 'expandable_table';
 @import 'custom';
+@import '../../javascript/stylesheets/actiontext';
 
 .modal-dialog {
   display: flex;

--- a/app/javascript/stylesheets/actiontext.scss
+++ b/app/javascript/stylesheets/actiontext.scss
@@ -38,3 +38,9 @@
     }
   }
 }
+
+// Hide the "Attach Files" button in the Trix toolbar that appears when adding a new FAQ 
+// question.
+.trix-button--icon-attach {
+  display: none;
+}


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5070

### Description
An unneeded "Attach Files" button was appearing on the form to create a new FAQ when logged in as an administrator, as described in #5070.

Digging in the code (and some maintainer help!) revealed that the relevant row of buttons is a Trix toolbar. The only way we could figure out how to hide the button was to do it via the CSS. However, after adding and testing the button-hiding code in `actiontext.scss`, we found that the changes weren't showing live. (It's not clear `actiontext.scss` is actually getting used anywhere?) 

Importing `actiontext.scss` into `application.scss` fixed this... but maybe someone with better knowledge of the codebase can suggest a cleaner approach?

Big thanks to Albert and Rachel at the SCaLE workshop, who both sat and dug around in the code with me to find a solution 💫 

[This Medium article](https://medium.com/@makenakong/how-to-add-and-customize-the-trix-editor-for-your-ruby-on-rails-application-c0a5d3082254) was also a helpful reference. 

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Sign in as [superadmin@example.com](mailto:superadmin@example.com)
2. Click on FAQ
3. Click on Write New Question and Answer
4. You should no longer see a button labeled "Attach Files" in the row of buttons below the input field

### Screenshots
<img width="914" alt="image" src="https://github.com/user-attachments/assets/4a053c9a-dc05-4541-9da0-b3f71707d080" />

_"Attach Files" button is no longer visible in the list of toolbar buttons below the input field._