### PR TITLE
Add git SHA to footer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -225,3 +225,7 @@ div.distribution-request-unit {
   margin-right: 20px;
   white-space: nowrap;
 }
+
+.git-version {
+  color: gray;
+}

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -141,4 +141,4 @@ $diaper-font-family-sans-serif-alt: "Helvetica Neue", Helvetica, Arial, sans-ser
 
 // sizes
 $diaper-navbar-height: 57;
-$diaper-footer-height: 57;
+$diaper-footer-height: 75;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,6 +98,7 @@
     <div class="pull-right hidden-xs">
     </div>
     <strong>Human Essentials was built with <i class="fa fa-heart fa-beat" style="color:red;"></i> by <a href="http://rubyforgood.org">Ruby for Good</a>.</strong>
+    <br/><span class="git-version">Version: <%= ENV['GIT_SHA'] %></span>
   </footer>
 
   </aside>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,7 +98,7 @@
     <div class="pull-right hidden-xs">
     </div>
     <strong>Human Essentials was built with <i class="fa fa-heart fa-beat" style="color:red;"></i> by <a href="http://rubyforgood.org">Ruby for Good</a>.</strong>
-    <br/><span class="git-version">Version: <%= ENV['GIT_SHA'] %></span>
+    <br><span class="git-version">Version: <%= ENV['GIT_SHA'] %></span>
   </footer>
 
   </aside>

--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -1,9 +1,1 @@
-require 'open3'
-
-sha, _, status = Open3.capture3('git rev-parse HEAD')
-if status.exitstatus == 128
-  `git config --global --add safe.directory #{Rails.root}`
-  sha = `git rev-parse HEAD`
-end
-ENV['GIT_SHA'] = sha
-
+ENV['GIT_SHA'] = `cat #{Rails.root}/REVISION`

--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -1,0 +1,9 @@
+require 'open3'
+
+sha, _, status = Open3.capture3('git rev-parse HEAD')
+if status.exitstatus == 128
+  `git config --global --add safe.directory #{Rails.root}`
+  sha = `git rev-parse HEAD`
+end
+ENV['GIT_SHA'] = sha
+


### PR DESCRIPTION
Fixes #5017 .

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/dc6d5455-1632-431e-a885-40151ef510cf" />

I'm going to test this on staging with a deploy, but it seems to work locally.