### PR TITLE
Update text in request for distribution email

### DIFF
--- a/app/views/requests_confirmation_mailer/confirmation_email.html.erb
+++ b/app/views/requests_confirmation_mailer/confirmation_email.html.erb
@@ -7,7 +7,7 @@
   <% end %>
 </ul>
 
-<p>You will receive a notification when a distribution has been created of the pick-up time and date.</p>
+<p>You will receive a notification when a distribution has been created.</p>
 
 <p>Your friends at</p>
 <p><%= @organization.name %></p>

--- a/app/views/requests_confirmation_mailer/confirmation_email.text.erb
+++ b/app/views/requests_confirmation_mailer/confirmation_email.text.erb
@@ -5,7 +5,7 @@ This email confirms that <%= @organization.name %> has received a request<%= " s
   <%= item_request.item_name %> - <%= item_request.quantity_with_units %>
 <% end %>
 
-You will receive a notification when a distribution has been created of the pick-up time and date.
+You will receive a notification when a distribution has been created.
 
 Your friends at
 <%= @organization.name %>

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
       organization.update!(email: "me@org.com")
       expect(mail.body.encoded).to match('This email confirms')
       expect(mail.body.encoded).to match('For more info, please e-mail me@org.com')
+      expect(mail.body.encoded).to match('You will receive a notification when a distribution has been created.')
     end
 
     it 'CCs the organization if they opt in' do


### PR DESCRIPTION
Resolves #5561 

### Description
Text change in request for distribution email

Background: when partners submit a request for a distribution and they receive an email confirming their request, some of the current text in that email is confusing to users

Old text: "You will receive a notification when a distribution has been created of the pick-up time and date."
New text: "You will receive a notification when a distribution has been created."

### How Has This Been Tested?
- Login as a partner
- Go to Requests
- Make a new Request
- Submit request
- Receive a version of the attached email (language is the same beyond names and request details)
