### PR TITLE
Fix failing organizations request spec

### DIFF
--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -537,10 +537,13 @@ RSpec.describe "Organizations", type: :request do
       context "when user is not an org user" do
         let(:user) { create(:user, organization: create(:organization)) }
 
-        it 'raises an error' do
-          post remove_user_organization_path(user_id: user.id)
+        it "raises an error" do
+          post remove_user_organization_path(
+            user_id: user.id,
+            organization_name: organization.short_name
+          )
 
-          expect(response).to be_not_found
+          expect(response).to have_http_status(:not_found)
         end
       end
     end


### PR DESCRIPTION
Related to #4557 

### Description
After adding the require_organization authorization checks, a `current_organization` is required or the request will return a 302 and redirect to the dashboard.

### Type of change
* Internal (only related to automated tests)

### How Has This Been Tested?
The failing test isn't technically flaky because it fails 100% of the time, so it is easy to check that the test fails on `main` but passes on this branch.