### PR TITLE
5262. Disallow editing of inventory past a snapshot

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -192,6 +192,7 @@ class DistributionsController < ApplicationController
       @storage_locations = current_organization.storage_locations.active.alphabetized.select do |storage_loc|
         !inventory.quantity_for(storage_location: storage_loc.id).negative?
       end
+      @changes_disallowed = SnapshotEvent.intervening?(@distribution)
     else
       redirect_to distributions_path, error: 'To edit a distribution,
       you must be an organization admin or the current date must be later than today.'

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -82,6 +82,7 @@ class DonationsController < ApplicationController
     @donation = Donation.find(params[:id])
     @donation.line_items.build
     @audit_performed_and_finalized = Audit.finalized_since?(@donation, @donation.storage_location_id)
+    @changes_disallowed = SnapshotEvent.intervening?(@donation)
 
     load_form_collections
   end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -64,6 +64,7 @@ class PurchasesController < ApplicationController
     @purchase = current_organization.purchases.find(params[:id])
     @purchase.line_items.build
     @audit_performed_and_finalized = Audit.finalized_since?(@purchase, @purchase.storage_location_id)
+    @changes_disallowed = SnapshotEvent.intervening?(@purchase)
 
     load_form_collections
   end

--- a/app/events/snapshot_event.rb
+++ b/app/events/snapshot_event.rb
@@ -1,6 +1,12 @@
 class SnapshotEvent < Event
   serialize :data, coder: EventTypes::StructCoder.new(EventTypes::Inventory)
 
+  # @param record [#organization_id, #created_at]
+  # @return [Boolean] true if there is an intervening snapshot event
+  def self.intervening?(record)
+    where(organization_id: record.organization_id, event_time: record.created_at..).any?
+  end
+
   # @param organization [Organization]
   def self.publish(organization)
     inventory = InventoryAggregate.inventory_for(organization.id)

--- a/app/services/itemizable_update_service.rb
+++ b/app/services/itemizable_update_service.rb
@@ -1,63 +1,77 @@
 module ItemizableUpdateService
-  # @param itemizable [Itemizable]
-  # @param params [Hash] Parameters passed from the controller. Should include `line_item_attributes`.
-  # @param event_class [Class<Event>] the event class to publish the itemizable to.
-  def self.call(itemizable:, params: {}, event_class: nil)
-    original_storage_location = itemizable.storage_location
-    StorageLocation.transaction do
-      item_ids = params[:line_items_attributes]&.values&.map { |i| i[:item_id].to_i } || []
-      inactive_item_names = Item.where(id: item_ids, active: false).pluck(:name)
-      if inactive_item_names.any?
-        raise "Update failed: The following items are currently inactive: #{inactive_item_names.join(", ")}. Please reactivate them before continuing."
-      end
+  class << self
+    # @param itemizable [Itemizable]
+    # @param params [Hash] Parameters passed from the controller. Should include `line_item_attributes`.
+    # @param event_class [Class<Event>] the event class to publish the itemizable to.
+    def call(itemizable:, params: {}, event_class: nil)
+      original_storage_location = itemizable.storage_location
+      StorageLocation.transaction do
+        item_ids = params[:line_items_attributes]&.values&.map { |i| i[:item_id].to_i } || []
+        inactive_item_names = Item.where(id: item_ids, active: false).pluck(:name)
+        if inactive_item_names.any?
+          raise "Update failed: The following items are currently inactive: #{inactive_item_names.join(", ")}. Please reactivate them before continuing."
+        end
 
-      from_location = to_location = itemizable.storage_location
-      to_location = StorageLocation.find(params[:storage_location_id]) if params[:storage_location_id]
+        from_location = to_location = itemizable.storage_location
+        to_location = StorageLocation.find(params[:storage_location_id]) if params[:storage_location_id]
 
-      verify_intervening_audit_on_storage_location_items(itemizable: itemizable, from_location_id: from_location.id, to_location_id: to_location.id)
+        verify_intervening_audit_on_storage_location_items(itemizable: itemizable, from_location_id: from_location.id, to_location_id: to_location.id)
 
-      previous = nil
-      # TODO once event sourcing has been out for long enough, we can safely remove this
-      if Event.where(eventable: itemizable).none? || UpdateExistingEvent.where(eventable: itemizable).any?
         previous = itemizable.line_items.map(&:dup)
