### PR TITLE
Fix table alignment bug

### DIFF
--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -102,7 +102,7 @@
               </tbody>
               <tfoot>
               <tr>
-                <td colspan="2" style="text-align: left"><strong>Total</strong></td>
+                <td colspan="3" style="text-align: left"><strong>Total</strong></td>
                 <td class="numeric">
                   <%= @paginated_purchases_quantity %> (This page)
                   <br>
@@ -117,14 +117,15 @@
                   <strong>
                     <%= dollar_value(@total_value_all_purchases) %> (Total)
                   </strong>
-                  </td>
-                  <td class="numeric">
-                    <%= dollar_value(@paginated_fair_market_values) %> (This page)
+                </td>
+                <td class="numeric">
+                  <%= dollar_value(@paginated_fair_market_values) %> (This page)
                   <br>
                   <strong>
                     <%= dollar_value(@total_fair_market_values) %> (Total)
                   </strong>
-                  </td>
+                </td>
+                <td></td>
                 <td></td>
               </tr>
               </tfoot>


### PR DESCRIPTION
Resolves #5638  <!--fill issue number-->

### Description
Bug fix: fixed the alignment of the totals in the all purchases table 

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?


- Login and go to the all purchases page you can verify the alignment is correct now
- Purely a visual change not tested. But related system specs pass 

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
Before: 
<img width="1512" height="982" alt="Screenshot 2026-07-24 at 11 31 57 AM" src="https://github.com/user-attachments/assets/6c01678e-7377-4480-b7a7-852092ace907" />
After:
<img width="1512" height="982" alt="Screenshot 2026-07-24 at 11 28 02 AM" src="https://github.com/user-attachments/assets/1aa5e691-98e5-47de-9f03-622ea2d98ec6" />
