### PR TITLE
Fix 500 on open-ended date input in donations#index (5608)

### DIFF
--- a/app/helpers/date_range_helper.rb
+++ b/app/helpers/date_range_helper.rb
@@ -34,14 +34,11 @@ module DateRangeHelper
   end
 
   def selected_interval
-    date_range_params.split(" - ").map do |d|
-      Date.strptime(d, "%B %d, %Y")
-    rescue
-      flash.now[:notice] = "Invalid Date range provided. Reset to default date range"
-      return default_date.split(" - ").map do |d|
-        Date.strptime(d.to_s, "%B %d, %Y")
-      end
-    end
+    start_date, end_date = date_range_params.split(" - ")
+    [Date.strptime(start_date.to_s, "%B %d, %Y"), Date.strptime(end_date.to_s, "%B %d, %Y")]
+  rescue
+    flash.now[:notice] = "Invalid Date range provided. Reset to default date range"
+    default_date.split(" - ").map { |d| Date.strptime(d, "%B %d, %Y") }
   end
 
   def selected_range

--- a/spec/helpers/date_range_helper_spec.rb
+++ b/spec/helpers/date_range_helper_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe DateRangeHelper do
       end
     end
 
+    context "with an open-ended date range" do
+      it "falls back to default date range and sets a flash notice" do
+        open_ended_range = "August 25, 2025 - "
+        flash_now = {}
+        flash_double = double("flash", now: flash_now)
+        helper = dummy_class.new({filters: {date_range: open_ended_range}}, flash_double)
+
+        interval = helper.selected_interval
+        default_start, default_end = helper.default_date.split(" - ").map { |d| Date.strptime(d, "%B %d, %Y") }
+
+        expect(interval).to eq([default_start, default_end])
+        expect(flash_now[:notice]).to eq("Invalid Date range provided. Reset to default date range")
+      end
+    end
+
     context "with an invalid date range" do
       it "falls back to default date range and sets a flash notice" do
         invalid_range = "November 08 - February 08"


### PR DESCRIPTION
Resolves #5608

### Description

`donations#index` (and any page using the dashboard date-range picker) raised a 500 when an open-ended date was entered in the picker — e.g. a start date with no end date. Bugsnag reported `NoMethodError: undefined method 'to_fs' for nil` from `DateRangeHelper#selected_range_described`.

Root cause: `selected_interval` split the raw range on `" - "` and mapped each part to a `Date`. An open-ended value such as `"August 25, 2025 - "` splits to a single element, so the method returned `[Date]` with a `nil` end date. That `nil` then propagated to `selected_range_described` (`end_date.to_fs(:short)`), `selected_range` (`end_date.end_of_day`), and `application_controller.rb` (`selected_interval.map { |d| d.to_fs(:long) }`), any of which crashes.

Fix: `selected_interval` now destructures into start/end and parses both. When the end date is missing (or either date is unparseable) it falls back to the default range and sets the existing `"Invalid Date range provided. Reset to default date range"` flash notice — the same graceful behavior already used for invalid ranges. This keeps all downstream callers receiving a complete `[start, end]` pair.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added a request-helper spec covering the open-ended date range (asserting fallback to the default range plus the flash notice). Existing valid/invalid range specs still pass.

- `bundle exec rspec spec/helpers/date_range_helper_spec.rb` → 3 examples, 0 failures
- `bundle exec rspec spec/requests/donations_requests_spec.rb spec/helpers/` → 87 examples, 0 failures
- `bin/lint app/helpers/date_range_helper.rb spec/helpers/date_range_helper_spec.rb` → no offenses
