### PR TITLE
Bring back in `matrix` which is needed by pinned prawn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,7 @@ gem 'bootsnap', require: false
 gem "nokogiri", ">= 1.10.4"
 gem "sprockets", "~> 4.2.2"
 gem "prawn", "~> 2.4.0"
+gem "matrix" # Used by prawn
 gem "ttfunk", "~>1.7.0"
 
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -792,6 +792,7 @@ DEPENDENCIES
   listen (~> 3.9.0)
   lograge
   magic_test
+  matrix
   memory_profiler
   money-rails
   newrelic_rpm


### PR DESCRIPTION
We pinned to an older version of `prawn`, and now our staging deploy fails, and we think it might be that the older version used the default ruby `matrix` and the new one would have pulled it in explicitly.