### PR TITLE
Add validation for square footage in StorageLocation model

### DIFF
--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -46,6 +46,7 @@ class StorageLocation < ApplicationRecord
   validates :name, :address, presence: true
   validates :warehouse_type, inclusion: { in: WAREHOUSE_TYPES },
                              allow_blank: true
+  validates :square_footage, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   before_destroy :validate_empty_inventory, prepend: true
 
   include Discard::Model

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe StorageLocation, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:address) }
     it "ensures that square_footage cannot be negative" do
-      expect(build(:storage_location, square_footage: -100)).not_to be_valid
+      expect(build(:storage_location, square_footage: -1)).not_to be_valid
       expect(build(:storage_location, square_footage: 0)).to be_valid
       expect(build(:storage_location, square_footage: 100)).to be_valid
       expect(build(:storage_location, square_footage: nil)).to be_valid

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe StorageLocation, type: :model do
   context "Validations >" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:address) }
+    it "ensures that square_footage cannot be negative" do
+      expect(build(:storage_location, square_footage: -100)).not_to be_valid
+      expect(build(:storage_location, square_footage: 0)).to be_valid
+      expect(build(:storage_location, square_footage: 100)).to be_valid
+      expect(build(:storage_location, square_footage: nil)).to be_valid
+    end
   end
 
   context "Callbacks >" do

--- a/spec/requests/storage_locations_requests_spec.rb
+++ b/spec/requests/storage_locations_requests_spec.rb
@@ -488,6 +488,41 @@ RSpec.describe "StorageLocations", type: :request do
       end
     end
 
+    describe "POST #create" do
+      let(:params) do
+        {
+          storage_location: {
+            name: "New Storage Location",
+            address: "123 New Street",
+            square_footage: -100
+          }
+        }
+      end
+
+      it "shows an error when square footage is negative" do
+        post storage_locations_path, params: params
+        expect(response.body).to include("Square footage must be greater than or equal to 0")
+      end
+    end
+
+    describe "PATCH #update" do
+      let(:storage_location) { create(:storage_location, organization: organization) }
+      let(:params) do
+        {
+          storage_location: {
+            name: "Updated Name",
+            address: "123 Updated Street",
+            square_footage: -100
+          }
+        }
+      end
+
+      it "shows an error when square footage is negative" do
+        patch storage_location_path(storage_location), params: params
+        expect(response.body).to include("Square footage must be greater than or equal to 0")
+      end
+    end
+
     context "Looking at a different organization" do
       let(:object) { create(:storage_location, organization: create(:organization)) }
       include_examples "requiring authorization"


### PR DESCRIPTION
Resolves #5058

### Description
- Added numericality validation to ensure square footage is non-negative.
- Updated model specs to test square footage validation.
- Added request specs to verify error handling for negative square footage during create and update actions.

### Type of change

* Hygiene

### How Has This Been Tested?

running `bundle exec rake` or `bundle exec rspec spec/requests/storage_locations_requests_spec.rb` and `bundle exec rspec spec/models/storage_location_spec.rb `