### PR TITLE
5084 Display Drive Count on Summary page for Selected Dates

### DIFF
--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -16,6 +16,11 @@ module DonationsHelper
     number_with_delimiter total_received_from_product_drives_unformatted(range)
   end
 
+  def total_number_of_drives(range = selected_range)
+    formatted_range = format_date_range_to_iso(range)
+    current_organization.product_drives.within_date_range(formatted_range).count
+  end
+
   private
 
   def total_received_donations_unformatted(range = selected_range)
@@ -24,5 +29,9 @@ module DonationsHelper
 
   def total_received_from_product_drives_unformatted(range = selected_range)
     LineItem.active.where(itemizable: current_organization.donations.by_source(:product_drive).during(range)).sum(:quantity)
+  end
+
+  def format_date_range_to_iso(range)
+    "#{range.begin.to_date.iso8601} - #{range.end.to_date.iso8601}"
   end
 end

--- a/app/views/reports/product_drives_summary.html.erb
+++ b/app/views/reports/product_drives_summary.html.erb
@@ -11,6 +11,12 @@
 ) do %>
 
   <h3 class="text-center">
+    <span class="total_drives">
+      <%= total_number_of_drives %>
+    </span> drives active
+    <%= @selected_date_range_label %>
+  </h3>
+  <h3 class="text-center">
     <span class="total_received_donations">
       <%= total_received_from_product_drives %>
     </span> items

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -31,9 +31,14 @@ FactoryBot.define do
     end
 
     factory :product_drive_donation do
-      product_drive
+      product_drive { build(:product_drive) }
       product_drive_participant
       source { Donation::SOURCES[:product_drive] }
+
+      after(:build) do |donation|
+        donation.product_drive.start_date = donation.issued_at
+        donation.product_drive.end_date = donation.issued_at
+      end
     end
 
     factory :donation_site_donation do

--- a/spec/requests/reports/product_drives_summary_spec.rb
+++ b/spec/requests/reports/product_drives_summary_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "Reports::ProductDrivesSummary", type: :request do
         it "shows the correct total and links" do
           expect(response.body).to match(%r{<span class="total_received_donations">\s*14\s*</span>})
           expect(response.body).to match(%r{<span class="total_money_raised">\s*\$24.00\s*</span>})
+          expect(response.body).to match(%r{<span class="total_drives">\s*2\s*</span>})
         end
       end
 
@@ -54,6 +55,7 @@ RSpec.describe "Reports::ProductDrivesSummary", type: :request do
         it "shows the correct total and links" do
           expect(response.body).to match(%r{<span class="total_received_donations">\s*16\s*</span>})
           expect(response.body).to match(%r{<span class="total_money_raised">\s*\$24.00\s*</span>})
+          expect(response.body).to match(%r{<span class="total_drives">\s*2\s*</span>})
         end
       end
 
@@ -62,6 +64,7 @@ RSpec.describe "Reports::ProductDrivesSummary", type: :request do
         it "shows the correct total and links" do
           expect(response.body).to match(%r{<span class="total_received_donations">\s*122\s*</span>})
           expect(response.body).to match(%r{<span class="total_money_raised">\s*\$24.00\s*</span>})
+          expect(response.body).to match(%r{<span class="total_drives">\s*2\s*</span>})
         end
       end
 
@@ -70,6 +73,7 @@ RSpec.describe "Reports::ProductDrivesSummary", type: :request do
         it "shows the correct total and links" do
           expect(response.body).to match(%r{<span class="total_received_donations">\s*248\s*</span>})
           expect(response.body).to match(%r{<span class="total_money_raised">\s*\$48.00\s*</span>})
+          expect(response.body).to match(%r{<span class="total_drives">\s*4\s*</span>})
         end
       end
 
@@ -78,6 +82,7 @@ RSpec.describe "Reports::ProductDrivesSummary", type: :request do
         it "shows the correct total and links" do
           expect(response.body).to match(%r{<span class="total_received_donations">\s*422\s*</span>})
           expect(response.body).to match(%r{<span class="total_money_raised">\s*\$120.00\s*</span>})
+          expect(response.body).to match(%r{<span class="total_drives">\s*10\s*</span>})
         end
       end
     end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

[x] I have performed a self-review of my own code,
[x] I have commented my code, particularly in hard-to-understand areas,
[x] I have made corresponding changes to the documentation,
[x] I have added tests that prove my fix is effective or that my feature works,
[x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
[x]Title include "WIP" if work is in progress.
[x] I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5084 

### Description

This adds a new line at the top of the summary information about the number of drives following the following format:
`[number of drives] drives active during the period [start date] to [end date]`


### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested via RSpec and checking the page in the local browser. 

### Screenshots
<img width="744" alt="Screenshot 2025-03-22 at 11 09 54 PM" src="https://github.com/user-attachments/assets/e3db3582-7d1b-4b44-9e83-3779935e441d" />


