### PR TITLE
Make item dropdown width responsive to window resizing (5556)

### DIFF
--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -23,7 +23,7 @@
                             collection: @item_labels_with_quantities || @items, prompt: "Choose an item",
                             include_blank: "",
                             label: false,
-                            input_html: { class: "my-0 line_item_name", "data-controller": "select2" } %>
+                            input_html: { class: "my-0 line_item_name", "data-controller": "select2", "data-select2-config-value": '{"width": "100%"}' } %>
             <% if requested.present? %>
               <%= field.input :item_id, as: :hidden %>
             <% end %>

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -706,8 +706,26 @@ RSpec.feature "Distributions", type: :system do
       expect(@request.distribution_id).to eq @distribution.id
       expect(@request).to be_status_fulfilled
     end
-  end
 
+    it "keeps the item dropdown within the form width when the window is narrowed" do
+      item_id = storage_location.items.first.id
+      request_items = [{ "item_id" => item_id, "quantity" => 10 }]
+      @request = create(:request, organization:, request_items:, partner:)
+      create(:item_request, request: @request, item_id:, quantity: 10)
+
+      visit request_path(id: @request.id)
+      click_on "Fulfill request"
+
+      expect(page).to have_css(".li-name .select2-container")
+
+      current_window.resize_to(600, 800)
+
+      dropdown_width = page.evaluate_script("document.querySelector('.li-name .select2-container').offsetWidth")
+      column_width = page.evaluate_script("document.querySelector('.li-name').offsetWidth")
+
+      expect(dropdown_width).to be <= column_width
+    end
+  end
   context "via barcode entry" do
     let(:existing_barcode) { create(:barcode_item, quantity: 50) }
     let(:item_with_barcode) { existing_barcode.item }


### PR DESCRIPTION
Resolves #5556

## Description

On distributions (both when fulfilling a request and on the regular form), the item dropdown kept a fixed pixel width computed when select2 initialized. Narrowing the window left the dropdown wider than its column, hiding the Quantity input and the Requested column.

Passing `width: "100%"` to the dropdown's select2 config makes the control follow its container as the window resizes — the same pattern already used in the product drive form. The change is in the shared `_line_item_fields` partial, so it also covers the regular distribution form mentioned in the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added a system spec that narrows the window and asserts the item dropdown stays within its column (fails without the change, passes with it).
- `bundle exec rspec spec/system/distribution_system_spec.rb` — 53 examples, 0 failures
- `bundle exec rubocop` and `bundle exec erb_lint` on the changed files — clean

## Screenshots

Fulfilment form at a narrow (600px) window.

**Before**
<img width="600" height="1450" alt="issue5556_before_buggy" src="https://github.com/user-attachments/assets/17d4572f-bb71-4967-867f-25066983e1ec" />



**After**
<img width="600" height="1450" alt="issue5556_after_fixed" src="https://github.com/user-attachments/assets/63e7132a-200b-4224-93ed-e539a3ac8879" />


## Follow-up

The item dropdown is now responsive. A separate, pre-existing layout roughness in the line-item column headers on narrow screens (header wrapping/alignment) is tracked in #5603 to keep this PR scoped.
