### PR TITLE
Sort secondarily off of id for identical name stability

### DIFF
--- a/app/controllers/partners/children_controller.rb
+++ b/app/controllers/partners/children_controller.rb
@@ -101,7 +101,7 @@ module Partners
 
     helper_method :sort_column # used in SortableHelper
     def sort_column
-      Child.column_names.include?(params[:sort]) ? params[:sort] : "last_name"
+      Child.column_names.include?(params[:sort]) ? params[:sort] : "last_name, id"
     end
 
     helper_method :fetch_valid_item_name

--- a/app/controllers/partners/families_controller.rb
+++ b/app/controllers/partners/families_controller.rb
@@ -100,7 +100,7 @@ module Partners
     end
 
     def sort_column
-      Family.column_names.include?(params[:sort]) ? params[:sort] : "guardian_last_name"
+      Family.column_names.include?(params[:sort]) ? params[:sort] : "guardian_last_name, id"
     end
 
     def archive_children


### PR DESCRIPTION
Fixes some flaky tests -- the test users had identical names, so the order was unstable.