### PR TITLE
Resolves #5230 - Update Organization Details to 'Profile' in Partner…

### DIFF
--- a/app/views/partners/profiles/show.html.erb
+++ b/app/views/partners/profiles/show.html.erb
@@ -7,7 +7,7 @@
           <div class="alert alert-danger"><i class="fa fa-warning"></i>&nbsp;
             Please review your application details and submit for approval.</div>
         <% end %>
-        <h1><i class="fa fa-building"></i>&nbsp;&nbsp;Organization Details&nbsp;&nbsp;&nbsp;
+        <h1><i class="fa fa-building"></i>&nbsp;&nbsp;Profile&nbsp;&nbsp;&nbsp;
           <%= partner_status_badge(current_partner) %>
           <small>for <%= current_partner.name %></small>
         </h1>

--- a/spec/system/partners/profile_served_area_system_spec.rb
+++ b/spec/system/partners/profile_served_area_system_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Partners profile served area behaviour", type: :system, js: true
       expect(page).to have_content("100 %")
       expect(page).not_to have_content("The total client share must be either 0 or 100 %")
       click_on "Update Information"
-      expect(page).to have_content("Organization Details")
+      expect(page).to have_content("Profile")
       expect(page).to have_content("26 %")
     end
 


### PR DESCRIPTION
… view profile


- [x] any tests that use that text are updated
- [x] text change made
- [x] Please provide screenshots in your PR

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5230  - https://github.com/rubyforgood/human-essentials/issues/5230

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

This is a 1-line copy change in http://127.0.0.1:3000/partners/profile to update the heading of the page from 'Organization Details' to 'Profile'. Motivation is to match the "My profile" tab on the left. 

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Ran `bin/lint` and `bundle exec rspec`

### Screenshots

Before: 
<img width="1397" alt="Screenshot 2025-06-22 at 5 44 00 PM" src="https://github.com/user-attachments/assets/83df9237-1b48-4a5e-b605-9b5d8fa4a80e" />

After: 

<img width="1397" alt="Screenshot 2025-06-22 at 5 43 06 PM" src="https://github.com/user-attachments/assets/7de53631-6f38-4dee-a101-90b528b8f66a" />
