### PR TITLE
Refactor Requests controller

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -12,7 +12,7 @@ class RequestsController < ApplicationController
   end
 
   def show
-   @request_info = View::RequestInfo.from_params(params:, organization: current_organization)
+    @request_info = View::RequestInfo.from_params(params:, organization: current_organization)
   end
 
   # Clicking the "New Distribution" button will set the the request to started

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -3,27 +3,11 @@ class RequestsController < ApplicationController
   def index
     setup_date_range_picker
 
-    @requests = current_organization
-                .ordered_requests
-                .undiscarded
-                .during(helpers.selected_range)
-                .class_filter(filter_params)
-    @unfulfilled_requests_count = current_organization.requests.where(status: [:pending, :started]).during(helpers.selected_range).class_filter(filter_params).count
-    @paginated_requests = @requests.includes(:partner).page(params[:page])
-    @calculate_product_totals = RequestsTotalItemsService.new(requests: @requests).calculate
-    @items = current_organization.items.alphabetized.select(:id, :name)
-    @partners = current_organization.partners.alphabetized.select(:id, :name, :status)
-    @statuses = Request.statuses.transform_keys(&:humanize)
-    @partner_users = User.where(id: @paginated_requests.map(&:partner_user_id)).select(:id, :name, :email)
-    @request_types = Request.request_types.transform_keys(&:humanize)
-    @selected_request_type = filter_params[:by_request_type]
-    @selected_request_item = filter_params[:by_request_item_id]
-    @selected_partner = filter_params[:by_partner]
-    @selected_status = filter_params[:by_status]
+    @request_info = View::Requests.from_params(params: params, organization: current_organization, helpers: helpers)
 
     respond_to do |format|
       format.html
-      format.csv { send_data Exports::ExportRequestService.new(@requests).generate_csv, filename: "Requests-#{Time.zone.today}.csv" }
+      format.csv { send_data Exports::ExportRequestService.new(@request_info.requests).generate_csv, filename: "Requests-#{Time.zone.today}.csv" }
     end
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -12,7 +12,7 @@ class RequestsController < ApplicationController
   end
 
   def show
-    @request_info = View::RequestInfo.from_params(params:, organization: current_organization)
+    @request_info = View::RequestInfo.new(params:, organization: current_organization)
   end
 
   # Clicking the "New Distribution" button will set the the request to started

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -3,7 +3,7 @@ class RequestsController < ApplicationController
   def index
     setup_date_range_picker
 
-    @requests_info = View::Requests.from_params(params: params, organization: current_organization, helpers: helpers)
+    @requests_info = View::Requests.new(params: params, organization: current_organization, helpers: helpers)
 
     respond_to do |format|
       format.html

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -3,23 +3,16 @@ class RequestsController < ApplicationController
   def index
     setup_date_range_picker
 
-    @request_info = View::Requests.from_params(params: params, organization: current_organization, helpers: helpers)
+    @requests_info = View::Requests.from_params(params: params, organization: current_organization, helpers: helpers)
 
     respond_to do |format|
       format.html
-      format.csv { send_data Exports::ExportRequestService.new(@request_info.requests).generate_csv, filename: "Requests-#{Time.zone.today}.csv" }
+      format.csv { send_data Exports::ExportRequestService.new(@requests_info.requests).generate_csv, filename: "Requests-#{Time.zone.today}.csv" }
     end
   end
 
   def show
-    @request = current_organization.requests.find(params[:id])
-    @item_requests = @request.item_requests.includes(:item)
-
-    @inventory = View::Inventory.new(@request.organization_id)
-    @default_storage_location = @request.partner.default_storage_location_id || @request.organization.default_storage_location
-    @location = StorageLocation.find_by(id: @default_storage_location)
-
-    @custom_units = Flipper.enabled?(:enable_packs) && @request.item_requests.any? { |item| item.request_unit }
+   @request_info = View::RequestInfo.from_params(params:, organization: current_organization)
   end
 
   # Clicking the "New Distribution" button will set the the request to started

--- a/app/models/view/donations.rb
+++ b/app/models/view/donations.rb
@@ -31,7 +31,6 @@ module View
           .includes(:storage_location,
             :donation_site,
             :product_drive,
-            :product_drive_participant,
             :manufacturer,
             line_items: [:item])
           .order(created_at: :desc)

--- a/app/models/view/request_info.rb
+++ b/app/models/view/request_info.rb
@@ -2,7 +2,6 @@ module View
   RequestInfo = Data.define(
     :request
   ) do
-
     class << self
       def from_params(params:, organization:)
         request = organization.requests.find(params[:id])

--- a/app/models/view/request_info.rb
+++ b/app/models/view/request_info.rb
@@ -1,0 +1,34 @@
+module View
+  RequestInfo = Data.define(
+    :request
+  ) do
+
+    class << self
+      def from_params(params:, organization:)
+        request = organization.requests.find(params[:id])
+
+        new(request:)
+      end
+    end
+
+    def item_requests
+      request.item_requests.includes(:item)
+    end
+
+    def inventory
+      View::Inventory.new(request.organization_id)
+    end
+
+    def default_storage_location
+      request.partner.default_storage_location_id || request.organization.default_storage_location
+    end
+
+    def location
+      StorageLocation.find_by(id: default_storage_location)
+    end
+
+    def custom_units
+      Flipper.enabled?(:enable_packs) && request.item_requests.any? { |item| item.request_unit }
+    end
+  end
+end

--- a/app/models/view/request_info.rb
+++ b/app/models/view/request_info.rb
@@ -1,29 +1,29 @@
 module View
-  RequestInfo = Data.define(
-    :request
-  ) do
-    class << self
-      def from_params(params:, organization:)
-        request = organization.requests.find(params[:id])
+  class RequestInfo
+    attr_reader :request
 
-        new(request:)
-      end
+    def initialize(params:, organization:)
+      @request = organization.requests.find(params[:id])
     end
 
     def item_requests
-      request.item_requests.includes(:item)
+      @item_requests ||= @request.item_requests.includes(:item)
     end
 
     def inventory
