### PR TITLE
Resolves #5224: Banks can see partners's active children using items when deactivating

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -52,6 +52,7 @@ class Item < ApplicationRecord
   has_many :donations, through: :line_items, source: :itemizable, source_type: "::Donation"
   has_many :distributions, through: :line_items, source: :itemizable, source_type: "::Distribution"
   has_many :request_units, class_name: "ItemUnit", dependent: :destroy
+  has_and_belongs_to_many :children, class_name: 'Partners::Child'
 
   scope :active, -> { where(active: true) }
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -52,7 +52,7 @@ class Item < ApplicationRecord
   has_many :donations, through: :line_items, source: :itemizable, source_type: "::Donation"
   has_many :distributions, through: :line_items, source: :itemizable, source_type: "::Distribution"
   has_many :request_units, class_name: "ItemUnit", dependent: :destroy
-  has_and_belongs_to_many :children, class_name: 'Partners::Child'
+  has_and_belongs_to_many :children, class_name: "Partners::Child"
 
   scope :active, -> { where(active: true) }
 


### PR DESCRIPTION
Resolves #5224 

**Description**
In inventory when an item is deactivated it displays list of partners which contains child requests

Screenshot 
<img width="1919" height="782" alt="image" src="https://github.com/user-attachments/assets/32cfdd38-378d-4dc9-a9c9-7c110762257d" />


