### PR TITLE
Resolves #5000

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -826,4 +826,4 @@ DEPENDENCIES
   webmock (~> 3.24)
 
 BUNDLED WITH
-   2.6.5
+   2.6.6

--- a/app/views/layouts/_lte_navbar.html.erb
+++ b/app/views/layouts/_lte_navbar.html.erb
@@ -50,10 +50,12 @@
         <i class="fa fa-repeat text-aqua"></i><%= "Switch to: #{role.resource&.name || "Super Admin"}" %>
       <% end %>
     <% end %>
-    <% if current_user.has_cached_role?(Role::ORG_ADMIN, current_organization) %>
+   <% if current_user.has_cached_role?(Role::ORG_ADMIN, current_organization) %>
         <div class="dropdown-divider"></div>
-        <%= link_to users_path, class:"dropdown-item" do %>
-          <i class="fas fa-users mr-2"></i> My Co-Workers
+        <% if current_user.has_cached_role?(:partner) %>
+          <%= link_to users_path, class:"dropdown-item" do %>
+            <i class="fas fa-users mr-2"></i> My Co-Workers
+          <% end %>
         <% end %>
         <%= link_to organization_path, class:"dropdown-item" do %>
           <i class="fas fa-sitemap mr-2"></i> My Organization

--- a/spec/requests/user_dropdown_requests_spec.rb
+++ b/spec/requests/user_dropdown_requests_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe "UsernameDropdown", type: :request do
+  let(:organization) { create(:organization) }
+
+  describe "My Co-Workers link visibility" do
+    context "when user does not have partner role" do
+      let(:user) { create(:user, organization: organization) }
+
+      before do
+        user.add_role(Role::ORG_ADMIN, organization)
+        sign_in(user)
+      end
+
+      it "does not show the My Co-Workers link" do
+        get dashboard_path
+        expect(response.body).not_to include("My Co-Workers")
+      end
+    end
+  end
+end

--- a/spec/system/navigation_system_spec.rb
+++ b/spec/system/navigation_system_spec.rb
@@ -52,18 +52,6 @@ RSpec.describe "Navigation", type: :system, js: true do
           end
         end
       end
-      it "dropdown menu does not show My Co-Workers" do
-        expect(user.has_role?(Role::ORG_ADMIN, user.organization)).to be true
-        expect(user.has_role?(:partner)).to be false
-        click_on user.display_name
-        puts "DROPDOWN LINKS:"
-        page.all(".dropdown-menu a").each do |link|
-          puts "- #{link.text.strip}"
-        end
-
-        expect(page).not_to have_link("My Co-Workers")
-        expect(page).not_to have_content("My Co-Workers")
-      end
     end
   end
 

--- a/spec/system/navigation_system_spec.rb
+++ b/spec/system/navigation_system_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe "Navigation", type: :system, js: true do
           end
         end
       end
+      it "dropdown menu does not show My Co-Workers" do
+        expect(user.has_role?(Role::ORG_ADMIN, user.organization)).to be true
+        expect(user.has_role?(:partner)).to be false
+        click_on user.display_name
+        puts "DROPDOWN LINKS:"
+        page.all(".dropdown-menu a").each do |link|
+          puts "- #{link.text.strip}"
+        end
+
+        expect(page).not_to have_link("My Co-Workers")
+        expect(page).not_to have_content("My Co-Workers")
+      end
     end
   end
 


### PR DESCRIPTION
# Checklist:

yes - I have performed a self-review of my own code,
yes - I have commented my code, particularly in hard-to-understand areas,
yes - I have made corresponding changes to the documentation,
yes - I have added tests that prove my fix is effective or that my feature works,
yes - New and existing unit tests pass locally with my changes ("bundle exec rake"),
yes - Title include "WIP" if work is in progress.
yes - I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5000 

### Description
Hid the "My Co-Workers" item from the top-right dropdown for 'banks/org' users by adding an additional 'if' statement in the views/layouts/_lte_navbar.html.erb file to check if the user is a partner or not.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I added an rspec test which checks that "My Co-Workers" is not visible for org users after clicking on the top-right button. I added it to the most appropriate place I could find, spec/system/navigation_system_spec.rb. If we want to add more tests for the top-right dropdown menu we would probably add a new file, but it seemed out of the scope of this issue.

All tests passed.

### Screenshots
<img width="786" alt="mycoworker_visible_verifieduser" src="https://github.com/user-attachments/assets/9a944808-6eff-4ecc-b069-434a3ce4d32b" />
<img width="787" alt="org_user_mycoworker_notvisible" src="https://github.com/user-attachments/assets/858bb01e-1cb4-4963-8c90-0b78447db6e6" />