-      View::Inventory.new(request.organization_id)
+      @inventory ||= View::Inventory.new(@request.organization_id)
     end
 
     def default_storage_location
-      request.partner.default_storage_location_id || request.organization.default_storage_location
+      return @default_storage_location if defined?(@default_storage_location)
+
+      @efault_storage_location ||= @request.partner.default_storage_location_id || @request.organization.default_storage_location
     end
 
     def location
-      StorageLocation.find_by(id: default_storage_location)
+      return @location if defined?(@location)
+
+      @location ||= StorageLocation.find_by(id: default_storage_location)
     end
 
     def custom_units

--- a/app/models/view/requests.rb
+++ b/app/models/view/requests.rb
@@ -66,19 +66,19 @@ module View
     end
 
     def selected_request_type
-      filter_params[:by_request_type]
+      filters[:by_request_type]
     end
 
     def selected_request_item
-      filter_params[:by_request_item_id]
+      filters[:by_request_item_id]
     end
 
     def selected_partner
-      filter_params[:by_partner]
+      filters[:by_partner]
     end
 
     def selected_status
-      filter_params[:by_status]
+      filters[:by_status]
     end
   end
 end

--- a/app/models/view/requests.rb
+++ b/app/models/view/requests.rb
@@ -1,0 +1,84 @@
+module View
+  Requests = Data.define(
+    :requests,
+    :filters,
+    :paginated_requests,
+    :organization,
+    :helpers
+  ) do
+    include DateRangeHelper
+
+    class << self
+      def filter_params(params = {})
+        if params.key?(:filters)
+          params.require(:filters).permit(:by_request_item_id, :by_partner, :by_status, :by_request_type)
+        else
+          {}
+        end
+      end
+
+      def from_params(params:, organization:, helpers:)
+        filters = filter_params(params)
+
+        requests = organization
+          .ordered_requests
+          .undiscarded
+          .during(helpers.selected_range)
+          .class_filter(filters)
+
+        paginated_requests = requests.includes(:partner).page(params[:page])
+
+        new(requests:, filters:, paginated_requests:, organization:, helpers:)
+      end
+    end
+
+    def unfulfilled_requests_count
+      organization
+        .requests
+        .where(status: [:pending, :started])
+        .during(helpers.selected_range)
+        .class_filter(filters)
+        .count
+    end
+
+    def calculate_product_totals
+      RequestsTotalItemsService.new(requests: requests).calculate
+    end
+
+    def items
+      organization.items.alphabetized.select(:id, :name)
+    end
+
+    def partners
+      organization.partners.alphabetized.select(:id, :name, :status)
+    end
+
+    def statuses
+      Request.statuses.transform_keys(&:humanize)
+    end
+
+    def partner_users
+      User.where(id: paginated_requests.map(&:partner_user_id)).select(:id, :name, :email)
+    end
+
+    def request_types
+      Request.request_types.transform_keys(&:humanize)
+    end
+
+    def selected_request_type
+      filter_params[:by_request_type]
+    end
+
+    def selected_request_item
+      filter_params[:by_request_item_id]
+    end
+
+    def selected_partner
+      filter_params[:by_partner]
+    end
+
+    def selected_status
+      filter_params[:by_status]
+    end
+  end
+end

--- a/app/models/view/requests.rb
+++ b/app/models/view/requests.rb
@@ -1,39 +1,34 @@
 module View
-  Requests = Data.define(
-    :requests,
-    :filters,
-    :paginated_requests,
-    :organization,
-    :helpers
-  ) do
+  class Requests
     include DateRangeHelper
 
-    class << self
-      def filter_params(params = {})
-        if params.key?(:filters)
-          params.require(:filters).permit(:by_request_item_id, :by_partner, :by_status, :by_request_type)
-        else
-          {}
-        end
-      end
+    attr_reader :filters, :helpers, :organization, :paginated_requests, :params, :requests
 
-      def from_params(params:, organization:, helpers:)
-        filters = filter_params(params)
+    def initialize(params:, organization:, helpers:)
+      @params = params
+      @organization = organization
+      @filters = filter_params(params)
+      @helpers = helpers
 
-        requests = organization
-          .ordered_requests
-          .undiscarded
-          .during(helpers.selected_range)
-          .class_filter(filters)
+      @requests = organization
+        .ordered_requests
+        .undiscarded
+        .during(helpers.selected_range)
+        .class_filter(filters)
 
-        paginated_requests = requests.includes(:partner).page(params[:page])
+      @paginated_requests = requests.includes(:partner).page(params[:page])
+    end
 
-        new(requests:, filters:, paginated_requests:, organization:, helpers:)
+    def filter_params(params = {})
+      if params.key?(:filters)
+        params.require(:filters).permit(:by_request_item_id, :by_partner, :by_status, :by_request_type)
+      else
+        {}
       end
     end
 
     def unfulfilled_requests_count
-      organization
+      @unfulfilled_requests_count ||= organization
         .requests
         .where(status: [:pending, :started])
         .during(helpers.selected_range)
@@ -42,27 +37,27 @@ module View
     end
 
     def calculate_product_totals
-      RequestsTotalItemsService.new(requests: requests).calculate
+      @calculate_product_totals ||= RequestsTotalItemsService.new(requests: requests).calculate
     end
 
     def items
-      organization.items.alphabetized.select(:id, :name)
+      @items ||= organization.items.alphabetized.select(:id, :name)
     end
 
     def partners
-      organization.partners.alphabetized.select(:id, :name, :status)
+      @partners ||= organization.partners.alphabetized.select(:id, :name, :status)
     end
 
     def statuses
-      Request.statuses.transform_keys(&:humanize)
+      @statuses ||= Request.statuses.transform_keys(&:humanize)
     end
 
     def partner_users
-      User.where(id: paginated_requests.map(&:partner_user_id)).select(:id, :name, :email)
+      @partner_users ||= User.where(id: paginated_requests.map(&:partner_user_id)).select(:id, :name, :email)
     end
 
     def request_types
