### PR TITLE
Fix request fulfilled issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -842,4 +842,4 @@ DEPENDENCIES
   webmock (~> 3.25)
 
 BUNDLED WITH
-   2.7.0
+   2.7.1

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -37,9 +37,14 @@ class RequestsController < ApplicationController
   # pre-filled distribution containing all the requested items.
   def start
     request = Request.find(params[:id])
-    request.status_started!
-    flash[:notice] = "Request started"
-    redirect_to new_distribution_path(request_id: request.id)
+    begin
+      request.status_started!
+      flash[:notice] = "Request started"
+      redirect_to new_distribution_path(request_id: request.id)
+    rescue ActiveRecord::RecordInvalid
+      flash[:alert] = "Request has already been fulfilled"
+      redirect_to request_path(request)
+    end
   end
 
   def print_picklist

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -37,6 +37,7 @@ class Request < ApplicationRecord
   validates :distribution_id, uniqueness: true, allow_nil: true
   validate :item_requests_uniqueness_by_item_id
   validate :not_completely_empty
+  validate :cannot_change_status_once_fulfilled, on: :update
 
   after_validation :sanitize_items_data
 
@@ -83,6 +84,12 @@ class Request < ApplicationRecord
   def not_completely_empty
     if comments.blank? && item_requests.blank?
       errors.add(:base, "completely empty request")
+    end
+  end
+
+  def cannot_change_status_once_fulfilled
+    if status_changed? && status_was == "fulfilled"
+      errors.add(:status, "cannot be changed once fulfilled")
     end
   end
 end

--- a/db/migrate/20250826223940_backfill_fulfilled_requests.rb
+++ b/db/migrate/20250826223940_backfill_fulfilled_requests.rb
@@ -1,0 +1,21 @@
+class BackfillFulfilledRequests < ActiveRecord::Migration[8.0]
+  def up
+    # This migration fixes requests that should be marked as "fulfilled" 
+    # but are currently marked as "started"
+    # A request should be "fulfilled" if its associated distribution is "complete"
+    Request.joins(:distribution)
+      .where(status: "started", distributions: { state: "complete" })
+      .update_all(status: "fulfilled")
+  end
+
+  def down
+    # This is a data correction migration, so we make it irreversible
+    # to prevent accidental data corruption
+    raise ActiveRecord::IrreversibleMigration
+  end
+end
+
+# Migration Context:
+# Previously, fulfilled requests could be incorrectly changed back to "started" status.
+# This has been fixed in the Request model with validation, but this migration 
+# corrects existing data that may be in an inconsistent state.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_11_094943) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_26_223940) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/migrations/backfill_fulfilled_requests_spec.rb
+++ b/spec/migrations/backfill_fulfilled_requests_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+require Rails.root.join("db/migrate/20250826223940_backfill_fulfilled_requests")
+
+RSpec.describe BackfillFulfilledRequests, type: :migration do
+  let(:migration) { described_class.new }
+  let(:organization) { create(:organization, :with_items) }
+  let(:partner) { create(:partner, organization: organization) }
+
+  it "updates started requests with complete distributions to fulfilled" do
+    # Create a distribution with complete state
+    distribution = create(:distribution, organization: organization, partner: partner, state: "complete")
+    
+    # Create a request with started status and link it to the distribution
+    request = create(:request, :started, organization: organization, partner: partner, distribution: distribution)
+
+    expect {
+      migration.up
+    }.to change { request.reload.status }.from("started").to("fulfilled")
+  end
+
+  it "does not change requests without complete distributions" do
+    # Create a distribution with scheduled state (not complete)
+    distribution = create(:distribution, organization: organization, partner: partner, state: "scheduled")
+    
+    # Create a request with started status and link it to the distribution
+    request = create(:request, :started, organization: organization, partner: partner, distribution: distribution)
+
+    expect {
+      migration.up
+    }.not_to change { request.reload.status }
+  end
+
+  it "does not change requests without any distribution" do
+    # Create a request with started status but no distribution
+    request = create(:request, :started, organization: organization, partner: partner, distribution: nil)
+
+    expect {
+      migration.up
+    }.not_to change { request.reload.status }
+  end
+
+  it "does not change fulfilled requests even if they have complete distributions" do
+    # Create a distribution with complete state
+    distribution = create(:distribution, organization: organization, partner: partner, state: "complete")
+    
+    # Create a request that's already fulfilled
+    request = create(:request, :fulfilled, organization: organization, partner: partner, distribution: distribution)
+
+    expect {
+      migration.up
+    }.not_to change { request.reload.status }
+  end
+
+  it "does not change pending requests even if they have complete distributions" do
+    # Create a distribution with complete state
+    distribution = create(:distribution, organization: organization, partner: partner, state: "complete")
+    
+    # Create a request with pending status
+    request = create(:request, :pending, organization: organization, partner: partner, distribution: distribution)
+
+    expect {
+      migration.up
+    }.not_to change { request.reload.status }
+  end
+end

