### PR TITLE
Transfers exports include quantity moved for each item

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -15,7 +15,7 @@ class TransfersController < ApplicationController
     @to_storage_locations = StorageLocation.with_transfers_to(current_organization)
     respond_to do |format|
       format.html
-      format.csv { send_data Transfer.generate_csv(@transfers), filename: "Transfers-#{Time.zone.today}.csv" }
+      format.csv { send_data Exports::ExportTransfersCSVService.new(transfers: @transfers, organization: current_organization).generate_csv, filename: "Transfers-#{Time.zone.today}.csv" }
     end
   end
 

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -15,7 +15,7 @@ class TransfersController < ApplicationController
     @to_storage_locations = StorageLocation.with_transfers_to(current_organization)
     respond_to do |format|
       format.html
-      format.csv { send_data Exports::ExportTransfersCSVService.new(transfers: @transfers, organization: current_organization).generate_csv, filename: "Transfers-#{Time.zone.today}.csv" }
+      format.csv { send_data Exports::ExportTransfersCSVService.new(transfers: @transfers.includes(line_items: :item), organization: current_organization).generate_csv, filename: "Transfers-#{Time.zone.today}.csv" }
     end
   end
 

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -19,7 +19,6 @@ class Transfer < ApplicationRecord
 
   include Itemizable
   include Filterable
-  include Exportable
   # to make it play nice with Itemizable - alias of `from`
   belongs_to :storage_location, class_name: "StorageLocation", inverse_of: :transfers_from, foreign_key: :from_id
   scope :from_location, ->(location_id) { where(from_id: location_id) }
@@ -30,19 +29,6 @@ class Transfer < ApplicationRecord
   validate :storage_locations_must_be_different
   validate :from_storage_quantities
   validate :line_items_quantity_is_positive
-
-  def self.csv_export_headers
-    ["From", "To", "Comment", "Total Moved"]
-  end
-
-  def csv_export_attributes
-    [
-      from.name,
-      to.name,
-      comment || "none",
-      line_items.total
-    ]
-  end
 
   private
 

--- a/app/services/exports/export_transfers_csv_service.rb
+++ b/app/services/exports/export_transfers_csv_service.rb
@@ -1,0 +1,58 @@
+module Exports
+  class ExportTransfersCSVService
+    def initialize(transfers:, organization:)
+      @transfers = transfers
+      @organization = organization
+    end
+
+    def generate_csv
+      csv_data = generate_csv_data
+
+      CSV.generate(headers: true) do |csv|
+        csv_data.each { |row| csv << row }
+      end
+    end
+
+    def generate_csv_data
+      csv_data = []
+
+      csv_data << headers
+      @transfers.each do |transfer|
+        csv_data << build_row_data(transfer)
+      end
+
+      csv_data
+    end
+
+    private
+
+    def headers
+      base_headers
+    end
+
+    def base_table
+      {
+        "From" => ->(transfer) {
+          transfer.from.name
+        },
+        "To" => ->(transfer) {
+          transfer.to.name
+        },
+        "Comment" => ->(transfer) {
+          transfer.comment || "none"
+        },
+        "Total Moved" => ->(transfer) {
+          transfer.line_items.total
+        }
+      }
+    end
+
+    def base_headers
+      base_table.keys
+    end
+
+    def build_row_data(transfer)
+      base_table.values.map { |closure| closure.call(transfer) }
+    end
+  end
+end

--- a/app/services/exports/export_transfers_csv_service.rb
+++ b/app/services/exports/export_transfers_csv_service.rb
@@ -38,6 +38,9 @@ module Exports
         "To" => ->(transfer) {
           transfer.to.name
         },
+        "Date" => ->(transfer) {
+          transfer.created_at.strftime("%F")
+        },
         "Comment" => ->(transfer) {
           transfer.comment || "none"
         },

--- a/spec/services/exports/export_transfers_csv_service_spec.rb
+++ b/spec/services/exports/export_transfers_csv_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Exports::ExportTransfersCSVService do
       end
     end
 
-    let(:non_item_headers) { ["From", "To", "Comment", "Total Moved"] }
+    let(:non_item_headers) { ["From", "To", "Date", "Comment", "Total Moved"] }
     let(:expected_headers) { non_item_headers + all_org_items.pluck(:name) }
 
     it "should match the expected content for the csv" do
