### PR TITLE
Flaky date range specs

### DIFF
--- a/spec/support/date_range_picker_shared_example.rb
+++ b/spec/support/date_range_picker_shared_example.rb
@@ -141,7 +141,7 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
 
       valid_date_range = "#{Time.zone.local(2019, 7, 22).to_fs(:date_picker)} - #{Time.zone.local(2019, 7, 28).to_fs(:date_picker)}"
       fill_in "filters_date_range", with: valid_date_range
-      find(:id, 'filters_date_range').native.send_keys(:enter)
+      click_button "Filter"
       expect(page).to have_css("table tbody tr", count: 1)
     end
   end

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe "Adjustment management", type: :system, js: true do
       before do
         visit subject
         click_on "New Adjustment"
-        select storage_location.name, from: "From storage location"
+        await_select2("#adjustment_line_items_attributes_0_item_id") do
+          select storage_location.name, from: "From storage location"
+        end
         fill_in "Comment", with: "something"
         select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
       end
@@ -67,7 +69,9 @@ RSpec.describe "Adjustment management", type: :system, js: true do
         storage_location = create(:storage_location, :with_items, name: "PICK THIS ONE", item_quantity: 10, organization: organization)
         visit adjustments_path
         click_on "New Adjustment"
-        select storage_location.name, from: "From storage location"
+        await_select2("#adjustment_line_items_attributes_0_item_id") do
+          select storage_location.name, from: "From storage location"
+        end
         fill_in "Comment", with: "something"
         select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
         fill_in "adjustment_line_items_attributes_0_quantity", with: sub_quantity.to_s
@@ -84,7 +88,9 @@ RSpec.describe "Adjustment management", type: :system, js: true do
         storage_location = create(:storage_location, :with_items, name: "PICK THIS ONE", item_quantity: 10, organization: organization)
         visit adjustments_path
         click_on "New Adjustment"
-        select storage_location.name, from: "From storage location"
+        await_select2("#adjustment_line_items_attributes_0_item_id") do
+          select storage_location.name, from: "From storage location"
+        end
         fill_in "Comment", with: "something"
         select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
         fill_in "adjustment_line_items_attributes_0_quantity", with: sub_quantity.to_s

--- a/spec/system/item_system_spec.rb
+++ b/spec/system/item_system_spec.rb
@@ -205,4 +205,3 @@ RSpec.describe "Item management", type: :system do
     end
   end
 end
-


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

Resolves #5381

### Description
- Try to resolve flaky date range specs but not relying on focus + enter
- Clicking button filter should be more reliable, and it seems everywhere date range picker is used is paired with the `filter_button`

### Type of change
* Bug fix (non-breaking change which fixes an issue)

