### PR TITLE
Fix cat REVISION file warning on app startup

### DIFF
--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -1,1 +1,1 @@
-ENV['GIT_SHA'] = `cat #{Rails.root}/REVISION`
+ENV['GIT_SHA'] = File.read(File.join(Rails.root, "REVISION")).strip if File.exist?(File.join(Rails.root, "REVISION"))


### PR DESCRIPTION
(Just a minor nit of a PR)

### Description
Fixes the following error message that occurs on app startup in dev:
`cat: ./REVISION: No such file or directory`

That file is created in prod by Cloud 66, but not in dev/test hence the warning/error message.

### Type of change
* Internal Refactor

### How Has This Been Tested?
Manually. See screenshots

### Screenshots
Before the change:
![Screenshot from 2025-03-20 12-50-04](https://github.com/user-attachments/assets/89d23f2a-3825-4bbd-a746-797d658796cd)

After the change (first without the REVISION file like in non-prod environments and then with the file):
![Screenshot from 2025-03-20 12-48-06](https://github.com/user-attachments/assets/a51295c2-b59e-4400-9a40-c50552c2e9fa)