### PR TITLE
Resolves #5281

### DIFF
--- a/app/views/partners/profiles/step/_agency_information_form.html.erb
+++ b/app/views/partners/profiles/step/_agency_information_form.html.erb
@@ -3,18 +3,20 @@
 </div>
 
 <%= f.fields_for :profile, profile do |pf| %>
-  <div class="form-group">
-    <%= pf.input :agency_type,
-    # Symbolize keys, because simple_form will only do a I18n lookup for
-    # symbols
-      collection: Partners::Profile.agency_types_for_selection,
-      label: "Agency Type",
-      class: "form-control",
-      wrapper: :input_group %>
-  </div>
+  <div data-controller="hide-by-source-val" 
+       data-hide-by-source-val-values-to-hide-value='["career","abuse","bnb","church","college","cdc","health","outreach","legal","crisis","disab","district","domv","ece","child","edu","family","food","foster","govt","headstart","homevisit","homeless","hosp","infpan","lib","mhealth","military","police","preg","presch","ref","es","hs","ms","senior","tribal","treat","twoycollege","wic"]'>
+    <div class="form-group">
+      <%= pf.input :agency_type,
+        collection: Partners::Profile.agency_types_for_selection,
+        label: "Agency Type",
+        class: "form-control",
+        wrapper: :input_group,
+        input_html: { data: { "hide-by-source-val-target": "source", action: "change->hide-by-source-val#sourceChanged" } } %>
+    </div>
 
-  <div class="form-group">
-    <%= pf.input :other_agency_type, label: "Other Agency Type", class: "form-control" %>
+    <div class="form-group" data-hide-by-source-val-target="destination">
+      <%= pf.input :other_agency_type, label: "Other Agency Type", class: "form-control" %>
+    </div>
   </div>
 
   <%= render "shared/custom_file_input",


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.
- [x] I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5281

### Description

Implements conditional visibility for the "Other Agency Type" field in partner profile forms. Previously, the "Other Agency Type" input field was always visible, creating confusion when users selected specific agency types.

**Solution:**
- Added a Stimulus controller (`hide-by-source-val`) to handle field visibility
- Field now only shows when "Other" is selected from the Agency Type dropdown
- Works in both admin (editing partner profiles) and partner (editing own profile) views

**Alternative considered:** CSS-only solution, but JavaScript provides better user experience with dynamic behavior.

**Dependencies:** No new dependencies - uses existing Stimulus framework and jQuery.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

**Manual Testing:**
1. Tested in admin view (`/partners/1/profile/edit`)
   - Selected various agency types → "Other Agency Type" field hides
   - Selected "Other" → "Other Agency Type" field shows
2. Tested in partner view (signed in as partner)
   - Same behavior confirmed in partner's own profile edit

**Browser Testing:** Verified functionality works in Chrome.

**Note:** Automated tests still need to be added for this feature.

<img width="1394" height="576" alt="image" src="https://github.com/user-attachments/assets/f1fc487c-b079-416c-8ab3-9a8119f94789" />

<img width="1394" height="547" alt="image" src="https://github.com/user-attachments/assets/dffe5196-4c0e-4264-ada4-5d027d56fd79" />

