### PR TITLE
Generalize duplicate modal and use it for kits

### DIFF
--- a/app/javascript/controllers/duplicate_items_controller.js
+++ b/app/javascript/controllers/duplicate_items_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = ["itemSubmitButton"]
+
   connect() {
     this.boundHandleSubmit = this.handleSubmit.bind(this)
     this.element.addEventListener("submit", this.boundHandleSubmit)
@@ -18,11 +20,7 @@ export default class extends Controller {
   handleSubmit(event) {
     const submitter = event.submitter
 
-    if (!submitter?.name) return
-    if (!submitter.name.includes('save_progress') && 
-        !submitter.name.includes('confirm_audit')) {
-      return
-    }
+    if (!this.itemSubmitButtonTargets.includes(submitter)) return
 
     event.preventDefault()
     

--- a/app/views/audits/_form.html.erb
+++ b/app/views/audits/_form.html.erb
@@ -13,7 +13,7 @@
               <div class="box-header with-border">
               </div>
               <div class="box-body">
-                <%= simple_form_for @audit, data: { controller: "form-input audit-duplicates" }, html: {class: "storage-location-required"} do |f| %>
+                <%= simple_form_for @audit, data: { controller: "form-input duplicate-items" }, html: {class: "storage-location-required"} do |f| %>
                   <%= render partial: "storage_locations/source", object: f, locals: { label: "Storage location", error: "What storage location are you auditing?", include_omitted_items: true } %>
                   <fieldset style="margin-bottom: 2rem;">
                     <legend>Items in this audit</legend>
@@ -33,8 +33,9 @@
                   <div class="card-footer">
                     <%= submit_button({ text: 'Confirm Audit', name: 'confirm_audit', icon: 'check-circle', align: 'left', size: 'md'}, {
                         confirm: "Are you sure?\n\nPlease note that this audit must also be finalized by someone with organization admin rights before changes to inventory will take place.\n\nWe strongly recommend completing that step before doing any further actions that affect inventory.",
+                        "duplicate-items-target": "itemSubmitButton"
                     }) %>
-                    <%= submit_button({text: 'Save Progress', name: 'save_progress', size: 'md'}) %>
+                    <%= submit_button({text: 'Save Progress', name: 'save_progress', size: 'md'}, {"duplicate-items-target": "itemSubmitButton"}) %>
                   </div>
                 <% end %>
                 </div>

--- a/app/views/kits/_form.html.erb
+++ b/app/views/kits/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @kit, remote: request.xhr?, data: { controller: "form-input" }, html: { class: 'form-horizontal' } do |f| %>
+<%= simple_form_for @kit, remote: request.xhr?, data: { controller: "form-input duplicate-items" }, html: { class: 'form-horizontal' } do |f| %>
   <section class="content">
     <div class="container-fluid">
       <div class="row">
@@ -36,7 +36,7 @@
             </div>
             <div class="card-footer">
               <p><b>NB: You will not be able to change the composition of the kit once saved. Partner visibility and name can be changed via the kit's item.</b></p>
-              <%= submit_button %>
+              <%= submit_button({}, {"duplicate-items-target": "itemSubmitButton"}) %>
             </div>
           </div>
         </div>

--- a/spec/system/kit_system_spec.rb
+++ b/spec/system/kit_system_spec.rb
@@ -226,4 +226,51 @@ RSpec.describe "Kit management", type: :system do
       expect(page).to have_content(item.name)
     end
   end
+
+  describe "when duplicate items" do
+    it "detects duplicate items and shows modal", js: true do
+      # Disable server-side validation to test JS modal
+      #allow_any_instance_of(Audit).to receive(:line_items_unique_by_item_id)
+      visit new_kit_path
+      click_link "New Kit"
+
+      kit_traits = attributes_for(:kit)
+      fill_in "Name", with: kit_traits[:name]
+      find(:css, '#kit_value_in_dollars').set('10.10')
+      
+      item = Item.last
+
+      # Add first entry for the item
+      select item.name, from: "item_line_items_attributes_0_item_id"
+      fill_in "item_line_items_attributes_0_quantity", with: "10"
+      
+      # Add a new line item row
+      find("[data-form-input-target='addButton']").click
+      
+      # Add second entry for the same item
+      within all('.line_item_section').last do
+        item_select = find('select[name*="[item_id]"]')
+        select item.name, from: item_select[:id]
+        quantity_input = find('input[name*="[quantity]"]')
+        fill_in quantity_input[:id], with: "15"
+      end
+      
+      # Try to save - should trigger duplicate detection modal
+      click_button "Save"
+      
+      # JavaScript modal should appear
+      expect(page).to have_css("#duplicateItemsModal", visible: true)
+      expect(page).to have_content("Multiple Item Entries Detected")
+      expect(page).to have_content("Merge Items")
+      expect(page).to have_content("Make Changes")
+      
+      
+      # Test merge functionality
+      click_button "Merge Items"
+      
+      expect(page.find(".alert")).to have_content "Kit created successfully"
+      expect(page).to have_content(kit_traits[:name])
+      expect(page).to have_content("25 #{item.name}")
+    end
+  end
 end

--- a/spec/system/kit_system_spec.rb
+++ b/spec/system/kit_system_spec.rb
@@ -229,24 +229,22 @@ RSpec.describe "Kit management", type: :system do
 
   describe "when duplicate items" do
     it "detects duplicate items and shows modal", js: true do
-      # Disable server-side validation to test JS modal
-      #allow_any_instance_of(Audit).to receive(:line_items_unique_by_item_id)
       visit new_kit_path
       click_link "New Kit"
 
       kit_traits = attributes_for(:kit)
       fill_in "Name", with: kit_traits[:name]
       find(:css, '#kit_value_in_dollars').set('10.10')
-      
+
       item = Item.last
 
       # Add first entry for the item
       select item.name, from: "item_line_items_attributes_0_item_id"
       fill_in "item_line_items_attributes_0_quantity", with: "10"
-      
+
       # Add a new line item row
       find("[data-form-input-target='addButton']").click
-      
+
       # Add second entry for the same item
       within all('.line_item_section').last do
         item_select = find('select[name*="[item_id]"]')
@@ -254,20 +252,19 @@ RSpec.describe "Kit management", type: :system do
         quantity_input = find('input[name*="[quantity]"]')
         fill_in quantity_input[:id], with: "15"
       end
-      
+
       # Try to save - should trigger duplicate detection modal
       click_button "Save"
-      
+
       # JavaScript modal should appear
       expect(page).to have_css("#duplicateItemsModal", visible: true)
       expect(page).to have_content("Multiple Item Entries Detected")
       expect(page).to have_content("Merge Items")
       expect(page).to have_content("Make Changes")
-      
-      
+
       # Test merge functionality
       click_button "Merge Items"
-      
+
       expect(page.find(".alert")).to have_content "Kit created successfully"
       expect(page).to have_content(kit_traits[:name])
       expect(page).to have_content("25 #{item.name}")


### PR DESCRIPTION
Work toward #5464 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

generalized the duplicate modal from the audit controller to be able to be reused in other locations. For this PR, I only have kits using it, but there are other potential places to use this duplicate modal. This can be done in follow-up PRs.

### Type of change
* Bug fix (non-breaking change which fixes an issue)
### How Has This Been Tested?
This has been tested by running the app locally and writing a system spec

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
﻿
<img width="1159" height="679" alt="image" src="https://github.com/user-attachments/assets/56305880-1e59-4122-b0b8-45b307306de5" />
