### PR TITLE
[5301] Fix Idempotency Issue During Partner Info Upload

### DIFF
--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -53,6 +53,7 @@
                       <% if doc.persisted? %>
                         <li class="attached-document d-flex justify-content-between align-items-center p-2 border rounded mb-2" data-document-id="<%= doc.signed_id %>">
                           <%= link_to doc.blob.filename.to_s, rails_blob_path(doc), class: "font-weight-bold w-75 text-truncate" %>
+                          <%= f.hidden_field :documents, multiple: true, value: doc.signed_id %>
                           <%= delete_button_to attachment_path(doc), { text: "Remove", size: "md", confirm: "Are you sure you want to permanently remove this document?" } %>
                         </li>
                       <% end %>

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -403,6 +403,34 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         expect(page).to have_link("distribution_program_address.pdf")
         expect(page).to have_link("distribution_same_address.pdf")
       end
+
+      it "allows documents to be uploaded and persists documents across multiple refreshes", :aggregate_failures do
+        document_1 = Rails.root.join("spec/fixtures/files/distribution_program_address.pdf")
+        document_2 = Rails.root.join("spec/fixtures/files/distribution_same_address.pdf")
+        documents = [document_1, document_2]
+
+        # Upload the documents
+        visit subject
+        attach_file(documents, make_visible: true) do
+          page.find('input#partner_documents').click
+        end
+
+        # Test document persistence across multiple refresh cycles
+        3.times do |iteration|
+          # Save progress
+          click_button "Update Partner"
+
+          # Verify documents on show page
+          expect(page).to have_current_path(partner_path(partner.id))
+          expect(page).to have_link("distribution_program_address.pdf")
+          expect(page).to have_link("distribution_same_address.pdf")
+
+          # Visit edit page and verify documents persist
+          visit subject
+          expect(page).to have_link("distribution_program_address.pdf")
+          expect(page).to have_link("distribution_same_address.pdf")
+        end
+      end
     end
 
     describe "#edit_profile" do


### PR DESCRIPTION
Resolves #5301 

### Description
This PR addresses an idempotency issue with bank partner uploads. The issue manifested when a user would upload a file to the "Edit Partner Information" page, save the page, and then repeat this process of saving the page and navigating back 3+ times. This PR ensures that a user no longer needs to re-upload the file after multiple form updates and page refreshes. This PR also adds tests for the change.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
To test this change, please do the following:

- Navigate to a specific partner from the "All Partners" page.
- Click the "Edit Partner Information" button and under the "Documents" section, select and upload a document to the page. Click the "Update Partner" button. Observe that the document has been uplaoded.
- Navigate back to the edit page and click the "Update Partner" button again, leaving the document untouched. Observe that the document is still there.
- Once again, navigate back tot he edit page and click the "Update Partner" button again, leaving the document untouched. Observe that the document is still there, when previously the document would have disappeared from the UI.
- Test this with multiple documents to ensure it works when multiple documents are attached. Observe that upon update, the documents remain.