### PR TITLE
Add view request button to distribution row

### DIFF
--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -4,17 +4,18 @@
   <td class="date"><%= distribution_row.created_at.strftime("%m/%d/%Y") %></td>
   <td class="date"><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %></td>
   <td><%= distribution_row.storage_location.name %></td>
-
   <td class="numeric"><%= @distribution_totals[distribution_row.id].quantity %></td>
   <td class="numeric"><%= dollar_value(@distribution_totals[distribution_row.id].value) %></td>
   <td><%= distribution_row.delivery_method.humanize %></td>
   <td><%= distribution_shipping_cost(distribution_row.shipping_cost) %></td>
   <td><%= distribution_row.comment %></td>
   <td><%= distribution_row.state&.humanize %></td>
-
   <% distribution_has_inactive_item = @distributions_with_inactive_items.include?(distribution_row.id) %>
   <td class="text-right">
     <%= view_button_to distribution_path(distribution_row) %>
+    <% if distribution_row.request %>
+      <%= view_button_to request_path(distribution_row.request), {icon: "eye", type: "secondary", text: "View Request"} %>
+    <% end %>
     <% if (!distribution_row.complete? && !distribution_row.future?) || current_user.has_cached_role?(Role::ORG_ADMIN, current_organization) %>
       <%= edit_button_to edit_distribution_path(distribution_row), enabled: !distribution_has_inactive_item %>
     <% end %>

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -340,6 +340,7 @@ RSpec.feature "Distributions", type: :system do
   context "With an existing distribution" do
     let!(:distribution) { create(:distribution, :with_items, agency_rep: "A Person", delivery_method: delivery_method, organization: user.organization, reminder_email_enabled: true) }
     let(:delivery_method) { "pick_up" }
+    let!(:request) { create(:request, distribution: distribution) }
 
     before do
       sign_in(organization_admin)
@@ -355,6 +356,12 @@ RSpec.feature "Distributions", type: :system do
 
       distribution.reload
       expect(distribution.agency_rep).to eq("SOMETHING DIFFERENT")
+    end
+
+    it "the user can view related request" do
+      click_on "View Request"
+
+      expect(page).to have_content "Request from #{distribution.request.partner.name}"
     end
 
     it "sends an email if reminders are enabled" do


### PR DESCRIPTION
Resolves #5371 

### Description
- Add button to view a request for a distribution (when present).

### How Has This Been Tested?

- Tested manually + with spec

### Screenshots

<img width="1198" height="201" alt="Screenshot 2025-09-12 at 4 25 37 PM" src="https://github.com/user-attachments/assets/85b01e76-f137-4e44-8cfd-436513aee735" />
