### PR TITLE
Itemizable checks if the storage location changes, and updates inventory

### DIFF
--- a/app/services/itemizable_update_service.rb
+++ b/app/services/itemizable_update_service.rb
@@ -37,7 +37,7 @@ module ItemizableUpdateService
         # TODO once event sourcing has been out for long enough, we can safely remove this
         if Event.where(eventable: itemizable).none? || UpdateExistingEvent.where(eventable: itemizable).any?
           UpdateExistingEvent.publish(itemizable, previous, original_storage_location)
-        elsif inventory_changes?(previous, params[:line_items_attributes])
+        elsif inventory_changes?(previous, params[:line_items_attributes]) || itemizable.storage_location_id != original_storage_location.id
           event_class&.publish(itemizable)
         end
       end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5476 <!--fill issue number-->

### Description

I've updated the conditional logic in the `call` method of `ItemizableUpdateService` to detect changes in `storage_location_id`. 

Previously, the service only published a new event if the *quantities* of items changed (`inventory_changes?`). Now, it also publishes an event if the storage location has changed, ensuring the Inventory Aggregate correctly moves items from the old location to the new one.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I've added a new test case: `"should send an event when the storage location changes"`.
*   **Test Steps:**
    1.  Setup a `Donation` and publish its initial event.
    2.  Call `ItemizableUpdateService` with parameters that change the `storage_location_id` but keep the item quantities exactly the same.
    3.  **Assertion:** Verified that the event count increments (e.g., from 1 to 2), confirming that the service now recognizes the move and publishes the necessary event to update the inventory system.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

Previously, changing locations (Bulk Storage in this example) would not trigger an update on the inventory page. Now that same action updates to show the correct location

Before:
<img width="1476" height="1147" alt="image" src="https://github.com/user-attachments/assets/d3529524-37a4-4a3f-9a05-51ea25ad18f2" />
<img width="1788" height="155" alt="Screenshot 2026-01-28 at 11 10 07 PM" src="https://github.com/user-attachments/assets/ae332a78-a85d-4a02-9328-f1f17285b659" />



After:
<img width="1854" height="163" alt="Screenshot 2026-01-28 at 11 09 07 PM" src="https://github.com/user-attachments/assets/450ccb15-2c17-424c-bb0d-2cca6a1e6fd0" />


