### PR TITLE
Change the annual report to take advantage of the new reporting categories

### DIFF
--- a/app/models/base_item.rb
+++ b/app/models/base_item.rb
@@ -39,7 +39,7 @@ class BaseItem < ApplicationRecord
     "Adult Briefs (XXXL)" => "adult_incontinence",
     "Adult Cloth Diapers (Large/XL/XXL)" => "adult_incontinence",
     "Adult Cloth Diapers (Small/Medium)" => "adult_incontinence",
-    "adult_incontinence Pads" => "adult_incontinence",
+    "Adult Incontinence Pads" => "adult_incontinence",
     "Bed Pads (Cloth)" => "other",
     "Bed Pads (Disposable)" => "other",
     "Bibs (Adult & Child)" => "other",

--- a/app/models/base_item.rb
+++ b/app/models/base_item.rb
@@ -69,7 +69,7 @@ class BaseItem < ApplicationRecord
     "Kids S/M (38-65 lbs)" => "disposable_diapers",
     "Kit" => nil,
     "Liners (Incontinence)" => "adult_incontinence",
-    "Liners (Menstrual)" => "menstrual",
+    "Liners (Menstrual)" => "period_liners",
     "Other" => "other",
     "Pads" => "pads",
     "Swimmers" => "disposable_diapers",

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -47,7 +47,7 @@ class Distribution < ApplicationRecord
   enum :state, { scheduled: 5, complete: 10 }
   enum :delivery_method, { pick_up: 0, delivery: 1, shipped: 2 }
   scope :active, -> { joins(:line_items).joins(:items).where(items: { active: true }) }
-  scope :with_diapers, -> { joins(line_items: :item).merge(Item.disposable.or(Item.cloth_diapers)) }
+  scope :with_diapers, -> { joins(line_items: :item).merge(Item.disposable_diapers.or(Item.cloth_diapers)) }
   scope :with_period_supplies, -> { joins(line_items: :item).merge(Item.period_supplies) }
   # add item_id scope to allow filtering distributions by item
   scope :by_item_id, ->(item_id) { includes(:items).where(items: { id: item_id }) }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -76,7 +76,7 @@ class Item < ApplicationRecord
     cloth_diapers: "cloth_diapers",
     disposable_diapers: "disposable_diapers",
     menstrual: "menstrual",
-    other: "other",
+    other_categories: "other",
     pads: "pads",
     period_liners: "period_liners",
     period_other: "period_other",

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -67,45 +67,8 @@ class Item < ApplicationRecord
 
   scope :by_size, ->(size) { joins(:base_item).where(base_items: { size: size }) }
 
-  # Scopes - explanation of business rules for filtering scopes as of 20240527.  This was a mess, but is much better now.
-  # 1/  Disposable.   Disposables are only the disposable diapers for children.  So we deliberately exclude adult and cloth
-  # 2/  Cloth.  Cloth diapers for children.  Exclude adult cloth. Cloth training pants also go here.
-  # 3/  Adult incontinence.  Items for adult incontinence -- diapers, ai pads, but not adult wipes.
-  # 4/  Period supplies.  All things with 'menstrual in the category'
-  # 5/  Other -- Miscellaneous, and wipes
-  # Known holes and ambiguities as of 20240527.  Working on these with the business
-  # 1/  Liners.   We are adding a new item for AI liners,  and renaming the current liners to be specifically for periods,
-  # having confirmed with the business that the majority of liners are for menstrual use.
-  # However, there is a product which can be used for either, so we are still sussing out what to do about that.
-
-  scope :disposable, -> {
-    joins(:base_item)
-      .where("lower(base_items.category) LIKE '%diaper%'")
-      .where.not("lower(base_items.category) LIKE '%cloth%' OR lower(base_items.name) LIKE '%cloth%'")
-      .where.not("lower(base_items.category) LIKE '%adult%'")
-  }
-
-  scope :cloth_diapers, -> {
-    joins(:base_item)
-      .where("lower(base_items.category) LIKE '%cloth%'")
-      .or(where("base_items.category = 'Training Pants'"))
-      .where.not("lower(base_items.category) LIKE '%adult%'")
-  }
-
-  scope :adult_incontinence, -> {
-    joins(:base_item)
-      .where("lower(base_items.category) LIKE '%adult%' AND lower(base_items.category) NOT LIKE '%wipes%'")
-  }
-
   scope :period_supplies, -> {
-    joins(:base_item)
-      .where("lower(base_items.category) LIKE '%menstrual%'")
-  }
-
-  scope :other_categories, -> {
-    joins(:base_item)
-      .where("lower(base_items.category) LIKE '%wipes%'")
-      .or(where("base_items.category = 'Miscellaneous'"))
+    where(reporting_category: [:pads, :tampons, :period_liners, :period_underwear, :period_other])
   }
 
   enum :reporting_category, {
@@ -115,8 +78,11 @@ class Item < ApplicationRecord
     menstrual: "menstrual",
     other: "other",
     pads: "pads",
+    period_liners: "period_liners",
+    period_other: "period_other",
+    period_underwear: "period_underwear",
     tampons: "tampons"
-  }, scopes: false, instance_methods: false
+  }, instance_methods: false
 
   def self.reactivate(item_ids)
     item_ids = Array.wrap(item_ids)

