### PR TITLE
[5432] Skip existing user email validation for account requests that are rejected or closed by admin

### DIFF
--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -94,6 +94,7 @@ class AccountRequest < ApplicationRecord
   end
 
   def email_not_already_used_by_user
+    return if rejected? || admin_closed?
     user = User.find_by(email: email)
     if user && (!organization || user.organization_id != organization.id)
       errors.add(:email, 'already used by an existing User')

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe AccountRequest, type: :model do
         expect(subject.valid?).to eq(false)
         expect(subject.errors.messages[:email]).to match_array(["already used by an existing User"])
       end
+
+      [:rejected, :admin_closed].each do |status|
+        context "when the status is #{status}" do
+          before { subject.status = status }
+
+          it 'allows the email' do
+            expect(subject).to be_valid
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #5432

### Description

When updating an AccountRequest record, the validation that checks for an existing user email address is skipped if the status is either `rejected` or `admin_closed`. Essentially the check does not need to be performed if the request is not being accepted. 

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested functionality in rails console and via the locally running application with no issues. 
