### PR TITLE
5547 Stream Distributions CSV instead of pregenerating

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -75,8 +75,8 @@ class DistributionsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_stream filename: "Distributions-#{Time.zone.today}.csv" do |stream| 
-          Exports::ExportDistributionsCSVService.new(distributions: @distributions.includes(line_items: :item), organization: current_organization, filters: scope_filters).generate_csv_stream do |row| 
+        send_stream filename: "Distributions-#{Time.zone.today}.csv" do |stream|
+          Exports::ExportDistributionsCSVService.new(distributions: @distributions.includes(line_items: :item), organization: current_organization, filters: scope_filters).generate_csv_stream do |row|
             stream.write(row)
           end
         end

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -7,6 +7,7 @@ class DistributionsController < ApplicationController
   include DateRangeHelper
   include DistributionHelper
   include Validatable
+  include ActionController::Live
 
   before_action :enable_turbo!, only: %i[new show]
   skip_before_action :authenticate_user!, only: %i(calendar)
@@ -74,7 +75,11 @@ class DistributionsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data Exports::ExportDistributionsCSVService.new(distributions: @distributions.includes(line_items: :item), organization: current_organization, filters: scope_filters).generate_csv, filename: "Distributions-#{Time.zone.today}.csv"
+        send_stream filename: "Distributions-#{Time.zone.today}.csv" do |stream| 
+          Exports::ExportDistributionsCSVService.new(distributions: @distributions.includes(line_items: :item), organization: current_organization, filters: scope_filters).generate_csv_stream do |row| 
+            stream.write(row)
+          end
+        end
       end
     end
   end

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -42,7 +42,7 @@ module Exports
     def generate_csv_stream
       yield CSV.generate_line(base_headers + item_headers)
 
-      distributions.find_each(batch_size: 500) do |distribution|
+      distributions.each do |distribution|
         yield CSV.generate_line(build_row_data(distribution))
       end
     end

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -39,6 +39,14 @@ module Exports
       csv_data
     end
 
+    def generate_csv_stream
+      yield CSV.generate_line(base_headers + item_headers)
+
+      distributions.find_each(batch_size: 500) do |distribution|
+        yield CSV.generate_line(build_row_data(distribution))
+      end
+    end
+
     private
 
     attr_reader :distributions

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -5,8 +5,14 @@ RSpec.describe Exports::ExportDistributionsCSVService do
   let(:include_in_kind_values) { false }
   let(:include_packages) { false }
 
-  describe '#generate_csv' do
-    subject { described_class.new(distributions: distributions, organization: organization, filters: filters).generate_csv }
+  describe '#generate_csv_stream' do
+    subject do
+      rows = ""
+      described_class.new(distributions: distributions, organization: organization, filters: filters).generate_csv_stream do |row|
+        rows << row
+      end
+      rows
+    end
 
     let(:duplicate_item) { create(:item, name: "Dupe Item", value_in_cents: 300, organization: organization, package_size: 2) }
 
@@ -174,7 +180,7 @@ RSpec.describe Exports::ExportDistributionsCSVService do
     end
 
     context 'when there are no distributions but the report is requested' do
-      subject { described_class.new(distributions: [], organization: organization, filters: filters).generate_csv }
+      let(:distributions) { [] }
       it 'returns a csv with only headers and no rows' do
         csv = <<~CSV
           Partner,Initial Allocation,Scheduled for,Source Inventory,Total Number of #{item_name},Total Value of #{item_name},Delivery Method,Shipping Cost,Status,Agency Representative,Comments,Reporting Category,Dupe Item

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe Exports::ExportDistributionsCSVService do
 
   describe '#generate_csv_stream' do
     subject do
-      rows = ""
-      described_class.new(distributions: distributions, organization: organization, filters: filters).generate_csv_stream do |row|
-        rows << row
-      end
-      rows
+      Proc.new { described_class.new(distributions: distributions, organization: organization, filters: filters).generate_csv_stream }
     end
 
     let(:duplicate_item) { create(:item, name: "Dupe Item", value_in_cents: 300, organization: organization, package_size: 2) }
