### PR TITLE
Removes the kit value/visibility copy based on prod data validation

### DIFF
--- a/db/migrate/20260612120000_copy_kit_attributes_to_kit_items_and_repoint_events.rb
+++ b/db/migrate/20260612120000_copy_kit_attributes_to_kit_items_and_repoint_events.rb
@@ -1,23 +1,13 @@
 class CopyKitAttributesToKitItemsAndRepointEvents < ActiveRecord::Migration[8.0]
   # The Kit model is being removed; KitItem (an Item) becomes the standalone kit.
-  # Move the kit's value_in_cents/visible_to_partners onto its kit item (the real values
-  # previously lived on the kit), and repoint existing kit inventory events at the kit item
-  # so inventory replay keeps working without the Kit class.
+  # Repoint existing kit inventory events at the kit item so inventory replay keeps
+  # working without the Kit class.
   #
   # Schema is intentionally left in place (kits table and items.kit_id remain) so this is
   # reversible at the data level; the columns just become vestigial.
   def up
     # Data-only updates against existing tables; safe to run.
     safety_assured do
-      execute(<<-SQL.squish)
-        UPDATE items
-        SET value_in_cents = kits.value_in_cents,
-            visible_to_partners = kits.visible_to_partners,
-            updated_at = NOW()
-        FROM kits
-        WHERE items.kit_id = kits.id
-      SQL
-
       execute(<<-SQL.squish)
         UPDATE events
         SET eventable_type = 'Item',
@@ -27,10 +17,31 @@ class CopyKitAttributesToKitItemsAndRepointEvents < ActiveRecord::Migration[8.0]
         WHERE events.eventable_type = 'Kit'
           AND items.kit_id = events.eventable_id
       SQL
+
+      # Every kit event must now point at an item; a leftover means a kit with no item
+      # row, which would break event replay and event history once the Kit class is gone.
+      leftover = select_value("SELECT COUNT(*) FROM events WHERE eventable_type = 'Kit'")
+      if leftover.to_i.positive?
+        raise "#{leftover} events still reference Kit eventables with no matching item; " \
+              "fix those kits before migrating"
+      end
     end
   end
 
   def down
-    raise ActiveRecord::IrreversibleMigration
+    # Kit allocate/deallocate events were the only events with Kit eventables.
+    safety_assured do
+      execute(<<-SQL.squish)
+        UPDATE events
+        SET eventable_type = 'Kit',
+            eventable_id = items.kit_id,
+            updated_at = NOW()
+        FROM items
+        WHERE events.eventable_type = 'Item'
+          AND events.eventable_id = items.id
+          AND events.type IN ('KitAllocateEvent', 'KitDeallocateEvent')
+          AND items.kit_id IS NOT NULL
+      SQL
+    end
   end
 end


### PR DESCRIPTION
I looked at the before/after migrating with a prod snapshot and found that the value and visible_to_partners parts didn't do what we want; if we keep them then there will be visible changes, but if we remove them then everything looks the same before and after for users. Also I added a safety check and a reverse (which might work without the copies).

With this on top of the existing branch we should be good to merge+deploy, but I wanted to break it out for review. I suppose the file is misnamed now, meh.
