### PR TITLE
Add Drive Participant column to the donation details page (5590)

### DIFF
--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -21,6 +21,10 @@ module DonationsHelper
     current_organization.product_drives.within_date_range(formatted_range).count
   end
 
+  def drive_participant_view(donation)
+    donation.product_drive_participant.nil? ? "N/A" : donation.product_drive_participant.display_name
+  end
+
   def options_with_new(records)
     model_class = records.klass
     label = "---Create New #{model_class.model_name.human}---"

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -120,10 +120,6 @@ class Donation < ApplicationRecord
     donation_site.nil? ? "N/A" : donation_site.name
   end
 
-  def drive_participant_view
-    product_drive_participant.nil? ? "N/A" : product_drive_participant.display_name
-  end
-
   def storage_view
     storage_location.nil? ? "N/A" : storage_location.name
   end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -120,6 +120,10 @@ class Donation < ApplicationRecord
     donation_site.nil? ? "N/A" : donation_site.name
   end
 
+  def drive_participant_view
+    product_drive_participant.nil? ? "N/A" : product_drive_participant.display_name
+  end
+
   def storage_view
     storage_location.nil? ? "N/A" : storage_location.name
   end

--- a/app/models/product_drive_participant.rb
+++ b/app/models/product_drive_participant.rb
@@ -49,4 +49,8 @@ class ProductDriveParticipant < ApplicationRecord
 
     "#{contact_name} (participant)"
   end
+
+  def display_name
+    business_name.presence || contact_name
+  end
 end

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -34,6 +34,7 @@
                 <th>Date</th>
                 <th>Source</th>
                 <th>Donation Site</th>
+                <th>Drive Participant</th>
                 <th>Storage Location</th>
               </tr>
               </thead>
@@ -41,6 +42,7 @@
               <td><%= @donation.created_at.to_fs(:distribution_date) %></td>
               <td><%= @donation.source %></td>
               <td><%= @donation.donation_site_view %></td>
+              <td><%= @donation.drive_participant_view %></td>
               <td><%= @donation.storage_view %></td>              </tbody>
             </table>
           </div>

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -42,7 +42,7 @@
               <td><%= @donation.created_at.to_fs(:distribution_date) %></td>
               <td><%= @donation.source %></td>
               <td><%= @donation.donation_site_view %></td>
-              <td><%= @donation.drive_participant_view %></td>
+              <td><%= drive_participant_view(@donation) %></td>
               <td><%= @donation.storage_view %></td>              </tbody>
             </table>
           </div>

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -237,6 +237,34 @@ RSpec.describe "Donations", type: :request do
         expect(pdf.text).to include("Print")
       end
 
+      context "with a donation from a product drive participant" do
+        let(:participant) do
+          create(:product_drive_participant, business_name: "Acme Diaper Drive", organization: organization)
+        end
+        let!(:donation) do
+          create(:product_drive_donation, :with_items, item: item, product_drive_participant: participant, organization: organization)
+        end
+
+        it "shows the participant in the Drive Participant column" do
+          get donation_path(id: donation.id)
+          page = Nokogiri::HTML(response.body)
+          headers = page.at_css("table thead").css("th").map(&:text)
+          cells = page.at_css("table tbody").css("td").map(&:text)
+          expect(headers.index("Drive Participant")).to eq(headers.index("Donation Site") + 1)
+          expect(cells[headers.index("Drive Participant")]).to eq("Acme Diaper Drive")
+        end
+      end
+
+      context "with a donation that has no product drive participant" do
+        it "shows N/A in the Drive Participant column" do
+          get donation_path(id: donation.id)
+          page = Nokogiri::HTML(response.body)
+          headers = page.at_css("table thead").css("th").map(&:text)
+          cells = page.at_css("table tbody").css("td").map(&:text)
+          expect(cells[headers.index("Drive Participant")]).to eq("N/A")
+        end
+      end
+
       it "shows an enabled edit button" do
         get donation_path(id: donation.id)
         page = Nokogiri::HTML(response.body)


### PR DESCRIPTION
Resolves #5590

### Description
The donation details page did not show the product drive participant, even though it is captured when creating a product drive donation. This adds a `Drive Participant` column to the donation summary table, between `Donation Site` and `Storage Location`, as specified in the issue.

The participant is displayed by business name, falling back to contact name — the same representation used in the participant dropdown on the donation form, so users see the same label they picked when creating the donation. When the donation has no participant, the column shows `N/A`, consistent with the existing `Donation Site` and `Storage Location` columns.

Implementation mirrors the existing `Donation#donation_site_view` / `#storage_view` pattern with a new `Donation#drive_participant_view`, backed by a new `ProductDriveParticipant#display_name`.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added two request spec examples to `spec/requests/donations_requests_spec.rb` (GET #show): one asserting the participant's business name appears in the new column positioned right after `Donation Site`, and one asserting `N/A` for a donation without a participant. Both were written first and failed before the change.

- `bundle exec rspec spec/requests/donations_requests_spec.rb` — 43 examples, 0 failures
- `bundle exec rspec spec/models/donation_spec.rb spec/models/product_drive_participant_spec.rb` — 51 examples, 0 failures
- `bundle exec rspec spec/system/donation_system_spec.rb -e "When viewing an existing donation"` — 4 examples, 0 failures
- `bundle exec rubocop` on touched files and `bundle exec erb_lint` on the view — no offenses

### Screenshots
Before / after screenshots coming in a follow-up comment.