-      end
+        if inventory_changes?(previous, params[:line_items_attributes]) && SnapshotEvent.intervening?(itemizable)
+          raise "Cannot update #{itemizable.class.name.downcase} because there has been an intervening snapshot of the inventory."
+        end
 
-      line_item_attrs = Array.wrap(params[:line_items_attributes]&.values)
-      line_item_attrs.each { |attr| attr.delete(:id) }
+        line_item_attrs = Array.wrap(params[:line_items_attributes]&.values)
+        line_item_attrs.each { |attr| attr.delete(:id) }
 
-      update_storage_location(itemizable: itemizable, params: params)
-      if previous
-        UpdateExistingEvent.publish(itemizable, previous, original_storage_location)
-      else
-        event_class&.publish(itemizable)
+        update_storage_location(itemizable: itemizable, params: params)
+
+        # TODO once event sourcing has been out for long enough, we can safely remove this
+        if Event.where(eventable: itemizable).none? || UpdateExistingEvent.where(eventable: itemizable).any?
+          UpdateExistingEvent.publish(itemizable, previous, original_storage_location)
+        elsif inventory_changes?(previous, params[:line_items_attributes])
+          event_class&.publish(itemizable)
+        end
       end
     end
-  end
 
-  # @param itemizable [Itemizable]
-  # @param params [Hash] Parameters passed from the controller. Should include `line_item_attributes`.
-  def self.update_storage_location(itemizable:, params:)
-    # Delete the line items -- they'll be replaced later
-    itemizable.line_items.delete_all
-    # Update the current model with the new parameters
-    itemizable.update!(params)
-    itemizable.reload
-  end
+    # @param previous [Array<LineItem>] Previous line items before the update.
+    # @param line_item_attributes [Hash] The new line item attributes from the params.
+    # @return [Boolean] Returns true if the inventory has changed, false otherwise.
+    def inventory_changes?(previous, line_item_attributes)
+      previous_attrs = previous.to_h { |li| [li.item_id, li.quantity] }
+      new_attrs = line_item_attributes.to_h do |_, li|
+        [li[:item_id].to_i, li[:quantity].to_i]
+      end
+      previous_attrs != new_attrs
+    end
 
-  # @param itemizable [Itemizable]
-  # @param from_location [StorageLocation]
-  # @param to_location [StorageLocation]
-  def self.verify_intervening_audit_on_storage_location_items(itemizable:, from_location_id:, to_location_id:)
-    return if from_location_id == to_location_id || !Audit.finalized_since?(itemizable, [from_location_id, to_location_id])
+    # @param itemizable [Itemizable]
+    # @param params [Hash] Parameters passed from the controller. Should include `line_item_attributes`.
+    def update_storage_location(itemizable:, params:)
+      # Delete the line items -- they'll be replaced later
+      itemizable.line_items.delete_all
+      # Update the current model with the new parameters
+      itemizable.update!(params)
+      itemizable.reload
+    end
 
-    itemizable_type = itemizable.class.name.downcase
-    case itemizable_type
-    when "distribution"
-      raise "Cannot change the storage location because there has been an intervening audit of some items. " \
-      "If you need to change the storage location, please reclaim this distribution and create a new distribution from the new storage location."
-    else
-      raise "Cannot change the storage location because there has been an intervening audit of some items. " \
-      "If you need to change the storage location, please delete this #{itemizable_type} and create a new #{itemizable_type} with the new storage location."
+    # @param itemizable [Itemizable]
+    # @param from_location [StorageLocation]
+    # @param to_location [StorageLocation]
+    def verify_intervening_audit_on_storage_location_items(itemizable:, from_location_id:, to_location_id:)
+      return if from_location_id == to_location_id || !Audit.finalized_since?(itemizable, [from_location_id, to_location_id])
+
+      itemizable_type = itemizable.class.name.downcase
+      case itemizable_type
+      when "distribution"
+        raise "Cannot change the storage location because there has been an intervening audit of some items. " \
+        "If you need to change the storage location, please reclaim this distribution and create a new distribution from the new storage location."
+      else
+        raise "Cannot change the storage location because there has been an intervening audit of some items. " \
+        "If you need to change the storage location, please delete this #{itemizable_type} and create a new #{itemizable_type} with the new storage location."
+      end
     end
   end
 end

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -48,13 +48,15 @@
         <% end %>
       </div>
       <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
