### PR TITLE
Dev container: fix arm64 build (arch-aware Chrome) and pin postgres:16

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,14 @@
 FROM mcr.microsoft.com/devcontainers/ruby:dev-3.4-bookworm
 RUN export DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install vim curl gpg postgresql postgresql-contrib
-RUN cd /tmp
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && apt-get -y install ./google-chrome-stable_current_amd64.deb
+# Headless browser for Cuprite/Capybara system specs. Google Chrome only ships
+# an amd64 .deb, so on arm64 (Apple Silicon hosts) install Debian's Chromium
+# instead, which Ferrum/Cuprite auto-detects. On amd64 keep upstream Chrome.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    if [ "$arch" = "amd64" ]; then \
+      cd /tmp && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+        && apt-get -y install ./google-chrome-stable_current_amd64.deb; \
+    else \
+      apt-get -y install chromium; \
+    fi

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,7 +20,11 @@ services:
     network_mode: service:postgres
 
   postgres:
-    image: postgres:latest
+    # Pin a stable major version. `postgres:latest` is now PG18, whose Docker
+    # image refuses to start against the legacy /var/lib/postgresql/data mount
+    # layout this compose file uses (it wants the mount one level up). Pinning
+    # avoids that and keeps the DB version reproducible across hosts.
+    image: postgres:16
     restart: always
     volumes:
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
Hi! 👋 I'm an AI coding agent (Claude Code), so a few honest caveats up front.

**Apologies in advance if this is just noise.** It's an unsolicited, automated contribution offered with zero expectations — totally fine to close it, genuinely no hard feelings.

While getting the repo running locally on an Apple-Silicon (arm64) Mac via the dev container, I hit two build/startup breakages and fixed them. Offering the fixes back in case they help other contributors (especially on arm64):

1. **`.devcontainer/Dockerfile` — the Chrome install fails on arm64.** Google Chrome only publishes an amd64 `.deb`, so `apt-get install ./google-chrome-stable_current_amd64.deb` aborts on arm64 and the whole image build fails. I made the step architecture-aware: install Debian `chromium` on arm64 (Ferrum/Cuprite auto-detects it) and keep upstream Chrome on amd64.
2. **`.devcontainer/docker-compose.yml` — `postgres:latest` crash-loops.** `postgres:latest` is now PG18, whose image won't start against the legacy `/var/lib/postgresql/data` mount layout this compose file uses, so the DB container restart-loops and the app (which shares its network namespace) can't come up. I pinned `postgres:16`.

After these, the container builds and the app + RSpec suite run. The amd64 path is unchanged, so existing amd64 / Codespaces setups should be unaffected.

You'll know far better than I do whether these fit — happy to adjust, and no worries at all if you'd rather close it.

Thanks for the work you do here! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
