### PR TITLE
[5384] Redirect to the allocations view when clicking on a kit link from the history report

### DIFF
--- a/app/controllers/kits_controller.rb
+++ b/app/controllers/kits_controller.rb
@@ -1,4 +1,8 @@
 class KitsController < ApplicationController
+  def show
+    redirect_to allocations_kit_path
+  end
+
   def index
     @kits = current_organization.kits.includes(:item, line_items: :item).class_filter(filter_params)
     @inventory = View::Inventory.new(current_organization.id)

--- a/spec/requests/kit_requests_spec.rb
+++ b/spec/requests/kit_requests_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe "/kits", type: :request do
       sign_in(user)
     end
 
+    describe "GET #show" do
+      it "should redirect to the allocations page" do
+        get kit_url(kit)
+        expect(response).to redirect_to allocations_kit_path(kit.id)
+      end
+    end
+
     describe "GET #index" do
       before do
         # this shouldn't be shown


### PR DESCRIPTION
Resolves #5384

### Description
Added a `show` action to the kits controller that redirects to the `allocations` action.

Discussed with @awwaiid, and we decided on this approach to avoid adding business logic to the report view just for the Kit event types.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Added a test for the `show` action to the kits request spec.
- Tested changes locally with no issues. 
