### PR TITLE
5037 default the quantity per individual to 50 in the data

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -29,6 +29,7 @@ class Item < ApplicationRecord
   include Exportable
   include Valuable
 
+  after_initialize :set_default_distribution_quantity, if: :new_record?
   after_update :update_associated_kit_name, if: -> { kit.present? }
   before_create :set_reporting_category
   before_destroy :validate_destroy, prepend: true
@@ -226,6 +227,10 @@ class Item < ApplicationRecord
     return unless reporting_category.blank?
 
     self.reporting_category = base_item.reporting_category if base_item.reporting_category
+  end
+
+  def set_default_distribution_quantity
+    self.distribution_quantity ||= kit_id.present? ? 1 : 50
   end
 
   def update_associated_kit_name

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -27,7 +27,7 @@
               <% end %>
 
               <%= f.input :name, label: "Quantity Per Individual", wrapper: :input_group do %>
-                <%= f.input_field :distribution_quantity, class: "form-control" %>
+                <%= f.input_field :distribution_quantity, class: "form-control", value: f.object.distribution_quantity || (f.object.kit_id.present? ? 1 : 50) %>
               <% end %>
 
               <% if current_user.has_cached_role?(Role::ORG_ADMIN, current_organization) %>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -27,7 +27,7 @@
               <% end %>
 
               <%= f.input :name, label: "Quantity Per Individual", wrapper: :input_group do %>
-                <%= f.input_field :distribution_quantity, class: "form-control", value: f.object.distribution_quantity || (f.object.kit_id.present? ? 1 : 50) %>
+                <%= f.input_field :distribution_quantity, class: "form-control" %>
               <% end %>
 
               <% if current_user.has_cached_role?(Role::ORG_ADMIN, current_organization) %>

--- a/db/migrate/20250307161544_set_default_distribution_quantity.rb
+++ b/db/migrate/20250307161544_set_default_distribution_quantity.rb
@@ -1,0 +1,11 @@
+class SetDefaultDistributionQuantity < ActiveRecord::Migration[7.2]
+  def up
+    Item.where(distribution_quantity: nil).find_each do |item|
+      item.update_column(:distribution_quantity, item.kit_id.present? ? 1 : 50)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_02_154355) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_07_161544) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -434,6 +434,22 @@ RSpec.describe Item, type: :model do
     end
   end
 
+  describe "when distribution_quantity is set by default" do
+    it "should set distribution_quantity to 50 for regular items" do
+      item = Item.new
+      item.valid?
+      expect(item.distribution_quantity).to eq(50)
+    end
+
+    it "should set distribution_quantity to 1 for kits" do
+      organization = create(:organization)
+      kit = create(:kit, organization: organization)
+      item = Item.new(kit: kit)
+      item.valid?
+      expect(item.distribution_quantity).to eq(1)
+    end
+  end
+
   describe "distribution_quantity and package size" do
     it "have nil values if an empty string is passed" do
       expect(create(:item, distribution_quantity: '').distribution_quantity).to be_nil

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -437,7 +437,6 @@ RSpec.describe Item, type: :model do
   describe "when distribution_quantity is set by default" do
     it "should set distribution_quantity to 50 for regular items" do
       item = Item.new
-      item.valid?
       expect(item.distribution_quantity).to eq(50)
     end
 
@@ -445,7 +444,6 @@ RSpec.describe Item, type: :model do
       organization = create(:organization)
       kit = create(:kit, organization: organization)
       item = Item.new(kit: kit)
-      item.valid?
       expect(item.distribution_quantity).to eq(1)
     end
   end


### PR DESCRIPTION
REFERENCE: https://github.com/rubyforgood/human-essentials/issues/5037

# Checklist:

[x] I have performed a self-review of my own code,
[x] I have commented my code, particularly in hard-to-understand areas,
[x] I have made corresponding changes to the documentation,
[x] I have added tests that prove my fix is effective or that my feature works,
[x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
[x] Title include "WIP" if work is in progress.
[x] I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5037

### Description
1. When creating a new item through the interface, the value for quantity per individual is defaulted to 50
2. When we create a kit, that value on the accompanying item (the one that represents the kit) is defaulted to 1
3. Migration to set blank quantities per individual on items to 50, unless the item represents a kit, in which case a blank quantity will be set to 1.


### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Added two tests in item spect to verify:  `rspec spec/models/item_spec.rb`
1. should set distribution_quantity to 50 for regular items
2. should set distribution_quantity to 1 for kits

### Screenshots
<img width="1455" alt="Screenshot 2025-03-07 at 9 35 24 AM" src="https://github.com/user-attachments/assets/03a3e434-9330-4578-be69-d2cbc044b366" />

