### PR TITLE
3805 partial Don't set partner_id when inviting existing users as partners.

### DIFF
--- a/app/services/partner_invite_service.rb
+++ b/app/services/partner_invite_service.rb
@@ -7,11 +7,6 @@ class PartnerInviteService
   end
 
   def call
-    existing_user = User.find_by(email: partner.email)
-    if existing_user && existing_user.partner_id.nil?
-      existing_user.update!(partner_id: partner.profile.id)
-    end
-
     partner.update!(status: 'invited')
     UserInviteService.invite(email: partner.email,
       name: partner.name,


### PR DESCRIPTION
Partial #3805 <!--fill issue number-->

### Description

Remove setting of user.partner_id in the case where we are inviting an existing user as a partner.

This is cleanup from the implementation of roles.   

However -- there is the question of why it wasn't done in the first place, so we should be thorough in functional testing..

Once this goes in,  we can do the final part of #3805,  which will be some cleanup of the user record.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
### How Has This Been Tested?

I've run the existing tests -- none of the ones that look relevant to the change broke.  

As well, I did the following sequence

As org_admin1,   create a new partner with the email org_admin2@example.com.   Invite them.  Accept the invitation (otherwise you are locked out).  Logged in as org_admin2,  check that you can switch to the new partner.

I also went through the request/distribution cycle once as that partner.  No obvious flaws, but this was definitely a light pass.

# NB 
I have *not*, as yet,  manually tested adding an existing user to an existing partner,   or adding an existing user as a partner.  
