### PR TITLE
give new role assigned response when existing user is assigned a new role

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -41,13 +41,14 @@ class Admin::UsersController < AdminController
     validate_role_resource_params
     klass = Role::TITLE_TO_RESOURCE[params[:resource_type].to_sym]
     resource = klass&.find(params[:resource_id])
+    existing_user = User.find_by(email: user_params[:email])
     UserInviteService.invite(
       name: user_params[:name],
       email: user_params[:email],
       roles: [params[:resource_type].to_sym],
       resource: resource
     )
-    flash[:notice] = "Created a new user!"
+    flash[:notice] = existing_user ? "Added new role to existing user" : "Created a new user!"
     redirect_to admin_users_path
   rescue => e
     flash.now[:error] = "Failed to create user: #{e}"

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -152,6 +152,34 @@ RSpec.describe "Admin::UsersController", type: :request do
         expect(new_user.has_role?(Role::ORG_ADMIN, organization)).to be_falsey
       end
 
+      context "flash notice behavior" do
+        context "when creating a new user" do
+          it "shows 'Created a new user!' message" do
+            post admin_users_path, params: {
+              user: { name: "New User", email: "new@example.com" },
+              resource_type: Role::ORG_USER,
+              resource_id: organization.id
+            }
+            expect(response).to redirect_to(admin_users_path)
+            expect(flash[:notice]).to eq("Created a new user!")
+          end
+        end
+
+        context "when adding a role to an existing user" do
+          let!(:existing_user) { create(:user, email: "existing@example.com", organization: organization) }
+
+          it "shows 'Added new role to existing user' message" do
+            post admin_users_path, params: {
+              user: { name: existing_user.name, email: existing_user.email },
+              resource_type: Role::PARTNER,
+              resource_id: partner.id
+            }
+            expect(response).to redirect_to(admin_users_path)
+            expect(flash[:notice]).to eq("Added new role to existing user")
+          end
+        end
+      end
+
       it "creates an org admin" do
         post admin_users_path, params: {
           user: { name: "New Org Admin", email: organization.email },


### PR DESCRIPTION
Resolves #5195

### Description
- When superuser adds a user that already exists, The message that appears is "Created a new user!" It should be "Added new role to existing user". This PR fixes this issue.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Locally tested and added 2 cases in rspec.

Login as superadmin, 
add a new user with a new email - You will be redirected to user index page with a notice - 'Created a new user!'
add a new user with an existing user email - You will be redirected to user index page with a notice - 'Added new role to existing user'

### Screenshots
New user message
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/946e0cea-5448-4542-a209-1e8a340cea18" />

Existing User message
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/84a3dd9e-8e25-44d5-8fdc-39f1df107efd" />