-      Request.request_types.transform_keys(&:humanize)
+      @request_types ||= Request.request_types.transform_keys(&:humanize)
     end
 
     def selected_request_type

--- a/app/views/requests/_calculate_product_totals.html.erb
+++ b/app/views/requests/_calculate_product_totals.html.erb
@@ -16,7 +16,7 @@
           </tr>
           </thead>
           <tbody>
-            <% @request_info.calculate_product_totals.sort_by { |name, quantity| name.downcase }.each do |name, quantity| %>
+            <% @requests_info.calculate_product_totals.sort_by { |name, quantity| name.downcase }.each do |name, quantity| %>
               <tr>
                 <td><%= name %></td>
                 <td><%= quantity %></td>

--- a/app/views/requests/_calculate_product_totals.html.erb
+++ b/app/views/requests/_calculate_product_totals.html.erb
@@ -16,7 +16,7 @@
           </tr>
           </thead>
           <tbody>
-            <% @calculate_product_totals.sort_by { |name, quantity| name.downcase }.each do |name, quantity| %>
+            <% @request_info.calculate_product_totals.sort_by { |name, quantity| name.downcase }.each do |name, quantity| %>
               <tr>
                 <td><%= name %></td>
                 <td><%= quantity %></td>

--- a/app/views/requests/_new.html.erb
+++ b/app/views/requests/_new.html.erb
@@ -10,7 +10,7 @@
       <div class="modal-body p-4">
         <%= form_with(url: new_partners_request_path, method: :get) do |form| %>
           <div class="form-group">
-            <%= form.collection_select(:partner_id, @request_info.partners.active, :id, :name, {include_blank: "Select a partner", required: true}, {class: "form-control mb-2"} ) %>
+            <%= form.collection_select(:partner_id, @requests_info.partners.active, :id, :name, {include_blank: "Select a partner", required: true}, {class: "form-control mb-2"} ) %>
           </div>
           <%= submit_button({text: "Next", icon: nil, name: ""}) %>
         <% end %>

--- a/app/views/requests/_new.html.erb
+++ b/app/views/requests/_new.html.erb
@@ -10,7 +10,7 @@
       <div class="modal-body p-4">
         <%= form_with(url: new_partners_request_path, method: :get) do |form| %>
           <div class="form-group">
-            <%= form.collection_select(:partner_id, @partners.active, :id, :name, {include_blank: "Select a partner", required: true}, {class: "form-control mb-2"} ) %>
+            <%= form.collection_select(:partner_id, @request_info.partners.active, :id, :name, {include_blank: "Select a partner", required: true}, {class: "form-control mb-2"} ) %>
           </div>
           <%= submit_button({text: "Next", icon: nil, name: ""}) %>
         <% end %>

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -2,7 +2,7 @@
   <td class="date"><%= request_row.created_at.strftime("%m/%d/%Y") %></td>
   <td><%= request_row.partner.name %> </td>
   <td>
-    <% partner_user = @request_info.partner_users.find { |pu| pu.id == request_row.partner_user_id } %>
+    <% partner_user = @requests_info.partner_users.find { |pu| pu.id == request_row.partner_user_id } %>
     <%= "#{partner_user&.formatted_email}" %>
   </td>
   <td class="<%= quota_column_class(request_row.total_items, request_row.partner) %> text-right">

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -2,7 +2,7 @@
   <td class="date"><%= request_row.created_at.strftime("%m/%d/%Y") %></td>
   <td><%= request_row.partner.name %> </td>
   <td>
-    <% partner_user = @partner_users.find { |pu| pu.id == request_row.partner_user_id } %>
+    <% partner_user = @request_info.partner_users.find { |pu| pu.id == request_row.partner_user_id } %>
     <%= "#{partner_user&.formatted_email}" %>
   </td>
   <td class="<%= quota_column_class(request_row.total_items, request_row.partner) %> text-right">

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -37,21 +37,21 @@
           <div class="card-body">
             <%= form_tag(requests_path, method: :get) do |f| %>
               <div class="row">
-                <% if @request_info.items.present? %>
+                <% if @requests_info.items.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= filter_select(label: "Filter by item", scope: :by_request_item_id, collection: @items, selected: @selected_request_item) %>
                   </div>
                 <% end %>
-                <% if @request_info.partners.present? %>
+                <% if @requests_info.partners.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= filter_select(scope: :by_partner, collection: @partners, selected: @selected_partner) %>
                   </div>
                 <% end %>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_request_type, collection: @request_info.request_types, key: :last, value: :first, selected: @selected_request_type) %>
+                  <%= filter_select(scope: :by_request_type, collection: @requests_info.request_types, key: :last, value: :first, selected: @selected_request_type) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_status, collection: @request_info.statuses, key: :last, value: :first, selected: @selected_status) %>
+                  <%= filter_select(scope: :by_status, collection: @requests_info.statuses, key: :last, value: :first, selected: @selected_status) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>
@@ -67,13 +67,13 @@
                     <%= modal_button_to("#calculateTotals", {text: "Calculate Product Totals", icon: nil, size: "md", type: "success"}) %>
                   </div>
                   <div class="d-flex flex-wrap gap-2">
-                    <% if @request_info.unfulfilled_requests_count > 0 %>
+                    <% if @requests_info.unfulfilled_requests_count > 0 %>
                       <%= print_button_to(
                         print_unfulfilled_requests_path(format: :pdf, filters: filter_params.merge(date_range: date_range_params)),
-                        text: "Print Unfulfilled Picklists (#{@request_info.unfulfilled_requests_count})",
+                        text: "Print Unfulfilled Picklists (#{@requests_info.unfulfilled_requests_count})",
                         size: "md") %>
                     <% end %>
