### PR TITLE
[4118] Add total Fair Market Value to individual storage location view and CSV export

### DIFF
--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -159,7 +159,7 @@ class StorageLocation < ApplicationRecord
   end
 
   def self.csv_export_headers
-    ["Name", "Address", "Square Footage", "Warehouse Type", "Total Inventory"]
+    ["Name", "Address", "Square Footage", "Warehouse Type", "Total Inventory", "Fair Market Value"]
   end
 
   # @param storage_locations [Array<StorageLocation>]
@@ -171,7 +171,7 @@ class StorageLocation < ApplicationRecord
     CSV.generate(headers: true) do |csv|
       csv_data = storage_locations.map do |sl|
         total_quantity = inventory.quantity_for(storage_location: sl.id)
-        attributes = [sl.name, sl.address, sl.square_footage, sl.warehouse_type, total_quantity] +
+        attributes = [sl.name, sl.address, sl.square_footage, sl.warehouse_type, total_quantity, sl.inventory_total_value_in_dollars] +
           all_items.map { |i| inventory.quantity_for(storage_location: sl.id, item_id: i.item_id) }
         attributes.map { |attr| normalize_csv_attribute(attr) }
       end

--- a/app/views/storage_locations/show.html.erb
+++ b/app/views/storage_locations/show.html.erb
@@ -36,6 +36,7 @@
                 <th>Address</th>
                 <th>Square Footage</th>
                 <th>Warehouse Type</th>
+                <th>Fair Market Value</th>
               </tr>
               </thead>
               <tbody>
@@ -44,6 +45,7 @@
                 <td><%= @storage_location.address %></td>
                 <td><%= @storage_location.square_footage %></td>
                 <td><%= @storage_location.warehouse_type %></td>
+                <td><%= number_to_currency @storage_location.inventory_total_value_in_dollars %></td>
               </tr>
               </tbody>
             </table>

--- a/docs/user_guide/bank/exports.md
+++ b/docs/user_guide/bank/exports.md
@@ -413,7 +413,8 @@ For each Storage Location in the filtered list:
 - Address,
 - Square Footage,
 - Warehouse Type,
-- Total Inventory, and
+- Total Inventory,
+- Fair Market Value,
 - Quantity for each of the organization's Items.
 
 ## Transfers

--- a/spec/requests/storage_locations_requests_spec.rb
+++ b/spec/requests/storage_locations_requests_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "StorageLocations", type: :request do
+  include ActionView::Helpers::NumberHelper
+
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }
   let(:organization_admin) { create(:organization_admin, organization: organization) }
@@ -170,12 +172,12 @@ RSpec.describe "StorageLocations", type: :request do
           get storage_locations_path(format: response_format)
           # The first address below is quoted since it contains commas
           csv = <<~CSV
-            Name,Address,Square Footage,Warehouse Type,Total Inventory,A,B,C,D
-            Storage Location with Duplicate Items,"1500 Remount Road, Front Royal, VA 22630",100,Residential space used,1,0,0,1,0
-            Storage Location with Items,123 Donation Site Way,100,Residential space used,3,1,1,1,0
-            Storage Location with Unique Items,Smithsonian Conservation Center new,100,Residential space used,5,0,0,0,5
-            Test Storage Location,123 Donation Site Way,100,Residential space used,0,0,0,0,0
-            Test Storage Location 1,123 Donation Site Way,100,Residential space used,0,0,0,0,0
+            Name,Address,Square Footage,Warehouse Type,Total Inventory,Fair Market Value,A,B,C,D
+            Storage Location with Duplicate Items,"1500 Remount Road, Front Royal, VA 22630",100,Residential space used,1,0.0,0,0,1,0
+            Storage Location with Items,123 Donation Site Way,100,Residential space used,3,0.0,1,1,1,0
+            Storage Location with Unique Items,Smithsonian Conservation Center new,100,Residential space used,5,0.0,0,0,0,5
+            Test Storage Location,123 Donation Site Way,100,Residential space used,0,0.0,0,0,0,0
+            Test Storage Location 1,123 Donation Site Way,100,Residential space used,0,0.0,0,0,0,0
           CSV
           expect(response.body).to eq(csv)
         end
@@ -208,13 +210,13 @@ RSpec.describe "StorageLocations", type: :request do
             get storage_locations_path(include_inactive_storage_locations: "1", format: response_format)
 
             csv = <<~CSV
-              Name,Address,Square Footage,Warehouse Type,Total Inventory,A,B,C,D
-              Inactive Storage Location,123 Donation Site Way,100,Residential space used,3,1,1,1,0
-              Storage Location with Duplicate Items,"1500 Remount Road, Front Royal, VA 22630",100,Residential space used,1,0,0,1,0
-              Storage Location with Items,123 Donation Site Way,100,Residential space used,3,1,1,1,0
-              Storage Location with Unique Items,Smithsonian Conservation Center new,100,Residential space used,5,0,0,0,5
-              Test Storage Location,123 Donation Site Way,100,Residential space used,0,0,0,0,0
-              Test Storage Location 1,123 Donation Site Way,100,Residential space used,0,0,0,0,0
+              Name,Address,Square Footage,Warehouse Type,Total Inventory,Fair Market Value,A,B,C,D
+              Inactive Storage Location,123 Donation Site Way,100,Residential space used,3,0.0,1,1,1,0
+              Storage Location with Duplicate Items,"1500 Remount Road, Front Royal, VA 22630",100,Residential space used,1,0.0,0,0,1,0
+              Storage Location with Items,123 Donation Site Way,100,Residential space used,3,0.0,1,1,1,0
+              Storage Location with Unique Items,Smithsonian Conservation Center new,100,Residential space used,5,0.0,0,0,0,5
+              Test Storage Location,123 Donation Site Way,100,Residential space used,0,0.0,0,0,0,0
+              Test Storage Location 1,123 Donation Site Way,100,Residential space used,0,0.0,0,0,0,0
             CSV
 
             expect(response.body).to eq(csv)
@@ -413,6 +415,12 @@ RSpec.describe "StorageLocations", type: :request do
               end
             end
           end
+        end
+
+        it "should include the inventory total market value" do
+          get storage_location_path(storage_location, format: response_format)
+          expect(response).to be_successful
+          expect(response.body).to include(number_to_currency(storage_location.inventory_total_value_in_dollars))
         end
       end
 


### PR DESCRIPTION
Resolves #4118

### Description

This adds a total market value for all items in a storage location to the individual storage location view and to the storage locations CSV export report.

This also updates the user guide to include the new field in the CSV report. 

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- Added tests to the storage locations request spec
- performed local acceptance testing with no issues (screenshots below)

### Screenshots
<img width="1305" height="598" alt="image" src="https://github.com/user-attachments/assets/4e6d3f2a-a1ea-4610-a216-bf61ec91a617" />
<img width="1241" height="158" alt="image" src="https://github.com/user-attachments/assets/5024db8b-51a9-4e8f-b2e4-273c6ee53712" />

