### PR TITLE
Perf: Fix N+1 in kits#index

### DIFF
--- a/app/controllers/kits_controller.rb
+++ b/app/controllers/kits_controller.rb
@@ -1,6 +1,6 @@
 class KitsController < ApplicationController
   def index
-    @kits = current_organization.kits.includes(line_items: :item).class_filter(filter_params)
+    @kits = current_organization.kits.includes(:item, line_items: :item).class_filter(filter_params)
     @inventory = View::Inventory.new(current_organization.id)
     unless params[:include_inactive_items]
       @kits = @kits.active


### PR DESCRIPTION
### Description
Found this N+1 while looking into a different issue.

### Type of change
* Internal (performance related)

### How Has This Been Tested?
Manually, and with automated test suite.

The items index request went from `(25 queries, 5 cached)` to `(22 queries, 5 cached)` when I had 4 kits being returned (-4 requests + 1 for the new includes query equals 3 fewer requests), and the bullet notification went away.