### PR TITLE
[5383] Remove partner_status field from parnter_profiles table

### DIFF
--- a/app/models/partners/profile.rb
+++ b/app/models/partners/profile.rb
@@ -37,7 +37,6 @@
 #  new_client_times               :string
 #  no_social_media_presence       :boolean
 #  other_agency_type              :string
-#  partner_status                 :string           default("pending")
 #  pick_up_email                  :string
 #  pick_up_name                   :string
 #  pick_up_phone                  :string

--- a/db/migrate/20250913173217_remove_partner_status_from_partner_profiles.rb
+++ b/db/migrate/20250913173217_remove_partner_status_from_partner_profiles.rb
@@ -1,0 +1,5 @@
+class RemovePartnerStatusFromPartnerProfiles < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured { remove_column :partner_profiles, :partner_status, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_11_094943) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_13_173217) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -524,7 +524,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_11_094943) do
     t.bigint "essentials_bank_id"
     t.text "application_data"
     t.integer "partner_id"
-    t.string "partner_status", default: "pending"
     t.string "name"
     t.string "distributor_type"
     t.string "agency_type"

--- a/spec/factories/partners/profiles.rb
+++ b/spec/factories/partners/profiles.rb
@@ -37,7 +37,6 @@
 #  new_client_times               :string
 #  no_social_media_presence       :boolean
 #  other_agency_type              :string
-#  partner_status                 :string           default("pending")
 #  pick_up_email                  :string
 #  pick_up_name                   :string
 #  pick_up_phone                  :string

--- a/spec/models/partners/profile_spec.rb
+++ b/spec/models/partners/profile_spec.rb
@@ -37,7 +37,6 @@
 #  new_client_times               :string
 #  no_social_media_presence       :boolean
 #  other_agency_type              :string
-#  partner_status                 :string           default("pending")
 #  pick_up_email                  :string
 #  pick_up_name                   :string
 #  pick_up_phone                  :string

--- a/spec/system/partners/approval_process_spec.rb
+++ b/spec/system/partners/approval_process_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Approval process for partners", type: :system, js: true do
     let(:partner) { FactoryBot.create(:partner) }
 
     before do
-      partner.profile.update(website: '', facebook: '', twitter: '', instagram: '', no_social_media_presence: false, partner_status: 'pending')
+      partner.profile.update(website: '', facebook: '', twitter: '', instagram: '', no_social_media_presence: false)
       login_as(partner_user)
       visit partner_user_root_path
       click_on 'My Profile'


### PR DESCRIPTION
Resolves #5383

### Description

Remove the obsolete `partner_status` column from the `partner`_profiles` table.

### Type of change

* Clean Up

### How Has This Been Tested?

Since this is removal of an obsolete DB column, there were no specs to add. I performed some local acceptance testing to ensure interactions with partner profiles could still be completed successfully.
