### PR TITLE
Fix existing user names in partner invites

### DIFF
--- a/app/controllers/partner_users_controller.rb
+++ b/app/controllers/partner_users_controller.rb
@@ -2,11 +2,16 @@
 
 class PartnerUsersController < ApplicationController
   before_action :authorize_admin
-  before_action :set_partner, only: %i[index create destroy resend_invitation]
+  before_action :set_partner, only: %i[index lookup create destroy resend_invitation]
 
   def index
     @users = @partner.users
     @user = User.new(name: "")
+  end
+
+  def lookup
+    user = User.find_by("LOWER(email) = ?", params[:email].to_s.downcase)
+    render json: {exists: user.present?}
   end
 
   def create

--- a/app/controllers/partner_users_controller.rb
+++ b/app/controllers/partner_users_controller.rb
@@ -11,7 +11,7 @@ class PartnerUsersController < ApplicationController
 
   def lookup
     user = User.find_by("LOWER(email) = ?", params[:email].to_s.downcase)
-    render json: {exists: user.present?}
+    render json: {exists: user.present?, has_name: user&.name.present?}
   end
 
   def create
@@ -69,7 +69,7 @@ class PartnerUsersController < ApplicationController
   private
 
   def set_partner
-    @partner = Partner.find(params[:partner_id])
+    @partner = current_organization.partners.find(params[:partner_id])
   end
 
   def user_params

--- a/app/javascript/controllers/existing_user_controller.js
+++ b/app/javascript/controllers/existing_user_controller.js
@@ -4,7 +4,14 @@ export default class extends Controller {
   static targets = ["email", "name", "message"]
   static values = { lookupUrl: String }
 
+  disconnect() {
+    this.abortController?.abort()
+  }
+
   async lookup() {
+    this.abortController?.abort()
+    this.abortController = new AbortController()
+
     const email = this.emailTarget.value.trim()
 
     if (email === "") {
@@ -14,7 +21,8 @@ export default class extends Controller {
 
     try {
       const response = await fetch(`${this.lookupUrlValue}?email=${encodeURIComponent(email)}`, {
-        headers: { "Accept": "application/json" }
+        headers: { "Accept": "application/json" },
+        signal: this.abortController.signal
       })
       if (!response.ok || this.emailTarget.value.trim() !== email) return
 
@@ -23,10 +31,10 @@ export default class extends Controller {
         this.resetNameField()
       } else {
         this.nameTarget.disabled = false
-        this.messageTarget.textContent = "This user already exists. The submitted name will only be used if their profile has no name yet."
+        this.messageTarget.textContent = "This user already exists. Their current profile name will be kept; the submitted name is used only if their profile has no name yet."
       }
-    } catch (_error) {
-      this.resetNameField()
+    } catch (error) {
+      if (error.name !== "AbortError") this.messageTarget.textContent = ""
     }
   }
 

--- a/app/javascript/controllers/existing_user_controller.js
+++ b/app/javascript/controllers/existing_user_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["email", "name", "message"]
+  static values = { lookupUrl: String }
+
+  async lookup() {
+    const email = this.emailTarget.value.trim()
+
+    if (email === "") {
+      this.resetNameField()
+      return
+    }
+
+    try {
+      const response = await fetch(`${this.lookupUrlValue}?email=${encodeURIComponent(email)}`, {
+        headers: { "Accept": "application/json" }
+      })
+      if (!response.ok || this.emailTarget.value.trim() !== email) return
+
+      const user = await response.json()
+      if (!user.exists) {
+        this.resetNameField()
+      } else {
+        this.nameTarget.disabled = false
+        this.messageTarget.textContent = "This user already exists. The submitted name will only be used if their profile has no name yet."
+      }
+    } catch (_error) {
+      this.resetNameField()
+    }
+  }
+
+  resetNameField() {
+    this.nameTarget.disabled = false
+    this.messageTarget.textContent = ""
+  }
+}

--- a/app/javascript/controllers/existing_user_controller.js
+++ b/app/javascript/controllers/existing_user_controller.js
@@ -31,7 +31,9 @@ export default class extends Controller {
         this.resetNameField()
       } else {
         this.nameTarget.disabled = false
-        this.messageTarget.textContent = "This user already exists. Their current profile name will be kept; the submitted name is used only if their profile has no name yet."
+        this.messageTarget.textContent = user.has_name
+          ? "This user already exists. Their current profile name will be kept."
+          : "This user already exists. The submitted name will be used because their profile has no name yet."
       }
     } catch (error) {
       if (error.name !== "AbortError") this.messageTarget.textContent = ""

--- a/app/services/user_invite_service.rb
+++ b/app/services/user_invite_service.rb
@@ -20,7 +20,7 @@ module UserInviteService
       roles.append(Role::ORG_USER)
     end
 
-    user = User.find_by(email: email)
+    user = User.find_by("LOWER(email) = ?", email.to_s.downcase)
 
     # return if user already has all the roles we're trying to add
     if !force && user && roles.all? { |role| user.has_role?(role, resource) }
@@ -28,6 +28,7 @@ module UserInviteService
     end
 
     if user
+      user.update!(name: name) if user.name.blank? && name.present?
       add_roles(user, resource: resource, roles: roles)
       if force
         user.invite!

--- a/app/views/partner_users/_form.html.erb
+++ b/app/views/partner_users/_form.html.erb
@@ -21,7 +21,7 @@
           input_html: {
             data: {
               existing_user_target: "email",
-              action: "blur->existing-user#lookup"
+              action: "change->existing-user#lookup"
             }
           } %>
         <small class="form-text text-muted" data-existing-user-target="message" role="status" aria-live="polite" aria-atomic="true"></small>

--- a/app/views/partner_users/_form.html.erb
+++ b/app/views/partner_users/_form.html.erb
@@ -3,13 +3,28 @@
     <h3 class="card-title">Invite New User</h3>
   </div>
 
-  <%= simple_form_for user, url: partner_users_path(partner) do |f| %>
+  <%= simple_form_for user,
+    url: partner_users_path(partner),
+    html: {
+      data: {
+        controller: "existing-user",
+        existing_user_lookup_url_value: lookup_partner_users_path(partner)
+      }
+    } do |f| %>
     <div class="card-body">
       <div class="form-group">
-        <%= f.input :name, label: "Name", placeholder: "Name", required: true %>
+        <%= f.input :name, label: "Name", placeholder: "Name", required: true,
+          input_html: {data: {existing_user_target: "name"}} %>
       </div>
       <div class="form-group">
-        <%= f.input :email, label: "Email", placeholder: "Email", required: true %>
+        <%= f.input :email, label: "Email", placeholder: "Email", required: true,
+          input_html: {
+            data: {
+              existing_user_target: "email",
+              action: "blur->existing-user#lookup"
+            }
+          } %>
+        <small class="form-text text-muted" data-existing-user-target="message" aria-live="polite"></small>
       </div>
     </div>
 

--- a/app/views/partner_users/_form.html.erb
+++ b/app/views/partner_users/_form.html.erb
@@ -24,7 +24,7 @@
               action: "blur->existing-user#lookup"
             }
           } %>