@@ -66,7 +62,9 @@ RSpec.describe Exports::ExportDistributionsCSVService do
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 2,Disposable Diapers,0,0,2,0,0
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 3,Disposable Diapers,0,0,0,0,3
         CSV
-        expect(subject).to eq(csv)
+        subject do |subject_row|
+          expect(row).to eq(csv.next)
+        end
       end
     end
 
@@ -81,7 +79,9 @@ RSpec.describe Exports::ExportDistributionsCSVService do
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 2,Disposable Diapers,0,0.00,0,0.00,2,60.00,0,0.00,0,0.00
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 3,Disposable Diapers,0,0.00,0,0.00,0,0.00,0,0.00,3,120.00
         CSV
-        expect(subject).to eq(csv)
+        subject do |subject_row|
+          expect(row).to eq(csv.next)
+        end
       end
     end
 
@@ -96,7 +96,9 @@ RSpec.describe Exports::ExportDistributionsCSVService do
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 2,Disposable Diapers,0,0,0,0,2,0,0,0,0,0
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 3,Disposable Diapers,0,0,0,0,0,0,0,0,3,0
         CSV
-        expect(subject).to eq(csv)
+        subject do |subject_row|
+          expect(row).to eq(csv.next)
+        end
       end
     end
 
@@ -112,7 +114,9 @@ RSpec.describe Exports::ExportDistributionsCSVService do
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 2,Disposable Diapers,0,0.00,0,0,0.00,0,2,60.00,0,0,0.00,0,0,0.00,0
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 3,Disposable Diapers,0,0.00,0,0,0.00,0,0,0.00,0,0,0.00,0,3,120.00,0
         CSV
-        expect(subject).to eq(csv)
+        subject do |subject_row|
+          expect(row).to eq(csv.next)
+        end
       end
     end
 
@@ -134,12 +138,23 @@ RSpec.describe Exports::ExportDistributionsCSVService do
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 2,Disposable Diapers,0,0,2,0,0,0
           #{partner.name},04/04/2025,04/04/2025,#{storage_location.name},0,0.0,shipped,$15.01,scheduled,"",comment 3,Disposable Diapers,0,0,0,0,3,0
         CSV
-        expect(subject).to eq(csv)
+
+        subject do |subject_row|
+          expect(row).to eq(csv.next)
+        end
       end
     end
 
     context 'reporting category column' do
       let(:filters) { {} }
+
+      subject do
+        rows = ""
+        described_class.new(distributions: distributions, organization: organization, filters: filters).generate_csv_stream do |row|
+          rows << row
+        end
+        rows
+      end
 
       it 'includes a Reporting Category column with the humanized category for each distribution' do
         csv = CSV.parse(subject, headers: true)
@@ -185,7 +200,9 @@ RSpec.describe Exports::ExportDistributionsCSVService do
         csv = <<~CSV
           Partner,Initial Allocation,Scheduled for,Source Inventory,Total Number of #{item_name},Total Value of #{item_name},Delivery Method,Shipping Cost,Status,Agency Representative,Comments,Reporting Category,Dupe Item
         CSV
-        expect(subject).to eq(csv)
+        subject do |subject_row|
+          expect(row).to eq(csv.next)
+        end
       end
     end
   end

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Exports::ExportDistributionsCSVService do
 
   describe '#generate_csv_stream' do
     subject do
-      Proc.new { described_class.new(distributions: distributions, organization: organization, filters: filters).generate_csv_stream }
+      proc { described_class.new(distributions: distributions, organization: organization, filters: filters).generate_csv_stream }
     end
 
     let(:duplicate_item) { create(:item, name: "Dupe Item", value_in_cents: 300, organization: organization, package_size: 2) }


### PR DESCRIPTION
Resolves #5477

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Stream the exporting of the Distributions CSV instead of generating the CSV before download. This allows download to start immediately and at this point the download can occur as long as the client wants.

### Type of change

<!-- Please delete options that are not relevant. -->
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

- Changed the rspec to handle streams

Another test that I did was to simulate a large download with the following code on my local env.

```
1000.times do
  distributions.each do |distribution|
    yield CSV.generate_line(build_row_data(distribution))
  end
end
```

This downloaded a 3.5 MB file over >30 seconds.