### PR TITLE
5307 Remove adjustment creation in AuditsController#finalize and update corresponding tests

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -21,9 +21,6 @@ class AuditsController < ApplicationController
   end
 
   def finalize
-    @audit.adjustment = Adjustment.new(organization_id: @audit.organization_id, storage_location_id: @audit.storage_location_id, user_id: current_user.id, comment: 'Created Automatically through the Auditing Process')
-    @audit.save
-
     AuditEvent.publish(@audit)
     @audit.finalized!
     redirect_to audit_path(@audit), notice: "Audit is Finalized."

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe "Audit management", type: :system, js: true do
       end
 
       describe "Finalizing an audit" do
-        it "creates an adjustment with the differential" do
+        it "updates inventory based on audit" do
           item_quantity = 10
 
           visit subject
@@ -288,7 +288,6 @@ RSpec.describe "Audit management", type: :system, js: true do
             end
             expect(page).to have_content("Audit is Finalized.")
           end.to change { storage_location.size }.by(quantity - item_quantity)
-          expect(Adjustment.last.comment == "Created Automatically through the Auditing Process").to be_truthy
         end
 
         it "is immutable" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5307 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

As specified in the linked issue in the AuditsController#finalize the two lines of code that initialize and save a new Adjustment were removed so that this finalizing an audit does not create an adjustment at all.

**How I approached this issue:**
In #finalize, I removed the lines for initializing and creating a new Adjustment.

I checked in the Adjustment model if there are any callbacks to ensure that removing those lines of code will not break something.

The `@audit` gets published to the AuditEvent. Having a look at the `audit_event.rb` and `inventory_aggregate.rb`, AuditEvent seems to be responsible for updating the quantity of items in the inventory. Thus, removing those two lines from #finalize indeed seems to be safe.

The only test affected was: 
“Audit management while signed in as an organization admin with a confirmed audit Finalizing an audit creates an adjustment with the differential”

As this test verified not only the presence of the created Adjustment but also that the quantity in the inventory gets updated, I just updated and renamed the test.

--> As the way events are handled is new to me, please pay particular attention to this aspect and let me know if there is something I may have overlooked.


### Type of change

<!-- Please delete options that are not relevant. -->

* Feature update to remove obsolete creation of adjustments


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

No new test was added for this update. The existing test suite run locally. The failing test was updated by removing the expectation that checks if an adjustment was created.

