### PR TITLE
5465 Remove "Saving" State to Allow Submit Buttons to Remain in Original State

### DIFF
--- a/app/javascript/controllers/audit_duplicates_controller.js
+++ b/app/javascript/controllers/audit_duplicates_controller.js
@@ -4,6 +4,15 @@ export default class extends Controller {
   connect() {
     this.boundHandleSubmit = this.handleSubmit.bind(this)
     this.element.addEventListener("submit", this.boundHandleSubmit)
+    
+    // Disable Rails UJS for this form to prevent "Saving" state
+    this.element.removeAttribute('data-remote')
+    
+    // Remove data-disable-with from all submit buttons
+    const buttons = this.element.querySelectorAll('input[type="submit"], button[type="submit"]')
+    buttons.forEach(button => {
+      button.removeAttribute('data-disable-with')
+    })
   }
 
   handleSubmit(event) {


### PR DESCRIPTION
Resolves 5465

### Description
When creating or editing an audit, if duplicate items are detected and the modal is shown, dismissing the modal without merging (by clicking "Make Changes" or the X button) leaves the "Save Progress" and "Confirm Audit" buttons stuck in a disabled "Saving" state.  Rails UJS automatically changes button text to "Saving" and disables buttons when form submission begins. 

I disabled Rails UJS for the audit form as "Saving" didn't really make sense on these buttons in this context.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Navigate to the Inventory Audit page
- Add the same item multiple times with different quantities
- Click "Save Progress" or "Confirm Audit"
- Duplicate items modal appears
- Click "Make Changes" or the X button to close the modal
- Observe that the submit buttons remain unchanged and no longer say "Saving"

### Screenshots
<img width="1851" height="951" alt="image" src="https://github.com/user-attachments/assets/cacbcb3d-ccc2-4225-aef1-c3ece896142d" />