--- a/spec/migrations/backfill_fulfilled_requests_spec.rb
+++ b/spec/migrations/backfill_fulfilled_requests_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BackfillFulfilledRequests, type: :migration do
   it "updates started requests with complete distributions to fulfilled" do
     # Create a distribution with complete state
     distribution = create(:distribution, organization: organization, partner: partner, state: "complete")
-    
+
     # Create a request with started status and link it to the distribution
     request = create(:request, :started, organization: organization, partner: partner, distribution: distribution)
 
@@ -21,7 +21,7 @@ RSpec.describe BackfillFulfilledRequests, type: :migration do
   it "does not change requests without complete distributions" do
     # Create a distribution with scheduled state (not complete)
     distribution = create(:distribution, organization: organization, partner: partner, state: "scheduled")
-    
+
     # Create a request with started status and link it to the distribution
     request = create(:request, :started, organization: organization, partner: partner, distribution: distribution)
 
@@ -42,7 +42,7 @@ RSpec.describe BackfillFulfilledRequests, type: :migration do
   it "does not change fulfilled requests even if they have complete distributions" do
     # Create a distribution with complete state
     distribution = create(:distribution, organization: organization, partner: partner, state: "complete")
-    
+
     # Create a request that's already fulfilled
     request = create(:request, :fulfilled, organization: organization, partner: partner, distribution: distribution)
 
@@ -54,7 +54,7 @@ RSpec.describe BackfillFulfilledRequests, type: :migration do
   it "does not change pending requests even if they have complete distributions" do
     # Create a distribution with complete state
     distribution = create(:distribution, organization: organization, partner: partner, state: "complete")
-    
+
     # Create a request with pending status
     request = create(:request, :pending, organization: organization, partner: partner, distribution: distribution)
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe Request, type: :model do
         expect(Request.status_started).to eq([request_started])
         expect(Request.status_fulfilled).to eq([request_fulfilled])
       end
+
+      it "does not regress from fulfilled to started" do
+        expect { request_fulfilled.status_started! }
+          .to raise_error(ActiveRecord::RecordInvalid, /cannot be changed once fulfilled/)
+      end
+
+      it "does not regress from fulfilled to pending" do
+        expect { request_fulfilled.status_pending! }
+          .to raise_error(ActiveRecord::RecordInvalid, /cannot be changed once fulfilled/)
+      end
+
+      it "allows normal transitions" do
+        expect { request_pending.status_started! }.not_to raise_error
+        expect { request_started.status_fulfilled! }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5326 

### Description
Originally it was possible to change the status of an already fulfilled request to "started".
This PR adds:
- validation to the requests class to check it's already fulfilled before allowing a change
- updates to the requests controller to fail gracefully if attempting to change a fulfilled request
- a migration file to correct any existing requests that are "started", yet associated with a "complete" distribution
- passing tests and rubocop
   
However, there are 5 failing tests that are unrelated to this pr. This is consistent with the current main branch. I just wanted to bring it to your attention.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Rspec tests have been added, and I've tested it manually.
<img width="2408" height="984" alt="image" src="https://github.com/user-attachments/assets/74a8449b-49a9-4f4c-b212-c78c06693255" />
