### PR TITLE
[5374] Hide Additional Custom Request Units section when editing item if the organization has no request units

### DIFF
--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -44,7 +44,7 @@
                 <%= f.input_field :package_size, class: "form-control", min: 0 %>
               <% end %>
 
-              <% if Flipper.enabled?(:enable_packs) %>
+              <% if Flipper.enabled?(:enable_packs) && current_organization.request_units.present? %>
                 <%= f.input :request_units, label: "Additional Custom Request Units" do %>
                   <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, checked: selected_item_request_units(@item), label_method: :name, value_method: :id, class: "form-check-input" %>
                 <% end %>

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -111,6 +111,16 @@ RSpec.describe "Items", type: :request do
         end
       end
 
+      context "when the organization has no request_units" do
+        let(:item) { create(:item, organization: organization) }
+        before { organization.request_units.destroy_all }
+
+        it "does not show the Additional Custom Request Units section" do
+          get edit_item_path(item)
+          expect(response.body).to_not match "Additional Custom Request Units"
+        end
+      end
+
       context "when item is housing a kit" do
         let(:kit) { create(:kit, organization:) }
         let(:item) { create(:item, organization: organization, kit:) }


### PR DESCRIPTION
Resolves #5374

### Description

If an organization has no custom request units, then the Additional Custom Request Units section will no longer be visible when creating or editing an inventory item.

### How Has This Been Tested?

Updated the request spec for editing items. 
Ran acceptance testing locally:
1. Click "My Organization", scroll down and click "Edit"
2. About half way down, there is a field "Custom request units used". Remove the contents of that field, then save.
3. Now, go to Inventory, then Items & Inventory
4. Click "Edit" beside an item
5. Section "Additional Custom Request Units" with "Request Units" under it should NOT be visible.

### Screenshots
<img width="2232" height="1203" alt="image" src="https://github.com/user-attachments/assets/fa191003-1ca2-4224-980d-f1461cfa29f3" />