--- a/app/services/reports/children_served_report_service.rb
+++ b/app/services/reports/children_served_report_service.rb
@@ -44,17 +44,15 @@ module Reports
     end
 
     # These joins look circular but are needed due to polymorphic relationships.
-    # A distribution has many line_items, items, and base_items but kits also
+    # A distribution has many line_items and  items, but kits also
     # have the same relationships and we want to perform calculations on the
     # items in the kits not the kit items themselves.
     def children_served_with_kits_containing_disposables
       kits_subquery = organization
         .distributions
         .for_year(year)
-        .joins(line_items: { item: { kit: { line_items: {item: :base_item} }}})
-        .where("base_items.category ILIKE '%diaper%' AND
-          NOT base_items.category ILIKE '%cloth%' OR base_items.name ILIKE '%cloth%' AND
-          NOT base_items.category ILIKE '%adult%'")
+        .joins(line_items: { item: { kit: { line_items: :item} }})
+        .where("items_line_items.reporting_category = 'disposable_diapers'")
         .select("DISTINCT ON (distributions.id, line_items.id, kits.id) line_items.quantity, items.distribution_quantity")
         .to_sql
 

--- a/app/services/reports/children_served_report_service.rb
+++ b/app/services/reports/children_served_report_service.rb
@@ -38,7 +38,7 @@ module Reports
       .distributions
       .for_year(year)
       .joins(line_items: :item)
-      .merge(Item.loose.disposable)
+      .merge(Item.loose.disposable_diapers)
       .pick(Arel.sql("CEILING(SUM(line_items.quantity::numeric / COALESCE(items.distribution_quantity, 50)))"))
       .to_i
     end

--- a/app/services/reports/diaper_report_service.rb
+++ b/app/services/reports/diaper_report_service.rb
@@ -59,11 +59,9 @@ module Reports
         INNER JOIN kits ON kits.id = items.kit_id 
         INNER JOIN line_items AS kit_line_items ON kits.id = kit_line_items.itemizable_id
         INNER JOIN items AS kit_items ON kit_items.id = kit_line_items.item_id
-        INNER JOIN base_items ON base_items.partner_key = kit_items.partner_key 
         WHERE distributions.organization_id = ?
           AND EXTRACT(year FROM issued_at) = ?
-          AND LOWER(base_items.category) LIKE '%diaper%'
-          AND NOT (LOWER(base_items.category) LIKE '%cloth%' OR LOWER(base_items.name) LIKE '%cloth%')
+          AND kit_items.reporting_category = 'disposable_diapers'
           AND kit_line_items.itemizable_type = 'Kit';
       SQL
 

--- a/app/services/reports/diaper_report_service.rb
+++ b/app/services/reports/diaper_report_service.rb
@@ -43,7 +43,7 @@ module Reports
         .distributions
         .for_year(year)
         .joins(line_items: :item)
-        .merge(Item.disposable)
+        .merge(Item.disposable_diapers)
         .sum("line_items.quantity")
     end
 
@@ -100,7 +100,7 @@ module Reports
     # @return [Integer]
     def disposable_diapers_from_drives
       @disposable_diapers_from_drives ||=
-        annual_drives.joins(donations: {line_items: :item}).merge(Item.disposable).sum(:quantity)
+        annual_drives.joins(donations: {line_items: :item}).merge(Item.disposable_diapers).sum(:quantity)
     end
 
     def cloth_diapers_from_drives
@@ -127,7 +127,7 @@ module Reports
     def disposable_diapers_from_virtual_drives
       @disposable_diapers_from_virtual_drives ||= virtual_product_drives
         .joins(donations: {line_items: :item})
-        .merge(Item.disposable)
+        .merge(Item.disposable_diapers)
         .sum(:quantity)
     end
 
@@ -202,7 +202,7 @@ module Reports
     # @return [Integer]
     def purchased_loose_disposable_diapers
       @purchased_disposable_diapers ||= LineItem.joins(:item)
-        .merge(Item.disposable)
+        .merge(Item.disposable_diapers)
         .where(itemizable: organization.purchases.for_year(year))
         .sum(:quantity)
     end
@@ -228,7 +228,7 @@ module Reports
     # @return [Integer]
     def donated_disposable_diapers
       @donated_diapers ||= LineItem.joins(:item)
-        .merge(Item.disposable)
+        .merge(Item.disposable_diapers)
         .where(itemizable: organization.donations.for_year(year))
         .sum(:quantity)
     end

--- a/app/services/reports/period_supply_report_service.rb
+++ b/app/services/reports/period_supply_report_service.rb
@@ -116,11 +116,9 @@ module Reports
         INNER JOIN kits ON kits.id = items.kit_id 
         INNER JOIN line_items AS kit_line_items ON kits.id = kit_line_items.itemizable_id
         INNER JOIN items AS kit_items ON kit_items.id = kit_line_items.item_id
-        INNER JOIN base_items ON base_items.partner_key = kit_items.partner_key 
         WHERE #{itemizable_type}.organization_id = ?
           AND EXTRACT(year FROM issued_at) = ?
-          AND LOWER(base_items.category) LIKE '%menstrual supplies%'
-          AND NOT (LOWER(base_items.category) LIKE '%diaper%' OR LOWER(base_items.name) LIKE '%cloth%')
+          AND kit_items.reporting_category IN ('pads', 'tampons', 'period_liners', 'period_underwear', 'period_other')
           AND kit_line_items.itemizable_type = 'Kit';
       SQL
 

--- a/app/services/reports/summary_report_service.rb
+++ b/app/services/reports/summary_report_service.rb
@@ -71,7 +71,7 @@ module Reports
     # @return [Integer]
     def diapers(year)
       LineItem.joins(:item)
-              .merge(Item.disposable)
+              .merge(Item.disposable_diapers)
               .where(itemizable: organization.donations.for_year(year))
               .sum(:quantity)
     end

--- a/db/migrate/20250404102321_fix_liners_reporting_category.rb
+++ b/db/migrate/20250404102321_fix_liners_reporting_category.rb
@@ -1,0 +1,23 @@
+class FixLinersReportingCategory < ActiveRecord::Migration[8.0]
+  def up
+    BaseItem
+      .where(name: "Liners (Menstrual)")
+      .update_all(reporting_category: :period_liners)
+
+    Item
+      .joins(:base_item)
+      .where(base_item: { name: "Liners (Menstrual)" })
+      .update_all(reporting_category: :period_liners)
+  end
+
+  def down
+    BaseItem
+      .where(name: "Liners (Menstrual)")
+      .update_all(reporting_category: :menstrual)
+
+    Item
+      .joins(:base_item)
+      .where(base_item: { name: "Liners (Menstrual)"})
+      .update_all(reporting_category: :menstrual)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_02_154355) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_05_153423) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -299,6 +299,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_02_154355) do
     t.string "group_id"
     t.index ["organization_id", "event_time"], name: "index_events_on_organization_id_and_event_time"
     t.index ["user_id"], name: "index_events_on_user_id"
