### PR TITLE
 fix-5567 : Update the text in the distribution update mailer ( wording change )

### DIFF
--- a/app/views/distribution_mailer/_distribution_changes.html.erb
+++ b/app/views/distribution_mailer/_distribution_changes.html.erb
@@ -1,4 +1,4 @@
-<p>Here are some Items that we need change based on Human Essentials</p>
+<p>We've had to change some items on your distribution</p>
 <ul style="list-style-type:none">
 <% if @distribution_changes[:updates].any? %>
     <li>Items Updated</li>

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe DistributionMailer, type: :mailer do
         mail = DistributionMailer.partner_mailer(organization, distribution, 'test subject', distribution_changes)
         expect(mail.body.encoded).to match(distribution_changes[:removed][0][:name])
         expect(mail.body.encoded).to match(distribution_changes[:updates][0][:name])
+        expect(mail.body.encoded).to match("We've had to change some items on your distribution")
       end
     end
 

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -96,9 +96,11 @@ RSpec.describe DistributionMailer, type: :mailer do
       it "renders the body with changes that happened in the distribution" do
         distribution = create(:distribution, organization: user.organization, comment: "Distribution comment", partner: partner, delivery_method: :delivery)
         mail = DistributionMailer.partner_mailer(organization, distribution, 'test subject', distribution_changes)
-        expect(mail.body.encoded).to match(distribution_changes[:removed][0][:name])
-        expect(mail.body.encoded).to match(distribution_changes[:updates][0][:name])
-        expect(mail.body.encoded).to match("We've had to change some items on your distribution")
+        html = html_body(mail)
+
+        expect(html).to match(distribution_changes[:removed][0][:name])
+        expect(html).to match(distribution_changes[:updates][0][:name])
+        expect(html).to match("We've had to change some items on your distribution")
       end
     end
 


### PR DESCRIPTION
Resolves #5567 <!--fill issue number-->

### Description
- Updated the text in the distribution update mailer as per the text given in the issue.

### Type of change
- Text change

### How Has This Been Tested?
- Updated the distribution update mailer spec to include the updated text.
- Manually tested the working of the changes in the text.

### Screenshots
| Before | After |
|--------|-------|
| 
<img width="603" height="189" alt="Screenshot 2026-05-22 at 9 01 29 PM" src="https://github.com/user-attachments/assets/c07c39dc-b586-43f1-ac54-a4ef3acff836" />
 | [
<img width="621" height="205" alt="Screenshot 2026-05-22 at 9 02 13 PM" src="https://github.com/user-attachments/assets/84db4947-6735-448f-8406-bed59050fa70" />
](url) |
