### PR TITLE
Fix default purchase correction to use recorded location instead of org default (5536)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,6 +126,6 @@ module ApplicationHelper
   end
 
   def default_location(source_object)
-    current_organization.default_storage_location || source_object.storage_location_id.presence || current_organization.intake_location
+    source_object.storage_location_id.presence || current_organization.default_storage_location || current_organization.intake_location
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -151,6 +151,14 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to eq(2) }
     end
 
+    context "returns source object's storage_location_id even when org has different default" do
+      let(:organization) { build(:organization, default_storage_location: 42) }
+      let(:purchase) { build(:purchase, storage_location_id: 1) }
+      subject { helper.default_location(purchase) }
+
+      it { is_expected.to eq(1) }
+    end
+
     context "returns current_organization intake_location if storage_location_id is not present" do
       let(:organization) { build(:organization, intake_location: 1) }
       let(:purchase) { build(:purchase, storage_location_id: nil) }


### PR DESCRIPTION
Resolves #5536

### Description

When correcting a purchase, the storage location dropdown was incorrectly defaulting to the organization's default storage location, instead of the location recorded on the existing purchase.

**Root cause:** The `default_location` helper in `ApplicationHelper` prioritized `current_organization.default_storage_location` before checking the source object's `storage_location_id`.

**Fix:** Reordered the logic to check the source object's `storage_location_id` first, falling back to org defaults only when no location is recorded.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Unit test added in `spec/helpers/application_helper_spec.rb`, verifying that `default_location` returns the source object's `storage_location_id` even when the organization has a different default.