### PR TITLE
Fix kits not updating

### DIFF
--- a/app/events/kit_allocate_event.rb
+++ b/app/events/kit_allocate_event.rb
@@ -20,7 +20,7 @@ class KitAllocateEvent < Event
   end
 
   def self.publish(kit, storage_location, quantity)
-    create(
+    create!(
       eventable: kit,
       group_id: "kit-allocate-#{kit.id}-#{SecureRandom.hex}",
       organization_id: kit.organization_id,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,6 +45,7 @@ class Event < ApplicationRecord
   def no_intervening_snapshot
     return if is_a?(SnapshotEvent)
     return unless eventable.respond_to?(:organization)
+    return if eventable.is_a?(Kit)
 
     intervening = SnapshotEvent.intervening(eventable)
     if intervening.present?

--- a/spec/events/inventory_aggregate_spec.rb
+++ b/spec/events/inventory_aggregate_spec.rb
@@ -385,6 +385,9 @@ RSpec.describe InventoryAggregate do
         {item_id: item1.id, quantity: 10},
         {item_id: item2.id, quantity: 3}
       ])
+      # it should work even if snapshot is after the kit
+      kit.update!(created_at: 1.week.ago)
+      SnapshotEvent.publish(organization)
 
       KitAllocateEvent.publish(kit, storage_location1.id, 2)
 


### PR DESCRIPTION
This is a regression when we stopped allowing intervening snapshots. In this case, kits were created before the initial snapshot so it's disallowing edits.

We don't care if a kit is older than the snapshot, so I'm disabling this check for kits.