### PR TITLE
Improve Availability date on annual report

### DIFF
--- a/app/controllers/reports/annual_reports_controller.rb
+++ b/app/controllers/reports/annual_reports_controller.rb
@@ -9,8 +9,6 @@ class Reports::AnnualReportsController < ApplicationController
     @actual_year = Time.current.year
 
     @years = (foundation_year...@actual_year).to_a
-
-    @month_remaining_to_report = 12 - Time.current.month
   end
 
   def show

--- a/app/helpers/reports/annual_reports_helper.rb
+++ b/app/helpers/reports/annual_reports_helper.rb
@@ -1,0 +1,7 @@
+module Reports
+  module AnnualReportsHelper
+    def available_date
+      (Date.current + 1.year).beginning_of_year.strftime("%B%e, %Y")
+    end
+  end
+end

--- a/app/views/reports/annual_reports/index.html.erb
+++ b/app/views/reports/annual_reports/index.html.erb
@@ -25,7 +25,7 @@
     <div class="row">
       <div class="col-md-12 mb-2">
         <h5 class="mb-1">Reports are available at the end of every year.</h5>
-        <span class="text-muted"> <%= "#{@actual_year} (available in #{available_date})" %> </span>
+        <span class="text-muted"> <%= "#{@actual_year} (available on #{available_date})" %> </span>
       </div>
       <div class="col-md-12">
         <div class="card card-primary">

--- a/app/views/reports/annual_reports/index.html.erb
+++ b/app/views/reports/annual_reports/index.html.erb
@@ -25,7 +25,7 @@
     <div class="row">
       <div class="col-md-12 mb-2">
         <h5 class="mb-1">Reports are available at the end of every year.</h5>
-        <span class="text-muted"> <%= "#{@actual_year} (available in #{pluralize(@month_remaining_to_report, 'month')})" %> </span>
+        <span class="text-muted"> <%= "#{@actual_year} (available in #{available_date})" %> </span>
       </div>
       <div class="col-md-12">
         <div class="card card-primary">

--- a/spec/helpers/reports/annual_reports_helper_spec.rb
+++ b/spec/helpers/reports/annual_reports_helper_spec.rb
@@ -1,7 +1,19 @@
 RSpec.describe Reports::AnnualReportsHelper, type: :helper do
   describe "#available_date" do
-    it "returns the first day of the following year with a custom date format" do
+    it "returns the first day of the following year when the current date is the first day of a given year" do
       travel_to Time.zone.local(2026, 0o1, 0o1)
+
+      expect(helper.available_date).to eq("January 1, 2027")
+    end
+
+    it "returns the first day of the following year when the current date is the last day of a given year" do
+      travel_to Time.zone.local(2026, 12, 31)
+
+      expect(helper.available_date).to eq("January 1, 2027")
+    end
+
+    it "returns the first day of the following year" do
+      travel_to Time.zone.local(2026, 0o4, 15)
 
       expect(helper.available_date).to eq("January 1, 2027")
     end

--- a/spec/helpers/reports/annual_reports_helper_spec.rb
+++ b/spec/helpers/reports/annual_reports_helper_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Reports::AnnualReportsHelper, type: :helper do
+  describe "#available_date" do
+    it "returns the first day of the following year with a custom date format" do
+      travel_to Time.zone.local(2026, 0o1, 0o1)
+
+      expect(helper.available_date).to eq("January 1, 2027")
+    end
+  end
+end

--- a/spec/requests/reports/annual_reports_requests_spec.rb
+++ b/spec/requests/reports/annual_reports_requests_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe "Annual Reports", type: :request do
         get reports_annual_reports_path(default_params)
         expect(response).to have_http_status(:success)
       end
+
+      it "displays the first day of the following year as the date when the report will be available" do
+        get reports_annual_reports_path(default_params)
+
+        expect(response.body).to include("available in #{(Date.current + 1.year).beginning_of_year.strftime("%B%e, %Y")}")
+      end
     end
 
     describe "GET /show" do

--- a/spec/requests/reports/annual_reports_requests_spec.rb
+++ b/spec/requests/reports/annual_reports_requests_spec.rb
@@ -19,9 +19,11 @@ RSpec.describe "Annual Reports", type: :request do
       end
 
       it "displays the first day of the following year as the date when the report will be available" do
+        travel_to Time.zone.local(2026, 12, 31)
+
         get reports_annual_reports_path(default_params)
 
-        expect(response.body).to include("available in #{(Date.current + 1.year).beginning_of_year.strftime("%B%e, %Y")}")
+        expect(response.body).to include("available on January 1, 2027")
       end
     end
 


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/human-essentials/issues/5570

### Description

The annual report shows a number of months until the current year's report is available:

<img width="452" height="187" alt="Screenshot 2026-05-20 at 17-12-20 Reports - Pawnee Diaper Bank" src="https://github.com/user-attachments/assets/c525d2d4-f549-41fd-ab00-0f6ddf6f2097" />

But it's confusing depending on when this page is accessed. In December, for example, it says it is 0 months until the report is available:

<img width="555" height="186" alt="before" src="https://github.com/user-attachments/assets/b8e05e9e-dc34-45b5-9c12-ae35922bd0f3" />

We want to instead display the date when the report will be available -- which is the first day of the following year, i.e., January 1, 2027.

### Type of change

<!-- Please delete options that are not relevant. -->

- UI update

### How Has This Been Tested?

- unit and request tests

### Screenshots

How it looks now:

<img width="423" height="265" alt="Screenshot 2026-05-21 at 2 53 37 PM" src="https://github.com/user-attachments/assets/4ee5e432-4bc3-42b2-bc1c-e0428edb8a4b" />