### PR TITLE
5428 Sort vendor purchases by issued_at in reverse chronological order

### DIFF
--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -47,6 +47,7 @@ class VendorsController < ApplicationController
 
   def show
     @vendor = current_organization.vendors.includes(:purchases).find(params[:id])
+    @purchases = @vendor.purchases.order(issued_at: :desc)
   end
 
   def update

--- a/app/views/vendors/show.html.erb
+++ b/app/views/vendors/show.html.erb
@@ -74,7 +74,7 @@
               </tr>
               </thead>
               <tbody>
-              <% @vendor.purchases.order(issued_at: :desc).each do |purchase| %>
+              <% @purchases.each do |purchase| %>
                 <tr>
                   <td><%= purchase.issued_at.strftime("%m/%d/%Y") %></td>
                   <td><%= purchase.line_items.total %></td>

--- a/spec/requests/vendors_requests_spec.rb
+++ b/spec/requests/vendors_requests_spec.rb
@@ -134,8 +134,15 @@ RSpec.describe "Vendors", type: :request do
 
         get vendor_path(vendor)
 
-        expect(vendor.reload.purchases.order(issued_at: :desc).to_a).to eq([new_purchase, middle_purchase, old_purchase])
-        expect(response).to be_successful
+        old_date = old_purchase.issued_at.strftime("%m/%d/%Y")
+        middle_date = middle_purchase.issued_at.strftime("%m/%d/%Y")
+        new_date = new_purchase.issued_at.strftime("%m/%d/%Y")
+
+        dates = [new_date, middle_date, old_date]
+        dates.each { |date| expect(response.body).to include(date) }
+
+        expect(response.body.index(new_date)).to be < response.body.index(middle_date)
+        expect(response.body.index(middle_date)).to be < response.body.index(old_date)
       end
     end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5428  <!--fill issue number-->

### Description
We fixed the list of purchases in the vendor view to be in reverse chronological order by entered date (which is the issued_at date instead of the created_at) of purchased goods.  The issued_at date is the date when the goods were actually purchased on the store receipt (which is entered manually by a user) vs. just when the event was created (possibly weeks later).

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I tested this code locally and saw that the purchase dates are now being ordered correctly.  I have also created an automated test that appears to be passing.


### Screenshots
Before: 
<img width="1371" height="765" alt="image" src="https://github.com/user-attachments/assets/a2659d38-5e50-4c4a-ab47-126d6b289897" />


After:
<img width="1351" height="793" alt="image" src="https://github.com/user-attachments/assets/71252e3b-e9df-4e48-83e9-7b35caf5c96d" />