-                    <%= download_button_to(requests_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Requests", size: "md"}) if @request_info.requests.any? %>
+                    <%= download_button_to(requests_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Requests", size: "md"}) if @requests_info.requests.any? %>
                     <%= modal_button_to("#newRequest", text: "New Quantity Request", icon: "plus", type: "success") if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
                   </div>
                 </div>
@@ -112,13 +112,13 @@
               </tr>
               </thead>
               <tbody>
-                <%= render partial: "request_row", collection: @request_info.paginated_requests %>
+                <%= render partial: "request_row", collection: @requests_info.paginated_requests %>
               </tbody>
             </table>
           </div>
           <!-- /.card-body -->
           <div class="card-footer clearfix">
-            <%= paginate @request_info.paginated_requests %>
+            <%= paginate @requests_info.paginated_requests %>
           </div>
           <!-- /.card-footer-->
         </div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -39,19 +39,19 @@
               <div class="row">
                 <% if @requests_info.items.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                    <%= filter_select(label: "Filter by item", scope: :by_request_item_id, collection: @items, selected: @selected_request_item) %>
+                    <%= filter_select(label: "Filter by item", scope: :by_request_item_id, collection: @requests_info.items, selected: @requests_info.selected_request_item) %>
                   </div>
                 <% end %>
                 <% if @requests_info.partners.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                    <%= filter_select(scope: :by_partner, collection: @partners, selected: @selected_partner) %>
+                    <%= filter_select(scope: :by_partner, collection: @requests_info.partners, selected: @requests_info.selected_partner) %>
                   </div>
                 <% end %>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_request_type, collection: @requests_info.request_types, key: :last, value: :first, selected: @selected_request_type) %>
+                  <%= filter_select(scope: :by_request_type, collection: @requests_info.request_types, key: :last, value: :first, selected: @requests_info.selected_request_type) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_status, collection: @requests_info.statuses, key: :last, value: :first, selected: @selected_status) %>
+                  <%= filter_select(scope: :by_status, collection: @requests_info.statuses, key: :last, value: :first, selected: @requests_info.selected_status) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -37,21 +37,21 @@
           <div class="card-body">
             <%= form_tag(requests_path, method: :get) do |f| %>
               <div class="row">
-                <% if @items.present? %>
+                <% if @request_info.items.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= filter_select(label: "Filter by item", scope: :by_request_item_id, collection: @items, selected: @selected_request_item) %>
                   </div>
                 <% end %>
-                <% if @partners.present? %>
+                <% if @request_info.partners.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= filter_select(scope: :by_partner, collection: @partners, selected: @selected_partner) %>
                   </div>
                 <% end %>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_request_type, collection: @request_types, key: :last, value: :first, selected: @selected_request_type) %>
+                  <%= filter_select(scope: :by_request_type, collection: @request_info.request_types, key: :last, value: :first, selected: @selected_request_type) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
-                  <%= filter_select(scope: :by_status, collection: @statuses, key: :last, value: :first, selected: @selected_status) %>
+                  <%= filter_select(scope: :by_status, collection: @request_info.statuses, key: :last, value: :first, selected: @selected_status) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>
@@ -67,13 +67,13 @@
                     <%= modal_button_to("#calculateTotals", {text: "Calculate Product Totals", icon: nil, size: "md", type: "success"}) %>
                   </div>
                   <div class="d-flex flex-wrap gap-2">
-                    <% if @unfulfilled_requests_count > 0 %>
+                    <% if @request_info.unfulfilled_requests_count > 0 %>
                       <%= print_button_to(
                         print_unfulfilled_requests_path(format: :pdf, filters: filter_params.merge(date_range: date_range_params)),
-                        text: "Print Unfulfilled Picklists (#{@unfulfilled_requests_count})",
+                        text: "Print Unfulfilled Picklists (#{@request_info.unfulfilled_requests_count})",
                         size: "md") %>
                     <% end %>
