### PR TITLE
remove read_events feature flag from seeder file.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1107,8 +1107,6 @@ end
 # ----------------------------------------------------------------------------
 
 Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "new_logo")
-Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "read_events")
-Flipper.enable(:read_events)
 Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "partner_step_form")
 Flipper.enable(:partner_step_form)
 Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "enable_packs")


### PR DESCRIPTION
Resolves #5168 

### Description

Remove read_events feature flag from seeder file, since it's not used anywhere.

### Type of change
- clean up the code.
