### PR TITLE
Add link to landing page (#5279)

### DIFF
--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -28,7 +28,7 @@
       <div class='card-text' id='partner_info'>
         <p class='p-2'>Are you a current partner to diaper and/or period supply banks? If so please go <a href='https://humanessentials.app/users/sign_in'>here</a> to login.</p>
         <p class='p-2'>If you are wishing to receive diapers/period supplies and partner to a local diaper/period supply bank please contact your local bank. They are the only ones able create your account.</p>
-        <p class='p-2'>If you are looking for an essentials banks that distributes diapers, please refer to the <a href='https://nationaldiaperbanknetwork.org/member-directory/'>NDBN member directory</a>. If you are, instead, looking for an essentials bank that deals in period supplies, please refer to the <a href='https://allianceforperiodsupplies.org/allied-programs/'>Alliance for Period Supplies directory</a>.</p>
+        <p class='p-2'>If you are looking for an essentials bank that distributes diapers, please refer to the <a href='https://nationaldiaperbanknetwork.org/member-directory/'>NDBN member directory</a>. If you are, instead, looking for an essentials bank that deals in period supplies, please refer to the <a href='https://allianceforperiodsupplies.org/allied-programs/'>Alliance for Period Supplies directory</a>.</p>
       </div>
 
       <div class='card-text' id='create_bank'>

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -28,6 +28,7 @@
       <div class='card-text' id='partner_info'>
         <p class='p-2'>Are you a current partner to diaper and/or period supply banks? If so please go <a href='https://humanessentials.app/users/sign_in'>here</a> to login.</p>
         <p class='p-2'>If you are wishing to receive diapers/period supplies and partner to a local diaper/period supply bank please contact your local bank. They are the only ones able create your account.</p>
+        <p class='p-2'>If you are looking for an essentials banks that distributes diapers, please refer to the <a href='https://nationaldiaperbanknetwork.org/member-directory/'>NDBN member directory</a>. If you are, instead, looking for an essentials bank that deals in period supplies, please refer to the <a href='https://allianceforperiodsupplies.org/allied-programs/'>Alliance for Period Supplies directory</a>.</p>
       </div>
 
       <div class='card-text' id='create_bank'>


### PR DESCRIPTION
Resolves #5279

### Description
Added the following text at the end of the current text, in a new paragraph.

If you are looking for an essentials banks that distributes diapers, please refer to the NDBN member directory. If you are, instead, looking for an essentials bank that deals in period supplies, please refer to the Alliance for Period Supplies directory.

Made "NDBN member directory" a link to https://nationaldiaperbanknetwork.org/member-directory/.
Made "Alliance for Period Supplies directory" a link to https://allianceforperiodsupplies.org/allied-programs/.

### Type of change
New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
* Pasted \<div\> tag surrounding the relevant \<p\> tags into a barebones html file.
* Clicked on the new links and verified they reached the correct destinations
* Verified there were no errors or warnings in the inspect console