### PR TITLE
5280 combine same items save

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -57,6 +57,17 @@ class TransfersController < ApplicationController
     redirect_to transfers_path
   end
 
+  def validate
+    @transfer = current_organization.transfers.new(transfer_params)
+
+    if @transfer.valid?
+      body = render_to_string(partial: "transfers/validate_modal", formats: [:html], layout: false)
+      render json: {valid: true, body: body}
+    else
+      render json: { valid: false }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def load_form_collections

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -21,6 +21,7 @@ class TransfersController < ApplicationController
 
   def create
     @transfer = current_organization.transfers.new(transfer_params)
+    @transfer.line_items.combine!
 
     TransferCreateService.call(@transfer)
     redirect_to transfers_path, notice: "#{@transfer.line_items.total} items have been transferred from #{@transfer.from.name} to #{@transfer.to.name}!"
@@ -59,6 +60,7 @@ class TransfersController < ApplicationController
 
   def validate
     @transfer = current_organization.transfers.new(transfer_params)
+    @transfer.line_items.combine!
 
     if @transfer.valid?
       body = render_to_string(partial: "transfers/validate_modal", formats: [:html], layout: false)

--- a/app/views/transfers/_validate_modal.html.erb
+++ b/app/views/transfers/_validate_modal.html.erb
@@ -1,0 +1,43 @@
+<div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Transfer Confirmation</h5>
+        <button id="modalClose" type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" style="max-height: 60vh; overflow-y: auto;">
+        <%# Items and quantities %>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Item Name</th>
+              <th>Total Items</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @transfer.line_items.each do |line_item| %>
+              <tr>
+                <td><%= line_item.name %></td>
+                <td><%= line_item.quantity %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+
+        <% if @transfer.comment.present? %>
+          <p><strong>Note:</strong> <%= @transfer.comment %></p>
+        <% end %>
+
+      <%# Confirmation message %>
+      <div class="message fs-5">
+        <p>Please confirm that the above list is what you meant to transfer and that the comment is correct.</p>
+      </div>
+    </div>
+
+    <%# Actions %>
+    <div class="modal-footer">
+      <button id="modalNo" type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="No I need to make changes">No, I need to make changes</button>
+      <button id="modalYes" type="button" class="btn btn-success" data-action="confirmation#submitForm">Yes, it's correct</button>
+    </div>
+  </div>
+</div>
+

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -28,7 +28,9 @@
       <!-- left column -->
       <div class="col-md-12">
         <!-- jquery validation -->
-        <div class="card card-primary">
+        <div class="card card-primary"
+            data-controller="confirmation"
+            data-confirmation-pre-check-path-value="<%= validate_transfers_path(format: :json) %>">
           <!-- /.card-header -->
           <!-- form start -->
             <div class="card-body">
@@ -39,10 +41,9 @@
                     storage location to another.</p>
                 </div>
                 <div class="box-body">
-
                   <%= simple_form_for @transfer,
-                    data: { controller: "form-input" },
-                    html: { class: "storage-location-required", id: 'new_transfer' } do |f| %>
+                    data: { controller: "form-input", confirmation_target: "form" },
+                    html: { class: "storage-location-required", id: "new_transfer" } do |f| %>
                     <%= render partial: "storage_locations/source", object: f, locals: {label: "From storage location", error: "Which location are you moving inventory from?", association_field: :from} %>
 
                     <%= f.association :to,
@@ -69,10 +70,19 @@
 
                     </div>
                     <div class="card-footer">
-                      <%= submit_button %>
+                      <%= submit_button({}, { action: "click->confirmation#openModal" }) %>
                     </div>
                   <% end %>
                   </div>
+                <div 
+                  id="transferConfirmationModal"
+                  class="modal confirm"
+                  aria-labelledby="transferConfirmationModal"
+                  aria-hidden="true"
+                  tabindex="-1"
+                  data-bs-backdrop="static"
+                  data-confirmation-target="modal">
+                </div>
             </div><!-- /.box -->
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,7 +119,9 @@ Rails.application.routes.draw do
     get :activity_graph
   end
 
-  resources :transfers, only: %i(index create new show destroy)
+  resources :transfers, only: %i(index create new show destroy) do
+    post :validate, on: :collection
+  end
 
   resources :storage_locations do
     put :deactivate

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe TransfersController, type: :controller do
     end
 
     describe "POST #create" do
