### PR TITLE
5036 catch partner user create errors

### DIFF
--- a/app/controllers/partner_users_controller.rb
+++ b/app/controllers/partner_users_controller.rb
@@ -24,6 +24,9 @@ class PartnerUsersController < ApplicationController
       @users = @partner.users
       render :index
     end
+  rescue => e
+    flash[:error] = e.message
+    redirect_to partner_users_path(@partner)
   end
 
   def destroy

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe PartnerUsersController, type: :request do
       end
 
       context "with existing user params" do
-        it "renders the index template with alert" do
+        it "renders the index template with error" do
           existing_user = User.first
           expect {
             post partner_users_path(default_params.merge(partner_id: partner)), params: {user: {email: existing_user.email}}

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -73,9 +73,8 @@ RSpec.describe PartnerUsersController, type: :request do
 
       context "with existing user params" do
         it "renders the index template with error" do
-          existing_user = User.first
           expect {
-            post partner_users_path(default_params.merge(partner_id: partner)), params: {user: {email: existing_user.email}}
+            post partner_users_path(default_params.merge(partner_id: partner)), params: {user: {email: partner.email}}
           }.not_to change(User, :count)
 
           expect(response).to redirect_to(partner_users_path)

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe PartnerUsersController, type: :request do
           expect(flash[:alert]).to eq("Invitation failed. Check the form for errors.")
         end
       end
+
+      context "with existing user params" do
+        it "renders the index template with alert" do
+          existing_user = User.first
+          expect {
+            post partner_users_path(default_params.merge(partner_id: partner)), params: {user: {email: existing_user.email}}
+          }.not_to change(User, :count)
+
+          expect(response).to redirect_to(partner_users_path)
+          expect(flash[:error]).to eq("User already has the requested role!")
+        end
+      end
     end
 
     context "while signed in as org user" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5036  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

I added a `rescue` statement in PartnerUsersController#create to catch the error from the UserInviteService

The user will be redirected back and shown the error returned by UserInviteService. 

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

bundle exec rspec spec/requests/partner_users_requests_spec.rb:75

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

![5036](https://github.com/user-attachments/assets/a30dc423-d218-4f13-89e0-09c576a96ec9)
