### PR TITLE
Fix 500 on open-ended date range in donations#index

### DIFF
--- a/app/helpers/date_range_helper.rb
+++ b/app/helpers/date_range_helper.rb
@@ -34,14 +34,20 @@ module DateRangeHelper
   end
 
   def selected_interval
-    date_range_params.split(" - ").map do |d|
+    dates = date_range_params.split(" - ").map do |d|
       Date.strptime(d, "%B %d, %Y")
     rescue
+      nil
+    end
+
+    if dates.size != 2 || dates.any?(&:nil?)
       flash.now[:notice] = "Invalid Date range provided. Reset to default date range"
       return default_date.split(" - ").map do |d|
         Date.strptime(d.to_s, "%B %d, %Y")
       end
     end
+
+    dates
   end
 
   def selected_range

--- a/spec/helpers/date_range_helper_spec.rb
+++ b/spec/helpers/date_range_helper_spec.rb
@@ -45,5 +45,31 @@ RSpec.describe DateRangeHelper do
         expect(flash_now[:notice]).to eq("Invalid Date range provided. Reset to default date range")
       end
     end
+
+    context "with an open-ended date range" do
+      it "falls back to default date range and sets a flash notice instead of raising" do
+        open_ended_range = "August 25, 2025 - "
+        flash_now = {}
+        flash_double = double("flash", now: flash_now)
+        helper = dummy_class.new({filters: {date_range: open_ended_range}}, flash_double)
+
+        interval = helper.selected_interval
+        default_start, default_end = helper.default_date.split(" - ").map { |d| Date.strptime(d, "%B %d, %Y") }
+
+        expect(interval).to eq([default_start, default_end])
+        expect(flash_now[:notice]).to eq("Invalid Date range provided. Reset to default date range")
+      end
+    end
+  end
+
+  describe "#selected_range_described" do
+    it "does not raise when given an open-ended date range" do
+      open_ended_range = "August 25, 2025 - "
+      flash_now = {}
+      flash_double = double("flash", now: flash_now)
+      helper = dummy_class.new({filters: {date_range: open_ended_range}}, flash_double)
+
+      expect { helper.selected_range_described }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #5608 — Bugsnag reported a `NoMethodError` (`undefined method 'to_fs' for nil`) on `donations#index` when a bank enters an open-ended date range in the date picker.

`DateRangeHelper#selected_interval` only rescued `Date.strptime` raising an exception. An open-ended range like `"August 25, 2025 - "` (only the start date filled in) parses without error: `.split(" - ")` produces a single-element array, so `.map` only yields one date, and the destructuring `start_date, end_date = selected_interval` silently leaves `end_date` as `nil`. That `nil` then hits `end_date.to_fs(:short)` in `selected_range_described`, causing the 500.

## Fix

`selected_interval` now falls back to the default date range (same "Invalid Date range provided. Reset to default date range" flash notice already used for unparseable ranges) whenever fewer than 2 valid dates are parsed, not only when `strptime` raises.

## Test plan
- [x] `bundle exec rspec spec/helpers/date_range_helper_spec.rb`
- Added a regression spec for an open-ended range in `selected_interval`, plus a spec asserting `selected_range_described` no longer raises in that case