### PR TITLE
Adding user guide to confirmation email

### DIFF
--- a/app/views/account_request_mailer/confirmation.html.erb
+++ b/app/views/account_request_mailer/confirmation.html.erb
@@ -11,7 +11,7 @@
 <p>
       First, and most importantly, Human Essentials is 100% free! We're supported by the non-profit Code for Good and Microsoft sponsors the servers!
 </p>
-<p>We recommend taking a look at the  <a href = 'https://rubyforgood.github.io/human-essentials/user_guide/bank/'>Human Essentials User Guide</a>.  It includes some guidance on whether the system is right for you,  and some things you'll want to think about before starting.
+<p>We recommend taking a look at the <a href = 'https://rubyforgood.github.io/human-essentials/user_guide/bank/'>Human Essentials User Guide</a>. It includes some guidance on whether the system is right for you,  and some things you'll want to think about before starting.
 </p>
 
 <p>

--- a/app/views/account_request_mailer/confirmation.html.erb
+++ b/app/views/account_request_mailer/confirmation.html.erb
@@ -11,6 +11,9 @@
 <p>
       First, and most importantly, Human Essentials is 100% free! We're supported by the non-profit Code for Good and Microsoft sponsors the servers!
 </p>
+<p>
+  We recommend taking a look at the  <a href = 'https://rubyforgood.github.io/human-essentials/user_guide/bank/'>Human Essentials User Guide</a>.  It includes some guidance on whether the system is right for you,  and some things you'll want to think about before starting.
+</p>
 
 <p>
   If you'd like to experience the app, please log in to the sandbox/demo sites and test it out using the information below.
@@ -45,7 +48,7 @@
 </p>
 
 <p>
-    Finally, we've made a series of getting started videos with detailed directions on setting up your essentials bank in Human Essentials, check them out:
+    Finally, we've made a series of getting started videos with detailed directions on setting up your essentials bank in Human Essentials.  These are not being kept up-to-date, but may still be useful if you prefer videos to the User Guide :
 <br>
   <a href='https://youtu.be/w53iaJtlQUo'>Part 1</a><br>
   <a href='https://youtu.be/3-CF0wsG0h4'>Part 2</a><br>
@@ -55,7 +58,10 @@
   <a href='https://youtu.be/feg59oW6V3M'>Part 6</a><br>
   <a href='https://youtu.be/wyD034nvqag'>Part 7</a><br>
   <a href='https://youtu.be/v3AyrL0pHw0'>Part 8</a><br>
-Please let us know when you would like to begin using Human Essentials and we will set you up and send you a welcome email.
+
+
+
+Once you click 'Confirm This Request', above, we will set you up and send you a welcome email.
 </p>
 
     <p>Human Essential Team</p>

--- a/app/views/account_request_mailer/confirmation.html.erb
+++ b/app/views/account_request_mailer/confirmation.html.erb
@@ -11,8 +11,7 @@
 <p>
       First, and most importantly, Human Essentials is 100% free! We're supported by the non-profit Code for Good and Microsoft sponsors the servers!
 </p>
-<p>
-  We recommend taking a look at the  <a href = 'https://rubyforgood.github.io/human-essentials/user_guide/bank/'>Human Essentials User Guide</a>.  It includes some guidance on whether the system is right for you,  and some things you'll want to think about before starting.
+<p>We recommend taking a look at the  <a href = 'https://rubyforgood.github.io/human-essentials/user_guide/bank/'>Human Essentials User Guide</a>.  It includes some guidance on whether the system is right for you,  and some things you'll want to think about before starting.
 </p>
 
 <p>
@@ -58,9 +57,7 @@
   <a href='https://youtu.be/feg59oW6V3M'>Part 6</a><br>
   <a href='https://youtu.be/wyD034nvqag'>Part 7</a><br>
   <a href='https://youtu.be/v3AyrL0pHw0'>Part 8</a><br>
-
-
-
+<br>
 Once you click 'Confirm This Request', above, we will set you up and send you a welcome email.
 </p>
 

