### PR TITLE
5477 speed up distributions export

### DIFF
--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -149,10 +149,9 @@ module Exports
     def build_row_data(distribution)
       row = base_table.values.map { |closure| closure.call(distribution) }
 
+      grouped_line_items = distribution.line_items.group_by(&:name)
       item_names.each do |item_name|
-        # We are doing this in-memory so that we can use the already-loaded line item records
-        line_items = distribution.line_items.select { |item| item.name == item_name }
-
+        line_items = grouped_line_items.fetch(item_name, [])
         row << line_items.sum(&:quantity)
         row << Money.new(line_items.sum(&:value_per_line_item)) if @organization.include_in_kind_values_in_exported_files
         row << line_items.map(&:has_packages).compact.sum.round(2) if @organization.include_packages_in_distribution_export

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -7,7 +7,7 @@ module Exports
     include DistributionHelper
     include ItemsHelper
 
-    def initialize(distributions:, organization:, filters: [])
+    def initialize(distributions:, organization:, filters: {})
       # Currently, the @distributions are already loaded by the controllers that are delegating exporting
       # to this service object; this is happening within the same request/response cycle, so it's already
       # in memory, so we can pass that collection in directly. Should this be moved to a background / async

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -8,10 +8,10 @@ module Exports
     include ItemsHelper
 
     def initialize(distributions:, organization:, filters: {})
-      # Currently, the @distributions are already loaded by the controllers that are delegating exporting
-      # to this service object; this is happening within the same request/response cycle, so it's already
-      # in memory, so we can pass that collection in directly. Should this be moved to a background / async
-      # job, we will need to pass in a collection of IDs instead.
+      # Currently, `distributions` is a ActiveRecord::Relation from the controllers that are delegating exporting
+      # to this service object; this is happening within the same request/response cycle, so we pass the query in
+      # directly. Should this be moved to a background / async job, we will need to pass in a collection of IDs instead.
+      # The distribution model objects are not loaded until the `#find_each` in `generate_csv_data`
       # Also, adding in a `filters` parameter to make the filters that have been used available to this
       # service object.
       @distributions = distributions

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -147,17 +147,26 @@ module Exports
     end
 
     def build_row_data(distribution)
-      row = base_table.values.map { |closure| closure.call(distribution) }
+      base_row = base_table.values.map { |closure| closure.call(distribution) }
 
       grouped_line_items = distribution.line_items.group_by(&:name)
-      item_names.each do |item_name|
-        line_items = grouped_line_items.fetch(item_name, [])
-        row << line_items.sum(&:quantity)
-        row << Money.new(line_items.sum(&:value_per_line_item)) if @organization.include_in_kind_values_in_exported_files
-        row << line_items.map(&:has_packages).compact.sum.round(2) if @organization.include_packages_in_distribution_export
+      base_row + item_names.flat_map do |item_name|
+        line_items = grouped_line_items[item_name]
+        next missing_item unless line_items
+        [
+          line_items.sum(&:quantity),
+          (Money.new(line_items.sum(&:value_per_line_item)) if @organization.include_in_kind_values_in_exported_files),
+          (line_items.map(&:has_packages).compact.sum.round(2) if @organization.include_packages_in_distribution_export)
+        ].compact
       end
+    end
 
-      row
+    def missing_item
+      @missing_item ||= [
+        0,
+        ("0.00".freeze if @organization.include_in_kind_values_in_exported_files),
+        (0 if @organization.include_packages_in_distribution_export)
+      ].compact
     end
   end
 end

--- a/app/services/exports/export_distributions_csv_service.rb
+++ b/app/services/exports/export_distributions_csv_service.rb
@@ -32,7 +32,7 @@ module Exports
       csv_data = []
 
       csv_data << base_headers + item_headers
-      distributions.each do |distribution|
+      distributions.find_each do |distribution|
         csv_data << build_row_data(distribution)
       end
 

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -439,5 +439,29 @@ RSpec.describe DistributionsController, type: :controller do
         end
       end
     end
+
+    describe "GET #index" do
+      context "when distribution has items updated for minimum quantity" do
+        let(:storage_location) { create(:storage_location, organization: organization) }
+        let(:distribution_count) { 5 }
+        let(:distributions) { create_list(:distribution, distribution_count, :with_items, item: items.sample, storage_location: storage_location, organization: organization) }
+        let(:items) { create_list(:item, 500, organization:, on_hand_minimum_quantity: 5) }
+
+        it "responds 200" do
+          get :index
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "downloads a CSV" do
+          distributions
+          get :index, format: :csv
+
+          expect(response.header["Content-Type"]).to include "text/csv"
+          expect(response).to have_http_status(:ok)
+          expect(CSV.parse(response.body).size).to eq(distribution_count + 1)
+        end
+      end
+    end
   end
 end

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -183,4 +183,26 @@ RSpec.describe Exports::ExportDistributionsCSVService do
       end
     end
   end
