### PR TITLE
Allow saving on purchase form with deactivated vendor

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -65,7 +65,7 @@ class PurchasesController < ApplicationController
     @purchase.line_items.build
     @audit_performed_and_finalized = Audit.finalized_since?(@purchase, @purchase.storage_location_id)
 
-    load_form_collections
+    load_form_collections(@purchase)
   end
 
   def show
@@ -82,7 +82,7 @@ class PurchasesController < ApplicationController
     flash[:success] = "Purchase updated successfully"
     redirect_to purchases_path
   rescue => e
-    load_form_collections
+    load_form_collections(@purchase)
     flash.now[:alert] = "Error updating purchase: #{e.message}"
     render "edit"
   end
@@ -102,10 +102,13 @@ class PurchasesController < ApplicationController
 
   private
 
-  def load_form_collections
+  def load_form_collections(purchase = nil)
     @storage_locations = current_organization.storage_locations.active.alphabetized
     @items = current_organization.items.active.alphabetized
-    @vendors = current_organization.vendors.active.alphabetized
+
+    @vendors = current_organization.vendors.active
+    @vendors = @vendors.or(Vendor.where(id: purchase.vendor_id)) if purchase
+    @vendors = @vendors.alphabetized
   end
 
   def purchase_params

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -254,6 +254,19 @@ RSpec.describe "Purchases", type: :system, js: true do
               expect(page.current_path).to eq(purchases_path)
             end
           end
+
+          context "with a deactivated vendor" do
+            let(:deactivated_vendor) { create(:vendor, active: false) }
+            let(:purchase) { create(:purchase, vendor: deactivated_vendor) }
+
+            it "can save the purchase" do
+              visit edit_purchase_path(purchase)
+              click_button "Save"
+
+              expect(page).to have_content("Purchase updated successfully")
+              expect(page.current_path).to eq(purchases_path)
+            end
+          end
         end
 
         context "with another organization's purchase" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

-->

Resolves #5377

### Description
- Fix saving on form if vendor for purchase is deactivated
- Refactor existing tests to be clearer

### How Has This Been Tested?
- Tested manually and with a new system_spec.