-        <small class="form-text text-muted" data-existing-user-target="message" aria-live="polite"></small>
+        <small class="form-text text-muted" data-existing-user-target="message" role="status" aria-live="polite" aria-atomic="true"></small>
       </div>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,9 @@ Rails.application.routes.draw do
 
   resources :partners do
     resources :users, only: [:index, :create, :destroy], controller: 'partner_users' do
+      collection do
+        get :lookup
+      end
       member do
         post :resend_invitation
         post :reset_password

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe PartnerUsersController, type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq("exists" => true)
     end
+
+    it "reports when a user does not exist" do
+      get lookup_partner_users_path(
+        default_params.merge(partner_id: partner, email: "missing@example.com")
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq("exists" => false)
+    end
   end
 
   describe "POST #create" do

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -1,7 +1,7 @@
 # spec/requests/partner_users_controller_spec.rb
 
 RSpec.describe PartnerUsersController, type: :request do
-  let!(:partner) { create(:partner) } # Assuming you have a factory for creating partners
+  let!(:partner) { create(:partner, organization: organization) }
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }
   let(:org_admin) { create(:organization_admin, organization: organization) }
@@ -49,7 +49,18 @@ RSpec.describe PartnerUsersController, type: :request do
       )
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq("exists" => true)
+      expect(response.parsed_body).to eq("exists" => true, "has_name" => false)
+    end
+
+    it "reports when an existing user has a name" do
+      existing_user = create(:user, name: "Existing Name", email: "named@example.com")
+
+      get lookup_partner_users_path(
+        default_params.merge(partner_id: partner, email: existing_user.email)
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq("exists" => true, "has_name" => true)
     end
 
     it "reports when a user does not exist" do
@@ -58,7 +69,7 @@ RSpec.describe PartnerUsersController, type: :request do
       )
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq("exists" => false)
+      expect(response.parsed_body).to eq("exists" => false, "has_name" => false)
     end
   end
 

--- a/spec/requests/partner_users_requests_spec.rb
+++ b/spec/requests/partner_users_requests_spec.rb
@@ -36,6 +36,23 @@ RSpec.describe PartnerUsersController, type: :request do
     end
   end
 
