### PR TITLE
4739 Prevent deletion of product drives with donations

### DIFF
--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -88,10 +88,18 @@ class ProductDrivesController < ApplicationController
   end
 
   def destroy
-    current_organization.product_drives.find(params[:id]).destroy
+    product_drive = current_organization.product_drives.find(params[:id])
+    success = product_drive.destroy
+
     respond_to do |format|
-      format.html { redirect_to product_drives_url, notice: 'Product drive was successfully destroyed.' }
-      format.json { head :no_content }
+      if success
+        format.html { redirect_to product_drives_url, notice: 'Product drive was successfully destroyed.' }
+        format.json { head :no_content }
+      else
+        error_message = "Cannot delete product drive with donations."
+        format.html { redirect_to product_drive_path(product_drive), error: error_message }
+        format.json { render json: {error: error_message}, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/product_drives_controller.rb
+++ b/app/controllers/product_drives_controller.rb
@@ -96,7 +96,7 @@ class ProductDrivesController < ApplicationController
         format.html { redirect_to product_drives_url, notice: 'Product drive was successfully destroyed.' }
         format.json { head :no_content }
       else
-        error_message = "Cannot delete product drive with donations."
+        error_message = product_drive.errors.full_messages.to_sentence
         format.html { redirect_to product_drive_path(product_drive), error: error_message }
         format.json { render json: {error: error_message}, status: :unprocessable_entity }
       end

--- a/app/models/product_drive.rb
+++ b/app/models/product_drive.rb
@@ -31,7 +31,7 @@ class ProductDrive < ApplicationRecord
           search_dates[:end_date])
   }
 
-  has_many :donations, dependent: :nullify
+  has_many :donations, dependent: :restrict_with_error
   has_many :product_drive_participants, -> { distinct }, through: :donations
   validates :name, presence:
     { message: "A name must be chosen." }

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -294,11 +294,21 @@ RSpec.describe "ProductDrives", type: :request do
     end
 
     describe "DELETE #destroy" do
-      it "redirects to the index" do
-        product_drive = create(:product_drive, organization: organization)
+      let(:product_drive) { create(:product_drive, organization: organization) }
 
+      it "redirects to the index" do
         delete product_drive_path(id: product_drive.id)
         expect(response).to redirect_to(product_drives_path)
+      end
+
+      context "when the product drive has associated donations" do
+        it "does not delete and redirects with an error" do
+          create(:donation, product_drive: product_drive)
+
+          delete product_drive_path(id: product_drive.id)
+          expect(response).to redirect_to(product_drive_path(product_drive))
+          expect(flash[:error]).to eq("Cannot delete product drive with donations.")
+        end
       end
     end
   end

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe "ProductDrives", type: :request do
 
           delete product_drive_path(id: product_drive.id)
           expect(response).to redirect_to(product_drive_path(product_drive))
-          expect(flash[:error]).to eq("Cannot delete product drive with donations.")
+          expect(flash[:error]).to eq("Cannot delete record because dependent donations exist")
         end
       end
     end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #4739  <!--fill issue number-->. 

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
* Prevented deletion of product drives that have associated donations by setting dependent: :restrict_with_error on the has_many :donations association in the ProductDrive model.
* Added logic to display an error message and redirect back to the product drive page when deletion fails.
* Added a request spec to verify this behavior.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
Verified that a product drive with associated donations cannot be deleted.
In addition to the request spec, manual testing was done with the following steps:

1. Log in as Organization Admin
```
Email: org_admin1@example.com
Password: password!
```
2. From the sidebar, go to:
Community > Product Drives > View (for a product drive with donations)
Example:
```
http://localhost:3000/product_drives/2
```
3. Click the **Delete** button and confirm that the following message appears:
`Cannot delete product drive with donations.`
Also, make sure it redirects back to the product drive page.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
When you click the Delete button, a flash message like the one in the image is displayed, and you are redirected back to the original page.
<img width="946" height="852" alt="image" src="https://github.com/user-attachments/assets/e19d49c8-deed-4316-87a0-69cc2283c055" />

