### PR TITLE
Add validation for money_raised in Donation model to ensure it is non…

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -61,6 +61,7 @@ class Donation < ApplicationRecord
   validates :manufacturer, presence:
     { message: "must be specified since you chose '#{SOURCES[:manufacturer]}'" }, if: :from_manufacturer?
   validates :source, presence: true, inclusion: { in: SOURCES.values, message: "Must be a valid source." }
+  validates :money_raised, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validate :line_items_quantity_is_positive
 
   # TODO: move this to Organization.donations as an extension

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Donation, type: :model do
       d.line_items << build(:line_item, quantity: -1)
       expect(d).not_to be_valid
     end
+    it "ensures that money_raised cannot be negative" do
+      expect(build(:donation, money_raised: -100)).not_to be_valid
+      expect(build(:donation, money_raised: 0)).to be_valid
+      expect(build(:donation, money_raised: 100)).to be_valid
+      expect(build(:donation, money_raised: nil)).to be_valid
+    end
   end
 
   context "Callbacks >" do

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Donation, type: :model do
       expect(d).not_to be_valid
     end
     it "ensures that money_raised cannot be negative" do
-      expect(build(:donation, money_raised: -100)).not_to be_valid
+      expect(build(:donation, money_raised: -1)).not_to be_valid
       expect(build(:donation, money_raised: 0)).to be_valid
       expect(build(:donation, money_raised: 100)).to be_valid
       expect(build(:donation, money_raised: nil)).to be_valid

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe "Donations", type: :request do
       let(:manufacturer) { create(:manufacturer, organization:) }
       let(:source) { Donation::SOURCES[:manufacturer] }
       let(:issued_at) { Date.yesterday }
+      let(:money_raised) { 5 }
 
       let(:params) do
         {
@@ -114,7 +115,7 @@ RSpec.describe "Donations", type: :request do
             manufacturer_id: manufacturer.id,
             product_drive_id: product_drive.id,
             storage_location_id: storage_location.id,
-            money_raised_in_dollars: 5,
+            money_raised_in_dollars: money_raised,
             product_drive_participant_id: nil,
             comment: "",
             issued_at: issued_at,
@@ -144,6 +145,15 @@ RSpec.describe "Donations", type: :request do
           expect(flash[:error]).to include("Issue date can't be blank")
         end
       end
+
+      context "with negative money raised" do
+        let(:money_raised) { -5 }
+
+        it "flashes the correct validation error" do
+          post donations_path(params)
+          expect(flash[:error]).to include("Money raised must be greater than or equal to 0")
+        end
+      end
     end
 
     describe "PATCH #update" do
@@ -164,6 +174,15 @@ RSpec.describe "Donations", type: :request do
           put donation_path(params)
 
           expect(flash[:alert]).to include("Issue date can't be blank")
+        end
+      end
+
+      context "with negative money raised" do
+        it "flashes the correct validation error" do
+          donation_params[:money_raised_in_dollars] = -5
+          put donation_path(params)
+
+          expect(flash[:alert]).to include("Money raised must be greater than or equal to 0")
         end
       end
     end


### PR DESCRIPTION
Resolves #5065 

### Description

This pull request addresses issue #5065 by adding validation to ensure that the `money_raised` attribute in the `Donation` model cannot be negative. This change was motivated by the need to prevent invalid data entry that could lead to incorrect financial reporting. The solution involves adding a numericality validation to the `money_raised` attribute and updating the request specs to test for this validation.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

The changes have been tested by adding new unit tests in `spec/models/donation_spec.rb` to verify that the `money_raised` attribute cannot be negative. Additionally, request specs in `spec/requests/donations_requests_spec.rb` have been updated to ensure that the correct validation error messages are flashed when attempting to create or update a donation with a negative `money_raised` value. These tests can be run using `bundle exec rake`, or `bundle exec rspec spec/requests/donations_requests_spec.rb` and `bundle exec rspec spec/models/donation_spec.rb` to verify that all validations and error messages are functioning as expected.

