### PR TITLE
Fix error when variable is computed

### DIFF
--- a/app/assets/stylesheets/simple_form-bootstrap/_form_floating_labels.scss
+++ b/app/assets/stylesheets/simple_form-bootstrap/_form_floating_labels.scss
@@ -70,7 +70,7 @@ $sf-floating-input-padding-y: $input-padding-y * 2 !default;
       background-color: $input-bg;
       padding: 0 0 0 $sf-floating-input-padding-x;
       margin-top: $input-border-width;
-      margin-left: $input-border-width * 2;
+      margin-left: calc($input-border-width * 2);
       width: 99%;
     }
   }


### PR DESCRIPTION

### Description
- `_form_floating_labels.scss` is based on Bootstrap 4. In Bootstrap 4 the variable `input-border-width` was defined as a set amount of pixels, it is now `var(--bs-border-width)` which needs `calc` to multiply by 2. 


### Type of change

* Bug fix (non-breaking change which fixes an issue)