--- a/app/views/account_request_mailer/confirmation.html.erb
+++ b/app/views/account_request_mailer/confirmation.html.erb
@@ -11,7 +11,7 @@
 <p>
       First, and most importantly, Human Essentials is 100% free! We're supported by the non-profit Code for Good and Microsoft sponsors the servers!
 </p>
-<p>We recommend taking a look at the <a href = 'https://rubyforgood.github.io/human-essentials/user_guide/bank/'>Human Essentials User Guide</a>. It includes some guidance on whether the system is right for you,  and some things you'll want to think about before starting.
+<p>We recommend taking a look at the <a href='https://rubyforgood.github.io/human-essentials/user_guide/bank/'>Human Essentials User Guide</a>. It includes some guidance on whether the system is right for you,  and some things you'll want to think about before starting.
 </p>
 
 <p>

--- a/app/views/account_request_mailer/confirmation.text.erb
+++ b/app/views/account_request_mailer/confirmation.text.erb
@@ -6,7 +6,9 @@ We're delighted to hear from you and hope you're all staying well!
 
 First, and most importantly, Human Essentials is 100% free! We're supported by the non-profit Code for Good and Microsoft sponsors the servers!
 
-If you'd like to experience the app, please log in to the sandbox/demo sites and test it out using the information below.
+We recommend taking a look at the Human Essentials User Guide (at https://rubyforgood.github.io/human-essentials/user_guide/bank/ ).
+
+If you'd like to experience the app before continuing, please log in to the sandbox/demo sites and test it out using the information below.
 
 ***The details below allow you to log into a demo site. All data on the demo site is reset every day at 6 AM EST.***
 
@@ -24,7 +26,8 @@ Password: password!
 A couple things to know about the sandbox servers before you start using them:
   The development team uses the servers for testing our new features and upgrades before putting them on the live site to ensure that no bugs get pushed through to the live site, so if something looks different than the (real) humanessentials.app site that is probably why! Please don’t enter any sensitive information into the demo servers, several users have access to the demo servers and it will be visible to all users.
 
-Finally, we made a series of getting started videos with detailed directions on setting up your essentials bank in Human Essentials, check theme out here:
+Finally, we made a series of getting started videos with detailed directions on setting up your essentials bank in Human Essentials.   These are not being kept up-to-date,
+but might still be useful if you prefer video to the User Guide.
 Part 1 - https://youtu.be/w53iaJtlQUo
 Part 2 - https://youtu.be/3-CF0wsG0h4
 Part 3 - https://youtu.be/WkJahWsdZzc
@@ -33,6 +36,7 @@ Part 5 - https://youtu.be/oREioR1Qg6c
 Part 6 - https://youtu.be/feg59oW6V3M
 Part 7 - https://youtu.be/wyD034nvqag
 Part 8 - https://youtu.be/v3AyrL0pHw0
-Please let us know when you would like to begin using Human Essentials and we will set you up and send you a welcome email.
+
+When you are ready to begin using Human Essentials, please visit: <%= confirmation_account_requests_url(token: @account_request.identity_token) %> and we will set you up and send you a welcome email.
 
 Human Essentials Team

--- a/spec/mailers/account_request_mailer_spec.rb
+++ b/spec/mailers/account_request_mailer_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe AccountRequestMailer, type: :mailer do
         expect(text).to match('Password: password!')
       end
 
+      it 'should include the user guide link' do
+        expect(text_body(mail)).to include('https://rubyforgood.github.io/human-essentials/user_guide/bank/')
+      end
+
       it 'should include the instruction video link' do
         expect(text_body(mail)).to include('https://youtu.be/w53iaJtlQUo')
       end


### PR DESCRIPTION
No issue -- follow on from user guide

### Description

Adding the user guide to the confirmation email
both text and html

Also added text indicating that, while you *can* use the videos, they are no longer being kept up to date

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

Manually checked that the correct html/text is generated and that the link works
Added a check that the user guide link is included to the automated texts
Ran the tests for the account request email.