-                    <%= download_button_to(requests_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Requests", size: "md"}) if @requests.any? %>
+                    <%= download_button_to(requests_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Requests", size: "md"}) if @request_info.requests.any? %>
                     <%= modal_button_to("#newRequest", text: "New Quantity Request", icon: "plus", type: "success") if current_user.has_role?(Role::ORG_ADMIN, current_organization) %>
                   </div>
                 </div>
@@ -112,13 +112,13 @@
               </tr>
               </thead>
               <tbody>
-                <%= render partial: "request_row", collection: @paginated_requests %>
+                <%= render partial: "request_row", collection: @request_info.paginated_requests %>
               </tbody>
             </table>
           </div>
           <!-- /.card-body -->
           <div class="card-footer clearfix">
-            <%= paginate @paginated_requests %>
+            <%= paginate @request_info.paginated_requests %>
           </div>
           <!-- /.card-footer-->
         </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -2,10 +2,10 @@
   <div class="container-fluid">
     <div class="row mb-2">
       <div class="col-sm-6">
-        <% content_for :title, "Requests - #{@request.id} - #{current_organization.name}" %>
+        <% content_for :title, "Requests - #{@request_info.request.id} - #{current_organization.name}" %>
         <h1>
           Request
-          <small>from <%= @request.partner.name %></small>
+          <small>from <%= @request_info.request.partner.name %></small>
         </h1>
       </div>
       <div class="col-sm-6">
@@ -15,8 +15,8 @@
             <% end %>
           </li>
           <li class="breadcrumb-item"><%= link_to "Requests", requests_path %></li>
-          <li class="breadcrumb-item"><a href="#"> Request from <%= @request.partner.name %>
-            at <%= @request.created_at.to_fs(:distribution_date) %></a></li>
+          <li class="breadcrumb-item"><a href="#"> Request from <%= @request_info.request.partner.name %>
+            at <%= @request_info.request.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>
     </div>
@@ -29,7 +29,7 @@
       <div class="col-12">
         <div class="card">
           <div class="card-header">
-            <h3 class="card-title">This request was sent on <%= @request.created_at.to_fs(:distribution_date) %></h3>
+            <h3 class="card-title">This request was sent on <%= @request_info.request.created_at.to_fs(:distribution_date) %></h3>
           </div>
           <div class="card-body p-0">
             <table class="table">
@@ -44,11 +44,11 @@
               </thead>
               <tbody>
               <tr>
-                <td><%= @request.partner.name %></td>
-                <td><%= @request.partner_user&.formatted_email %></td>
-                <td><%= @request.request_type&.humanize %></td>
-                <td><%= render partial: "status", locals: {status: @request.status} %></td>
-                <td><%= @request.comments || 'None' %></td>
+                <td><%= @request_info.request.partner.name %></td>
+                <td><%= @request_info.request.partner_user&.formatted_email %></td>
+                <td><%= @request_info.request.request_type&.humanize %></td>
+                <td><%= render partial: "status", locals: {status: @request_info.request.status} %></td>
+                <td><%= @request_info.request.comments || 'None' %></td>
               </tr>
             </table>
           </div>
@@ -67,36 +67,36 @@
               <tr>
                 <th>Item</th>
                 <th>Quantity</th>
-                <% if @custom_units %>
+                <% if @request_info.custom_units %>
                   <th>Units (if applicable)</th>
                 <% end %>
-                <% if @default_storage_location %>
+                <% if @request_info.default_storage_location %>
                   <th>Default storage location inventory</th>
                 <% end %>
                 <th>Total Inventory</th>
               </tr>
               </thead>
               <tbody>
-              <% @item_requests.each do |item_request| %>
+              <% @request_info.item_requests.each do |item_request| %>
                 <tr>
                   <td><%= item_request.item_name %></td>
                   <td><%= item_request.quantity %></td>
-                  <% if @custom_units %>
+                  <% if @request_info.custom_units %>
                     <td><%= item_request.request_unit&.pluralize(item_request.quantity.to_i) %></td>
                   <% end %>
-                  <% if @default_storage_location %>
-                    <% on_hand_for_location = @inventory.quantity_for(storage_location: @location&.id, item_id: item_request.item_id) %>
+                  <% if @request_info.default_storage_location %>
+                    <% on_hand_for_location = @request_info.inventory.quantity_for(storage_location: @request_info.location&.id, item_id: item_request.item_id) %>
                     <td><%= on_hand_for_location&.positive? ? on_hand_for_location : 'N/A' %></td>
                   <% end %>
-                  <% on_hand = @inventory.quantity_for(item_id: item_request.item_id) %>
+                  <% on_hand = @request_info.inventory.quantity_for(item_id: item_request.item_id) %>
                   <td><%= on_hand || 0 %></td>
                 </tr>
               <% end %>
               <tr>
                 <td>Total (Quota)</td>
                 <td>
-                  <%= @request.total_items %>
-                  <%= quota_display(@request.partner) %>
+                  <%= @request_info.request.total_items %>
+                  <%= quota_display(@request_info.request.partner) %>
                 </td>
                 <td />
               </tr>
@@ -104,11 +104,11 @@
             </table>
           </div>
           <div class="card-footer flex flex-row space-x-2">
-            <%= submit_button_to start_request_path(@request), {text: "Fulfill request", size: "md"} unless @request.distribution %>
-            <%= view_button_to(distribution_path(@request.distribution), {text: "View Associated Distribution", size: "md"}) if @request.distribution %>
-            <%= print_button_to print_picklist_request_path(@request), { format: :pdf, text: "Print", size: "md" } %>
-            <% unless @request.status_fulfilled? %>
-              <%= button_to 'Cancel', new_request_cancelation_path(request_id: @request.id),
+            <%= submit_button_to start_request_path(@request_info.request), {text: "Fulfill request", size: "md"} unless @request_info.request.distribution %>
+            <%= view_button_to(distribution_path(@request_info.request.distribution), {text: "View Associated Distribution", size: "md"}) if @request_info.request.distribution %>
+            <%= print_button_to print_picklist_request_path(@request_info.request), { format: :pdf, text: "Print", size: "md" } %>
+            <% unless @request_info.request.status_fulfilled? %>
+              <%= button_to 'Cancel', new_request_cancelation_path(request_id: @request_info.request.id),
                             method: :get, data: { disable_with: "Please wait..." }, form_class: 'd-inline', class: 'btn btn-danger btn-md' %>
             <% end %>
           </div>

--- a/spec/models/view/request_info_spec.rb
+++ b/spec/models/view/request_info_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe View::RequestInfo do
   end
 
   describe "#custom_units" do
-    context "when a request has request units for an item request" do
+    context "when there are request units for an item request" do
        context "when enable_packs is disabled" do
         it "returns false" do
           organization = build(:organization)

--- a/spec/models/view/request_info_spec.rb
+++ b/spec/models/view/request_info_spec.rb
@@ -1,4 +1,45 @@
 RSpec.describe View::RequestInfo do
+  describe "#item_requests" do
+    context "when the request has item requests" do
+      it "returns the request's item requests" do
+        organization = build(:organization)
+        item = build(:item)
+        item_request = build(:item_request, item: item, quantity: 5)
+        request = create(
+          :request,
+          organization:,
+          item_requests: [item_request]
+        )
+
+        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+        expect(request_info.item_requests).to eq([item_request])
+      end
+    end
+
+    context "when the request has no item requests" do
+      it "returns an empty array" do
+        organization = build(:organization)
+        request = create(:request, organization:)
+
+        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+        expect(request_info.item_requests).to eq([])
+      end
+    end
+  end
+
+  describe "#inventory" do
+    it "returns a View::Inventory instance" do
+      organization = build(:organization)
+      request = create(:request, organization:)
+
+      request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+      expect(request_info.inventory).to be_a_kind_of(View::Inventory)
+    end
+  end
+
   describe "#default_storage_location" do
     context "when the request partner has a default_storage_location_id" do
       it "returns the request partner's default_storage_location_id" do
@@ -10,9 +51,9 @@ RSpec.describe View::RequestInfo do
           organization:
         )
 
-        request = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
 
-        expect(request.default_storage_location).to eq(storage_location.id)
+        expect(request_info.default_storage_location).to eq(storage_location.id)
       end
     end
 
@@ -26,9 +67,38 @@ RSpec.describe View::RequestInfo do
           organization:
         )
 
-        request = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
 