+  describe "GET #lookup" do
+    before do
+      sign_in(org_admin)
+    end
+
+    it "reports when a user already exists" do
+      existing_user = create(:user, name: nil, email: "existing@example.com")
+
+      get lookup_partner_users_path(
+        default_params.merge(partner_id: partner, email: existing_user.email.upcase)
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq("exists" => true)
+    end
+  end
+
   describe "POST #create" do
     let(:valid_user_params) do
       {

--- a/spec/services/user_invite_service_spec.rb
+++ b/spec/services/user_invite_service_spec.rb
@@ -49,12 +49,41 @@ RSpec.describe UserInviteService, type: :service do
     end
 
     it "should add roles to existing user" do
-      described_class.invite(email: "email@email.com",
+      described_class.invite(email: "EMAIL@EMAIL.COM",
         roles: [Role::ORG_USER, Role::ORG_ADMIN],
         resource: organization)
       expect(user).to have_role(Role::ORG_USER, organization)
       expect(user).to have_role(Role::ORG_ADMIN, organization)
       expect(user).not_to have_role(Role::PARTNER, :any)
+    end
+
+    it "should find an existing user case-insensitively" do
+      uppercase_email = user.email.upcase
+      target_partner = partner
+      expect(User.find_by("LOWER(email) = ?", uppercase_email.downcase)).to eq(user)
+
+      expect {
+        described_class.invite(
+          email: uppercase_email,
+          roles: [Role::PARTNER],
+          resource: target_partner
+        )
+      }.not_to change(User, :count)
+
+      expect(user.reload).to have_role(Role::PARTNER, target_partner)
+    end
+
+    it "should add a submitted name when the existing user has no name" do
+      user.update!(name: nil)
+
+      described_class.invite(
+        name: "Existing User",
+        email: user.email,
+        roles: [Role::PARTNER],
+        resource: partner
+      )
+
+      expect(user.reload.name).to eq("Existing User")
     end
   end
 

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -589,6 +589,29 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           expect(page).to have_content(partner_user.name)
           expect(page).to have_content(partner_user.email)
         end
+
+        it 'checks an existing user when leaving the email field', js: true do
+          existing_user = create(:user, name: nil, email: "existing@example.com")
+          visit subject
+
+          fill_in "Email", with: existing_user.email
+          find_field("Email").send_keys(:tab)
+
+          expect(page).to have_content("This user already exists. The submitted name will only be used if their profile has no name yet.")
+          expect(page).to have_field("Name", disabled: false)
+        end
+
+        it 'keeps the name of an existing named user', js: true do
+          existing_user = create(:user, name: "Existing Name", email: "named@example.com")
+          visit subject
+
+          fill_in "Name", with: "Replacement Name"
+          fill_in "Email", with: existing_user.email
+          find_field("Email").send_keys(:tab)
+
+          expect(page).to have_content("This user already exists. The submitted name will only be used if their profile has no name yet.")
+          expect(page).to have_field("Name", with: "Replacement Name", disabled: false)
+        end
       end
 
       context "when partner has :awaiting_review status" do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -597,7 +597,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           fill_in "Email", with: existing_user.email
           find_field("Email").send_keys(:tab)
 
-          expect(page).to have_content("This user already exists. The submitted name will only be used if their profile has no name yet.")
+          expect(page).to have_content("This user already exists. The submitted name will be used because their profile has no name yet.")
           expect(page).to have_field("Name", disabled: false)
         end
 
@@ -609,7 +609,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           fill_in "Email", with: existing_user.email
           find_field("Email").send_keys(:tab)
 
-          expect(page).to have_content("This user already exists. The submitted name will only be used if their profile has no name yet.")
+          expect(page).to have_content("This user already exists. Their current profile name will be kept.")
           expect(page).to have_field("Name", with: "Replacement Name", disabled: false)
         end
       end


### PR DESCRIPTION
Resolves #5612

### Description

When a bank user leaves the email field, the form now checks whether that account already exists and explains how the submitted name will be handled. Existing accounts keep their current name, while an account without a name receives the submitted one when the partner role is added.

The lookup and invitation paths also match email addresses case-insensitively, consistent with the user email uniqueness rule.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- `bundle exec rspec spec/services/user_invite_service_spec.rb spec/requests/partner_users_requests_spec.rb` (30 examples)
- Focused JavaScript system scenarios for existing users with and without names (2 examples)
- `bin/lint` (RuboCop and ERB lint)
- `bundle exec brakeman --no-pager --quiet` (0 warnings)
- `node --check app/javascript/controllers/existing_user_controller.js`
- `git diff --check origin/main...HEAD`

The full RSpec suite is deferred to CI.
