### PR TITLE
WIP: Adding link to User Guide for org_admin and org_users

### DIFF
--- a/app/views/layouts/_lte_navbar.html.erb
+++ b/app/views/layouts/_lte_navbar.html.erb
@@ -1,5 +1,9 @@
 <li id="help" class="nav-item dropdown">
-  <%= link_to 'Need Help?', help_path, class: 'nav-link bg-yellow-400 mx-2 font-bold rounded-2xl' %>
+  <% if current_user.has_cached_role?(Role::ORG_ADMIN, current_organization) || current_user.has_cached_role?(Role::ORG_USER, current_organization) %>
+    <%= link_to 'User Guide', 'https://rubyforgood.github.io/human-essentials/user_guide/bank/', class: 'nav-link bg-yellow-400 mx-2 font-bold rounded-2xl' %>
+  <% else %>
+    <%= link_to 'Need Help?', help_path, class: 'nav-link bg-yellow-400 mx-2 font-bold rounded-2xl' %>
+  <% end %>
 </li>
 
 <li class="nav-item dropdown">

--- a/docs/user_guide/bank/intro_ii.md
+++ b/docs/user_guide/bank/intro_ii.md
@@ -11,7 +11,7 @@ It's a good place to ask about how other banks *actually* use the system
 
 It's often the quickest way to get support from the human essentials team as well, and the easiest way to interact with the development team.
 ### Support tickets
-There is a link to submit a support ticket is at the bottom of the "Need Help?"  screen.   This will get to us, 
+Submit a support ticket [here](https://humanessentials.app/help).  This will get to us,
     but it will take longer.  We generally look at these about once a week, on Sundays.
 ### Email
 

--- a/spec/requests/dashboard_requests_spec.rb
+++ b/spec/requests/dashboard_requests_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe "Dashboard", type: :request do
           expect(response.body).to include(organization.name)
         end
       end
+
+      it "displays User Guide link" do
+        get dashboard_path
+
+        expect(response.body).to include('User Guide')
+        expect(response.body).to include('https://rubyforgood.github.io/human-essentials/user_guide/bank/')
+        expect(response.body).not_to include('Need Help?')
+      end
     end
 
     context "BroadcastAnnouncement card" do

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe "/partners/dashboard", type: :request do
       expect(response.body).to include(request.comments)
       expect(response.body).to include(request.requester.email)
     end
+
+    it "displays Need Help instead of User Guide link for partner users" do
+      partner = create(:partner, organization: organization)
+      partner_user = partner.primary_user
+      sign_in(partner_user)
+
+      get partners_dashboard_path
+
+      expect(response.body).not_to include("User Guide")
+      expect(response.body).to include("Need Help?")
+    end
   end
 
   it "displays upcoming distributions" do


### PR DESCRIPTION


# Checklist:

X I have performed a self-review of my own code,
NA I have commented my code, particularly in hard-to-understand areas,
X I have made corresponding changes to the documentation,
X I have added tests that prove my fix is effective or that my feature works,
TODO New and existing unit tests pass locally with my changes ("bundle exec rake"),
X- Title include "WIP" if work is in progress.
X I acknowledge that I will *not* force push my branch once reviews have started.



Resolves #5185

### Description

- Replaced the link to "Need Help" with a link to the "user guide" for org_admin, org_user only.
- Added check

### Type of change

* New feature (non-breaking change which adds functionality)
* Documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Steps:

1. Log in as org_admin (org_admin1@example.com). Verify link is now User Guide
2. Same for org_user
3. Log in as partner user (verified@example.com). Verified the link is still Need Help