-        expect(request.default_storage_location).to eq(storage_location.id)
+        expect(request_info.default_storage_location).to eq(storage_location.id)
+      end
+    end
+  end
+
+  describe "#location" do
+    context "when no storage location is found" do
+      it "returns nil" do
+        organization = build(:organization)
+        request = create(:request, organization:)
+
+        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+        expect(request_info.location).to be_nil
+      end
+    end
+
+    context "when a storage location is found" do
+      it "returns the found location" do
+        organization = build(:organization)
+        storage_location = create(:storage_location, organization:)
+        organization.update!(default_storage_location: storage_location.id)
+        request = create(
+          :request,
+          organization:
+        )
+
+        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+        expect(request_info.location).to be_a_kind_of(StorageLocation)
       end
     end
   end
@@ -49,9 +119,9 @@ RSpec.describe View::RequestInfo do
             ]
           )
 
-          request = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+          request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
 
-          expect(request.custom_units).to be_falsey
+          expect(request_info.custom_units).to be_falsey
         end
       end
 
@@ -70,9 +140,9 @@ RSpec.describe View::RequestInfo do
               {item_id: item.id, quantity: "559", request_unit: "flat"}
             ]
           )
-          request = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+          request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
 
-          expect(request.custom_units).to be_truthy
+          expect(request_info.custom_units).to be_truthy
 
           Flipper.disable(:enable_packs)
         end

--- a/spec/models/view/request_info_spec.rb
+++ b/spec/models/view/request_info_spec.rb
@@ -1,0 +1,82 @@
+RSpec.describe View::RequestInfo do
+  describe "#default_storage_location" do
+    context "when the request partner has a default_storage_location_id" do
+      it "returns the request partner's default_storage_location_id" do
+        storage_location = build(:storage_location)
+        organization = build(:organization)
+        request = create(
+          :request,
+          partner: build(:partner, default_storage_location_id: storage_location.id),
+          organization:
+        )
+
+        request = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+        expect(request.default_storage_location).to eq(storage_location.id)
+      end
+    end
+
+    context "when the request organization has a default_storage_location_id" do
+      it "returns the request organization's default_storage_location_id" do
+        organization = build(:organization)
+        storage_location = build(:storage_location, organization:)
+        organization.update!(default_storage_location: storage_location.id)
+        request = create(
+          :request,
+          organization:
+        )
+
+        request = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+        expect(request.default_storage_location).to eq(storage_location.id)
+      end
+    end
+  end
+
+  describe "#custom_units" do
+    context "when a request has request units for an item request" do
+       context "when enable_packs is disabled" do
+        it "returns false" do
+          organization = build(:organization)
+          item = build(:item, name: "First item")
+          create(:item_unit, item: item, name: "flat")
+          request = create(
+            :request,
+            :with_item_requests,
+            organization:,
+            request_items: [
+              {item_id: item.id, quantity: '559', request_unit: 'flat'}
+            ]
+          )
+
+          request = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+          expect(request.custom_units).to be_falsey
+        end
+      end
+
+      context "when enable_packs is enabled" do
+        it "returns true" do
+          Flipper.enable(:enable_packs)
+
+          organization = build(:organization)
+          item = build(:item, name: "First item")
+          create(:item_unit, item: item, name: "flat")
+          request = create(
+            :request,
+            :with_item_requests,
+            organization:,
+            request_items: [
+              {item_id: item.id, quantity: '559', request_unit: 'flat'},
+            ]
+          )
+          request = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+
+          expect(request.custom_units).to be_truthy
+
+          Flipper.disable(:enable_packs)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/view/request_info_spec.rb
+++ b/spec/models/view/request_info_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe View::RequestInfo do
 
   describe "#custom_units" do
     context "when there are request units for an item request" do
-       context "when enable_packs is disabled" do
+      context "when enable_packs is disabled" do
         it "returns false" do
           organization = build(:organization)
           item = build(:item, name: "First item")
@@ -45,7 +45,7 @@ RSpec.describe View::RequestInfo do
             :with_item_requests,
             organization:,
             request_items: [
-              {item_id: item.id, quantity: '559', request_unit: 'flat'}
+              {item_id: item.id, quantity: "559", request_unit: "flat"}
             ]
           )
 
@@ -67,7 +67,7 @@ RSpec.describe View::RequestInfo do
             :with_item_requests,
             organization:,
             request_items: [
-              {item_id: item.id, quantity: '559', request_unit: 'flat'},
+              {item_id: item.id, quantity: "559", request_unit: "flat"}
             ]
           )
           request = View::RequestInfo.from_params(params: {id: request.id}, organization:)

--- a/spec/models/view/request_info_spec.rb
+++ b/spec/models/view/request_info_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe View::RequestInfo do
           item_requests: [item_request]
         )
 
-        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+        request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
         expect(request_info.item_requests).to eq([item_request])
       end
@@ -22,7 +22,7 @@ RSpec.describe View::RequestInfo do
         organization = build(:organization)
         request = create(:request, organization:)
 
-        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+        request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
         expect(request_info.item_requests).to eq([])
       end
@@ -34,7 +34,7 @@ RSpec.describe View::RequestInfo do
       organization = build(:organization)
       request = create(:request, organization:)
 
-      request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+      request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
       expect(request_info.inventory).to be_a_kind_of(View::Inventory)
     end
@@ -51,7 +51,7 @@ RSpec.describe View::RequestInfo do
           organization:
         )
 
-        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+        request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
         expect(request_info.default_storage_location).to eq(storage_location.id)
       end
@@ -67,7 +67,7 @@ RSpec.describe View::RequestInfo do
           organization:
         )
 
-        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+        request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
         expect(request_info.default_storage_location).to eq(storage_location.id)
       end
@@ -80,7 +80,7 @@ RSpec.describe View::RequestInfo do
         organization = build(:organization)
         request = create(:request, organization:)
 
-        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+        request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
         expect(request_info.location).to be_nil
       end
@@ -96,7 +96,7 @@ RSpec.describe View::RequestInfo do
           organization:
         )
 