+      context 'when duplicate line_items with different quantities submitted' do
+        let!(:item1) { create(:item) }
+        let(:params) { attributes_for(
+            :transfer,
+            organization_id: organization.id,
+            to_id: create(:storage_location, organization: organization).id,
+            from_id: create(:storage_location, organization: organization).id,
+            line_items_attributes: {
+              "0" => { item_id: item1.id, quantity: 2 },
+              "1" => { item_id: item1.id, quantity: 3 }
+            }
+          )
+        }
+        
+        it "merges same line_items id items into one quantity" do
+          post :create, params: { transfer: params }
+
+          transfer = assigns(:transfer)
+
+          expect(transfer.line_items.size).to eq 1
+          expect(transfer.line_items.first.quantity).to eq 5
+        end
+      end
+
       it "redirects to #show when successful" do
         attributes = attributes_for(
           :transfer,
@@ -76,6 +100,33 @@ RSpec.describe TransfersController, type: :controller do
         expect(subject).to be_successful
       end
     end
+
+    describe "POST #validate" do
+      context 'when duplicate line_items with different quantities submitted' do
+        let!(:item1) { create(:item) }
+        let(:params) { attributes_for(
+            :transfer,
+            organization_id: organization.id,
+            to_id: create(:storage_location, organization: organization).id,
+            from_id: create(:storage_location, organization: organization).id,
+            line_items_attributes: {
+              "0" => { item_id: item1.id, quantity: 2 },
+              "1" => { item_id: item1.id, quantity: 3 }
+            }
+          )
+        }
+        
+        it "merges same line_items id items into one quantity" do
+          post :validate, params: { transfer: params }
+
+          transfer = assigns(:transfer)
+
+          expect(transfer.line_items.size).to eq 1
+          expect(transfer.line_items.first.quantity).to eq 5
+        end
+      end
+    end
+
     context "Looking at a different organization" do
       let(:object) do
         org = create(:organization)

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Transfer management", type: :system do
   end
   let(:item) { create(:item) }
 
-  def create_transfer(amount, from_name, to_name)
+  def create_transfer(amount, from_name, to_name, click_save: true, click_confirm: true)
     visit transfers_path
     click_link "New Transfer"
     within "form#new_transfer" do
@@ -18,13 +18,47 @@ RSpec.describe "Transfer management", type: :system do
       select item.name, from: "transfer_line_items_attributes_0_item_id"
       fill_in "transfer_line_items_attributes_0_quantity", with: amount
     end
-    click_on "Save"
+    click_on "Save" if click_save
+    click_on "Yes, it's correct" if click_save && click_confirm
+  end
+
+  context "when transfer submitted" do
+    it "shows the confirmation page" do
+      from_storage_location = create(:storage_location, :with_items, item: item, name: "From me", organization: organization)
+      to_storage_location = create(:storage_location, :with_items, name: "To me", organization: organization)
+      create_transfer("10", from_storage_location.name, to_storage_location.name, click_confirm: false)
+      
+      expect(page).to have_content("Transfer Confirmation")
+      expect(page).to have_content("Please confirm that the above list is what you meant to transfer and that the comment is correct.")
+      expect(page).to have_content("No, I need to make changes")
+      expect(page).to have_content("Yes, it's correct")
+    end
+
+    it "merges same items into one quantity" do
+      from_storage_location = create(:storage_location, :with_items, item: item, name: "From me", organization: organization)
+      to_storage_location = create(:storage_location, :with_items, name: "To me", organization: organization)
+
+      create_transfer("10", from_storage_location.name, to_storage_location.name, click_save: false, click_confirm: false)
+      # grabs the dynamically generated new item
+      click_on "Add Another Item"
+      new_select = all("select[id$='_item_id']").last
+      select_id = new_select[:id]  
+      select item.name, from: select_id
+      index = select_id[/attributes_(\d+)_item_id$/, 1]
+      quantity_field_id = "transfer_line_items_attributes_#{index}_quantity"
+      fill_in quantity_field_id, with: "30"
+
+      click_on "Save"
+
+      expect(page).to have_content("40")
+    end
   end
 
   it "can transfer an inventory from a storage location to another as a user" do
     from_storage_location = create(:storage_location, :with_items, item: item, name: "From me", organization: organization)
     to_storage_location = create(:storage_location, :with_items, name: "To me", organization: organization)
     create_transfer("10", from_storage_location.name, to_storage_location.name)
+    
     expect(page).to have_content("10 items have been transferred")
   end
 
@@ -96,7 +130,7 @@ RSpec.describe "Transfer management", type: :system do
   # 4438 - Bug Fix
   it "add item button should be activated when from storage location is selected after rendering again on failure" do
     from_storage_location = create(:storage_location, :with_items, item: item, name: "From me", organization: organization)
-    create_transfer('', '', '')
+    create_transfer('', '', '', click_confirm: false)
     select from_storage_location.name, from: "From storage location"
     expect(page).not_to have_css("#__add_line_item.disabled")
   end
@@ -106,7 +140,7 @@ RSpec.describe "Transfer management", type: :system do
     let!(:to_storage_location) { create(:storage_location, :with_items, name: "To me", organization: organization) }
 
     scenario "User can transfer an inventory from a storage location to another" do
-      create_transfer("100", from_storage_location.name, to_storage_location.name)
+      create_transfer("100", from_storage_location.name, to_storage_location.name, click_confirm: false)
       expect(page).to have_content("insufficient inventory")
     end
   end
@@ -134,4 +168,6 @@ RSpec.describe "Transfer management", type: :system do
 
     it_behaves_like "Date Range Picker", Transfer
   end
+
+  context "when submitting "
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5280 

### Description
   
Modeled after this PR https://github.com/rubyforgood/human-essentials/issues/5280 where it introduces the confirmation modal for other controllers/pages. This PR adds a similar confirmation modal for transfers and simultaneously merges identical items under separate entries into one entry with summed a summed quantity.

Originally I thought of adding a model validation where it would call combine!, but for visibility, I used the combine in the controller instead:
```ruby
before_validation :collapse_line_items
```

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)
* This change requires a documentation update
* Documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

1) Add multiple duplicate items with different quantities in the transfer form.
2) See that the confirmation page pops up.
3) Note that the confirmation page sums up the quantities input into one entry.
4) After modal confirmation, the dashboard page has the correct sum of the item.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
<img width="1440" height="675" alt="Screenshot 2025-07-24 at 9 14 14 PM" src="https://github.com/user-attachments/assets/fbfd91f6-7f3d-4034-a53f-7b4a4075fe50" />
item 1: 50
duplicate item 2: 55

totals 105

<img width="1440" height="501" alt="Screenshot 2025-07-24 at 9 16 48 PM" src="https://github.com/user-attachments/assets/cd5d59b9-d80c-4ef6-b439-eb2f962734f7" />
submits 105 for transfer.
