### PR TITLE
Update ferrum double_click helper to use their API

### DIFF
--- a/spec/support/double_click_helper.rb
+++ b/spec/support/double_click_helper.rb
@@ -17,13 +17,5 @@
 #
 #   # Assert something based on the double click.
 def ferrum_double_click(css_selector)
-  node = Capybara.page.driver.browser.at_css(css_selector)
-  x, y = node.find_position
-  mouse = node.page.mouse
-  mouse.move(x:, y:)
-  mouse.down
-  mouse.up
-  sleep(0.05)
-  mouse.down
-  mouse.up
+  Capybara.page.driver.browser.at_css(css_selector).click(mode: :double, delay: 0.05)
 end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -915,17 +915,16 @@ RSpec.feature "Distributions", type: :system do
       click_button "Yes, it's correct"
     end
 
+    expect(page).to have_content("Distribution created!")
+
     # Make sure the button is there before trying to double click it
-    expect(page.find('form[action*="/picked_up"] .btn.btn-success.btn-md')).to have_content("Distribution Complete")
+    expect(page).to have_button("Distribution Complete", visible: true)
 
-    # Double click on the Distribution complete button
-    ferrum_double_click('form[action*="/picked_up"] .btn.btn-success.btn-md')
+    # Double click on the Distribution Complete button
+    ferrum_double_click("form[action='#{distribution_path(id: organization.distributions.last.id)}/picked_up']")
 
-    # Capybara will be quick to determine that a screen doesn't have content.
-    # Make some positive assertions that only appears on the new screen to make
-    # sure it's loaded before asserting something isn't there.
-    expect(page).not_to have_content("Distribution Complete")
-    expect(page).to have_content("Complete")
+    expect(page).to have_content("This distribution has been marked as being completed!")
+    expect(page).not_to have_button("Distribution Complete")
 
     # If it tries to mark the distribution as completed twice, the second time
     # will fail (the distribution is already complete) and show this error


### PR DESCRIPTION
Closes https://github.com/rubyforgood/human-essentials/issues/5573

This spec was flaky and can be reproduced with the 61044 seed:

```
Failures:

  1) Distributions Double clicking distribution complete does not result in the distribution attemping to be completed twice
     Failure/Error: expect(page).not_to have_content("Sorry, we encountered an error when trying to mark this distribution as being completed")
       expected not to find text "Sorry, we encountered an error when trying to mark this distribution as being completed" in "User Guide\nDiaper McDiaperface\n \nDashboard\n \nDonations\n \nPurchases\n \nRequests\n \nDistributions\n \nPick Ups & Deliveries\n \nPartner Agencies\n \nInventory\n \nCommunity\n \nReports\nSorry, we encountered an error when trying to mark this distribution as being completed\nDistribution from Test Storage Location to Test Partner\n Home\nDistributions\nTest Partner (05/22/2026)\nID\tSource location:\tAgency representative:\tDelivery method:\tShipping cost:\tComments:\tStatus:\n5\tTest Storage Location\t\tDelivery\t\t\tComplete\nItem\tValue per item\tTotal value\tQuantity\tPackage count\n23Dont test this\t\t\t15\t\nTotal:\t\t\t15\t\n Make a Correction  Print\nHuman Essentials was built with  by Ruby for Good.\nVersion:"

     [Screenshot Image]: /home/runner/work/human-essentials/human-essentials/tmp/capybara/failures_r_spec_example_groups_distributions_2_double_clicking_distribution_complete_does_not_result_in_the_distribution_attemping_to_be_completed_twice_712.png
     # ./spec/system/distribution_system_spec.rb:932:in 'block (2 levels) in <top (required)>'
```

Using ferrum's double click with the `double: mode` makes the
test more consistent: https://github.com/rubycdp/ferrum/blob/main/spec/node_spec.rb#L115

The previous code was a solution shared in this issue: https://github.com/rubycdp/ferrum/issues/529 but the maintainer of the gem commented that this wans't accurate. With https://github.com/rubycdp/ferrum/pull/533, the `double_click` helper was fixed.

This commit updates the custom helper to use the official ferrum API to simulate double clicks, and hopefully it will prevent more flaky specs from happening.

I also reordered the assertions to check for the content in the page before asserting against what's not present.

### How Has This Been Tested?

I ran the test several times with a seed from a previous flaky spec run and did not get another flaky spec with this change.