### PR TITLE
#5593 product_drive_participants ordered alphabetically

### DIFF
--- a/app/models/product_drive_participant.rb
+++ b/app/models/product_drive_participant.rb
@@ -29,7 +29,7 @@ class ProductDriveParticipant < ApplicationRecord
   validates :business_name, presence: { message: "Must provide a name or a business name" }, if: proc { |pdp| pdp.contact_name.blank? }
   validates :comment, length: { maximum: 500 }
 
-  scope :alphabetized, -> { order(:contact_name) }
+  scope :alphabetized, -> { order(:business_name) }
   scope :with_volumes, -> {
     left_joins(donations: :line_items)
       .select("product_drive_participants.*, SUM(COALESCE(line_items.quantity, 0)) AS volume")

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -40,7 +40,7 @@
       </div>
       <div class="col-xs-8 col-md-6 col-lg-3">
         <%= f.association :product_drive_participant,
-                          collection: @product_drive_participants,
+                          collection: @product_drive_participants.sort_by { |x| x.business_name.upcase + x.contact_name.upcase },
                           selected: donation_form.product_drive_participant_id,
                           include_blank: true,
                           label_method: lambda { |x| "#{x.try(:business_name).presence || x.try(:contact_name)}" },


### PR DESCRIPTION

Resolves #5593

### Description

In new donation Product Drive Participants are now sorted alphabetically. They were originally being ordered by contact name in the model. This is now changed to business name. as some participants by only have a contact name they are ordered again in the view by a combination of both. I considered writing some SQL but didn't want to create any trickle down effects and new bugs.

### Type of change


* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

Verified by running app locally, adding new participants and confirming position