-          <%= render 'line_items/line_item_fields', form: f, locals: { show_request_items: true } %>
+          <%= render 'line_items/line_item_fields', form: f, changes_disallowed: @changes_disallowed %>
       </div>
-      <div class="row links justify-content-end">
-        <%= add_element_button "Add Another Item", container_selector: "#distribution_line_items" , id: "__add_line_item" do %>
-          <%= render 'line_items/line_item_fields', form: f, object: LineItem.new, locals: { show_request_items: true } %>
-        <% end %>
-      </div>
+      <% unless @changes_disallowed %>
+        <div class="row links justify-content-end">
+          <%= add_element_button "Add Another Item", container_selector: "#distribution_line_items" , id: "__add_line_item" do %>
+            <%= render 'line_items/line_item_fields', form: f, object: LineItem.new %>
+          <% end %>
+        </div>
+      <% end %>
 
     </fieldset>
   </div>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -107,14 +107,16 @@
       <legend>Items in this donation</legend>
       <div id="donation_line_items" data-capture-barcode="true">
 
-        <%= render 'line_items/line_item_fields', form: f, object: donation_form.line_items %>
+        <%= render 'line_items/line_item_fields', form: f, object: donation_form.line_items, changes_disallowed: @changes_disallowed %>
       </div>
 
-      <div class="row links justify-content-end">
-        <%= add_element_button "Add Another Item", container_selector: "#donation_line_items", id: "__add_line_item" do %>
-          <%= render 'line_items/line_item_fields', form: f, object: LineItem.new %>
-        <% end %>
-      </div>
+      <% unless @changes_disallowed %>
+        <div class="row links justify-content-end">
+          <%= add_element_button "Add Another Item", container_selector: "#donation_line_items", id: "__add_line_item" do %>
+            <%= render 'line_items/line_item_fields', form: f, object: LineItem.new %>
+          <% end %>
+        </div>
+      <% end %>
     </fieldset>
 
     <div class="card-footer">

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,20 +1,25 @@
+<% if local_assigns[:changes_disallowed] %>
+  <div class="alert alert-warning">This <%= form.object.class.name.downcase %> is too old to edit inventory. You can only change non-inventory fields.</div>
+<% end %>
 <%= form.simple_fields_for :line_items, defined?(object) ? object : nil  do |field| %>
   <% requested = field.object.requested_item %>
   <section class="nested-fields line_item_section">
     <div class="row mt-2 d-flex flex-row align-items-center justify-content-between">
       <div class='d-flex flex-column justify-content-center'>
         <% if requested.blank? %>
-          <div class='d-flex flex-row align-items-center'>
+          <% unless local_assigns[:changes_disallowed] %>
+          <div class='d-flex flex-row align-iteline_item_fieldsms-center'>
             <%= render partial: "barcode_items/barcode_item_lookup",
               locals: { index: field&.options[:child_index] || "new_item"  } %>
-            <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner mx-2"> </div>
+              <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner mx-2"> </div>
           </div>
           <label class='my-1 mx-auto font-weight-normal'>OR</label>
+          <% end %>
         <% end %>
         <div class='d-flex flex-row'>
           <span class="li-name w-100">
             <%= field.input :item_id,
-                            disabled: requested.present?,
+                            disabled: requested.present? || local_assigns[:changes_disallowed],
                             collection: @item_labels_with_quantities || @items, prompt: "Choose an item",
                             include_blank: "",
                             label: false,
@@ -26,6 +31,7 @@
           <div class="li-quantity mx-2">
             <%= field.input :quantity,
                             as: :string,
+                            disabled: local_assigns[:changes_disallowed],
                             placeholder: "Quantity",
                             label: false,
                             input_html: { class: "quantity my-0", data: { quantity: "" } } %>
@@ -44,7 +50,9 @@
         </div>
       </div>
 
-      <%= remove_element_button "Remove", container_selector: "section" %>
+      <% unless local_assigns[:changes_disallowed] %>
+        <%= remove_element_button "Remove", container_selector: "section" %>
+      <% end %>
     </div>
     <hr class="line-item-separator">
   </section>

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -82,14 +82,16 @@
       <legend>Items in this purchase</legend>
       <div id="purchase_line_items" data-capture-barcode="true">
 
-        <%= render 'line_items/line_item_fields', form: f %>
+        <%= render 'line_items/line_item_fields', form: f, changes_disallowed: @changes_disallowed %>
       </div>
 
