### PR TITLE
Update visual indicator for CSV downloads

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -146,6 +146,15 @@ class ApplicationController < ActionController::Base
     @selected_date_range_label = helpers.date_range_label
   end
 
+  def handle_csv_export
+    return unless params[:export_csv]
+
+    session[:trigger_csv_download] = true
+    clean_params = request.query_parameters.except("export_csv")
+    redirect_url = clean_params.any? ? "#{request.path}?#{clean_params.to_query}" : request.path
+    redirect_to redirect_url
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -149,7 +149,7 @@ class ApplicationController < ActionController::Base
   def handle_csv_export
     return unless params[:export_csv]
 
-    session[:trigger_csv_download] = true
+    flash[:trigger_csv_download] = true
     clean_params = request.query_parameters.except("export_csv")
     redirect_url = clean_params.any? ? "#{request.path}?#{clean_params.to_query}" : request.path
     redirect_to redirect_url

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -9,6 +9,7 @@ class DistributionsController < ApplicationController
   include Validatable
 
   before_action :enable_turbo!, only: %i[new show]
+  before_action :handle_csv_export, only: [:index]
   skip_before_action :authenticate_user!, only: %i(calendar)
   skip_before_action :authorize_user, only: %i(calendar)
   skip_before_action :require_organization, only: %i(calendar)
@@ -40,12 +41,6 @@ class DistributionsController < ApplicationController
   end
 
   def index
-    if params[:export_csv]
-      session[:trigger_csv_download] = true
-      redirect_to distributions_path(request.query_parameters.except("export_csv"))
-      return
-    end
-
     setup_date_range_picker
 
     @highlight_id = session.delete(:created_distribution_id)

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -40,6 +40,12 @@ class DistributionsController < ApplicationController
   end
 
   def index
+    if params[:export_csv]
+      session[:trigger_csv_download] = true
+      redirect_to distributions_path(request.query_parameters.except("export_csv"))
+      return
+    end
+
     setup_date_range_picker
 
     @highlight_id = session.delete(:created_distribution_id)

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="toast"
+// Shows a toastr notification when the element is rendered.
+//
+// Usage:
+//   <div data-controller="toast" data-toast-message-value="Hello!" data-toast-type-value="info"></div>
+//
+export default class extends Controller {
+  static values = {
+    message: String,
+    type: { type: String, default: "info" },
+    timeout: { type: Number, default: 5000 },
+    position: { type: String, default: "toast-top-center" }
+  }
+
+  connect() {
+    const previousTimeout = toastr.options.timeOut;
+    const previousPosition = toastr.options.positionClass;
+    toastr.options.timeOut = this.timeoutValue;
+    toastr.options.positionClass = this.positionValue;
+    toastr[this.typeValue](this.messageValue);
+    toastr.options.timeOut = previousTimeout;
+    toastr.options.positionClass = previousPosition;
+  }
+}

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -153,7 +153,4 @@
   </div>
 </section>
 
-<% if session.delete(:trigger_csv_download) %>
-  <iframe src="<%= distributions_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)) %>" class="d-none"></iframe>
-  <div data-controller="toast" data-toast-message-value="Your CSV export is downloading!" class="d-none"></div>
-<% end %>
+<%= render "shared/csv_download" %>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -71,7 +71,7 @@
                   <%=
                     if @distributions.any?
                       download_button_to(
-                        distributions_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)),
+                        distributions_path(export_csv: true, filters: filter_params.merge(date_range: date_range_params)),
                         text: "Export Distributions"
                       )
                     end
@@ -152,3 +152,8 @@
     </div>
   </div>
 </section>
+
+<% if session.delete(:trigger_csv_download) %>
+  <iframe src="<%= distributions_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)) %>" class="d-none"></iframe>
+  <div data-controller="toast" data-toast-message-value="Your CSV export is downloading!" class="d-none"></div>
+<% end %>

--- a/app/views/shared/_csv_download.html.erb
+++ b/app/views/shared/_csv_download.html.erb
@@ -1,0 +1,5 @@
+<% if session.delete(:trigger_csv_download) %>
+  <% csv_url = "#{request.path}.csv#{"?#{request.query_string}" if request.query_string.present?}" %>
+  <iframe src="<%= csv_url %>" class="d-none"></iframe>
+  <div data-controller="toast" data-toast-message-value="Your CSV export is downloading!" class="d-none"></div>
+<% end %>

--- a/app/views/shared/_csv_download.html.erb
+++ b/app/views/shared/_csv_download.html.erb
@@ -1,5 +1,8 @@
-<% if session.delete(:trigger_csv_download) %>
+<% if flash[:trigger_csv_download] %>
   <% csv_url = "#{request.path}.csv#{"?#{request.query_string}" if request.query_string.present?}" %>
+  <%# We use a hidden iframe to trigger the CSV download in the background so the user stays on the
+      current page. The iframe loads the .csv version of the current URL, which causes the browser
+      to download the file without navigating away. %>
   <iframe src="<%= csv_url %>" class="d-none"></iframe>
   <div data-controller="toast" data-toast-message-value="Your CSV export is downloading!" class="d-none"></div>
 <% end %>

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe "Distributions", type: :request do
         expect(response).to be_successful
       end
 
+      context "with export_csv param" do
+        it "redirects then renders an iframe to trigger CSV download" do
+          get distributions_path(export_csv: true, foo: "bar")
+          expect(response).to redirect_to(distributions_path(foo: "bar"))
+          follow_redirect!
+          expect(response.body).to include("iframe")
+          expect(response.body).to include("distributions.csv?foo=bar")
+        end
+      end
+
       it "sums distribution totals accurately" do
         create(:distribution, :with_items, item_quantity: 5, organization: organization)
         create(:line_item, :distribution, itemizable_id: distribution.id, quantity: 7)

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -931,4 +931,20 @@ RSpec.feature "Distributions", type: :system do
     # will fail (the distribution is already complete) and show this error
     expect(page).not_to have_content("Sorry, we encountered an error when trying to mark this distribution as being completed")
   end
+
+  describe "CSV export", js: true do
+    before do
+      create(:distribution, :with_items, organization: organization)
+      visit distributions_path
+    end
+
+    it "downloads a CSV and shows a toast notification" do
+      click_on "Export Distributions"
+
+      wait_for_download
+      expect(downloads.length).to eq(1)
+      expect(download).to match(/Distributions.*\.csv/)
+      expect(page).to have_text("Your CSV export is downloading!")
+    end
+  end
 end


### PR DESCRIPTION
Experimental change to download button (on distributions for now) to show a toast notification that the download is being processed/downloading. It disappears after 5 seconds.

There is a second PR upcoming that applies this to all CSV download buttons, but the scope for this PR is to look at the pattern first and apply it only to the Distributions csv export.