### PR TITLE
fix: use date safely within validation window in organization spec

### DIFF
--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -404,9 +404,9 @@ RSpec.describe Organization, type: :model do
 
     it 'is the year of the earliest of donation, purchase, or distribution if they are earlier ' do
       freeze_time do
-        create(:donation, organization: organization, issued_at: DateTime.current.next_year - 1.day)
-        create(:purchase, organization: organization, issued_at: DateTime.current.next_year - 1.day)
-        create(:distribution, organization: organization, issued_at: DateTime.current.next_year - 1.day)
+        create(:donation, organization: organization, issued_at: 6.months.from_now)
+        create(:purchase, organization: organization, issued_at: 6.months.from_now)
+        create(:distribution, organization: organization, issued_at: 6.months.from_now)
         expect(organization.earliest_reporting_year).to eq(organization.created_at.year)
         create(:donation, organization: organization, issued_at: 5.years.ago)
         expect(organization.earliest_reporting_year).to eq(5.years.ago.year)


### PR DESCRIPTION
## Summary

The test at `organization_spec.rb:407` uses `DateTime.current.next_year - 1.day` for the `issued_at` field, which sits right at the boundary of the `issued_at_cannot_be_further_than_1_year` validation. This causes the `rspec (2, 0)` CI check to fail.

Changed to `6.months.from_now` which keeps the same test intent (a future date that passes validation) while staying well within the allowed window.

## Test plan

- [x] `rspec spec/models/organization_spec.rb:405` passes
- [ ] Full `rspec (2, 0)` CI shard passes