### PR TITLE
Switch to in-memory item selection to speed up export

### DIFF
--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -1,3 +1,5 @@
+# Don't technically need to pull in csv for the code itself,
+# but this ensures that the unit test can run in isolation
 require 'csv'
 
 module Exports


### PR DESCRIPTION
We pre-load distribution items, but when applying a sub-filter we were accidentally re-querying the database a bunch. This changes it to an in-memory filter.

* Unit tests of the CSV export pass
* Even better, on a production-dataset we exported all of 2025 for a user before and after and got identical files!!!!