### PR TITLE
Fix flaky organization_spec.rb and donnation_summary_spec.rb specs

### DIFF
--- a/app/models/concerns/issued_at.rb
+++ b/app/models/concerns/issued_at.rb
@@ -21,7 +21,7 @@ module IssuedAt
   end
 
   def issued_at_cannot_be_further_than_1_year
-    if issued_at.present? && issued_at > DateTime.now.next_year
+    if issued_at.present? && issued_at > DateTime.current.next_year
       errors.add(:issued_at, "cannot be more than 1 year in the future")
     end
   end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     source { Donation::SOURCES[:misc] }
     storage_location
     organization { Organization.try(:first) || create(:organization) }
-    issued_at { Time.current }
+    issued_at { DateTime.current }
 
     factory :manufacturer_donation do
       manufacturer

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -107,7 +107,6 @@ RSpec.describe Organization, type: :model do
 
     describe 'users' do
       subject { organization.users }
-      let(:organization) { create(:organization) }
 
       context 'when a organizaton has a user that has two roles' do
         let(:user) { create(:user) }
@@ -361,7 +360,6 @@ RSpec.describe Organization, type: :model do
     end
 
     context 'with invisible items' do
-      let!(:organization) { create(:organization) }
       let!(:item1) { create(:item, organization: organization, active: true, visible_to_partners: true) }
       let!(:item2) { create(:item, organization: organization, active: true, visible_to_partners: false) }
       let!(:item3) { create(:item, organization: organization, active: false, visible_to_partners: true) }
@@ -401,21 +399,20 @@ RSpec.describe Organization, type: :model do
   describe 'earliest reporting year' do
     # re 2813 update annual report -- allowing an earliest reporting year will let us do system testing and staging for annual reports
     it 'is the organization created year if no associated data' do
-      org = create(:organization)
-      expect(org.earliest_reporting_year).to eq(org.created_at.year)
+      expect(organization.earliest_reporting_year).to eq(organization.created_at.year)
     end
+
     it 'is the year of the earliest of donation, purchase, or distribution if they are earlier ' do
-      org = create(:organization)
-      create(:donation, organization: org, issued_at: 364.days.from_now)
-      create(:purchase, organization: org, issued_at: 364.days.from_now)
-      create(:distribution, organization: org, issued_at: 364.days.from_now)
-      expect(org.earliest_reporting_year).to eq(org.created_at.year)
-      create(:donation, organization: org, issued_at: 5.years.ago)
-      expect(org.earliest_reporting_year).to eq(5.years.ago.year)
-      create(:purchase, organization: org, issued_at: 6.years.ago)
-      expect(org.earliest_reporting_year).to eq(6.years.ago.year)
-      create(:purchase, organization: org, issued_at: 7.years.ago)
-      expect(org.earliest_reporting_year).to eq(7.years.ago.year)
+      create(:donation, organization: organization, issued_at: 364.days.from_now)
+      create(:purchase, organization: organization, issued_at: 364.days.from_now)
+      create(:distribution, organization: organization, issued_at: 364.days.from_now)
+      expect(organization.earliest_reporting_year).to eq(organization.created_at.year)
+      create(:donation, organization: organization, issued_at: 5.years.ago)
+      expect(organization.earliest_reporting_year).to eq(5.years.ago.year)
+      create(:purchase, organization: organization, issued_at: 6.years.ago)
+      expect(organization.earliest_reporting_year).to eq(6.years.ago.year)
+      create(:purchase, organization: organization, issued_at: 7.years.ago)
+      expect(organization.earliest_reporting_year).to eq(7.years.ago.year)
     end
   end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -403,16 +403,20 @@ RSpec.describe Organization, type: :model do
     end
 
     it 'is the year of the earliest of donation, purchase, or distribution if they are earlier ' do
-      create(:donation, organization: organization, issued_at: 364.days.from_now)
-      create(:purchase, organization: organization, issued_at: 364.days.from_now)
-      create(:distribution, organization: organization, issued_at: 364.days.from_now)
-      expect(organization.earliest_reporting_year).to eq(organization.created_at.year)
-      create(:donation, organization: organization, issued_at: 5.years.ago)
-      expect(organization.earliest_reporting_year).to eq(5.years.ago.year)
-      create(:purchase, organization: organization, issued_at: 6.years.ago)
-      expect(organization.earliest_reporting_year).to eq(6.years.ago.year)
-      create(:purchase, organization: organization, issued_at: 7.years.ago)
-      expect(organization.earliest_reporting_year).to eq(7.years.ago.year)
+      freeze_time do
+        create(:donation, organization: organization, issued_at: DateTime.current.next_year - 1.day)
+        create(:purchase, organization: organization, issued_at: DateTime.current.next_year - 1.day)
+        create(:distribution, organization: organization, issued_at: DateTime.current.next_year - 1.day)
+        expect(organization.earliest_reporting_year).to eq(organization.created_at.year)
+        create(:donation, organization: organization, issued_at: 5.years.ago)
+        expect(organization.earliest_reporting_year).to eq(5.years.ago.year)
+        create(:purchase, organization: organization, issued_at: 6.years.ago)
+        expect(organization.earliest_reporting_year).to eq(6.years.ago.year)
+        create(:purchase, organization: organization, issued_at: 7.years.ago)
+        expect(organization.earliest_reporting_year).to eq(7.years.ago.year)
+      ensure
+        travel_back
+      end
     end
   end
 

--- a/spec/requests/reports/donations_summary_spec.rb
+++ b/spec/requests/reports/donations_summary_spec.rb
@@ -8,15 +8,16 @@ RSpec.describe "Reports::DonationsSummary", type: :request do
     end
 
     describe "time display" do
-      let!(:donation) { create(:donation, :with_items, issued_at: 1.day.ago) }
-
-      before do
-        freeze_time
-        get reports_donations_summary_path
-      end
-
       it "uses issued_at for the relative time display, not created_at" do
-        expect(response.body).to include("1 day ago")
+        freeze_time do
+          create(:donation, :with_items, issued_at: DateTime.current - 1.day)
+
+          get reports_donations_summary_path
+
+          expect(response.body).to include("1 day ago")
+        ensure
+          travel_back
+        end
       end
     end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves https://github.com/rubyforgood/human-essentials/issues/5515

### Description

Testing against time related scenarios can lead to flakiness. I couldn't reproduce the failures locally but based on my previous experience of fixing flaky tests, I:

- changed code and tests to use `DateTime.current` instead of `DateTime.now`. Rails extends the Time and DateTime objects, and includes the `current`` property for retrieving the time the Rails environment is set to (default = UTC), as opposed to the server time (could be anything). See https://stackoverflow.com/a/18811305
- updated tests and factories to use the same DateTime helper as the model does
- Wrap entire tests in a `freeze_time` block to ensure the dates are frozen when asserting against them.
- I removed extra organization created factories to reuse the existing one

### Type of change

* Flaky test fix

### How Has This Been Tested?

I could not reproduce the failure at all locally. All tests pass locally. But I believe this should help CI get more stable.