### PR TITLE
Fix: Includes audited and discarded storage locations in audits index

### DIFF
--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -60,7 +60,7 @@ class StorageLocation < ApplicationRecord
     joins(:adjustments).where(organization_id: organization.id).distinct.active.alphabetized
   }
   scope :with_audits_for, ->(organization) {
-    joins(:audits).where(organization_id: organization.id).distinct.active.alphabetized
+    joins(:audits).where(organization_id: organization.id).distinct.alphabetized
   }
   scope :with_transfers_to, ->(organization) {
     joins(:transfers_to).where(organization_id: organization.id).distinct.order(:name)

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -97,6 +97,13 @@ RSpec.describe StorageLocation, type: :model do
         create(:audit, storage_location: storage_location4, organization: storage_location4.organization)
         expect(StorageLocation.with_audits_for(organization).to_a).to match_array([storage_location1, storage_location2])
       end
+
+      it "returns audited storage locations that have been discarded" do
+        storage_location1 = create(:storage_location, organization: organization, discarded_at: Time.current)
+        create(:storage_location, organization: organization)
+        create(:audit, storage_location: storage_location1, organization: organization)
+        expect(StorageLocation.with_audits_for(organization).to_a).to match_array([storage_location1])
+      end
     end
 
     describe "with_adjustments_for" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5194 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
Fixes a display issue where Storage locations with audits where being hidden in the audit index if the storage location is disactivated.  
  - What are the tradeoffs for your solution?
 It doesn't use the .active scope which seems to be used in other scopes.
   
### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Locally tested behaviour and adds a case to rspec. 

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Do an audit on that storage location on an existing storage location (or a new one)
Deactivate the storage location.
Go back to the audits page, the storage location will display in the possible storage locations. 

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

Before : 
![Capture d'écran 2025-05-26 135534](https://github.com/user-attachments/assets/ba2a2725-9ca0-4b3a-af06-e1f24a481d71)

After :  
![Capture d'écran 2025-05-26 134902](https://github.com/user-attachments/assets/9d464c1d-6846-4309-803e-80989b1457ca)