-        request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+        request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
         expect(request_info.location).to be_a_kind_of(StorageLocation)
       end
@@ -119,7 +119,7 @@ RSpec.describe View::RequestInfo do
             ]
           )
 
-          request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+          request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
           expect(request_info.custom_units).to be_falsey
         end
@@ -140,7 +140,7 @@ RSpec.describe View::RequestInfo do
               {item_id: item.id, quantity: "559", request_unit: "flat"}
             ]
           )
-          request_info = View::RequestInfo.from_params(params: {id: request.id}, organization:)
+          request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
           expect(request_info.custom_units).to be_truthy
 

--- a/spec/models/view/requests_spec.rb
+++ b/spec/models/view/requests_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe View::Requests do
+  describe "#unfulfilled_requests_count" do
+    it "returns the unfulfilled requests count for the given date range" do
+      organization = create(:organization)
+      create(:request, :pending, organization:)
+      create(:request, :started, organization:)
+      create(:request, :fulfilled, organization:)
+
+      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+
+      expect(requests.unfulfilled_requests_count).to eq(2)
+    end
+  end
+
+  describe "#calculate_product_totals" do
+    it "returns the product total items service" do
+      organization = create(:organization)
+      create(:request, :pending, organization:)
+      total_items_service_double =  instance_double(RequestsTotalItemsService, calculate: {"Diaper" => 10})
+      allow(RequestsTotalItemsService).to receive(:new).with(requests: organization.requests).and_return(total_items_service_double)
+
+      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+
+      expect(requests.calculate_product_totals).to eq({"Diaper" => 10})
+    end
+  end
+
+  describe "selected filter params" do
+    it "returns the filter params given" do
+      organization = create(:organization)
+      create(:request, :pending, organization:)
+      params = ActionController::Parameters.new(
+      {
+        filters: {
+          by_request_type: "quantity",
+          by_request_item_id: "1",
+          by_partner: "A Local Partner",
+          by_status: "pending"
+        }
+      }
+    ).permit!
+
+      requests = View::Requests.from_params(params:, organization:, helpers:)
+
+      expect(requests.selected_request_type).to eq("quantity")
+      expect(requests.selected_request_item).to eq("1")
+      expect(requests.selected_partner).to eq("A Local Partner")
+      expect(requests.selected_status).to eq("pending")
+    end
+  end
+
+  def helpers
+    Class.new do
+      def self.selected_range
+        (1.month.ago..2.days.from_now)
+      end
+    end
+  end
+end

--- a/spec/models/view/requests_spec.rb
+++ b/spec/models/view/requests_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe View::Requests do
     it "returns the calculated product total items" do
       organization = build(:organization)
       build(:request, :pending, organization:)
-      total_items_service_double =  instance_double(RequestsTotalItemsService, calculate: {"Diaper" => 10})
+      total_items_service_double = instance_double(RequestsTotalItemsService, calculate: {"Diaper" => 10})
       allow(RequestsTotalItemsService).to receive(:new).with(requests: organization.requests).and_return(total_items_service_double)
 
       requests = View::Requests.from_params(params: {}, organization:, helpers:)

--- a/spec/models/view/requests_spec.rb
+++ b/spec/models/view/requests_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe View::Requests do
       create(:request, :started, organization:)
       create(:request, :fulfilled, organization:)
 
-      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+      requests = View::Requests.new(params: {}, organization:, helpers:)
 
       expect(requests.unfulfilled_requests_count).to eq(2)
     end
@@ -19,7 +19,7 @@ RSpec.describe View::Requests do
       total_items_service_double = instance_double(RequestsTotalItemsService, calculate: {"Diaper" => 10})
       allow(RequestsTotalItemsService).to receive(:new).with(requests: organization.requests).and_return(total_items_service_double)
 
-      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+      requests = View::Requests.new(params: {}, organization:, helpers:)
 
       expect(requests.calculate_product_totals).to eq({"Diaper" => 10})
     end
@@ -33,7 +33,7 @@ RSpec.describe View::Requests do
       item_two = create(:item, base_item:, organization:, name: "B item")
       item_one = create(:item, base_item:, organization:, name: "A item")
 
-      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+      requests = View::Requests.new(params: {}, organization:, helpers:)
 
       expect(requests.items.map(&:id)).to eq([item_one.id, item_two.id])
       expect(requests.items.map(&:name)).to eq(["A item", "B item"])
@@ -47,7 +47,7 @@ RSpec.describe View::Requests do
       partner_two = create(:partner, organization:, name: "B partner", status: "approved")
       partner_one = create(:partner, organization:, name: "A partner", status: "invited")
 
-      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+      requests = View::Requests.new(params: {}, organization:, helpers:)
 
       expect(requests.partners.map(&:id)).to eq([partner_one.id, partner_two.id])
       expect(requests.partners.map(&:name)).to eq(["A partner", "B partner"])
@@ -61,7 +61,7 @@ RSpec.describe View::Requests do
       build(:request, organization:)
       humanized_statuses = {"Discarded" => 3, "Fulfilled" => 2, "Pending" => 0, "Started" => 1}
 
-      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+      requests = View::Requests.new(params: {}, organization:, helpers:)
 
       expect(requests.statuses).to eq(humanized_statuses)
     end
@@ -73,7 +73,7 @@ RSpec.describe View::Requests do
       partner_user = create(:partner_user, name: "Jane Smith", email: "janesmith@example.com")
       create(:request, organization:, partner_user:)
 
-      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+      requests = View::Requests.new(params: {}, organization:, helpers:)
 
       expect(requests.partner_users.map(&:id)).to eq([partner_user.id])
       expect(requests.partner_users.map(&:name)).to eq(["Jane Smith"])
@@ -87,7 +87,7 @@ RSpec.describe View::Requests do
       build(:request, organization:)
       humanized_types = {"Child" => "child", "Individual" => "individual", "Quantity" => "quantity"}
 
-      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+      requests = View::Requests.new(params: {}, organization:, helpers:)
 
       expect(requests.request_types).to eq(humanized_types)
     end
