### PR TITLE
5193: Fix eventable filter to be across all time

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,6 @@ class EventsController < ApplicationController
     setup_date_range_picker
 
     @events = Event.for_organization(current_organization)
-      .during(helpers.selected_range)
       .includes(:eventable, :user)
     @events = if params[:eventable_id]
       @events.where(eventable_id: params[:eventable_id],

--- a/spec/requests/events_requests_spec.rb
+++ b/spec/requests/events_requests_spec.rb
@@ -195,9 +195,9 @@ RSpec.describe "Events", type: :request do
         let(:params) {
           {
             format: "html",
-            filters: {filters: {
+            filters: {
               date_range: date_range_picker_params(3.days.ago, Time.zone.tomorrow)
-            }}
+            }
           }
         }
 
@@ -219,9 +219,12 @@ RSpec.describe "Events", type: :request do
         end
         let(:params) { {format: "html", eventable_id: donation.id, eventable_type: "Donation"} }
         before do
-          DonationEvent.publish(donation)
-          donation.line_items.first.quantity = 33
-          DonationEvent.publish(donation) # an update
+          # should not be affected by the date range
+          travel -1.year do
+            DonationEvent.publish(donation)
+            donation.line_items.first.quantity = 33
+            DonationEvent.publish(donation) # an update
+          end
         end
 
         it "should only show events from that eventable" do


### PR DESCRIPTION
Resolves #5193 <!--fill issue number-->

### Description

Fixes the `eventable` filter in History so it ignores date. In fact, *all* filters were using date even if there was no date filled in.

### Type of change

* Bug fix (non-breaking change which fixes an issue)
