### PR TITLE
Add viewing/editing/filtering of item reporting category

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   def index
     @items = current_organization
       .items
-      .includes(:base_item, :kit, :line_items, :request_units, :item_category)
+      .includes(:kit, :line_items, :request_units, :item_category)
       .alphabetized
       .class_filter(filter_params)
       .group('items.id')
@@ -15,7 +15,7 @@ class ItemsController < ApplicationController
     @storages = current_organization.storage_locations.active.order(id: :asc)
 
     @include_inactive_items = params[:include_inactive_items]
-    @selected_base_item = filter_params[:by_base_item]
+    @selected_reporting_category = filter_params[:by_reporting_category]
 
     @paginated_items = @items.page(params[:page])
 
@@ -164,6 +164,7 @@ class ItemsController < ApplicationController
     @item_params = params.require(:item).permit(
       :name,
       :item_category_id,
+      :reporting_category,
       :partner_key,
       :value_in_cents,
       :package_size,
@@ -205,6 +206,6 @@ class ItemsController < ApplicationController
     def filter_params(_parameters = nil)
     return {} unless params.key?(:filters)
 
-    params.require(:filters).permit(:by_base_item, :include_inactive_items)
+    params.require(:filters).permit(:by_reporting_category, :include_inactive_items)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -64,6 +64,7 @@ class Item < ApplicationRecord
   scope :visible, -> { where(visible_to_partners: true) }
   scope :alphabetized, -> { order(:name) }
   scope :by_base_item, ->(base_item) { where(base_item: base_item) }
+  scope :by_reporting_category, ->(reporting_category) { where(reporting_category: reporting_category) }
   scope :by_partner_key, ->(partner_key) { where(partner_key: partner_key) }
 
   scope :by_size, ->(size) { joins(:base_item).where(base_items: { size: size }) }
@@ -83,7 +84,13 @@ class Item < ApplicationRecord
     period_other: "period_other",
     period_underwear: "period_underwear",
     tampons: "tampons"
-  }, instance_methods: false
+  }, instance_methods: false, validate: { allow_nil: true }
+
+  def self.reporting_categories_for_select
+    reporting_categories.map do |key, value|
+      Option.new(id: key, name: value.titleize)
+    end
+  end
 
   def self.reactivate(item_ids)
     item_ids = Array.wrap(item_ids)
@@ -140,6 +147,10 @@ class Item < ApplicationRecord
     else
       update!(active: false)
     end
+  end
+
+  def reporting_category_humanized
+    Item.reporting_categories[reporting_category].titleize
   end
 
   def other?

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -78,12 +78,12 @@ class Item < ApplicationRecord
     cloth_diapers: "cloth_diapers",
     disposable_diapers: "disposable_diapers",
     menstrual: "menstrual",
-    other_categories: "other",
     pads: "pads",
     period_liners: "period_liners",
     period_other: "period_other",
     period_underwear: "period_underwear",
-    tampons: "tampons"
+    tampons: "tampons",
+    other_categories: "other"
   }, instance_methods: false, validate: { allow_nil: true }
 
   def self.reporting_categories_for_select

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -21,6 +21,10 @@
                 <%= f.input :item_category_id, label: 'Category', collection: @item_categories, hint: 'Categories can help organize and identify items' %>
               </div>
 
+              <div class='w-1/4'>
+                <%= f.input :reporting_category, label: 'Reporting Category', collection: Item.reporting_categories_for_select, hint: 'NDBN reporting category' %>
+              </div>
+
               <%= f.input :name, label: "Value per item", wrapper: :input_group do %>
                 <span class="input-group-text"><i class="fa fa-money"></i></span>
                 <%= f.input_field :value_in_dollars, class: "form-control" %>

--- a/app/views/items/_item_list.html.erb
+++ b/app/views/items/_item_list.html.erb
@@ -8,6 +8,7 @@
     <tr>
       <th>Category</th>
       <th>Name</th>
+      <th>Reporting Category</th>
       <th>Add. Info</th>
       <th class="text-right">Quantity Per Individual</th>
       <th class="text-right">Fair Market Value (per item)</th>

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -1,6 +1,7 @@
 <tr data-item-id="<%= item_row.id %>">
   <td><%= item_row.item_category && link_to(item_row.item_category&.name, item_category_path(item_row.item_category), class: 'text-blue-500') %></td>
   <td><%= item_row.name %></td>
+  <td><%= item_row.reporting_category_humanized %></td>
   <td><%= truncate item_row.additional_info, length: 25 %></td>
   <td class="text-right"> <%= item_row.distribution_quantity %></td>
   <td class="numeric"><%= dollar_value(item_row.value_in_cents) %></td>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -37,7 +37,7 @@
             <%= form_tag(items_path, method: :get) do |f| %>
               <div class="row">
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_base_item, collection: BaseItem.alphabetized, key: :partner_key, selected: @selected_base_item) %>
+                  <%= filter_select(scope: :by_reporting_category, collection: Item.reporting_categories_for_select, selected: @selected_reporting_category) %>
                 </div>
               </div>
               <div class="row">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -44,6 +44,10 @@
                 <td><%= @item&.item_category&.name %></td>
               </tr>
               <tr>
+                <th>Reporting Category</th>
+                <td><%= @item.reporting_category_humanized %></td>
+              </tr>
+              <tr>
                 <th>Value Per Item</th>
                 <td>$<%= @item.value_in_dollars || 0 %></td>
               </tr>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -135,6 +135,15 @@ RSpec.describe Item, type: :model do
       end
     end
 
+    describe "->by_reporting_category" do
+      it "shows the items for a particular reporting category" do
+        diaper = create(:item, reporting_category: :cloth_diapers, organization: organization)
+        create(:item, reporting_category: :adult_incontinence, organization: organization)
+
+        expect(Item.by_reporting_category(:cloth_diapers)).to eq([diaper])
+      end
+    end
+
     describe "->disposable_diapers" do
       it "returns records associated with disposable diapers" do
         disposable_1 = create(:item, :active, name: "Disposable Diaper 1", reporting_category: :disposable_diapers, organization:)


### PR DESCRIPTION
Resolves #5011

### Description
Added viewing, editing, and filtering of item reporting_category

### Type of change
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

Breaking change as you can no longer filter items by base item, only by reporting category. 

### How Has This Been Tested?
Added tests and manually tested.

### Screenshots

Item index:
![Screenshot from 2025-05-28 17-46-30](https://github.com/user-attachments/assets/e6512fd3-3bed-448f-8793-d3ab91dfeee8)

Item show:
![Screenshot from 2025-05-28 17-46-37](https://github.com/user-attachments/assets/d7830716-2d29-45b5-8e88-71ce16d226c3)

Item edit:
![Screenshot from 2025-05-28 17-46-52](https://github.com/user-attachments/assets/bdfa946c-a13b-45c0-bd9e-d0b1d5e1a1d4)



