### PR TITLE
Fix IDOR in Requests and Donations controllers (5509)

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -3,7 +3,7 @@ class DonationsController < ApplicationController
   before_action :authorize_admin, only: [:destroy]
 
   def print
-    @donation = Donation.find(params[:id])
+    @donation = current_organization.donations.find(params[:id])
     respond_to do |format|
       format.any do
         pdf = DonationPdf.new(current_organization, @donation)
@@ -53,7 +53,7 @@ class DonationsController < ApplicationController
   end
 
   def edit
-    @donation = Donation.find(params[:id])
+    @donation = current_organization.donations.find(params[:id])
     @donation.line_items.build
     @changes_disallowed = SnapshotEvent.intervening(@donation).present?
     @audit_performed_and_finalized = Audit.finalized_since?(@donation, @donation.storage_location_id) &&
@@ -63,12 +63,12 @@ class DonationsController < ApplicationController
   end
 
   def show
-    @donation = Donation.includes(line_items: :item).find(params[:id])
+    @donation = current_organization.donations.includes(line_items: :item).find(params[:id])
     @line_items = @donation.line_items
   end
 
   def update
-    @donation = Donation.find(params[:id])
+    @donation = current_organization.donations.find(params[:id])
     @original_source = @donation.source
     ItemizableUpdateService.call(itemizable: @donation,
       params: donation_params,

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -28,7 +28,7 @@ class RequestsController < ApplicationController
   end
 
   def show
-    @request = Request.find(params[:id])
+    @request = current_organization.requests.find(params[:id])
     @item_requests = @request.item_requests.includes(:item)
 
     @inventory = View::Inventory.new(@request.organization_id)
@@ -42,7 +42,7 @@ class RequestsController < ApplicationController
   # and will move the user to the new distribution page with a
   # pre-filled distribution containing all the requested items.
   def start
-    request = Request.find(params[:id])
+    request = current_organization.requests.find(params[:id])
     begin
       request.status_started!
       flash[:notice] = "Request started"

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -277,6 +277,36 @@ RSpec.describe "Donations", type: :request do
       end
     end
 
+    describe "when accessing a donation from another organization" do
+      let(:other_organization) { create(:organization) }
+      let(:other_donation) { create(:donation, organization: other_organization, comment: "Original comment") }
+
+      it "returns not found for show" do
+        get donation_path(id: other_donation.id)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for edit" do
+        get edit_donation_path(id: other_donation.id)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for print" do
+        get print_donation_path(id: other_donation.id)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for update and does not change donation" do
+        put donation_path(id: other_donation.id, donation: {comment: "Changed comment"})
+        
+        expect(response).to have_http_status(:not_found)
+        expect(other_donation.reload.comment).to eq("Original comment")
+      end
+    end
+
     describe "GET #edit" do
       it 'should not allow edits if there is an intervening snapshot' do
         donation = FactoryBot.create(:donation,

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe "Donations", type: :request do
 
       it "returns not found for update and does not change donation" do
         put donation_path(id: other_donation.id, donation: {comment: "Changed comment"})
-        
+
         expect(response).to have_http_status(:not_found)
         expect(other_donation.reload.comment).to eq("Original comment")
       end

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -77,8 +77,24 @@ RSpec.describe 'Requests', type: :request do
         end
       end
 
+      context 'When the request belongs to another organization' do
+        let(:other_organization) { create(:organization) }
+        let(:other_request) { create(:request, organization: other_organization) }
+
+        it 'responds with not found' do
+          get request_path(other_request)
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
       context 'When organization has a default storage location' do
-        let(:request) { create(:request, organization: create(:organization, default_storage_location: 1)) }
+        let(:storage_location) { create(:storage_location, organization: organization) }
+        let(:request) do
+          organization.update!(default_storage_location: storage_location.id)
+          create(:request, organization: organization)
+        end
+        
         it 'shows the column Default storage location inventory' do
           get request_path(request)
 
@@ -164,6 +180,19 @@ RSpec.describe 'Requests', type: :request do
       context 'When the request does not exist' do
         it 'responds with not found' do
           post start_request_path(1)
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context 'When the request belongs to another organization' do
+        let(:other_organization) { create(:organization) }
+        let(:other_request) { create(:request, organization: other_organization) }
+
+        it 'responds with not found and does not change status' do
+          expect do
+            post start_request_path(other_request)
+          end.not_to change { other_request.reload.status }
 
           expect(response).to have_http_status(:not_found)
         end

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Requests', type: :request do
           organization.update!(default_storage_location: storage_location.id)
           create(:request, organization: organization)
         end
-        
+
         it 'shows the column Default storage location inventory' do
           get request_path(request)
 


### PR DESCRIPTION
Partially resolves #5509 (other controller fixes in #5514)

### Description

Scopes Requests and Donations lookups to the current organization to prevent cross‑org access (IDOR). Adds request specs for cross‑org 404 behavior and updates the request show spec to use a valid default storage location.

Removes tenant isolation risk for Requests and Donations lookups.

Tradeoffs: 404s for cross‑org IDs instead of showing the record.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- `bundle exec rspec spec/requests/requests_requests_spec.rb spec/requests/donations_requests_spec.rb` - all green.
- When running the full test suite, experienced some flaky test failures, which I believe are currently being sorted out in #5516.