### PR TITLE
[#4821] Persist profile attached documents through validation errors

### DIFF
--- a/app/helpers/partners/profile_helper.rb
+++ b/app/helpers/partners/profile_helper.rb
@@ -1,0 +1,20 @@
+module Partners
+  module ProfileHelper
+    # Returns an array of filenames that are attached to the profile but not persisted.
+    # This is to display to the user that the system remembers their file selections
+    # even if there was a form validation error.
+    # The method returns a JSON string (an array of filenames) to be used in a Stimulus controller.
+    def attached_but_not_persisted_file_names(profile)
+      filenames = profile.documents.attachments
+        .select { |att| !att.persisted? }
+        .map { |att| att.blob.filename.to_s }
+
+      filenames.to_json
+    end
+
+    # Returns true if at least one document attachment is actually persisted
+    def has_persisted_documents?(profile)
+      profile.documents.attachments.any?(&:persisted?)
+    end
+  end
+end

--- a/app/views/partners/profiles/step/_attached_documents_form.html.erb
+++ b/app/views/partners/profiles/step/_attached_documents_form.html.erb
@@ -1,6 +1,10 @@
 <%= f.fields_for :profile, profile do |pf| %>
-  <div class="form-group" data-controller="file-input">
-    <% if profile.documents.attached? %>
+  <div class="form-group"
+      data-controller="file-input"
+      data-file-input-filenames-value="<%= attached_but_not_persisted_file_names(profile) %>">
+
+    <%# Allow user to download and/or remove existing attachments %>
+    <% if has_persisted_documents?(profile) %>
       <strong>Attached files:</strong>
       <ul class="list-unstyled">
         <% profile.documents.each do |doc| %>
@@ -17,8 +21,27 @@
       </ul>
     <% end %>
 
-    <%# Native file input and placeholder for selected file names %>
-    <%= pf.file_field :documents, multiple: true, class: "form-control-file", data: { file_input_target: "input" } %>
+    <%# Submit hidden fields for attachments that are not persisted to preserve them through form validation errors %>
+    <% profile.documents.attachments.each do |att| %>
+      <% if !att.persisted? %>
+        <%= pf.hidden_field :documents, multiple: true, value: att.blob.signed_id %>
+      <% end %>
+    <% end %>
+
+    <%# Hide native file input to support custom behaviour to display %>
+    <%# previously selected files when validation error occurs  %>
+    <%= pf.file_field :documents,
+      multiple: true,
+      direct_upload: true,
+      class: "form-control-file d-none",
+      data: { file_input_target: "input" } %>
+
+    <%# Custom button to trigger file selection %>
+    <button type="button" class="btn btn-outline-primary" data-action="click->file-input#triggerFileSelection">
+      Choose Files
+    </button>
+
+    <%# Placeholder to display selected file(s) populated by app/javascript/controllers/file_input_controller.js %>
     <div data-file-input-target="list" class="mt-2"></div>
   </div>
 <% end %>


### PR DESCRIPTION
Resolves #4821

### Description

This is the final [part 3 of improvements](https://github.com/rubyforgood/human-essentials/issues/4821#issuecomment-2676150125) to editing partner profile Attached Documents section. It fixes the following situation:
1. Invited partner edits their profile, uploading one or more documents in the "Attached Documents" section.
2. They also fill out some other field resulting in a validation error (eg: 4 pick up email addresses, or leaving all social media fields blank and not checking off "No social media presence").
3. When they click "Save Progress", the form re-renders with validation errors, BUT their file uploads are lost, and they need to realize this and select them again.

There are a few moving parts to solve this:

#### 1. Direct Uploads

The first part of the solution is to use direct uploads feature of Active Storage (already enabled via a previous PR). This ensures that the selected files are persisted to the storage service, and written as new records in `active_storage_blobs` table, via ajax requests, even if the model didn't get saved on form submission.

#### 2. Submit hidden signed_id

When direct uploads is enabled, each document's `signed_id` is accessible from the partner profile model, even if it failed to be saved due to validation errors. So the form partial `app/views/partners/profiles/step/_attached_documents_form.html.erb` can iterate over these and submit hidden field(s) for each document that was attempted to be attached, but not persisted. This allows Rails to associate these files to the model, upon the next successful form submission. The file names are also available from the model.

#### 3. Display to user previously selected files

It's one thing to have the signed_id's as hidden fields, it's quite another to let the user know that we still have their files so they don't need to select them again.

The native file picker (which is rendered from the `file_field` form helper), has a `files` attribute, and when its null/empty, it displays "No files selected". But the only way the `files` attribute of the native picker can be populated is from the user literally clicking on the "Choose file" button. This means that in the form validation error case, even though we still have the user's file selections, the native file picker will show "No file selected".

It would be nice if we could set the `files` attribute of the native file picker via JavaScript, but this is not supported - see [MDN on file input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#notes) for details.

The solution then is to hide the native file input (still functional though) and instead render a custom "Choose files" button that when clicked, delegates to the native file picker. This is handled via a Stimulus controller `app/javascript/controllers/file_input_controller.js`. This controller was introduced in a [previous PR](https://github.com/rubyforgood/human-essentials/pull/5090) related to attached documents. At the time the only purpose was to customize the display of selected files (because the native file picker only displays number of files chosen, not the actual file names).

Now the Stimulus controller is enhanced to accept a value Array of file names, and if provided, display these as the selected files.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

For manual testing - follow the steps in the description. When the form re-renders with validation errors, scroll down to the "Attached Documents" section, open it up, and you should see your previously selected files are still rendered as "Selected files". Then if you fix the validation error(s) and click Save Progress, the attached documents should be saved.

For automated testing - see `spec/system/partners/profile_edit_system_spec.rb`, new test added: `it "persists multiple file uploads when there are validation errors" do...`

### Screenshots

The native file picker for attached documents is hidden and a new custom button is displayed in its place:
![image](https://github.com/user-attachments/assets/43fb17e5-eb63-4e82-9750-9ed5955a5a6c)

After user selects some files, they're shown in a custom listing (this behaviour was added in a previous PR, but now a sub-header of "Selected files" is also rendered to make it clear these are what user just selected):
![image](https://github.com/user-attachments/assets/a537aa53-7cc4-4890-930e-f9541365f357)

If form re-renders with validation errors, and user previously selected files, they are preserved - i.e. rendering looks the same as if they had just selected those files:
![image](https://github.com/user-attachments/assets/3bfec6a3-c4b8-4e07-af9b-d4c1271c07ce)

After user fixes validation error and Saves Progress again, the preserved files are now attached:
![image](https://github.com/user-attachments/assets/b6cb27b5-af85-4d37-8ea3-735f654d2b55)

Here's what it looks like with a combination of existing attached files, plus a few new ones selected:
![image](https://github.com/user-attachments/assets/7923b987-0276-471e-99af-5406c61ee29c)

