### PR TITLE
5102 - 500 error on empty target_date on storage_locations#show

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -57,18 +57,19 @@ class StorageLocationsController < ApplicationController
   # TODO: Move these queries to Query Object
   def show
     @storage_location = current_organization.storage_locations.find(params[:id])
+    version_date = params[:version_date].presence&.to_date
     # TODO: Find a way to do these with less hard SQL. These queries have to be manually updated because they're not in-sync with the Model
     @items_out = ItemsOutQuery.new(organization: current_organization, storage_location: @storage_location).call
     @items_out_total = ItemsOutTotalQuery.new(organization: current_organization, storage_location: @storage_location).call
     @items_in = ItemsInQuery.new(organization: current_organization, storage_location: @storage_location).call
     @items_in_total = ItemsInTotalQuery.new(organization: current_organization, storage_location: @storage_location).call
-    if View::Inventory.within_snapshot?(current_organization.id, params[:version_date])
-      @inventory = View::Inventory.new(current_organization.id, event_time: params[:version_date])
+    if View::Inventory.within_snapshot?(current_organization.id, version_date)
+      @inventory = View::Inventory.new(current_organization.id, event_time: version_date)
     else
       @legacy_inventory = View::Inventory.legacy_inventory_for_storage_location(
         current_organization.id,
         @storage_location.id,
-        params[:version_date]
+        version_date
       )
     end
 

--- a/spec/requests/storage_locations_requests_spec.rb
+++ b/spec/requests/storage_locations_requests_spec.rb
@@ -324,6 +324,17 @@ RSpec.describe "StorageLocations", type: :request do
           expect(response.body).to include("200")
         end
 
+        it "should return a correct response with empty version date param" do
+          get storage_location_path(storage_location, format: response_format,
+            version_date: '')
+          expect(response).to be_successful
+          expect(response.body).to include("Smithsonian")
+          expect(response.body).to include("Test Item")
+          expect(response.body).to include("Test Item2")
+          expect(response.body).not_to include("Test Item3")
+          expect(response.body).to include("200")
+        end
+
         context "with version date set" do
           let!(:inventory_item) {
             InventoryItem.create!(storage_location_id: storage_location.id,


### PR DESCRIPTION
Resolves #5102 

### Description
storage_locations#show modified to handle empty string passed as param for version_date
Added test for empty string passed as param into above request.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Reproduced as per issue, and resolved with automated test to confirm fix.