### PR TITLE
4473 post pr bugfix

### DIFF
--- a/app/javascript/controllers/deadline_day_controller.js
+++ b/app/javascript/controllers/deadline_day_controller.js
@@ -47,7 +47,7 @@ export default class extends Controller {
 
     if (this.byDayOfMonthTarget.checked && this.dayOfMonthTarget.value) {
       const rule = new RRule({
-        dtstart: today,
+        dtstart: new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate(), 12)),
         freq: RRule.MONTHLY,
         interval: monthlyInterval,
         bymonthday: parseInt(this.dayOfMonthTarget.value),
@@ -57,7 +57,7 @@ export default class extends Controller {
     }
     if (this.byDayOfWeekTarget.checked && this.everyNthDayTarget.value && (this.dayOfWeekTarget.value)) {
       const rule = new RRule({
-        dtstart: today,
+        dtstart: new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate(), 12)),
         freq: RRule.MONTHLY,
         interval: monthlyInterval,
         byweekday: WEEKDAY_NUM_TO_OBJ[ parseInt(this.dayOfWeekTarget.value) ].nth( parseInt(this.everyNthDayTarget.value) ),

--- a/spec/support/deadline_day_fields_shared_example.rb
+++ b/spec/support/deadline_day_fields_shared_example.rb
@@ -74,6 +74,11 @@ RSpec.shared_examples_for "deadline and reminder form" do |form_prefix, save_but
     expect(page).to have_content("Deadline day must be between 1 and 28")
   end
 
+  # These tests make assertions about the dates calculated by the javascript in deadline_day_controller.js
+  # Because we currently don't have a great way of spoofing the date the headless browser sees during tests, they
+  # cannot effectively set the date for the tests (like with travel_to) and have to make due with the actual datetime
+  # of whenever the test is run. To the best of my knowledge, the tests are sound but be aware that they could
+  # pass or fail based on when they are run!
   describe "reported reminder and deadline dates" do
     context "when the reminder is a day of the month" do
       before do


### PR DESCRIPTION
Resolves #4473 

### Description

This PR fixes a bug with the javascript for the reminder schedule form caused by incorrect use of the RRule library (which wants you to [use UTC dates](https://github.com/jkbrzt/rrule?tab=readme-ov-file#important-use-utc-dates). Specifically, when the current local time plus the time offset is greater than 24 hours (for example, 18:00:00 in a UTC -7:00 time zone), the reminder date would be off by one day.

As the only part of the user's input that matters is the date, not the time, a static time was used instead.

The IceCube library used by the backend to calculate reminder text and which partners to send reminder emails in `FetchPartnersToRemindNowService` did not exhibit this buggy behavior.

A disclaimer was added to the `deadline_day_fields_shared_example.rb` to acknowledge that, due to tests in that file relying on the unspoofed date times returned by the browser, test's behavior could be dependent on what time they are ran.

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* Documentation update

### How Has This Been Tested?

Manually verified the change worked. Made sure all existing tests passed.