### PR TITLE
Fix spelling of "In Kind Value" to "In-kind Value" in product drives …

### DIFF
--- a/app/views/donations/index.html.erb
+++ b/app/views/donations/index.html.erb
@@ -118,7 +118,7 @@
                   <th>Storage Location</th>
                   <th>Quantity of Items</th>
                   <th>Money Raised</th>
-                  <th>In Kind Value</th>
+                  <th>In-kind Value</th>
                   <th>Comments</th>
                   <th class="text-right">Actions</th>
                 </tr>

--- a/app/views/product_drives/index.html.erb
+++ b/app/views/product_drives/index.html.erb
@@ -97,7 +97,7 @@
                 <th>Held Virtually?</th>
                 <th class="numeric">Quantity of Items</th>
                 <th class="numeric">Variety of Items</th>
-                <th class="numeric">In Kind Value</th>
+                <th class="numeric">In-kind Value</th>
                 <th class="text-right">Actions</th>
               </tr>
               </thead>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5310

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Visit https://humanessentials.app/product_drives and https://humanessentials.app/donations pages. Pay attention to 
In-kind Value columns


<br class="Apple-interchange-newline">

### Screenshots
<img width="3024" height="1538" alt="image" src="https://github.com/user-attachments/assets/61e9ad1a-a7c6-466a-92a4-c766bf4a47a4" />
<img width="6048" height="3076" alt="image" src="https://github.com/user-attachments/assets/1e4ffa8a-2bc3-43ca-b510-465f6a27925d" />