+
+  # this is intended for easier performance testing, not to be run with rest of suite
+  # also, better for testing consistency to disable config.order = :random
+  # lastly, test setup time gets long, the printed duration is the actual generation time to pay attention to
+  xcontext "performance timing" do
+    [500, 1000, 2000, 5000, 10_000, 20_000, 30_000].reverse_each do |distribution_count|
+      it "processes #{distribution_count} distributions" do
+        partners = create_list(:partner, 500)
+        items = create_list(:item, 5000, organization:, on_hand_minimum_quantity: 5)
+        create_list(:distribution, distribution_count, :with_items, item: items.sample, storage_location: storage_location, organization: organization, partner: partners.sample)
+        TestInventory.create_inventory(organization, {
+          storage_location.id => items.map { [it.id, rand(20..69)] }.to_h
+        })
+        t = Time.zone.now
+        csv = Exports::ExportDistributionsCSVService.new(distributions: organization.distributions.includes(:partner, :storage_location, line_items: :item), organization:).generate_csv
+        puts "================================================================="
+        puts "Duration: #{(d = Time.zone.now - t).round(4)} for #{distribution_count} distributions: #{(d / distribution_count).round(4)}/dist"
+        File.write("dist-#{distribution_count}.csv", csv)
+        expect(true)
+      end
+    end
+  end
 end

--- a/spec/services/exports/export_distributions_csv_service_spec.rb
+++ b/spec/services/exports/export_distributions_csv_service_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe Exports::ExportDistributionsCSVService do
   let(:partner) { create(:partner, name: "first partner", email: "firstpartner@gmail.com", notes: "just a note.", organization_id: organization.id) }
   let(:include_in_kind_values) { false }
   let(:include_packages) { false }
+  let(:distributions_query) { Distribution.where(id: distributions.map(&:id)).includes(:partner, :storage_location, line_items: :item) } # match the query design used in DistributionsController and PartnersController
 
   describe '#generate_csv' do
-    subject { described_class.new(distributions: distributions, organization: organization, filters: filters).generate_csv }
+    subject { described_class.new(distributions: distributions_query, organization: organization, filters: filters).generate_csv }
 
     let(:duplicate_item) { create(:item, name: "Dupe Item", value_in_cents: 300, organization: organization, package_size: 2) }
 
@@ -174,7 +175,7 @@ RSpec.describe Exports::ExportDistributionsCSVService do
     end
 
     context 'when there are no distributions but the report is requested' do
-      subject { described_class.new(distributions: [], organization: organization, filters: filters).generate_csv }
+      subject { described_class.new(distributions: Distribution.none, organization: organization, filters: filters).generate_csv }
       it 'returns a csv with only headers and no rows' do
         csv = <<~CSV
           Partner,Initial Allocation,Scheduled for,Source Inventory,Total Number of #{item_name},Total Value of #{item_name},Delivery Method,Shipping Cost,Status,Agency Representative,Comments,Reporting Category,Dupe Item


### PR DESCRIPTION
This improves the timeout issue in #5477. The two biggest factors for duration (slowness) are number of distributions and the number of items for an organization. (distributions x `organization.items` = total calculations)

#### _Overall, I think this can speed up processing up by roughly 6x, dependent upon data volumes and composition (ie associated data)_

My approach was to see how data volume impacts processing time. First, calculate processing time for various volumes of distributions, and then separately calculate across various volumes of items. All performance evaluation is relative, since my computer is not a typical server, and also not memory constrained for this purpose. I have attempted to have consistent system load across test runs, and run enough to get an idea for the potential speed processing, essentially the best realistic performance possible for each variation of code. All my testing is done on a MBP M2 Pro.

All of this is heavily dependent on what real world data looks like. My testing had few items per distribution, and primarily varied distribution count and organization item count. That could be wildly off from reality, but the performance gains should still be sizable.

I have added a skipped spec, which is what I primarily used for testing for various counts of distributions. Simple tweaks allowed for testing different item counts with the same distribution amount.

A couple general findings:
* processing time scales linearly as distribution count grows. This may not hold up for production systems that have other resource contention
* processing time scales (mostly) linearly as organization item count grows
* I have lots of data recorded, please let me know if that would be good to share as well

### Summary of changes, commit by commit:

adbfe3a
Add controller spec + perf test spec, and tweak method arg to match actual usage

b41deb0
Switch to `#find_each`. This did not have any speed impact on my machine, but memory usage is smoothed, and it will likely have some on production systems with other load and memory constraints. This will be better for the system overall

dcf3059
Use `group_by` to group `organization.line_items` (once per distribution), rather than doing `distribution.line_items.select` for each organization item per distribution. This removes about 60% of original processing time per distribution.

439ff17
Use a memoized array for organization line items which are not in the distribution. This replaces the 3 entry calculation in the inner most loop with a pre-computed set of zeroes. It also causes a shift to using flat_map instead of shoveling individual values. This entire change removed approximately 60% of processing time remaining after the prior improvement.

664e292
Update the comment for future devs

### Other thoughts

* The idea of moving to a background job would still be good long term, but this should buy some more runway
* I wanted to keep this maintainable and avoid turning this into a leetcode exercise. There are some further tweaks available to squeeze a hair more out of it, but I do not think they are meaningful enough for the maintainability cost (ie could do some clever data plucking to avoid instantiating so many line_item+item pairings, but that would get ugly quickly)
* The `distributions_controller#index` action has a bunch of statements that are unnecessary, but seem to have negligible impact. The `DistributionTotalsService` query is repeated (in controller, then export service), but 1) it probably hits ActiveRecord query cache the 2nd time and 2) at least with my test dataset composition, had negligible cost as well. But with different data in production, it could be relevant

# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.
- [x] I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5477 

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update
* Documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
