### PR TITLE
Fix issue where seed was intermittently failing part way through

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,7 +76,8 @@ Organization.all.find_each do |org|
 end
 
 def seed_random_item_with_name(organization, name)
-  base_items = BaseItem.all.map(&:to_h)
+  # Once we break the link between BaseItem and Item, we can remove the 'kit' BaseItem, and change this to BaseItem.all CLF 20251202
+  base_items = BaseItem.where.not(reporting_category: nil).map(&:to_h)
   base_item = Array.wrap(base_items).sample
   base_item[:name] = name
   organization.seed_items(base_item)


### PR DESCRIPTION

### Description
The seed was intermittently failing, causing there to be no transactions/history added to the organizations

Investigation revealed that the extra items added to the Second City bank were based on a random base item,  and that if the base  item it was based on had a null reporting category,  the item would not be created.   Later code fails unless there are 4 of these items.

This problem would go away eventually when we finish decoupling the items from base items, but in the meantime I have changed the collection of base items that the Second City Bank items are based on to only include the ones with a reporting category.   We could set this back to "all"  once we decouple items and base items.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I ran the seed several times without it failing.