### PR TITLE
Partners can view request comment and sender

### DIFF
--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -7,6 +7,7 @@
         <th scope="col" class="p-4" style='width:150px'>Request Date</th>
         <th scope="col" class="p-4">Number of Items Requested</th>
         <th scope="col" class="p-4">Items Requested</th>
+        <th scope="col" class="p-4">Comment and Sender</th>
       </tr>
     </thead>
     <tbody>
@@ -32,6 +33,10 @@
                 <%= item_request.item.name %>
               </span>
             <% end %>
+          </td>
+          <td class="p-4">
+            <div class="mb-2"><%= request.comments %></div>
+            <a href="mailto:<%= request.requester.email %>"><%= request.requester.email %></a>
           </td>
         </tr>
       <% end %>

--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -35,7 +35,12 @@
             <% end %>
           </td>
           <td class="p-4">
-            <div class="mb-2"><%= request.comments %></div>
+            <% comment = request.comments %>
+            <% if comment.present? %>
+              <div class="mb-2" data-bs-toggle="tooltip" data-bs-title="<%= comment %>">
+                <%= truncate(comment, length: 20) %>
+              </div>
+            <% end %>
             <a href="mailto:<%= request.requester.email %>"><%= request.requester.email %></a>
           </td>
         </tr>
@@ -43,3 +48,10 @@
     </tbody>
   </table>
 </section>
+
+<script type="module">
+  $(document).ready(function() {
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+  })
+</script>

--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -51,7 +51,7 @@
 
 <script type="module">
   $(document).ready(function() {
-    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    [...tooltipTriggerList].forEach(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
   })
 </script>

--- a/app/views/partners/requests/_history.html.erb
+++ b/app/views/partners/requests/_history.html.erb
@@ -5,7 +5,9 @@
     <thead>
       <tr class="border-bottom border-dark">
         <th scope="col" class="p-4 w-40">Request Date</th>
+        <th scope="col" class="p-4">Number of Items Requested</th>
         <th scope="col" class="p-4">Items Requested</th>
+        <th scope="col" class="p-4">Comment and Sender</th>
       </tr>
     </thead>
     <tbody>
@@ -23,8 +25,24 @@
               </span>
             <% end %>
           </td>
+          <td class="p-4">
+            <% comment = partner_request.comments %>
+            <% if comment.present? %>
+              <div class="mb-2" data-bs-toggle="tooltip" data-bs-title="<%= comment %>">
+                <%= truncate(comment, length: 20) %>
+              </div>
+            <% end %>
+            <a href="mailto:<%= partner_request.requester.email %>"><%= partner_request.requester.email %></a>
+          </td>
         </tr>
       <% end %>
     </tbody>
   </table>
 </section>
+
+<script type="module">
+  $(document).ready(function() {
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+  })
+</script>

--- a/app/views/partners/requests/_history.html.erb
+++ b/app/views/partners/requests/_history.html.erb
@@ -42,7 +42,7 @@
 
 <script type="module">
   $(document).ready(function() {
-    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    [...tooltipTriggerList].forEach(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
   })
 </script>

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe "/partners/dashboard", type: :request do
 
       expect(response.body).to match(/7\s+#{item1.name}/m)
     end
+
+    it "displays comment and sender" do
+      request = create(:request, :pending, partner:, request_items: [])
+      create(:item_request, request:, quantity: 16, item: item1)
+
+      get partners_dashboard_path
+
+      expect(response.body).to include(request.comments)
+      expect(response.body).to include(request.requester.email)
+    end
   end
 
   it "displays upcoming distributions" do

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe "/partners/requests", type: :request do
       subject.call
       expect(response.body).to include("684")
     end
+
+    it "displays comment and sender" do
+      request = create(:request, partner_id: partner.id, request_items: [{item_id: item1.id, quantity: '125'}])
+      subject.call
+      expect(response.body).to include(request.comments)
+      expect(response.body).to include(request.requester.email)
+    end
   end
 
   describe "GET #new" do


### PR DESCRIPTION
Resolves #5151 

### Description

Partners can now view comments for a given request, and the email for the person who made the request ("sender").
Per the issue description I've limited the length of the comments to 20 characters with the remainder displayed as a tooltip.

In order for Bootstrap tooltips to be displayed I had to add a small script on each page, as mentioned in [Bootstrap documentation](https://getbootstrap.com/docs/5.3/components/tooltips/#enable-tooltips).

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added some request specs.


### Screenshots

**Essentials Requests page**
![Essentials Requests](https://github.com/user-attachments/assets/4c48120f-00c3-404c-aa51-7b6a128f248a)

**Dashboard page**
![Dashboard](https://github.com/user-attachments/assets/0d0a1593-08c7-4177-8f7e-35b608db2556)

**Tooltip demo**

https://github.com/user-attachments/assets/123fbfbb-8945-4571-b895-3efadbf5828c


