### PR TITLE
Clear selected resource when role type changes

### DIFF
--- a/app/javascript/controllers/double_select_controller.js
+++ b/app/javascript/controllers/double_select_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
     const val = $(this.sourceTarget).val()
     const url = new URL(this.urlValue)
     url.searchParams.append('resource_type', val);
+    $(this.destinationTarget).empty().val(null).trigger('change');
     $(this.destinationTarget).select2({
       ajax: {
         url: url.toString(),

--- a/spec/system/admin/users_system_spec.rb
+++ b/spec/system/admin/users_system_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe "Admin Users Management", type: :system, js: true do
       expect(page.find(".error")).to have_content "Failed to create user: Please select an associated resource for the role."
     end
 
+    it "clears the resource when the role type changes" do
+      create(:partner, name: "Partner ABC", organization: organization)
+
+      visit new_admin_user_path
+      find('select#resource_type option', exact_text: "Organization").select_option
+      find("label", text: "Resource").sibling(".input-group").click
+      find('li[role="option"]', text: organization.name).click
+      find('select#resource_type option', text: "Partner").select_option
+      fill_in "user_name", with: "TestUser"
+      fill_in "user_email", with: "testuser@example.com"
+      click_on "Save"
+
+      expect(page.find(".error")).to have_content(
+        "Failed to create user: Please select an associated resource for the role."
+      )
+      expect(User.find_by(email: "testuser@example.com")).to be_nil
+    end
+
     it "hides the resource dropdown if super admin role is selected" do
       visit new_admin_user_path
       expect(page).to have_content("Resource")


### PR DESCRIPTION
Fixes #5565. Summary: clear the selected resource whenever the role resource type changes in the double select controller; add a system spec covering the Organization to Partner switch without selecting a new partner resource. Validation: git show --check; node --check app/javascript/controllers/double_select_controller.js. Local RSpec was not run because Ruby is not available on this machine. The regression is covered by the added system spec and ready for the project's CI.