### PR TITLE
Text change to reflect that we allow partial audits now

### DIFF
--- a/app/views/audits/edit.html.erb
+++ b/app/views/audits/edit.html.erb
@@ -28,7 +28,7 @@
       <div class="col-md-12">
         <div class="callout callout-info">
           <h5><i class="fas fa-info"></i> Note:</h5>
-          <p class="help">Edit the <strong>Audit</strong> recording all the inventory present in a particular storage location.</p>
+          <p class="help">Edit the <strong>Audit</strong> recording the inventory present in a particular storage location.</p>
           <p class="help">Enter <em>all</em> the items with their corresponding <em>quantity</em> that are present in the storage location</p>
           <p class="help">Click on <em>Save Progress</em> button to save the current progress of audit.</p>
           <p class="help">You can <em>resume</em> the saved audit at a later time again.</p>

--- a/app/views/audits/new.html.erb
+++ b/app/views/audits/new.html.erb
@@ -28,7 +28,7 @@
       <div class="col-md-12">
         <div class="callout callout-info">
           <h5><i class="fas fa-info"></i> Note:</h5>
-          <p class="box-title">Create an <strong>Audit</strong> recording all the inventory present in a
+          <p class="box-title">Create an <strong>Audit</strong> recording the inventory present in a
             particular storage location.</p>
             <p class="help">Enter the <em>items</em> with their corresponding <em>quantity</em> that are present in the storage location. You can do a partial audit - if you do not enter a new value, the level in the records will not be changed.</p>
           <p class="help">Click on <em>Save Progress</em> button to save the current progress of audit.</p>


### PR DESCRIPTION
No issue 

### Description

Removed "all " from "Create an <strong>Audit</strong> recording all the inventory present in a
            particular storage location.  

Because we now allow partials
   
### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Visual confirmation