+  end
+
+  create_table "fakes", force: :cascade do |t|
+    t.string "name", limit: 256, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "families", force: :cascade do |t|

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -190,9 +190,9 @@ RSpec.describe Distribution, type: :model do
     end
 
     describe "with_diapers >" do
-      let(:disposable_item) { create(:item, base_item: create(:base_item, category: "Diapers - Childrens")) }
-      let(:cloth_diaper_item) { create(:item, base_item: create(:base_item, category: "Diapers - Cloth (Kids)")) }
-      let(:non_diaper_item) { create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items")) }
+      let(:disposable_item) { create(:item, reporting_category: :disposable_diapers) }
+      let(:cloth_diaper_item) { create(:item, reporting_category: :cloth_diapers) }
+      let(:non_diaper_item) { create(:item, reporting_category: :tampons) }
 
       it "only includes distributions with disposable or cloth_diaper items" do
         dist1 = create(:distribution, :with_items, item: disposable_item)
@@ -208,8 +208,8 @@ RSpec.describe Distribution, type: :model do
     end
 
     describe "with_period_supplies >" do
-      let(:period_supplies_item) { create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items")) }
-      let(:non_period_supplies_item) { create(:item, base_item: create(:base_item, category: "Diapers - Childrens")) }
+      let(:period_supplies_item) { create(:item, reporting_category: :tampons) }
+      let(:non_period_supplies_item) { create(:item, reporting_category: :adult_incontinence) }
 
       it "only includes distributions with period supplies items" do
         dist1 = create(:distribution, :with_items, item: period_supplies_item)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -135,17 +135,13 @@ RSpec.describe Item, type: :model do
       end
     end
 
-    describe "->disposable" do
+    describe "->disposable_diapers" do
       it "returns records associated with disposable diapers" do
-        base_1 = create(:base_item, category: "Diapers - Childrens")
-        adult_base = create(:base_item, category: "Diapers - Adult")
-        cloth_base = create(:base_item, category: "Diapers - Cloth (Adult)")
+        disposable_1 = create(:item, :active, name: "Disposable Diaper 1", reporting_category: :disposable_diapers, organization:)
+        adult_1 = create(:item, :active, name: "Adult Diaper 1", reporting_category: :adult_incontinence, organization:)
+        cloth_1 = create(:item, :active, name: "Cloth Diaper", reporting_category: :cloth_diapers, organization:)
 
-        disposable_1 = create(:item, :active, name: "Disposable Diaper 1", base_item: base_1, organization: organization)
-        adult_1 = create(:item, :active, name: "Adult Diaper 1", base_item: adult_base, organization: organization)
-        cloth_1 = create(:item, :active, name: "Cloth Diaper", base_item: cloth_base, organization: organization)
-
-        disposables = Item.disposable
+        disposables = Item.disposable_diapers
 
         expect(disposables.count).to eq(1)
         expect(disposables).to include(disposable_1)
@@ -155,13 +151,9 @@ RSpec.describe Item, type: :model do
 
     describe "->cloth_diapers" do
       it "returns records associated with cloth diapers" do
-        disposable_base = create(:base_item, category: "Diapers - Childrens")
-        adult_cloth_base = create(:base_item, category: "Diapers - Cloth (Adult)")
-        cloth_base = create(:base_item, category: "Diapers - Cloth (Kids)")
-
-        cloth_item = create(:item, :active, name: "Cloth Diaper", base_item: cloth_base, organization: organization)
-        adult_cloth_item = create(:item, :active, name: "Adult_Cloth Diaper 1", base_item: adult_cloth_base, organization: organization)
-        disposable_item = create(:item, :active, name: "Disposable Diaper 1", base_item: disposable_base, organization: organization)
+        cloth_item = create(:item, :active, name: "Cloth Diaper", reporting_category: :cloth_diapers, organization:)
+        adult_cloth_item = create(:item, :active, name: "Adult_Cloth Diaper 1", reporting_category: :adult_incontinence, organization:)
+        disposable_item = create(:item, :active, name: "Disposable Diaper 1", reporting_category: :disposable_diapers, organization:)
 
         cloth_diapers = Item.cloth_diapers
 
@@ -173,54 +165,37 @@ RSpec.describe Item, type: :model do
 
     describe "->adult_incontinence" do
       it "returns records associated with adult incontinence" do
-        child_base = create(:base_item, category: "Diapers - Childrens")
-        adult_cloth_base = create(:base_item, category: "Diapers - Cloth (Adult)")
-        child_cloth_base = create(:base_item, category: "Diapers - Cloth (Kids)")
-        adult_brief_base = create(:base_item, category: "Diapers - Adult")
-        pad_base = create(:base_item, category: "Incontinence Pads - Adult", partner_key: "underpads")
-        adult_incontinence_base = create(:base_item, category: "Incontinence Pads - Adult", partner_key: "adult_incontinence")
-        liner_base_1 = create(:base_item, category: "Menstrual Supplies/Items", partner_key: "liners")
-        liner_base_2 = create(:base_item, category: "Incontinence Pads - Adult", partner_key: "ai_liners")
-        wipes_base = create(:base_item, category: "Wipes - Adults", partner_key: "adult_wipes")
-
-        child_disposable_item = create(:item, :active, name: "Item 1", base_item: child_base, organization: organization)
-        adult_cloth_item = create(:item, :active, name: "Item 2", base_item: adult_cloth_base, organization: organization)
-        child_cloth_item = create(:item, :active, name: "Item 3", base_item: child_cloth_base, organization: organization)
-        adult_brief_item = create(:item, :active, name: "Item 4", base_item: adult_brief_base, organization: organization)
-        adult_incontinence_item = create(:item, :active, name: "Item 5", base_item: adult_incontinence_base, organization: organization)
-        pad_item = create(:item, :active, name: "Item 6", base_item: pad_base, organization: organization)
-        liner_item_1 = create(:item, :active, name: "Item 7", base_item: liner_base_1, organization: organization)
-        liner_item_2 = create(:item, :active, name: "Item 8", base_item: liner_base_2, organization: organization)
-        wipes_item = create(:item, :active, name: "Item 9", base_item: wipes_base, organization: organization)
+        child_disposable_item = create(:item, :active, name: "Item 1", reporting_category: :disposable_diapers, organization:)
+        adult_cloth_item = create(:item, :active, name: "Item 2", reporting_category: :adult_incontinence, organization:)
+        child_cloth_item = create(:item, :active, name: "Item 3", reporting_category: :cloth_diapers, organization:)
+        liner_item = create(:item, :active, name: "Item 4", reporting_category: :other, organization:)
 
         ai_items = Item.adult_incontinence
 
-        expect(ai_items.count).to eq(5)
-        expect(ai_items).to include(adult_cloth_item, adult_brief_item, adult_incontinence_item, pad_item, liner_item_2)
-        expect(ai_items).to_not include(child_disposable_item, child_cloth_item, wipes_item, liner_item_1)
+        expect(ai_items.count).to eq(1)
+        expect(ai_items).to include(adult_cloth_item)
+        expect(ai_items).to_not include(child_disposable_item, child_cloth_item, liner_item)
       end
     end
   end
 
   describe "->period_supplies" do
     it "returns records associated with period supplies" do
-      liner_base_1 = create(:base_item, category: "Menstrual Supplies/Items", partner_key: "liners")
-      liner_base_2 = create(:base_item, category: "Incontinence Pads - Adult", partner_key: "ai_liners")
-      ai_pad_base = create(:base_item, category: "Incontinence Pads - Adult", partner_key: "underpads")
-      period_pad_base = create(:base_item, category: "Menstrual Supplies/Items", partner_key: "pads")
-      tampon_base = create(:base_item, category: "Menstrual Supplies/Items", partner_key: "tampons")
+      liner_item = create(:item, :active, name: "Item 1", reporting_category: :period_liners, organization:)
+      period_other_item = create(:item, :active, name: "Item 2", reporting_category: :period_other, organization:)
+      underwear_item = create(:item, :active, name: "Item 3", reporting_category: :period_underwear, organization:)
+      tampon_item = create(:item, :active, name: "Item 4", reporting_category: :period_underwear, organization:)
+      pad_item = create(:item, :active, name: "Item 5", reporting_category: :period_underwear, organization:)
 
-      liner_item_1 = create(:item, :active, name: "Item 1", base_item: liner_base_1, organization: organization)
-      liner_item_2 = create(:item, :active, name: "Item 2", base_item: liner_base_2, organization: organization)
-      ai_pad_item = create(:item, :active, name: "Item 3", base_item: ai_pad_base, organization: organization)
-      period_pad_item = create(:item, :active, name: "Item 4", base_item: period_pad_base, organization: organization)
-      tampon_item = create(:item, :active, name: "Item 5", base_item: tampon_base, organization: organization)
+      cloth_item = create(:item, :active, name: "Cloth Diaper", reporting_category: :cloth_diapers, organization:)
+      adult_cloth_item = create(:item, :active, name: "Adult_Cloth Diaper 1", reporting_category: :adult_incontinence, organization:)
+      disposable_item = create(:item, :active, name: "Disposable Diaper 1", reporting_category: :disposable_diapers, organization:)
 
       period_items = Item.period_supplies
 
-      expect(period_items.count).to eq(3)
-      expect(period_items).to include(liner_item_1, period_pad_item, tampon_item)
-      expect(period_items).to_not include(liner_item_2, ai_pad_item)
+      expect(period_items.count).to eq(5)
+      expect(period_items).to include(liner_item, period_other_item, underwear_item, tampon_item, pad_item)
+      expect(period_items).to_not include(cloth_item, adult_cloth_item, disposable_item)
     end
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Item, type: :model do
         child_disposable_item = create(:item, :active, name: "Item 1", reporting_category: :disposable_diapers, organization:)
         adult_cloth_item = create(:item, :active, name: "Item 2", reporting_category: :adult_incontinence, organization:)
         child_cloth_item = create(:item, :active, name: "Item 3", reporting_category: :cloth_diapers, organization:)
-        liner_item = create(:item, :active, name: "Item 4", reporting_category: :other, organization:)
+        liner_item = create(:item, :active, name: "Item 4", reporting_category: :period_liners, organization:)
 
         ai_items = Item.adult_incontinence
 

--- a/spec/services/exports/export_partners_csv_service_spec.rb
+++ b/spec/services/exports/export_partners_csv_service_spec.rb
@@ -96,10 +96,10 @@ RSpec.describe Exports::ExportPartnersCSVService do
           providing_diapers[:value] = "Y"
 
           case scope
-          when :disposable
-            item = create(:item, base_item: create(:base_item, category: "Diapers - Childrens"))
+          when :disposable_diapers
+            item = create(:item, reporting_category: :disposable_diapers)
           when :cloth_diapers
-            item = create(:item, base_item: create(:base_item, category: "Diapers - Cloth (Kids)"))
+            item = create(:item, reporting_category: :cloth_diapers)
           end
 
           create(:line_item, item: item, itemizable: distribution)
@@ -111,7 +111,7 @@ RSpec.describe Exports::ExportPartnersCSVService do
       end
 
       context "with a disposable item" do
-        include_examples "providing_diapers check", :disposable
+        include_examples "providing_diapers check", :disposable_diapers
       end
 
       context "with a cloth diaper item" do
@@ -122,7 +122,7 @@ RSpec.describe Exports::ExportPartnersCSVService do
         before do
           providing_period_supplies[:value] = "Y"
 
-          item = create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items"))
+          item = create(:item, organization:, reporting_category: :tampons)
           create(:line_item, item: item, itemizable: distribution)
         end
 
@@ -134,9 +134,9 @@ RSpec.describe Exports::ExportPartnersCSVService do
 
     context "when partner only has distribution older than a 12 months" do
       let(:distribution) { create(:distribution, issued_at: (12.months.ago.beginning_of_day - 1.day), partner: partner) }
-      let(:disposable_diapers_item) { create(:item, base_item: create(:base_item, category: "Diapers - Childrens")) }
-      let(:cloth_diapers_item) { create(:item, base_item: create(:base_item, category: "Diapers - Cloth (Kids)")) }
-      let(:period_supplies_item) { create(:item, base_item: create(:base_item, category: "Menstrual Supplies/Items")) }
+      let(:disposable_diapers_item) { create(:item, reporting_category: :disposable_diapers) }
+      let(:cloth_diapers_item) { create(:item, reporting_category: :cloth_diapers) }
+      let(:period_supplies_item) { create(:item, reporting_category: :tampons) }
 
       before do
         create(:line_item, item: disposable_diapers_item, itemizable: distribution)

--- a/spec/services/reports/children_served_report_service_spec.rb
+++ b/spec/services/reports/children_served_report_service_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Reports::ChildrenServedReportService, type: :service do
     it 'should report normal values' do
       organization = create(:organization, :with_items, distribute_monthly: true, repackage_essentials: true)
 
-      disposable_item = organization.items.disposable.first
+      disposable_item = organization.items.disposable_diapers.first
       disposable_item.update!(distribution_quantity: 20)
-      non_disposable_item = organization.items.where.not(id: organization.items.disposable).first
+      non_disposable_item = organization.items.where.not(id: organization.items.disposable_diapers).first
 
       # Kits
       create(:base_item, name: "Toddler Disposable Diaper", partner_key: "toddler diapers", category: "disposable diaper")
@@ -79,8 +79,8 @@ RSpec.describe Reports::ChildrenServedReportService, type: :service do
       within_time = Time.zone.parse("2020-05-31 14:00:00")
       outside_time = Time.zone.parse("2019-05-31 14:00:00")
 
-      disposable_item = organization.items.disposable.first
-      non_disposable_item = organization.items.where.not(id: organization.items.disposable).first
+      disposable_item = organization.items.disposable_diapers.first
+      non_disposable_item = organization.items.where.not(id: organization.items.disposable_diapers).first
 
       # Kits
       create(:base_item, name: "Toddler Disposable Diaper", partner_key: "toddler diapers", category: "disposable diaper")

--- a/spec/services/reports/children_served_report_service_spec.rb
+++ b/spec/services/reports/children_served_report_service_spec.rb
@@ -26,11 +26,8 @@ RSpec.describe Reports::ChildrenServedReportService, type: :service do
       non_disposable_item = organization.items.where.not(id: organization.items.disposable_diapers).first
 
       # Kits
-      create(:base_item, name: "Toddler Disposable Diaper", partner_key: "toddler diapers", category: "disposable diaper")
-      create(:base_item, name: "Infant Disposable Diaper", partner_key: "infant diapers", category: "infant disposable diaper")
-
-      toddler_disposable_kit_item = create(:item, name: "Toddler Disposable Diapers", partner_key: "toddler diapers")
-      infant_disposable_kit_item = create(:item, name: "Infant Disposable Diapers", partner_key: "infant diapers")
+      toddler_disposable_kit_item = create(:item, name: "Toddler Disposable Diapers", reporting_category: :disposable_diapers)
+      infant_disposable_kit_item = create(:item, name: "Infant Disposable Diapers", reporting_category: :disposable_diapers)
 
       kit_1 = create(:kit, organization: organization, line_items: [
         create(:line_item, item: toddler_disposable_kit_item),
@@ -83,11 +80,8 @@ RSpec.describe Reports::ChildrenServedReportService, type: :service do
       non_disposable_item = organization.items.where.not(id: organization.items.disposable_diapers).first
 
       # Kits
-      create(:base_item, name: "Toddler Disposable Diaper", partner_key: "toddler diapers", category: "disposable diaper")
-      create(:base_item, name: "Infant Disposable Diaper", partner_key: "infant diapers", category: "infant disposable diaper")
-
-      toddler_disposable_kit_item = create(:item, name: "Toddler Disposable Diapers", partner_key: "toddler diapers")
-      infant_disposable_kit_item = create(:item, name: "Infant Disposable Diapers", partner_key: "infant diapers")
+      toddler_disposable_kit_item = create(:item, name: "Toddler Disposable Diapers", reporting_category: :disposable_diapers)
+      infant_disposable_kit_item = create(:item, name: "Infant Disposable Diapers", reporting_category: :disposable_diapers)
 
       kit = create(:kit, organization: organization, line_items: [
         create(:line_item, item: toddler_disposable_kit_item),
@@ -125,13 +119,9 @@ RSpec.describe Reports::ChildrenServedReportService, type: :service do
     it "rounds children served to integer ceiling" do
       organization = create(:organization, :with_items)
 
-      create(:base_item, name: "Toddler Disposable Diaper", partner_key: "toddler diapers", category: "disposable diaper")
-      create(:base_item, name: "Infant Disposable Diaper", partner_key: "infant diapers", category: "infant disposable diaper")
-      create(:base_item, name: "Adult Diaper", partner_key: "adult diapers", category: "adult diaper")
-
-      toddler_disposable_kit_item = create(:item, name: "Toddler Disposable Diapers", partner_key: "toddler diapers")
-      infant_disposable_kit_item = create(:item, name: "Infant Disposable Diapers", partner_key: "infant diapers")
-      not_disposable_kit_item = create(:item, name: "Adult Diapers", partner_key: "adult diapers")
+      toddler_disposable_kit_item = create(:item, name: "Toddler Disposable Diapers", reporting_category: :disposable_diapers)
+      infant_disposable_kit_item = create(:item, name: "Infant Disposable Diapers", reporting_category: :disposable_diapers)
+      not_disposable_kit_item = create(:item, name: "Adult Diapers", reporting_category: :adult_incontinence)
 
       # this quantity shouldn't matter so I'm setting it to a high number to ensure it isn't used
       kit = create(:kit, organization: organization, line_items: [

--- a/spec/services/reports/diaper_report_service_spec.rb
+++ b/spec/services/reports/diaper_report_service_spec.rb
@@ -9,11 +9,8 @@ RSpec.describe Reports::DiaperReportService, type: :service, persisted_data: tru
 
     before do
       # Kits
-      create(:base_item, name: "Adult Disposable Diaper", partner_key: "adult diapers", category: "disposable diaper")
-      create(:base_item, name: "Infant Disposable Diaper", partner_key: "infant diapers", category: "disposable diaper")
-
-      disposable_kit_item = create(:item, name: "Adult Disposable Diapers", partner_key: "adult diapers")
-      another_disposable_kit_item = create(:item, name: "Infant Disposable Diapers", partner_key: "infant diapers")
+      disposable_kit_item = create(:item, name: "Adult Disposable Diapers", reporting_category: :disposable_diapers)
+      another_disposable_kit_item = create(:item, name: "Infant Disposable Diapers", reporting_category: :disposable_diapers)
 
       disposable_kit = create_kit(organization: organization, line_items_attributes: [
         {item_id: disposable_kit_item.id, quantity: 5}
@@ -31,11 +28,8 @@ RSpec.describe Reports::DiaperReportService, type: :service, persisted_data: tru
       # Total disposable items distributed so far: 5*10 + 5*10 = 100
 
       # create disposable and non disposable items
-      create(:base_item, name: "3T Diaper", partner_key: "toddler diapers", category: "disposable diaper")
-      create(:base_item, name: "Cloth Diapers", partner_key: "infant cloth diapers", category: "cloth diaper")
-
-      disposable_item = create(:item, name: "Disposable Diapers", partner_key: "toddler diapers")
-      non_disposable_item = create(:item, name: "Infant Cloth Diapers", partner_key: "infant cloth diapers")
+      disposable_item = create(:item, name: "Disposable Diapers", reporting_category: :disposable_diapers)
+      non_disposable_item = create(:item, name: "Infant Cloth Diapers", reporting_category: :cloth_diapers)
 
       # Distributions
       distributions = create_list(:distribution, 2, issued_at: within_time, organization: organization)

--- a/spec/services/reports/period_supply_report_service_spec.rb
+++ b/spec/services/reports/period_supply_report_service_spec.rb
@@ -40,12 +40,9 @@ RSpec.describe Reports::PeriodSupplyReportService, type: :service do
         purchased_period_supply_kit = create_kit(organization: organization)
         pad_and_tampon_kit = create_kit(organization: organization)
 
-        create(:base_item, name: "Adult Pads", partner_key: "adult pads", category: "Menstrual Supplies")
-        create(:base_item, name: "Adult Tampons", partner_key: "adult tampons", category: "Menstrual Supplies")
-
-        period_supplies_kit_item = create(:item, name: "Adult Pads", partner_key: "adult pads")
-        another_period_supplies_kit_item = create(:item, name: "Adult Tampons", partner_key: "adult tampons")
-        purchased_period_supplies_kit_item = create(:item, name: "Liners", partner_key: "adult tampons")
+        period_supplies_kit_item = create(:item, name: "Adult Pads", reporting_category: :pads, organization:)
+        another_period_supplies_kit_item = create(:item, name: "Adult Tampons", reporting_category: :tampons, organization:)
+        purchased_period_supplies_kit_item = create(:item, name: "Liners", reporting_category: :period_liners, organization:)
 
         period_supplies_kit.line_items.first.update!(item_id: period_supplies_kit_item.id, quantity: 5)
         another_period_supply_kit.line_items.first.update!(item_id: another_period_supplies_kit_item.id, quantity: 5)

--- a/spec/services/reports/summary_report_service_spec.rb
+++ b/spec/services/reports/summary_report_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Reports::SummaryReportService, type: :service do
       let(:organization) { create(:organization, :with_items) }
 
       it 'should report positive values' do
-        disposable_item = organization.items.disposable.first
-        non_disposable_item = organization.items.where.not(id: organization.items.disposable).first
+        disposable_item = organization.items.disposable_diapers.first
+        non_disposable_item = organization.items.where.not(id: organization.items.disposable_diapers).first
 
         last_year = year - 1
         this_year_time = Time.zone.parse("#{year}-05-31 14:00:00")
@@ -53,8 +53,8 @@ RSpec.describe Reports::SummaryReportService, type: :service do
       end
 
       it 'should report negative values' do
-        disposable_item = organization.items.disposable.first
-        non_disposable_item = organization.items.where.not(id: organization.items.disposable).first
+        disposable_item = organization.items.disposable_diapers.first
+        non_disposable_item = organization.items.where.not(id: organization.items.disposable_diapers).first
 
         last_year = year - 1
         this_year_time = Time.zone.parse("#{year}-05-31 14:00:00")


### PR DESCRIPTION
Resolves #5010

### Description
Changes made from this [comment](https://github.com/rubyforgood/human-essentials/issues/5010#issuecomment-2759922898):

> 1/ We'll need to change the scopes on item to take the reporting categories into account.
> 
> scope -> reporting categories
> 
> disposable-> disposable_diapers; (simpler than current)
> cloth_diapers->cloth_diapers; (simpler than current)
> adult_incontinence->adult_incontinence; (simpler than current)
> period_supplies->pads, tampons, period_liners, period_underwear, period_reusables, period_other; (we don't have all those represented yet)
> other->other (simpler than current)
> 
> 2/ I think we(I) miscategorized earlier: Liners(menstrual) should really be period_liners, rather than menstrual
> 
> 3/ Then in the actual reports,
> a) The AI could get complicated with regard to PR https://github.com/rubyforgood/human-essentials/pull/4794. We should see if we can coordinate with @jadekstewart3 -- but the pre-getting-kits-in-version will just rely on the scope update.
> b) children served, diaper report service -- we'll need to update the sql around kits to just apply to cloth or disposable as makes sense
> c) Other looks like it should follow from the scope .
> d) In period_supply_report_service, we'll need to update the sql around kits to match the new world.

### Type of change
- Breaking change (I think?)

Because previously these reports relied on the base item category name for an item. After this migration, they still do at first, but now you can change the reporting category for one item (without touching the base item) and it will change these reports. 

### How Has This Been Tested?
Refactored the automated test suite