-      <div class="row links justify-content-end">
-        <%= add_element_button "Add Another Item", container_selector: "#purchase_line_items", id: "__add_line_item" do %>
-          <%= render 'line_items/line_item_fields', form: f, object: LineItem.new %>
-        <% end %>
-      </div>
+      <% unless @changes_disallowed %>
+        <div class="row links justify-content-end">
+          <%= add_element_button "Add Another Item", container_selector: "#purchase_line_items", id: "__add_line_item" do %>
+            <%= render 'line_items/line_item_fields', form: f, object: LineItem.new %>
+          <% end %>
+        </div>
+      <% end %>
     </fieldset>
 
     <div class="card-footer">

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -79,4 +79,27 @@ RSpec.describe Event, type: :model do
       end
     end
   end
+
+  describe "#no_intervening_snapshot" do
+    let(:eventable) {
+      FactoryBot.create(:distribution,
+        organization_id: organization.id,
+        created_at: 1.week.ago)
+    }
+    let(:data) { EventTypes::Inventory.new(storage_locations: {}, organization_id: organization.id) }
+    let(:payload) { EventTypes::InventoryPayload.new(items: []) }
+
+    it "prevents creation if an intervening snapshot exists" do
+      travel(-1.day) do
+        SnapshotEvent.create!(organization_id: organization.id,
+          eventable: organization,
+          data: data,
+          event_time: Time.zone.now)
+      end
+
+      expect {
+        DistributionEvent.create!(eventable: eventable, organization_id: organization.id, data: payload)
+      }.to raise_error(ActiveRecord::RecordInvalid, /Cannot change inventory for an old action that has an intervening snapshot/)
+    end
+  end
 end

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -251,6 +251,27 @@ RSpec.describe "Donations", type: :request do
     end
 
     describe "GET #edit" do
+      it 'should not allow edits if there is an intervening snapshot' do
+        donation = FactoryBot.create(:donation,
+          :with_items,
+          organization: organization,
+          created_at: 1.week.ago)
+        SnapshotEvent.create!(organization_id: organization.id,
+          created_at: 1.day.ago,
+          event_time: 1.day.ago,
+          eventable: organization,
+          data: EventTypes::Inventory.new(
+            organization_id: organization.id, storage_locations: {}
+          ))
+        get edit_donation_path(id: donation.id)
+        expect(response.body)
+          .to include('This donation is too old to edit inventory. You can only change non-inventory fields.')
+        expect(response.body).not_to include('Add Another Item')
+        expect(response.body).not_to include('Remove Item')
+        parsed_body = Nokogiri::HTML(response.body)
+        expect(parsed_body.css('select.line_item_name[disabled]')).not_to be_empty
+      end
+
       context "when an finalized audit has been performed on the donated items" do
         it "shows a warning" do
           item = create(:item, organization: organization, name: "Brightbloom Seed")

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -271,6 +271,27 @@ RSpec.describe "Purchases", type: :request do
         expect(response).to be_successful
       end
 
+      it 'should not allow edits if there is an intervening snapshot' do
+        purchase = FactoryBot.create(:purchase,
+          :with_items,
+          organization: organization,
+          created_at: 1.week.ago)
+        SnapshotEvent.create!(organization_id: organization.id,
+          created_at: 1.day.ago,
+          event_time: 1.day.ago,
+          eventable: organization,
+          data: EventTypes::Inventory.new(
+            organization_id: organization.id, storage_locations: {}
+          ))
+        get edit_purchase_path(id: purchase.id)
+        expect(response.body)
+          .to include('This purchase is too old to edit inventory. You can only change non-inventory fields.')
+        expect(response.body).not_to include('Add Another Item')
+        expect(response.body).not_to include('Remove Item')
+        parsed_body = Nokogiri::HTML(response.body)
+        expect(parsed_body.css('select.line_item_name[disabled]')).not_to be_empty
+      end
+
       it "storage location is correct" do
         storage2 = create(:storage_location, name: "storage2")
         purchase2 = create(:purchase, storage_location: storage2)


### PR DESCRIPTION
This PR makes it so that donations, distributions and purchases can no longer have inventory changes once a snapshot event exists between its creation date and the current time.

This includes both internal model validations as well as UI indicators that show that editing inventory can no longer happen, while still allowing editing of other values.

<img width="1189" height="606" alt="image" src="https://github.com/user-attachments/assets/5cf977c7-623e-4429-939b-f844b4111421" />

