### PR TITLE
Fix flaky specs regarding pagination

### DIFF
--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -162,9 +162,10 @@ RSpec.describe "ProductDrives", type: :request do
 
       describe "pagination" do
         around do |ex|
+          old_default = Kaminari.config.default_per_page
           Kaminari.config.default_per_page = 2
           ex.run
-          Kaminari.config.default_per_page = 5
+          Kaminari.config.default_per_page = old_default
         end
 
         before do

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -83,9 +83,10 @@ RSpec.describe "Purchases", type: :request do
 
         describe "pagination" do
           around do |ex|
+            old_default = Kaminari.config.default_per_page
             Kaminari.config.default_per_page = 2
             ex.run
-            Kaminari.config.default_per_page = 50
+            Kaminari.config.default_per_page = old_default
           end
           before do
             item = create(:item, organization: organization)

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe "Admin Organization Management", type: :system, js: true, seed_items: false do
   around do |ex|
+    old_default = Kaminari.config.default_per_page
     Kaminari.config.default_per_page = 3
     ex.run
-    Kaminari.config.default_per_page = 50
+    Kaminari.config.default_per_page = old_default
   end
   before do
     Organization.delete_all # should not be needed once seed_data works


### PR DESCRIPTION
Should resolve all the flaky specs mentioned in this comment: https://github.com/rubyforgood/human-essentials/issues/4557#issuecomment-2734680897

### Description
The default pagination for the test env is supposed to be 50, but one set of specs was setting it to 5. So depending on the order the specs were run in, we had some flakiness.

### Type of change
* Internal (related to automated test suite)

### How Has This Been Tested?
Using bisect, I found this sequence reproduced the flakiness reliably:
`rspec ./spec/requests/events_requests_spec.rb[1:1:1:1,1:1:1:7:1] ./spec/requests/product_drives_requests_spec.rb[1:2:1:5:1] --seed 54905`

That command now passes after these changes.

I didn't test all the flaky tests mentioned in https://github.com/rubyforgood/human-essentials/issues/4557#issuecomment-2734680897, but they are all related to pagination so I think this will resolve them as well.
