### PR TITLE
Resolves #5063: Create product drive update button styling improvements

### DIFF
--- a/app/views/product_drives/_form.html.erb
+++ b/app/views/product_drives/_form.html.erb
@@ -44,7 +44,7 @@
             </div>
             <!-- /.card-body -->
             <div class="card-footer">
-              <%= f.button :submit, :class => 'diaper-drive-submit btn btn-primary', :id => 'product_drive_submit' %>
+              <%= f.button :submit, :class => 'diaper-drive-submit btn btn-success', :id => 'product_drive_submit' %>
             </div>
           </div>
           <!-- /.card -->

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -15,7 +15,7 @@
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Default class for buttons
-  config.button_class = 'btn btn-default'
+  # config.button_class = 'btn btn-default'
 
   # Define the default class of the input wrapper of the boolean input.
   config.boolean_label_class = 'form-check-label'

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -15,7 +15,6 @@
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Default class for buttons
-  # config.button_class = 'btn btn-default'
 
   # Define the default class of the input wrapper of the boolean input.
   config.boolean_label_class = 'form-check-label'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,5 @@ en:
         issued_at: "Purchase date"
       distribution:
         issued_at: "Distribution date and time"
+    models:
+      product_drive: "Product Drive"

--- a/spec/system/product_drive_system_spec.rb
+++ b/spec/system/product_drive_system_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
         fill_in 'Name', with: 'Normal 1'
         fill_in 'Start Date', with: Time.zone.today
         fill_in 'End Date', with: Time.zone.today + 4.hours
-        click_button 'Create Product drive'
+        click_button 'Create Product Drive'
       end.to change(ProductDrive, :count).by(1)
     end
 
@@ -70,7 +70,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
       fill_in 'Name', with: 'Normal 1'
       fill_in 'Start Date', with: Time.zone.today
       fill_in 'End Date', with: Time.zone.today + 1.day
-      click_button 'Create Product drive'
+      click_button 'Create Product Drive'
 
       expect(ProductDrive.last).to have_attributes({ name: 'Normal 1', start_date: Time.zone.today, end_date: Time.zone.today + 1.day, virtual: false })
     end
@@ -79,7 +79,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
       fill_in 'Name', with: 'Virtual 1'
       fill_in 'Start Date', with: Time.zone.today
       fill_in 'End Date', with: Time.zone.today + 4.hours
-      click_button 'Create Product drive'
+      click_button 'Create Product Drive'
 
       expect(page.find('.alert')).to have_content('added')
     end
@@ -96,7 +96,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
         fill_in 'Start Date', with: Time.zone.today
         fill_in 'End Date', with: Time.zone.today + 4.hours
         check 'virtual'
-        click_button 'Create Product drive'
+        click_button 'Create Product Drive'
       end.to change(ProductDrive, :count).by(1)
     end
 
@@ -105,7 +105,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
       fill_in 'Start Date', with: Time.zone.today
       fill_in 'End Date', with: Time.zone.today + 1.day
       check 'virtual'
-      click_button 'Create Product drive'
+      click_button 'Create Product Drive'
 
       expect(ProductDrive.last).to have_attributes({ name: 'Virtual 1', start_date: Time.zone.today, end_date: Time.zone.today + 1.day, virtual: true })
     end
@@ -115,7 +115,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
       fill_in 'Start Date', with: Time.zone.today
       fill_in 'End Date', with: Time.zone.today + 4.hours
       check 'virtual'
-      click_button 'Create Product drive'
+      click_button 'Create Product Drive'
 
       expect(page.find('.alert')).to have_content('added')
     end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/human-essentials/issues/5063

### Description

Styling change to product drive buttons - to bring in line with the rest of the system

### Type of change

* Updates the style and capitalization of the Create Product Drive and Update Product Drive buttons to white on green

### How Has This Been Tested?

`bundle exec rspec ./spec/system/product_drive_system_spec.rb`

### Screenshots

![create-product-drive](https://github.com/user-attachments/assets/5201e7c8-cda7-47b1-b4ba-44c4d947a563)
![update-product-drive](https://github.com/user-attachments/assets/d685c520-2410-419e-8bc4-3898514aa3d9)
![rspec-product-drive](https://github.com/user-attachments/assets/5b3269d7-595d-45d6-879e-3c436b8aa5e9)