@@ -108,7 +108,7 @@ RSpec.describe View::Requests do
       }
     ).permit!
 
-      requests = View::Requests.from_params(params:, organization:, helpers:)
+      requests = View::Requests.new(params:, organization:, helpers:)
 
       expect(requests.selected_request_type).to eq("quantity")
       expect(requests.selected_request_item).to eq("1")

--- a/spec/models/view/requests_spec.rb
+++ b/spec/models/view/requests_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe View::Requests do
   describe "#calculate_product_totals" do
     it "returns the calculated product total items" do
       organization = build(:organization)
-      build(:request, :pending, organization:)
+      build(:request, organization:)
       total_items_service_double = instance_double(RequestsTotalItemsService, calculate: {"Diaper" => 10})
       allow(RequestsTotalItemsService).to receive(:new).with(requests: organization.requests).and_return(total_items_service_double)
 
@@ -25,10 +25,78 @@ RSpec.describe View::Requests do
     end
   end
 
+  describe "#items" do
+    it "returns the organization's items id and name, alphabetized" do
+      organization = build(:organization)
+      build(:request, organization:)
+      base_item = build(:base_item)
+      item_two = create(:item, base_item:, organization:, name: "B item")
+      item_one = create(:item, base_item:, organization:, name: "A item")
+
+      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+
+      expect(requests.items.map(&:id)).to eq([item_one.id, item_two.id])
+      expect(requests.items.map(&:name)).to eq(["A item", "B item"])
+    end
+  end
+
+  describe "#partners" do
+    it "returns the organization's partners id, name and status, alphabetized" do
+      organization = build(:organization)
+      build(:request, organization:)
+      partner_two = create(:partner, organization:, name: "B partner", status: "approved")
+      partner_one = create(:partner, organization:, name: "A partner", status: "invited")
+
+      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+
+      expect(requests.partners.map(&:id)).to eq([partner_one.id, partner_two.id])
+      expect(requests.partners.map(&:name)).to eq(["A partner", "B partner"])
+      expect(requests.partners.map(&:status)).to eq(["invited", "approved"])
+    end
+  end
+
+  describe "#statuses" do
+    it "returns the request statuses" do
+      organization = build(:organization)
+      build(:request, organization:)
+      humanized_statuses = {"Discarded" => 3, "Fulfilled" => 2, "Pending" => 0, "Started" => 1}
+
+      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+
+      expect(requests.statuses).to eq(humanized_statuses)
+    end
+  end
+
+  describe "#partner_users" do
+    it "returns the organization's partner users id, name and email" do
+      organization = build(:organization)
+      partner_user = create(:partner_user, name: "Jane Smith", email: "janesmith@example.com")
+      create(:request, organization:, partner_user:)
+
+      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+
+      expect(requests.partner_users.map(&:id)).to eq([partner_user.id])
+      expect(requests.partner_users.map(&:name)).to eq(["Jane Smith"])
+      expect(requests.partner_users.map(&:email)).to eq(["janesmith@example.com"])
+    end
+  end
+
+  describe "#request_types" do
+    it "returns the request types" do
+      organization = build(:organization)
+      build(:request, organization:)
+      humanized_types = {"Child" => "child", "Individual" => "individual", "Quantity" => "quantity"}
+
+      requests = View::Requests.from_params(params: {}, organization:, helpers:)
+
+      expect(requests.request_types).to eq(humanized_types)
+    end
+  end
+
   describe "selected filter params" do
     it "returns the given filter params" do
       organization = build(:organization)
-      build(:request, :pending, organization:)
+      build(:request, organization:)
       params = ActionController::Parameters.new(
       {
         filters: {

--- a/spec/models/view/requests_spec.rb
+++ b/spec/models/view/requests_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe View::Requests do
   describe "#unfulfilled_requests_count" do
-    it "returns the unfulfilled requests count for the given date range" do
-      organization = create(:organization)
+    it "returns the unfulfilled requests count" do
+      organization = build(:organization)
       create(:request, :pending, organization:)
       create(:request, :started, organization:)
       create(:request, :fulfilled, organization:)
@@ -13,9 +13,9 @@ RSpec.describe View::Requests do
   end
 
   describe "#calculate_product_totals" do
-    it "returns the product total items service" do
-      organization = create(:organization)
-      create(:request, :pending, organization:)
+    it "returns the calculated product total items" do
+      organization = build(:organization)
+      build(:request, :pending, organization:)
       total_items_service_double =  instance_double(RequestsTotalItemsService, calculate: {"Diaper" => 10})
       allow(RequestsTotalItemsService).to receive(:new).with(requests: organization.requests).and_return(total_items_service_double)
 
@@ -26,9 +26,9 @@ RSpec.describe View::Requests do
   end
 
   describe "selected filter params" do
-    it "returns the filter params given" do
-      organization = create(:organization)
-      create(:request, :pending, organization:)
+    it "returns the given filter params" do
+      organization = build(:organization)
+      build(:request, :pending, organization:)
       params = ActionController::Parameters.new(
       {
         filters: {
@@ -50,7 +50,7 @@ RSpec.describe View::Requests do
   end
 
   def helpers
-    Class.new do
+    Module.new do
       def self.selected_range
         (1.month.ago..2.days.from_now)
       end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/human-essentials/issues/5557

### Description

In https://github.com/rubyforgood/human-essentials/pull/5543, I added one more variable to this controller. I didn't want to refactor the controller since the PR was already too big and it's a good practice to refactor in a separate stream of work.

This PR moves instance variables used in the views to View objects. This keeps the controller slim and it's more maintainable to add methods to the view objects from now on.

### Type of change

<!-- Please delete options that are not relevant. -->

* refactor

### How Has This Been Tested?

- Existing request and system tests pass
- Added coverage for the business logic in the view objects being introduced
- tested the requests index and view pages

### Screenshots

Short walk trough of requests page:

https://github.com/user-attachments/assets/cd19e25f-e17a-4a73-a0bb-05e89353e50b