@@ -58,6 +58,7 @@ RSpec.describe Exports::ExportTransfersCSVService do
         row = [
           transfer.from.name,
           transfer.to.name,
+          transfer.created_at.strftime("%F"),
           transfer.comment,
           transfer.line_items.total
         ]
@@ -79,6 +80,7 @@ RSpec.describe Exports::ExportTransfersCSVService do
           row = [
             transfer.from.name,
             transfer.to.name,
+            transfer.created_at.strftime("%F"),
             transfer.comment,
             transfer.line_items.total
           ]

--- a/spec/services/exports/export_transfers_csv_service_spec.rb
+++ b/spec/services/exports/export_transfers_csv_service_spec.rb
@@ -1,0 +1,102 @@
+RSpec.describe Exports::ExportTransfersCSVService do
+  let!(:organization) { create(:organization) }
+
+  describe "#generate_csv_data" do
+    subject { described_class.new(transfers:, organization:).generate_csv_data }
+
+    let(:from_location) { create(:storage_location, name: "From Location") }
+    let(:to_location) { create(:storage_location, name: "To Location") }
+    let(:duplicate_item) { create(:item, name: "Dupe Item") }
+
+    let(:items_lists) do # Used to created four transfers
+      [
+        [
+          [duplicate_item, 5],
+          [create(:item), 7],
+          [duplicate_item, 3]
+        ],
+
+        *(Array.new(3) do |i|
+          [[create(:item), i + 1]]
+        end)
+      ]
+    end
+
+    let(:transfers) do
+      items_lists.map do |items|
+        transfer = create(:transfer, from: from_location, to: to_location)
+
+        items.each do |(item, quantity)|
+          transfer.line_items << create(:line_item, quantity:, item:)
+        end
+
+        transfer
+      end
+    end
+
+    let(:all_org_items) { organization.items.sort_by { |item| item.name.downcase } }
+
+    let(:total_item_quantities) do
+      template = all_org_items.pluck(:name).index_with(0)
+
+      items_lists.map do |items_list|
+        row = template.dup
+        items_list.each do |(item, quantity)|
+          row[item.name] += quantity
+        end
+        row.values
+      end
+    end
+
+    let(:non_item_headers) { ["From", "To", "Comment", "Total Moved"] }
+    let(:expected_headers) { non_item_headers + all_org_items.pluck(:name) }
+
+    it "should match the expected content for the csv" do
+      expect(subject[0]).to eq(expected_headers)
+
+      transfers.zip(total_item_quantities).each_with_index do |(transfer, total_item_quantity), idx|
+        row = [
+          transfer.from.name,
+          transfer.to.name,
+          transfer.comment,
+          transfer.line_items.total
+        ]
+        row += total_item_quantity
+
+        expect(subject[idx + 1]).to eq(row)
+      end
+    end
+
+    context "when a new item is added to the organization" do
+      let!(:new_item) { create(:item, name: "New Item") }
+
+      it "should be included as the last column of the csv" do
+        expect(subject[0]).to eq(expected_headers).and end_with(new_item.name)
+      end
+
+      it "should have a quantity of 0 if this item isn't part of any transfer" do
+        transfers.zip(total_item_quantities).each_with_index do |(transfer, total_item_quantity), idx|
+          row = [
+            transfer.from.name,
+            transfer.to.name,
+            transfer.comment,
+            transfer.line_items.total
+          ]
+          row += total_item_quantity
+
+          expect(subject[idx + 1]).to eq(row).and end_with(0)
+        end
+      end
+    end
+
+    context "when there are no transfers but the report is requested" do
+      let(:transfers) { Transfer.none }
+
+      it "returns a csv with only headers and no rows" do
+        expect(subject.size).to eq(1)
+        header_row = subject[0]
+        expect(header_row).to eq(expected_headers)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #4988 

### Description

CSV exports of Transfers now how much of each item was moved for a given transfer. The Distributions export already had a similar behaviour built-in, so I re-used the same patterns to make this work for Transfers. The specs for the new `Exports::ExportTransfersCSVService` are also built following what was done for `Exports::ExportDistributionsCSVService`.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added new spec file `spec/services/exports/export_transfers_csv_service_spec.rb`.

### Screenshots

Transfers in the app and exported CSV file:

![Screenshot 2025-03-09 at 11 23 08](https://github.com/user-attachments/assets/eadc823e-5fe8-4c12-a9aa-6cebdf4debf8)
![Screenshot 2025-03-09 at 11 23 47](https://github.com/user-attachments/assets/078f353b-6a4c-4e7c-bc96-6c682fb9de9c)
