### PR TITLE
We no longer need enable packs to be Flippered

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,11 +31,7 @@ class ItemsController < ApplicationController
   end
 
   def create
-    create = if Flipper.enabled?(:enable_packs)
-      ItemCreateService.new(organization_id: current_organization.id, item_params: item_params, request_unit_ids:)
-    else
-      ItemCreateService.new(organization_id: current_organization.id, item_params: item_params)
-    end
+    create = ItemCreateService.new(organization_id: current_organization.id, item_params: item_params, request_unit_ids:)
     result = create.call
 
     if result.success?
@@ -81,7 +77,7 @@ class ItemsController < ApplicationController
       return
     end
 
-    if update_item
+    if update_item_and_request_units
       redirect_to items_path, notice: "#{@item.name} updated!"
     else
       flash.now[:error] = "Something didn't work quite right -- try again? #{@item.errors.map { |error| "#{error.attribute}: #{error.message}" }}"
@@ -183,15 +179,6 @@ class ItemsController < ApplicationController
 
   def request_unit_ids
     params.require(:item).permit(request_unit_ids: []).fetch(:request_unit_ids, [])
-  end
-
-  # We need to update both the item and the request_units together and fail together
-  def update_item
-    if Flipper.enabled?(:enable_packs)
-      update_item_and_request_units
-    else
-      @item.save
-    end
   end
 
   def update_item_and_request_units

--- a/app/controllers/partners/requests_controller.rb
+++ b/app/controllers/partners/requests_controller.rb
@@ -81,13 +81,12 @@ module Partners
 
     def fetch_items
       @requestable_items = PartnerFetchRequestableItemsService.new(partner_id: partner.id).call
-      if Flipper.enabled?(:enable_packs)
-        # hash of (item ID => hash of (request unit name => request unit plural name))
-        item_ids = @requestable_items.to_h.values
-        if item_ids.present?
-          @item_units = Item.where(id: item_ids).to_h do |i|
-            [i.id, i.request_units.to_h { |u| [u.name, u.name.pluralize] }]
-          end
+
+      # hash of (item ID => hash of (request unit name => request unit plural name))
+      item_ids = @requestable_items.to_h.values
+      if item_ids.present?
+        @item_units = Item.where(id: item_ids).to_h do |i|
+          [i.id, i.request_units.to_h { |u| [u.name, u.name.pluralize] }]
         end
       end
     end

--- a/app/models/partners/item_request.rb
+++ b/app/models/partners/item_request.rb
@@ -41,7 +41,7 @@ module Partners
     end
 
     def quantity_with_units
-      if Flipper.enabled?(:enable_packs) && request_unit.present?
+      if request_unit.present?
         "#{quantity} #{request_unit.pluralize(quantity.to_i)}"
       else
         quantity
@@ -49,7 +49,7 @@ module Partners
     end
 
     def name_with_unit(quantity_override = nil)
-      if Flipper.enabled?(:enable_packs) && request_unit.present?
+      if request_unit.present?
         "#{item_name} - #{request_unit.pluralize(quantity_override || quantity.to_i)}"
       else
         item_name

--- a/app/models/view/request_info.rb
+++ b/app/models/view/request_info.rb
@@ -27,7 +27,7 @@ module View
     end
 
     def custom_units
-      Flipper.enabled?(:enable_packs) && request.item_requests.any? { |item| item.request_unit }
+      request.item_requests.any? { |item| item.request_unit }
     end
 
     def cancellable?

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -288,7 +288,7 @@ class DistributionPdf
   end
 
   def request_display_qty(item_request)
-    if Flipper.enabled?(:enable_packs) && item_request&.request_unit
+    if item_request&.request_unit
       "#{item_request.quantity} #{item_request.request_unit.pluralize(item_request.quantity.to_i)}"
     else
       item_request&.quantity || ""

--- a/app/pdfs/picklists_pdf.rb
+++ b/app/pdfs/picklists_pdf.rb
@@ -144,7 +144,7 @@ class PicklistsPdf
   end
 
   def has_custom_units?(line_items)
-    Flipper.enabled?(:enable_packs) && line_items.any? { |line_item| line_item.request_unit }
+    line_items.any? { |line_item| line_item.request_unit }
   end
 
   def data_with_units(line_items)

--- a/app/services/exports/export_request_service.rb
+++ b/app/services/exports/export_request_service.rb
@@ -73,16 +73,14 @@ module Exports
         if item_request.item
           item = item_request.item
           item_names << item.name
-          if Flipper.enabled?(:enable_packs)
-            item.request_units.each do |unit|
-              item_names << "#{item.name} - #{unit.name.pluralize}"
-            end
+          item.request_units.each do |unit|
+            item_names << "#{item.name} - #{unit.name.pluralize}"
+          end
 
-            # It's possible that the unit is no longer valid, so we'd
-            # add that individually
-            if item_request.request_unit.present?
-              item_names << "#{item.name} - #{item_request.request_unit.pluralize}"
-            end
+          # It's possible that the unit is no longer valid, so we'd
+          # add that individually
+          if item_request.request_unit.present?
+            item_names << "#{item.name} - #{item_request.request_unit.pluralize}"
           end
         end
       end

--- a/app/services/exports/export_request_service.rb
+++ b/app/services/exports/export_request_service.rb
@@ -79,16 +79,14 @@ module Exports
         if item_request.item
           item = item_request.item
           item_names << item.name
-          if Flipper.enabled?(:enable_packs)
-            item.request_units.each do |unit|
-              item_names << "#{item.name} - #{unit.name.pluralize}"
-            end
+          item.request_units.each do |unit|
+            item_names << "#{item.name} - #{unit.name.pluralize}"
+          end
 
-            # It's possible that the unit is no longer valid, so we'd
-            # add that individually
-            if item_request.request_unit.present?
-              item_names << "#{item.name} - #{item_request.request_unit.pluralize}"
-            end
+          # It's possible that the unit is no longer valid, so we'd
+          # add that individually
+          if item_request.request_unit.present?
+            item_names << "#{item.name} - #{item_request.request_unit.pluralize}"
           end
         end
       end

--- a/app/services/item_create_service.rb
+++ b/app/services/item_create_service.rb
@@ -8,9 +8,7 @@ class ItemCreateService
   def call
     new_item = organization.items.new(item_params)
     new_item.save!
-    if Flipper.enabled?(:enable_packs)
-      new_item.sync_request_units!(@request_unit_ids)
-    end
+    new_item.sync_request_units!(@request_unit_ids)
 
     Result.new(value: new_item)
   rescue StandardError => e

--- a/app/services/organization_update_service.rb
+++ b/app/services/organization_update_service.rb
@@ -18,15 +18,13 @@ class OrganizationUpdateService
         org_params["partner_form_fields"] = org_params["partner_form_fields"].compact_blank
       end
 
-      if Flipper.enabled?(:enable_packs)
-        request_unit_names = org_params[:request_unit_names] || []
-        # Find or create units for the organization
-        request_unit_ids = request_unit_names.compact_blank.map do |request_unit_name|
-          Unit.find_or_create_by(organization: organization, name: request_unit_name).id
-        end
-        org_params.delete(:request_unit_names)
-        org_params[:request_unit_ids] = request_unit_ids
+      request_unit_names = org_params[:request_unit_names] || []
+      # Find or create units for the organization
+      request_unit_ids = request_unit_names.compact_blank.map do |request_unit_name|
+        Unit.find_or_create_by(organization: organization, name: request_unit_name).id
       end
+      org_params.delete(:request_unit_names)
+      org_params[:request_unit_ids] = request_unit_ids
 
       result = organization.update(org_params)
 

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -44,7 +44,7 @@
                 <%= f.input_field :package_size, class: "form-control", min: 0 %>
               <% end %>
 
-              <% if Flipper.enabled?(:enable_packs) && current_organization.request_units.present? %>
+              <% if current_organization.request_units.present? %>
                 <%= f.input :request_units, label: "Additional Custom Request Units" do %>
                   <%= f.association :request_units, as: :check_boxes, collection: current_organization.request_units, checked: selected_item_request_units(@item), label_method: :name, value_method: :id, class: "form-check-input" %>
                 <% end %>

--- a/app/views/items/_item_list.html.erb
+++ b/app/views/items/_item_list.html.erb
@@ -12,10 +12,8 @@
       <th>Add. Info</th>
       <th class="text-right">Quantity Per Individual</th>
       <th class="text-right">Fair Market Value (per item)</th>
-      <% if Flipper.enabled?(:enable_packs) %>
-        <% unless current_organization.request_units.empty? %>
-          <th>Custom Request Units</th>
-        <% end %>
+      <% unless current_organization.request_units.empty? %>
+        <th>Custom Request Units</th>
       <% end %>
       <th class="text-right">Actions</th>
     </tr>

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -5,10 +5,8 @@
   <td><%= truncate item_row.additional_info, length: 25 %></td>
   <td class="text-right"> <%= item_row.distribution_quantity %></td>
   <td class="numeric"><%= dollar_value(item_row.value_in_cents) %></td>
-  <% if Flipper.enabled?(:enable_packs) %>
-    <% unless current_organization.request_units.blank? %>
-     <td><%= item_row.request_units.pluck(:name).join(', ') %></td>
-    <% end %>
+  <% unless current_organization.request_units.blank? %>
+    <td><%= item_row.request_units.pluck(:name).join(', ') %></td>
   <% end %>
   <td class="text-right">
     <%= view_button_to item_path(item_row) %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -64,11 +64,9 @@
                 <td><%= @item.package_size || 0 %></td>
               </tr>
               <tr>
-                <% if Flipper.enabled?(:enable_packs) %>
-                  <th>Custom Units</th>
-                  <% item_units = @item.request_units&.pluck("item_units.name") %>
-                  <td><%= item_units&.join("; ") %></td>
-                <% end %>
+                <th>Custom Units</th>
+                <% item_units = @item.request_units&.pluck("item_units.name") %>
+                <td><%= item_units&.join("; ") %></td>
               </tr>
               <tr>
                 <th>Item is visible to partners</th>

--- a/app/views/organizations/_details.html.erb
+++ b/app/views/organizations/_details.html.erb
@@ -154,24 +154,22 @@
                 <%= humanize_boolean(@organization.enable_quantity_based_requests) %>
               </p>
             </div>
-            <% if Flipper.enabled?(:enable_packs) %>
-              <div>
-                <h6 class="font-weight-bold">Custom Request units used (please use singular form -- e.g. pack, not packs)</h6>
-                <p>
-                  <% if @organization.request_units.length > 0 %>
-                    <% @organization.request_units.map do |unit| %>
-                      <%= fa_icon "angle-right" %>
-                      <span>
-                          <%= unit.name.titlecase %>
-                      </span> <br>
-                    <% end %>
-                  <% else %>
+            <div>
+              <h6 class="font-weight-bold">Custom Request units used (please use singular form -- e.g. pack, not packs)</h6>
+              <p>
+                <% if @organization.request_units.length > 0 %>
+                  <% @organization.request_units.map do |unit| %>
                     <%= fa_icon "angle-right" %>
-                    <span> None </span>
+                    <span>
+                        <%= unit.name.titlecase %>
+                    </span> <br>
                   <% end %>
-                </p>
-              </div>
-            <% end %>
+                <% else %>
+                  <%= fa_icon "angle-right" %>
+                  <span> None </span>
+                <% end %>
+              </p>
+            </div>
             <hr>
 
             <h4>Other emails</h4>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -129,25 +129,23 @@
                 <%= f.input :enable_child_based_requests, label: 'Enable Partners to make child-based Requests?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
                 <%= f.input :enable_individual_requests, label: 'Enable Partners to make Requests by indicating number of individuals needing each Item?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
                 <%= f.input :enable_quantity_based_requests, label: 'Enable Partners to make quantity-based Requests?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
-                <% if Flipper.enabled?(:enable_packs) %>
-                  <%= label_tag "organization[request_unit_names]", 'Custom request units used. Please use singular form -- e.g. pack, not packs. There will be a default "unit" entry provided.' %>
-                  <%= select_tag(
-                    "organization[request_unit_names]",
-                    options_from_collection_for_select(
-                        current_organization.request_units,
-                        'name',
-                        'name',
-                        ->(_) { true } # Select all of the current request units
-                    ),
-                    {
-                      multiple: true,
-                      class: 'form-control custom-select',
-                      'data-controller': 'select2',
-                      'data-select2-hide-dropdown-value': true,
-                      'data-select2-config-value': '{"selectOnClose": "true", "tags": "true", "tokenSeparators": [",", "\t"]}'
-                    }
-                  ) %>
-                <% end %>
+                <%= label_tag "organization[request_unit_names]", 'Custom request units used. Please use singular form -- e.g. pack, not packs. There will be a default "unit" entry provided.' %>
+                <%= select_tag(
+                  "organization[request_unit_names]",
+                  options_from_collection_for_select(
+                      current_organization.request_units,
+                      'name',
+                      'name',
+                      ->(_) { true } # Select all of the current request units
+                  ),
+                  {
+                    multiple: true,
+                    class: 'form-control custom-select',
+                    'data-controller': 'select2',
+                    'data-select2-hide-dropdown-value': true,
+                    'data-select2-config-value': '{"selectOnClose": "true", "tags": "true", "tokenSeparators": [",", "\t"]}'
+                  }
+                ) %>
                 <hr>
 
                 <h4>Other emails</h4>

--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -24,7 +24,7 @@
           <td class="p-4 d-flex flex-wrap">
             <% request.item_requests.each do |item_request| %>
               <span class="p-1 mr-1 mb-2 lg:mb-0 border border-dark rounded-1">
-                <% if Flipper.enabled?(:enable_packs) && item_request.request_unit %>
+                <% if item_request.request_unit %>
                   <%= pluralize(item_request.quantity, item_request.request_unit) %>
                   —
                 <% else %>

--- a/app/views/partners/dashboards/_requests_in_progress.html.erb
+++ b/app/views/partners/dashboards/_requests_in_progress.html.erb
@@ -23,7 +23,7 @@
           <td class="p-4 d-flex flex-wrap">
             <% request.item_requests.each do |item_request| %>
               <span class="p-1 mr-1 mb-2 lg:mb-0 border border-dark rounded-1">
-                <% if Flipper.enabled?(:enable_packs) && item_request.request_unit %>
+                <% if item_request.request_unit %>
                   <%= pluralize(item_request.quantity, item_request.request_unit) %>
                   —
                 <% else %>

--- a/app/views/partners/requests/_error.html.erb
+++ b/app/views/partners/requests/_error.html.erb
@@ -8,7 +8,7 @@
     <h3 class='text-4xl font-extrabold'>Oops! Something went wrong with your Request</h3>
     <p class='text-lg font-bold'>
       Ensure each line item has a item selected AND a quantity greater than 0.
-      <% if Flipper.enabled?(:enable_packs) && (current_partner&.organization || current_organization).request_units.any? %>
+      <% if (current_partner&.organization || current_organization).request_units.any? %>
         Please ensure a single unit is selected for each item that supports it.
       <% end %>
     </p>

--- a/app/views/partners/requests/_item_request.html.erb
+++ b/app/views/partners/requests/_item_request.html.erb
@@ -12,7 +12,7 @@
       <%= field.number_field :quantity, label: false, step: 1, min: 1, class: 'form-control' %>
     </td>
 
-    <% if Flipper.enabled?(:enable_packs) && (current_partner ? current_partner.organization.request_units.any? : current_organization.request_units.any?) %>
+    <% if (current_partner ? current_partner.organization.request_units.any? : current_organization.request_units.any?) %>
       <td>
         <%= field.label :request_unit, "Unit", {class: 'sr-only'} %>
         <%= field.select :request_unit, [], {include_blank: 'units'},

--- a/app/views/partners/requests/new.html.erb
+++ b/app/views/partners/requests/new.html.erb
@@ -42,7 +42,7 @@
                 <tr>
                   <th>Item Requested</th>
                   <th>Quantity</th>
-                  <% if Flipper.enabled?(:enable_packs) && (current_partner ? current_partner.organization.request_units.any? : current_organization.request_units.any?) %>
+                  <% if (current_partner ? current_partner.organization.request_units.any? : current_organization.request_units.any?) %>
                     <th>Units (if applicable)</th>
                   <% end %>
                 </tr>

--- a/app/views/partners/requests/show.html.erb
+++ b/app/views/partners/requests/show.html.erb
@@ -56,7 +56,7 @@
                 <% @partner_request.item_requests.each do |item| %>
                   <li>
                     <%= item.name %> - <%= item.quantity %>
-                    <% if Flipper.enabled?(:enable_packs) && item.request_unit %>
+                    <% if item.request_unit %>
                       <%= item.request_unit.pluralize(item.quantity.to_i) %>
                     <% end %>
                   </li>

--- a/app/views/partners/requests/validate.html.erb
+++ b/app/views/partners/requests/validate.html.erb
@@ -11,7 +11,7 @@
             <tr>
               <th>Item Name</th>
               <th>Total Items</th>
-              <% if Flipper.enabled?(:enable_packs) && @partner_request.item_requests.any?( &:request_unit ) %>
+              <% if @partner_request.item_requests.any?( &:request_unit ) %>
                 <th>Units</th>
               <% end %>
             </tr>
@@ -21,7 +21,7 @@
               <tr>
                 <td><%= line_item.name %></td>
                 <td><%= line_item.quantity %></td>
-                <% if Flipper.enabled?(:enable_packs) && @partner_request.item_requests.any?( &:request_unit ) %>
+                <% if @partner_request.item_requests.any?( &:request_unit ) %>
                   <td><%= line_item.request_unit&.pluralize(line_item.quantity.to_i) %></td>
                 <% end %>
               </tr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1111,8 +1111,6 @@ end
 Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "new_logo")
 Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "partner_step_form")
 Flipper.enable(:partner_step_form)
-Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "enable_packs")
-Flipper.enable(:enable_packs)
 # ----------------------------------------------------------------------------
 # Account Requests
 # ----------------------------------------------------------------------------

--- a/docs/user_guide/bank/exports.md
+++ b/docs/user_guide/bank/exports.md
@@ -415,8 +415,7 @@ For each filtered Request,
 - Date,
 - Requestor (i.e. partner)
 - Status, and
-- the quantity of each Item requested.
-  - Note: If you have packs enabled (upcoming feature), there will be a column for each unit that you have enabled for each Item.  Otherwise, one column per Item.
+- the quantity of each Item requested. There will be a column for each unit that you have enabled for each Item.
 
 ## Storage Locations
 ### Navigating to export Storage Locations

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe ItemsController, type: :controller do
       end
 
       context "request units" do
-        before(:each) { Flipper.enable(:enable_packs) }
         let(:item) { create(:item, organization:) }
         let(:unit) { create(:unit, organization:) }
         it "should add new item's request units" do
@@ -168,7 +167,6 @@ RSpec.describe ItemsController, type: :controller do
         end
 
         it "should accept request_unit ids and create request_units" do
-          Flipper.enable(:enable_packs)
           unit = create(:unit, organization: organization)
           item_params[:item] = item_params[:item].merge({request_unit_ids: [unit.id]})
           post :create, params: item_params

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
   end
 
   it "shows units" do
-    Flipper.enable(:enable_packs)
     item1 = create(:item, organization:)
     item2 = create(:item, organization:)
     create(:item_unit, item: item1, name: "Pack")
@@ -77,7 +76,6 @@ RSpec.describe RequestsConfirmationMailer, type: :mailer do
   end
 
   it "skips units when are not provided" do
-    Flipper.enable(:enable_packs)
     item = create(:item, organization:)
     create(:item_unit, item: item, name: "Pack")
     request = create(:request, :pending, :with_item_requests, request_items: [{item_id: item.id, quantity: 7}])

--- a/spec/models/partners/item_request_spec.rb
+++ b/spec/models/partners/item_request_spec.rb
@@ -50,24 +50,18 @@ RSpec.describe Partners::ItemRequest, type: :model do
   end
 
   describe '#quantity_with_units' do
-    context 'when enable_packs is enabled' do
-      context 'when there is a request unit' do
-        it 'returns the quantity with the request unit' do
-          Flipper.enable(:enable_packs)
+    context 'when there is a request unit' do
+      it 'returns the quantity with the request unit' do
+        item = create(:item, organization: organization)
+        create(:item_unit, item:, name: 'flat')
+        request = create(:request, organization: organization)
+        item_request = create(:item_request, request:, item: item, request_unit: 'flat', name: "Item 1", quantity: 10)
 
-          item = create(:item, organization: organization)
-          create(:item_unit, item:, name: 'flat')
-          request = create(:request, organization: organization)
-          item_request = create(:item_request, request:, item: item, request_unit: 'flat', name: "Item 1", quantity: 10)
-
-          expect(item_request.quantity_with_units).to eq('10 flats')
-        end
+        expect(item_request.quantity_with_units).to eq('10 flats')
       end
 
       context 'when there is no request unit' do
         it 'returns only the quantity' do
-          Flipper.enable(:enable_packs)
-
           item = create(:item, organization: organization)
           create(:item_unit, item:, name: 'flat')
           request = create(:request, organization: organization)
@@ -80,31 +74,25 @@ RSpec.describe Partners::ItemRequest, type: :model do
   end
 
   describe '#name_with_unit' do
-    context 'when enable_packs is enabled' do
-      context 'when there is a request unit' do
-        it 'returns the item name with the request unit' do
-          Flipper.enable(:enable_packs)
+    context 'when there is a request unit' do
+      it 'returns the item name with the request unit' do
+        item = create(:item, organization: organization, name: 'Item name')
+        create(:item_unit, item:, name: 'flat')
+        request = create(:request, organization: organization)
+        item_request = create(:item_request, request:, item: item, request_unit: 'flat', name: "Item 1", quantity: 10)
 
-          item = create(:item, organization: organization, name: 'Item name')
-          create(:item_unit, item:, name: 'flat')
-          request = create(:request, organization: organization)
-          item_request = create(:item_request, request:, item: item, request_unit: 'flat', name: "Item 1", quantity: 10)
-
-          expect(item_request.name_with_unit).to eq('Item name - flats')
-        end
+        expect(item_request.name_with_unit).to eq('Item name - flats')
       end
+    end
 
-      context 'when there is no request unit' do
-        it 'returns only the item name' do
-          Flipper.enable(:enable_packs)
+    context 'when there is no request unit' do
+      it 'returns only the item name' do
+        item = create(:item, organization: organization, name: 'Item name')
+        create(:item_unit, item:, name: 'flat')
+        request = create(:request, organization: organization)
+        item_request = create(:item_request, request:, item: item, name: 'Item 1', quantity: 10)
 
-          item = create(:item, organization: organization, name: 'Item name')
-          create(:item_unit, item:, name: 'flat')
-          request = create(:request, organization: organization)
-          item_request = create(:item_request, request:, item: item, name: 'Item 1', quantity: 10)
-
-          expect(item_request.name_with_unit).to eq('Item name')
-        end
+        expect(item_request.name_with_unit).to eq('Item name')
       end
     end
   end

--- a/spec/models/view/request_info_spec.rb
+++ b/spec/models/view/request_info_spec.rb
@@ -105,47 +105,21 @@ RSpec.describe View::RequestInfo do
 
   describe "#custom_units" do
     context "when there are request units for an item request" do
-      context "when enable_packs is disabled" do
-        it "returns false" do
-          organization = build(:organization)
-          item = build(:item, name: "First item")
-          create(:item_unit, item: item, name: "flat")
-          request = create(
-            :request,
-            :with_item_requests,
-            organization:,
-            request_items: [
-              {item_id: item.id, quantity: "559", request_unit: "flat"}
-            ]
-          )
+      it "returns true" do
+        organization = build(:organization)
+        item = build(:item, name: "First item")
+        create(:item_unit, item: item, name: "flat")
+        request = create(
+          :request,
+          :with_item_requests,
+          organization:,
+          request_items: [
+            {item_id: item.id, quantity: "559", request_unit: "flat"}
+          ]
+        )
+        request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
 
-          request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
-
-          expect(request_info.custom_units).to be_falsey
-        end
-      end
-
-      context "when enable_packs is enabled" do
-        it "returns true" do
-          Flipper.enable(:enable_packs)
-
-          organization = build(:organization)
-          item = build(:item, name: "First item")
-          create(:item_unit, item: item, name: "flat")
-          request = create(
-            :request,
-            :with_item_requests,
-            organization:,
-            request_items: [
-              {item_id: item.id, quantity: "559", request_unit: "flat"}
-            ]
-          )
-          request_info = View::RequestInfo.new(params: {id: request.id}, organization:)
-
-          expect(request_info.custom_units).to be_truthy
-
-          Flipper.disable(:enable_packs)
-        end
+        expect(request_info.custom_units).to be_truthy
       end
     end
   end

--- a/spec/pdfs/distribution_pdf_spec.rb
+++ b/spec/pdfs/distribution_pdf_spec.rb
@@ -47,49 +47,7 @@ describe DistributionPdf do
 
     context "with request data" do
       describe "#hide_columns" do
-        context "when enable_packs is enabled" do
-          it "hides value and package columns when true on organization, and includes the request unit info" do
-            Flipper.enable(:enable_packs)
-
-            pdf = described_class.new(org_hiding_packages_and_values, distribution)
-            data = pdf.request_data
-            pdf.hide_columns(data)
-            expect(data).to eq([
-              ["Items Received", "Requested", "Received"],
-              ["Item 1", "", 50],
-              ["Item 2", "30", 100],
-              ["Item 3", "50", ""],
-              ["Item 4", "120 packs", ""],
-              ["", "", ""],
-              ["Total Items Received", 200, 150]
-            ])
-          end
-
-          it "hides value columns when true on organization" do
-            Flipper.enable(:enable_packs)
-
-            pdf = described_class.new(org_hiding_values, distribution)
-            data = pdf.request_data
-            pdf.hide_columns(data)
-            expect(data).to eq([
-              ["Items Received", "Requested", "Received", "Packages"],
-              ["Item 1", "", 50, "1"],
-              ["Item 2", "30", 100, nil],
-              ["Item 3", "50", "", nil],
-              ["Item 4", "120 packs", "", nil],
-              ["", "", ""],
-              ["Total Items Received", 200, 150, ""]
-            ])
-          end
-        end
-      end
-    end
-
-    context "with non request data" do
-      context "when enable_packs is enabled" do
-        it "hides value and package columns when true on organization, and includes request unit info" do
-          Flipper.enable(:enable_packs)
-
+        it "hides value and package columns when true on organization, and includes the request unit info" do
           pdf = described_class.new(org_hiding_packages_and_values, distribution)
           data = pdf.request_data
           pdf.hide_columns(data)
@@ -104,9 +62,7 @@ describe DistributionPdf do
           ])
         end
 
-        it "hides value columns when true on organization, and includes request unit info" do
-          Flipper.enable(:enable_packs)
-
+        it "hides value columns when true on organization" do
           pdf = described_class.new(org_hiding_values, distribution)
           data = pdf.request_data
           pdf.hide_columns(data)
@@ -123,25 +79,53 @@ describe DistributionPdf do
       end
     end
 
+    context "with non request data" do
+      it "hides value and package columns when true on organization, and includes request unit info" do
+        pdf = described_class.new(org_hiding_packages_and_values, distribution)
+        data = pdf.request_data
+        pdf.hide_columns(data)
+        expect(data).to eq([
+          ["Items Received", "Requested", "Received"],
+          ["Item 1", "", 50],
+          ["Item 2", "30", 100],
+          ["Item 3", "50", ""],
+          ["Item 4", "120 packs", ""],
+          ["", "", ""],
+          ["Total Items Received", 200, 150]
+        ])
+      end
+
+      it "hides value columns when true on organization, and includes request unit info" do
+        pdf = described_class.new(org_hiding_values, distribution)
+        data = pdf.request_data
+        pdf.hide_columns(data)
+        expect(data).to eq([
+          ["Items Received", "Requested", "Received", "Packages"],
+          ["Item 1", "", 50, "1"],
+          ["Item 2", "30", 100, nil],
+          ["Item 3", "50", "", nil],
+          ["Item 4", "120 packs", "", nil],
+          ["", "", ""],
+          ["Total Items Received", 200, 150, ""]
+        ])
+      end
+    end
+
     context "regardless of request data" do
       describe "#hide_columns" do
-        context "when enable_packs is enabled" do
-          it "hides package column when true on organization, and includes request unit info" do
-            Flipper.enable(:enable_packs)
-
-            pdf = described_class.new(org_hiding_packages, distribution)
-            data = pdf.request_data
-            pdf.hide_columns(data)
-            expect(data).to eq([
-              ["Items Received", "Requested", "Received", "Value/item", "In-Kind Value Received"],
-              ["Item 1", "", 50, "$1.00", "$50.00"],
-              ["Item 2", "30", 100, "$2.00", "$200.00"],
-              ["Item 3", "50", "", "$3.00", nil],
-              ["Item 4", "120 packs", "", "$4.00", nil],
-              ["", "", "", "", ""],
-              ["Total Items Received", 200, 150, "", "$250.00"]
-            ])
-          end
+        it "hides package column when true on organization, and includes request unit info" do
+          pdf = described_class.new(org_hiding_packages, distribution)
+          data = pdf.request_data
+          pdf.hide_columns(data)
+          expect(data).to eq([
+            ["Items Received", "Requested", "Received", "Value/item", "In-Kind Value Received"],
+            ["Item 1", "", 50, "$1.00", "$50.00"],
+            ["Item 2", "30", 100, "$2.00", "$200.00"],
+            ["Item 3", "50", "", "$3.00", nil],
+            ["Item 4", "120 packs", "", "$4.00", nil],
+            ["", "", "", "", ""],
+            ["Total Items Received", 200, 150, "", "$250.00"]
+          ])
         end
       end
     end

--- a/spec/pdfs/distribution_pdf_spec.rb
+++ b/spec/pdfs/distribution_pdf_spec.rb
@@ -21,8 +21,7 @@ describe DistributionPdf do
       PDFComparisonTestFactory.create_line_items_request(distribution: distribution, partner: partner, storage_creation: storage_creation)
     end
 
-    specify "#request_data with custom units feature" do
-      Flipper.enable(:enable_packs)
+    specify "#request_data" do
       results = described_class.new(organization, distribution).request_data
       expect(results).to eq([
         ["Items Received", "Requested", "Received", "Value/item", "In-Kind Value Received", "Packages"],
@@ -154,18 +153,12 @@ describe DistributionPdf do
       begin
         # Run the following from Rails sandbox console (bin/rails/console --sandbox) to regenerate these comparison PDFs:
         # => load "lib/test_helpers/pdf_comparison_test_factory.rb"
-        # => Flipper.enable(:enable_packs)
         # => PDFComparisonTestFactory.create_comparison_pdfs
         expect(pdf_file).to eq(IO.binread(expected_file_path))
       rescue RSpec::Expectations::ExpectationNotMetError => e
         Rails.root.join("tmp", "failed_match_distribution_" + distribution.delivery_method.to_s + "_" + expected_file_path.to_s.split("/").last + ".pdf").binwrite(pdf_file)
         raise e.class, "PDF does not match, written to tmp/", cause: nil
       end
-    end
-
-    # The generated PDFs (PDFs to use for comparison) are expecting the packs feature to be enabled.
-    before(:each) do
-      Flipper.enable(:enable_packs)
     end
 
     let(:partner) { PDFComparisonTestFactory.create_partner(organization) }

--- a/spec/pdfs/distribution_pdf_spec.rb
+++ b/spec/pdfs/distribution_pdf_spec.rb
@@ -21,8 +21,7 @@ describe DistributionPdf do
       PDFComparisonTestFactory.create_line_items_request(distribution: distribution, partner: partner, storage_creation: storage_creation)
     end
 
-    specify "#request_data with custom units feature" do
-      Flipper.enable(:enable_packs)
+    specify "#request_data" do
       results = described_class.new(organization, distribution).request_data
       expect(results).to eq([
         ["Items Received", "Requested", "Received", "Value/item", "In-Kind Value Received", "Packages"],
@@ -138,18 +137,12 @@ describe DistributionPdf do
       begin
         # Run the following from Rails sandbox console (bin/rails/console --sandbox) to regenerate these comparison PDFs:
         # => load "lib/test_helpers/pdf_comparison_test_factory.rb"
-        # => Flipper.enable(:enable_packs)
         # => PDFComparisonTestFactory.create_comparison_pdfs
         expect(pdf_file).to eq(IO.binread(expected_file_path))
       rescue RSpec::Expectations::ExpectationNotMetError => e
         Rails.root.join("tmp", "failed_match_distribution_" + distribution.delivery_method.to_s + "_" + expected_file_path.to_s.split("/").last + ".pdf").binwrite(pdf_file)
         raise e.class, "PDF does not match, written to tmp/", cause: nil
       end
-    end
-
-    # The generated PDFs (PDFs to use for comparison) are expecting the packs feature to be enabled.
-    before(:each) do
-      Flipper.enable(:enable_packs)
     end
 
     let(:partner) { PDFComparisonTestFactory.create_partner(organization) }

--- a/spec/pdfs/picklists_pdf_spec.rb
+++ b/spec/pdfs/picklists_pdf_spec.rb
@@ -108,40 +108,20 @@ describe PicklistsPdf do
     end
   end
 
-  context "When packs are not enabled" do
-    specify "#data_no_units" do
-      request = create(:request, :pending, organization: organization)
-      create(:item_request, request: request, item: item1, name: "Item 1", quantity: 5)
-      create(:item_request, request: request, item: item2, name: "Item 2", quantity: 10)
-      pdf = described_class.new(organization, [request])
-      data = pdf.data_no_units(request.item_requests)
+  specify "#data_with_units" do
+    item_with_units = create(:item, name: "Item with units", organization: organization)
+    create(:item_unit, item: item_with_units, name: "Pack")
+    request = create(:request, :pending, organization: organization)
+    create(:item_request, request: request, item: item_with_units, name: "Item with units", request_unit: "Pack", quantity: 5)
+    create(:item_request, request: request, item: item2, name: "Item 2", quantity: 10)
+    pdf = described_class.new(organization, [request])
+    data = pdf.data_with_units(request.item_requests)
 
-      expect(data).to eq([
-        ["Items Requested", "Quantity", "[X]", "Differences / Comments"],
-        ["Item 1", "5", "[  ]", ""],
-        ["Item 2", "10", "[  ]", ""]
-      ])
-    end
-  end
-
-  context "When packs are enabled" do
-    before { Flipper.enable(:enable_packs) }
-
-    specify "#data_with_units" do
-      item_with_units = create(:item, name: "Item with units", organization: organization)
-      create(:item_unit, item: item_with_units, name: "Pack")
-      request = create(:request, :pending, organization: organization)
-      create(:item_request, request: request, item: item_with_units, name: "Item with units", request_unit: "Pack", quantity: 5)
-      create(:item_request, request: request, item: item2, name: "Item 2", quantity: 10)
-      pdf = described_class.new(organization, [request])
-      data = pdf.data_with_units(request.item_requests)
-
-      expect(data).to eq([
-        ["Items Requested", "Quantity", "Unit (if applicable)", "[X]", "Differences / Comments"],
-        ["Item with units", "5", "Packs", "[  ]", ""],
-        ["Item 2", "10", nil, "[  ]", ""]
-      ])
-    end
+    expect(data).to eq([
+      ["Items Requested", "Quantity", "Unit (if applicable)", "[X]", "Differences / Comments"],
+      ["Item with units", "5", "Packs", "[  ]", ""],
+      ["Item 2", "10", nil, "[  ]", ""]
+    ])
   end
 
   describe "picklist pdf output" do
@@ -150,18 +130,12 @@ describe PicklistsPdf do
       begin
         # Run the following from Rails sandbox console (bin/rails/console --sandbox) to regenerate these comparison PDFs:
         # => load "lib/test_helpers/pdf_comparison_test_factory.rb"
-        # => Flipper.enable(:enable_packs)
         # => PDFComparisonTestFactory.create_comparison_pdfs
         expect(pdf_file).to eq(IO.binread(expected_file_path))
       rescue RSpec::Expectations::ExpectationNotMetError => e
         Rails.root.join("tmp", "failed_match_picklist_" + expected_file_path.to_s.split("/").last + ".pdf").binwrite(pdf_file)
         raise e.class, "PDF does not match, written to tmp/", cause: nil
       end
-    end
-
-    # The generated PDFs (PDFs to use for comparison) are expecting the packs feature to be enabled.
-    before(:each) do
-      Flipper.enable(:enable_packs)
     end
 
     let(:storage_creation) { PDFComparisonTestFactory.create_organization_storage_items }

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -452,10 +452,6 @@ RSpec.describe "Distributions", type: :request do
       end
 
       context 'with units' do
-        before(:each) do
-          Flipper.enable(:enable_packs)
-        end
-
         it 'should behave correctly' do
           get new_distribution_path(default_params)
           expect(response).to be_successful
@@ -907,7 +903,6 @@ RSpec.describe "Distributions", type: :request do
           ]
         }
         before(:each) do
-          Flipper.enable(:enable_packs)
           create(:line_item, itemizable: distribution, item_id: items[0].id, quantity: 25)
           create(:line_item, itemizable: distribution, item_id: items[2].id, quantity: 10)
         end

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe "Items", type: :request do
         expect(response.body).to include('2348')
         expect(response.body).to include('Package Size')
         expect(response.body).to include('100')
-        expect(response.body).not_to include('Custom Units')
+        expect(response.body).to include('Custom Units')
         expect(response.body).not_to include("#ITEM1; ITEM2")
         expect(response.body).to include('Item is visible to partners')
         expect(response.body).to include('Yes')

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe "Items", type: :request do
 
     describe "GET #new" do
       it "shows the organization request_units options if they exist" do
-        Flipper.enable(:enable_packs)
         organization_units = create_list(:unit, 3, organization: organization)
         get new_item_path
         organization_units.each do |unit|
@@ -91,7 +90,6 @@ RSpec.describe "Items", type: :request do
 
     describe "GET #edit" do
       it "shows the selected request_units" do
-        Flipper.enable(:enable_packs)
         organization_units = create_list(:unit, 3, organization: organization)
         selected_unit = organization_units.first
         item = create(:item, organization: organization)
@@ -319,8 +317,6 @@ RSpec.describe "Items", type: :request do
       end
 
       context "custom request items" do
-        before(:each) { Flipper.enable(:enable_packs) }
-
         it "does not show the column if the organization does not use custom request units" do
           get items_path
           expect(response.body).not_to include("Custom Request Units")
@@ -371,8 +367,7 @@ RSpec.describe "Items", type: :request do
         expect(response.body).to include('Yes')
       end
 
-      it 'shows custom request units when flipper enabled' do
-        Flipper.enable(:enable_packs)
+      it 'shows custom request units' do
         get item_path(id: item.id)
 
         expect(response.body).to include('Custom Units')

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -139,20 +139,9 @@ RSpec.describe "Organizations", type: :request do
         expect(response.body).to include("Default Center")
       end
 
-      context "when enable_packs flipper is on" do
-        it "displays organization's custom units" do
-          Flipper.enable(:enable_packs)
-          get organization_path
-          expect(response.body).to include "Wolf Pack"
-        end
-      end
-
-      context "when enable_packs flipper is off" do
-        it "does not display organization's custom units" do
-          Flipper.disable(:enable_packs)
-          get organization_path
-          expect(response.body).to_not include "Wolf Pack"
-        end
+      it "displays organization's custom units" do
+        get organization_path
+        expect(response.body).to include "Wolf Pack"
       end
 
       context "with a reminder schedule" do
@@ -231,20 +220,9 @@ RSpec.describe "Organizations", type: :request do
         expect(html.text).to include("Include packages in distribution export:")
       end
 
-      context "when enable_packs flipper is on" do
-        it "displays organization's custom units" do
-          Flipper.enable(:enable_packs)
-          get organization_path
-          expect(response.body).to include "Wolf Pack"
-        end
-      end
-
-      context "when enable_packs flipper is off" do
-        it "does not display organization's custom units" do
-          Flipper.disable(:enable_packs)
-          get organization_path
-          expect(response.body).to_not include "Wolf Pack"
-        end
+      it "displays organization's custom units" do
+        get organization_path
+        expect(response.body).to include "Wolf Pack"
       end
 
       it "can see 'Demote to User' button for admins" do
@@ -278,6 +256,7 @@ RSpec.describe "Organizations", type: :request do
 
       it { is_expected.to render_template(:edit) }
       it { expect(response).to be_successful }
+
       it 'initializing the given organization' do
         expect(assigns(:organization)).to be_a(Organization) &
                                           have_attributes(
@@ -287,22 +266,10 @@ RSpec.describe "Organizations", type: :request do
                                           )
       end
 
-      context "when enable_packs flipper is on" do
-        it "should display custom units and units form" do
-          Flipper.enable(:enable_packs)
-          get edit_organization_path
-          expect(response.body).to include("Custom request units used")
-          expect(response.body).to include "WolfPack"
-        end
-      end
-
-      context "when enable_packs flipper is off" do
-        it "should not display custom units and units form" do
-          Flipper.disable(:enable_packs)
-          get edit_organization_path
-          expect(response.body).to_not include("Custom request units used")
-          expect(response.body).to_not include "WolfPack"
-        end
+      it "displays custom units and units form" do
+        get edit_organization_path
+        expect(response.body).to include("Custom request units used")
+        expect(response.body).to include "WolfPack"
       end
     end
 

--- a/spec/requests/partners/dashboard_requests_spec.rb
+++ b/spec/requests/partners/dashboard_requests_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe "/partners/dashboard", type: :request do
     end
 
     it "shows units" do
-      Flipper.enable(:enable_packs)
       create(:item_unit, item: item1, name: "Pack")
       create(:item_unit, item: item2, name: "Pack")
       request = create(:request, :pending, partner: partner, request_items: [])
@@ -51,7 +50,6 @@ RSpec.describe "/partners/dashboard", type: :request do
     end
 
     it "skips units when are not provided" do
-      Flipper.enable(:enable_packs)
       create(:item_unit, item: item1, name: "Pack")
       request = create(:request, :pending, partner: partner, request_items: [])
       create(:item_request, request: request, quantity: 7, item: item1)

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -51,14 +51,9 @@ RSpec.describe "/partners/requests", type: :request do
       expect(response).to render_template(:new)
     end
 
-    context "when packs are enabled but there are no requestable items" do
+    context "when there are no requestable items" do
       before do
         allow_any_instance_of(PartnerFetchRequestableItemsService).to receive(:call).and_return({})
-        Flipper.enable(:enable_packs)
-      end
-
-      after do
-        Flipper.disable(:enable_packs)
       end
 
       it 'should render without any issues' do
@@ -181,17 +176,10 @@ RSpec.describe "/partners/requests", type: :request do
         ]
       )
 
-      Flipper.enable(:enable_packs)
       get partners_request_path(request)
       expect(response.body).to match(/First item - 125/m)
       expect(response.body).to match(/Second item - 559\s+flats/m)
       expect(response.body).to match(/Third item - 1\s+flat/m)
-
-      Flipper.disable(:enable_packs)
-      get partners_request_path(request)
-      expect(response.body).to match(/First item - 125/m)
-      expect(response.body).to match(/Second item - 559/m)
-      expect(response.body).to match(/Third item - 1/m)
     end
   end
 
@@ -290,7 +278,6 @@ RSpec.describe "/partners/requests", type: :request do
         end
 
         it "creates without error" do
-          Flipper.enable(:enable_packs)
           expect { subject }.to change { Request.count }.by(1)
           expect(response).to redirect_to(partners_request_path(Request.last.id))
           expect(response.request.flash[:success]).to eql "Request was successfully created."
@@ -319,7 +306,6 @@ RSpec.describe "/partners/requests", type: :request do
         end
 
         it "results in an error" do
-          Flipper.enable(:enable_packs)
           expect { post partners_requests_path, params: request_attributes }.to_not change { Request.count }
           expect(response).to be_unprocessable
           expect(response.body).to include("Please ensure a single unit is selected for each item")

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -153,40 +153,28 @@ RSpec.describe 'Requests', type: :request do
         end
       end
 
-      context 'When packs are enabled' do
-        before { Flipper.enable(:enable_packs) }
-        let(:item) { create(:item, name: "Item", organization: organization) }
-        let(:request) { create(:request, organization: organization) }
+      it 'shows a units column and custom unit if any item has custom units' do
+        item = create(:item, name: "Item", organization: organization)
+        request = create(:request, organization: organization)
+        create(:item_unit, item: item, name: "Pack")
+        create(:item_request, request: request, request_unit: "Pack", item: item)
 
-        it 'shows a units column and custom unit if any item has custom units' do
-          create(:item_unit, item: item, name: "Pack")
-          create(:item_request, request: request, request_unit: "Pack", item: item)
+        get request_path(request)
 
-          get request_path(request)
-
-          expect(response.body).to include('Units (if applicable)')
-          expect(response.body).to include('<td>Packs</td>')
-        end
-
-        it 'does not show a units column or any unit if no items have custom units' do
-          create(:item_unit, item: item, name: "Pack")
-          create(:item_request, request: request, request_unit: nil, item: item)
-
-          get request_path(request)
-
-          expect(response.body).to_not include('Units (if applicable)')
-          expect(response.body).to_not include('<td>Packs</td>')
-        end
+        expect(response.body).to include('Units (if applicable)')
+        expect(response.body).to include('<td>Packs</td>')
       end
 
-      context 'When packs are not enabled' do
-        let(:request) { create(:request, organization: organization) }
+      it 'does not show a units column or any unit if no items have custom units' do
+        item = create(:item, name: "Item", organization: organization)
+        request = create(:request, organization: organization)
+        create(:item_unit, item: item, name: "Pack")
+        create(:item_request, request: request, request_unit: nil, item: item)
 
-        it 'does not show a units column' do
-          get request_path(request)
+        get request_path(request)
 
-          expect(response.body).not_to include('Units (if applicable)')
-        end
+        expect(response.body).to_not include('Units (if applicable)')
+        expect(response.body).to_not include('<td>Packs</td>')
       end
 
       context 'when the request has a Fulfilled status' do

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -112,306 +112,162 @@ RSpec.describe Exports::ExportRequestService do
     described_class.new(Request.all, org).generate_csv_data
   end
 
-  context "with custom units feature enabled" do
-    before do
-      Flipper.enable(:enable_packs)
+  describe ".generate_csv_data" do
+    it "includes headers as the first row with ordered item names alphabetically with deleted item included at the end" do
+      expect(subject.first).to eq([
+        "Date",
+        "Requestor",
+        "Type",
+        "Status",
+        "2T Diapers -- UPDATED",
+        "3T Diapers",
+        "4T Diapers",
+        "4T Diapers - packs",
+        "apple",
+        "Banana",
+        "Inactive Item",
+        "Unrequested Item",
+        "Zebra",
+        "<DELETED_ITEMS>"
+      ])
     end
 
-    describe ".generate_csv_data" do
-      it "includes headers as the first row with ordered item names alphabetically with deleted item included at the end" do
-        expect(subject.first).to eq([
-          "Date",
-          "Requestor",
-          "Type",
-          "Status",
-          "2T Diapers -- UPDATED",
-          "3T Diapers",
-          "4T Diapers",
-          "4T Diapers - packs",
-          "apple",
-          "Banana",
-          "Inactive Item",
-          "Unrequested Item",
-          "Zebra",
-          "<DELETED_ITEMS>"
-        ])
-      end
-
-      it "includes rows for each request" do
-        expect(subject.count).to eq(8)
-      end
-
-      it "has expected data for the 3T Diapers request" do
-        expect(subject).to include([
-          request_3t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Child",
-          "Started",
-          0,   # 2T Diapers
-          150, # 3T Diapers
-          0,   # 4T Diapers
-          0,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the 2T Diapers request" do
-        expect(subject).to include([
-          request_2t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Individual",
-          "Fulfilled",
-          100, # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          0,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with deleted items" do
-        expect(subject).to include([
-          request_with_deleted_items.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          nil,
-          "Fulfilled",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          0,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          400  # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with multiple items" do
-        expect(subject).to include([
-          request_with_multiple_items.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          nil,
-          "Started",
-          3,   # 2T Diapers
-          2,   # 3T Diapers
-          0,   # 4T Diapers
-          4,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with 4T diapers without pack unit" do
-        expect(subject).to include([
-          request_4t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          77,  # 4T Diapers
-          0,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with 4T diapers with pack unit" do
-        expect(subject).to include([
-          request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          1,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data even when the unit was deleted" do
-        item_4t.request_units.destroy_all
-        expect(subject).to include([
-          request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          1, # 4T Diapers - packs
-          0, # apple
-          0, # Banana
-          0, # Inactive Item
-          0, # Unrequested Item
-          0, # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-    end
-  end
-
-  context "with custom units feature disabled" do
-    before do
-      Flipper.disable(:enable_packs)
+    it "includes rows for each request" do
+      expect(subject.count).to eq(8)
     end
 
-    describe ".generate_csv_data" do
-      it "includes headers as the first row with ordered item names alphabetically with deleted item included at the end" do
-        expect(subject.first).to eq([
-          "Date",
-          "Requestor",
-          "Type",
-          "Status",
-          "2T Diapers -- UPDATED",
-          "3T Diapers",
-          "4T Diapers",
-          "apple",
-          "Banana",
-          "Inactive Item",
-          "Unrequested Item",
-          "Zebra",
-          "<DELETED_ITEMS>"
-        ])
-      end
+    it "has expected data for the 3T Diapers request" do
+      expect(subject).to include([
+        request_3t.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "Child",
+        "Started",
+        0,   # 2T Diapers
+        150, # 3T Diapers
+        0,   # 4T Diapers
+        0,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "includes rows for each request" do
-        expect(subject.count).to eq(8)
-      end
+    it "has expected data for the 2T Diapers request" do
+      expect(subject).to include([
+        request_2t.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "Individual",
+        "Fulfilled",
+        100, # 2T Diapers
+        0,   # 3T Diapers
+        0,   # 4T Diapers
+        0,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the 3T Diapers request" do
-        expect(subject).to include([
-          request_3t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Child",
-          request_3t.status.humanize,
-          0,   # 2T Diapers
-          150, # 3T Diapers
-          0,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data for the request with deleted items" do
+      expect(subject).to include([
+        request_with_deleted_items.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        nil,
+        "Fulfilled",
+        0,   # 2T Diapers
+        0,   # 3T Diapers
+        0,   # 4T Diapers
+        0,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        400  # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the 2T Diapers request" do
-        expect(subject).to include([
-          request_2t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Individual",
-          "Fulfilled",
-          100, # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data for the request with multiple items" do
+      expect(subject).to include([
+        request_with_multiple_items.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        nil,
+        "Started",
+        3,   # 2T Diapers
+        2,   # 3T Diapers
+        0,   # 4T Diapers
+        4,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the request with deleted items" do
-        expect(subject).to include([
-          request_with_deleted_items.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          nil,
-          "Fulfilled",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          400  # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data for the request with 4T diapers without pack unit" do
+      expect(subject).to include([
+        request_4t.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "Quantity",
+        "Started",
+        0,   # 2T Diapers
+        0,   # 3T Diapers
+        77,  # 4T Diapers
+        0,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the request with multiple items" do
-        expect(subject).to include([
-          request_with_multiple_items.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          nil,
-          "Started",
-          3,   # 2T Diapers
-          2,   # 3T Diapers
-          4,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data for the request with 4T diapers with pack unit" do
+      expect(subject).to include([
+        request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "Quantity",
+        "Started",
+        0,   # 2T Diapers
+        0,   # 3T Diapers
+        0,   # 4T Diapers
+        1,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the request with 4T diapers without pack unit" do
-        expect(subject).to include([
-          request_4t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          77,  # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with 4T diapers with pack unit" do
-        expect(subject).to include([
-          request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          1,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data even when the unit was deleted" do
+      item_4t.request_units.destroy_all
+      expect(subject).to include([
+        request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "Quantity",
+        "Started",
+        0,   # 2T Diapers
+        0,   # 3T Diapers
+        0,   # 4T Diapers
+        1, # 4T Diapers - packs
+        0, # apple
+        0, # Banana
+        0, # Inactive Item
+        0, # Unrequested Item
+        0, # Zebra
+        0    # <DELETED_ITEMS>
+      ])
     end
   end
 end

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -112,336 +112,178 @@ RSpec.describe Exports::ExportRequestService do
     described_class.new(Request.all, org).generate_csv_data
   end
 
-  context "with custom units feature enabled" do
-    before do
-      Flipper.enable(:enable_packs)
+  describe ".generate_csv_data" do
+    it "includes headers as the first row with ordered item names alphabetically with deleted item included at the end" do
+      expect(subject.first).to eq([
+        "Date",
+        "Requestor",
+        "Request Sender",
+        "Comments",
+        "Type",
+        "Status",
+        "2T Diapers -- UPDATED",
+        "3T Diapers",
+        "4T Diapers",
+        "4T Diapers - packs",
+        "apple",
+        "Banana",
+        "Inactive Item",
+        "Unrequested Item",
+        "Zebra",
+        "<DELETED_ITEMS>"
+      ])
     end
 
-    describe ".generate_csv_data" do
-      it "includes headers as the first row with ordered item names alphabetically with deleted item included at the end" do
-        expect(subject.first).to eq([
-          "Date",
-          "Requestor",
-          "Request Sender",
-          "Comments",
-          "Type",
-          "Status",
-          "2T Diapers -- UPDATED",
-          "3T Diapers",
-          "4T Diapers",
-          "4T Diapers - packs",
-          "apple",
-          "Banana",
-          "Inactive Item",
-          "Unrequested Item",
-          "Zebra",
-          "<DELETED_ITEMS>"
-        ])
-      end
-
-      it "includes rows for each request" do
-        expect(subject.count).to eq(8)
-      end
-
-      it "has expected data for the 3T Diapers request" do
-        expect(subject).to include([
-          request_3t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Child",
-          "Started",
-          0,   # 2T Diapers
-          150, # 3T Diapers
-          0,   # 4T Diapers
-          0,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the 2T Diapers request" do
-        expect(subject).to include([
-          request_2t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Individual",
-          "Fulfilled",
-          100, # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          0,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with deleted items" do
-        expect(subject).to include([
-          request_with_deleted_items.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          nil,
-          "Fulfilled",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          0,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          400  # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with multiple items" do
-        expect(subject).to include([
-          request_with_multiple_items.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          nil,
-          "Started",
-          3,   # 2T Diapers
-          2,   # 3T Diapers
-          0,   # 4T Diapers
-          4,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with 4T diapers without pack unit" do
-        expect(subject).to include([
-          request_4t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          77,  # 4T Diapers
-          0,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with 4T diapers with pack unit" do
-        expect(subject).to include([
-          request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          1,   # 4T Diapers - packs
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data even when the unit was deleted" do
-        item_4t.request_units.destroy_all
-        expect(subject).to include([
-          request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          1, # 4T Diapers - packs
-          0, # apple
-          0, # Banana
-          0, # Inactive Item
-          0, # Unrequested Item
-          0, # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-    end
-  end
-
-  context "with custom units feature disabled" do
-    before do
-      Flipper.disable(:enable_packs)
+    it "includes rows for each request" do
+      expect(subject.count).to eq(8)
     end
 
-    describe ".generate_csv_data" do
-      it "includes headers as the first row with ordered item names alphabetically with deleted item included at the end" do
-        expect(subject.first).to eq([
-          "Date",
-          "Requestor",
-          "Request Sender",
-          "Comments",
-          "Type",
-          "Status",
-          "2T Diapers -- UPDATED",
-          "3T Diapers",
-          "4T Diapers",
-          "apple",
-          "Banana",
-          "Inactive Item",
-          "Unrequested Item",
-          "Zebra",
-          "<DELETED_ITEMS>"
-        ])
-      end
+    it "has expected data for the 3T Diapers request" do
+      expect(subject).to include([
+        request_3t.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "test@rfg.com",
+        "Urgent",
+        "Child",
+        "Started",
+        0,   # 2T Diapers
+        150, # 3T Diapers
+        0,   # 4T Diapers
+        0,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "includes rows for each request" do
-        expect(subject.count).to eq(8)
-      end
+    it "has expected data for the 2T Diapers request" do
+      expect(subject).to include([
+        request_2t.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "test@rfg.com",
+        "Urgent",
+        "Individual",
+        "Fulfilled",
+        100, # 2T Diapers
+        0,   # 3T Diapers
+        0,   # 4T Diapers
+        0,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the 3T Diapers request" do
-        expect(subject).to include([
-          request_3t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Child",
-          request_3t.status.humanize,
-          0,   # 2T Diapers
-          150, # 3T Diapers
-          0,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data for the request with deleted items" do
+      expect(subject).to include([
+        request_with_deleted_items.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "test@rfg.com",
+        "Urgent",
+        nil,
+        "Fulfilled",
+        0,   # 2T Diapers
+        0,   # 3T Diapers
+        0,   # 4T Diapers
+        0,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        400  # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the 2T Diapers request" do
-        expect(subject).to include([
-          request_2t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Individual",
-          "Fulfilled",
-          100, # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data for the request with multiple items" do
+      expect(subject).to include([
+        request_with_multiple_items.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "test@rfg.com",
+        "Urgent",
+        nil,
+        "Started",
+        3,   # 2T Diapers
+        2,   # 3T Diapers
+        0,   # 4T Diapers
+        4,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the request with deleted items" do
-        expect(subject).to include([
-          request_with_deleted_items.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          nil,
-          "Fulfilled",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          0,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          400  # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data for the request with 4T diapers without pack unit" do
+      expect(subject).to include([
+        request_4t.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "test@rfg.com",
+        "Urgent",
+        "Quantity",
+        "Started",
+        0,   # 2T Diapers
+        0,   # 3T Diapers
+        77,  # 4T Diapers
+        0,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the request with multiple items" do
-        expect(subject).to include([
-          request_with_multiple_items.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          nil,
-          "Started",
-          3,   # 2T Diapers
-          2,   # 3T Diapers
-          4,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data for the request with 4T diapers with pack unit" do
+      expect(subject).to include([
+        request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "test@rfg.com",
+        "Urgent",
+        "Quantity",
+        "Started",
+        0,   # 2T Diapers
+        0,   # 3T Diapers
+        0,   # 4T Diapers
+        1,   # 4T Diapers - packs
+        0,   # apple
+        0,   # Banana
+        0,   # Inactive Item
+        0,   # Unrequested Item
+        0,   # Zebra
+        0    # <DELETED_ITEMS>
+      ])
+    end
 
-      it "has expected data for the request with 4T diapers without pack unit" do
-        expect(subject).to include([
-          request_4t.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          77,  # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
-
-      it "has expected data for the request with 4T diapers with pack unit" do
-        expect(subject).to include([
-          request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
-          "Howdy Partner",
-          "test@rfg.com",
-          "Urgent",
-          "Quantity",
-          "Started",
-          0,   # 2T Diapers
-          0,   # 3T Diapers
-          1,   # 4T Diapers
-          0,   # apple
-          0,   # Banana
-          0,   # Inactive Item
-          0,   # Unrequested Item
-          0,   # Zebra
-          0    # <DELETED_ITEMS>
-        ])
-      end
+    it "has expected data even when the unit was deleted" do
+      item_4t.request_units.destroy_all
+      expect(subject).to include([
+        request_4t_pack.created_at.strftime("%m/%d/%Y").to_s,
+        "Howdy Partner",
+        "test@rfg.com",
+        "Urgent",
+        "Quantity",
+        "Started",
+        0,   # 2T Diapers
+        0,   # 3T Diapers
+        0,   # 4T Diapers
+        1, # 4T Diapers - packs
+        0, # apple
+        0, # Banana
+        0, # Inactive Item
+        0, # Unrequested Item
+        0, # Zebra
+        0    # <DELETED_ITEMS>
+      ])
     end
   end
 end

--- a/spec/services/item_create_service_spec.rb
+++ b/spec/services/item_create_service_spec.rb
@@ -26,53 +26,48 @@ RSpec.describe ItemCreateService, type: :service do
       allow(organization).to receive(:storage_locations).and_return(fake_organization_storage_locations)
     end
 
-    context 'when enable_packs is enabled' do
-      context 'when there are no issues' do
-        it 'should return a result object with success? returning true and the item' do
-          Flipper.enable(:enable_packs)
+    context 'when there are no issues' do
+      it 'should return a result object with success? returning true and the item' do
+        allow(fake_organization_item).to receive(:sync_request_units!).with([])
+
+        expect(subject).to be_a_kind_of(Result)
+        expect(subject.success?).to eq(true)
+        expect(subject.value).to eq(fake_organization_item)
+        expect(fake_organization_item).to have_received(:save!)
+        expect(fake_organization_item).to have_received(:sync_request_units!)
+      end
+    end
+
+    context 'when an issue occurs in transaction' do
+      context 'because the organization_id does not match any Organization' do
+        before do
+          allow(Organization).to receive(:find).with(organization_id).and_raise(ActiveRecord::RecordNotFound)
+        end
+
+        it 'should return a result object with an ActiveRecord::RecordNotFound error' do
           allow(fake_organization_item).to receive(:sync_request_units!).with([])
 
           expect(subject).to be_a_kind_of(Result)
-          expect(subject.success?).to eq(true)
-          expect(subject.value).to eq(fake_organization_item)
-          expect(fake_organization_item).to have_received(:save!)
-          expect(fake_organization_item).to have_received(:sync_request_units!)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to be_a_kind_of(ActiveRecord::RecordNotFound)
+          expect(fake_organization_item).not_to have_received(:sync_request_units!)
         end
       end
 
-      context 'when an issue occurs in transaction' do
-        context 'because the organization_id does not match any Organization' do
-          before do
-            allow(Organization).to receive(:find).with(organization_id).and_raise(ActiveRecord::RecordNotFound)
-          end
+      context 'because the item create raised an error' do
+        let(:fake_error) { StandardError.new('random-error') }
 
-          it 'should return a result object with an ActiveRecord::RecordNotFound error' do
-            Flipper.enable(:enable_packs)
-            allow(fake_organization_item).to receive(:sync_request_units!).with([])
-
-            expect(subject).to be_a_kind_of(Result)
-            expect(subject.success?).to eq(false)
-            expect(subject.error).to be_a_kind_of(ActiveRecord::RecordNotFound)
-            expect(fake_organization_item).not_to have_received(:sync_request_units!)
-          end
+        before do
+          allow(fake_organization_item).to receive(:save!).and_raise(fake_error)
         end
 
-        context 'because the item create raised an error' do
-          let(:fake_error) { StandardError.new('random-error') }
+        it 'should return a result object with the raised error' do
+          allow(fake_organization_item).to receive(:sync_request_units!).with([])
 
-          before do
-            allow(fake_organization_item).to receive(:save!).and_raise(fake_error)
-          end
-
-          it 'should return a result object with the raised error' do
-            Flipper.enable(:enable_packs)
-            allow(fake_organization_item).to receive(:sync_request_units!).with([])
-
-            expect(subject).to be_a_kind_of(Result)
-            expect(subject.success?).to eq(false)
-            expect(subject.error).to eq(fake_error)
-            expect(fake_organization_item).not_to have_received(:sync_request_units!)
-          end
+          expect(subject).to be_a_kind_of(Result)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to eq(fake_error)
+          expect(fake_organization_item).not_to have_received(:sync_request_units!)
         end
       end
     end

--- a/spec/services/organization_update_service_spec.rb
+++ b/spec/services/organization_update_service_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe OrganizationUpdateService do
       end
 
       it "Should set request_units on the organization" do
-        Flipper.enable(:enable_packs)
         params = {request_unit_names: ["newpack"]}
         described_class.update(organization, params)
         expect(organization.errors.none?).to eq(true)

--- a/spec/services/requests_total_items_service_spec.rb
+++ b/spec/services/requests_total_items_service_spec.rb
@@ -48,11 +48,7 @@ RSpec.describe RequestsTotalItemsService, type: :service do
         end
       end
 
-      context 'when custom request units are specified and enabled' do
-        before do
-          Flipper.enable(:enable_packs)
-        end
-
+      context 'when custom request units are specified' do
         it 'returns the names of items correctly' do
           expect(subject.keys).to eq([
             "item_name_0",

--- a/spec/services/requests_total_items_service_spec.rb
+++ b/spec/services/requests_total_items_service_spec.rb
@@ -33,11 +33,7 @@ RSpec.describe RequestsTotalItemsService, type: :service do
         ])
       end
 
-      context 'when custom request units are specified and enabled' do
-        before do
-          Flipper.enable(:enable_packs)
-        end
-
+      context 'when custom request units are specified' do
         it 'returns the names of items correctly' do
           expect(subject.keys).to eq([
             "item_name_0",

--- a/spec/services/requests_total_items_service_spec.rb
+++ b/spec/services/requests_total_items_service_spec.rb
@@ -21,30 +21,24 @@ RSpec.describe RequestsTotalItemsService, type: :service do
         Request.where(id: local_requests.map(&:id))
       end
 
-      context 'when enable_packs is enabled' do
-        context 'when not all items have request units' do
-          it 'return items with correct quantities calculated, by individual items' do
-            Flipper.enable(:enable_packs)
-
-            expect(subject).to eq({"item_name_0" => 20, "item_name_0 - bundles" => 60, "item_name_1" => 20, "item_name_1 - bundles" => 60, "item_name_2" => 20, "item_name_2 - bundles" => 60})
-          end
+      context 'when not all items have request units' do
+        it 'return items with correct quantities calculated, by individual items' do
+          expect(subject).to eq({"item_name_0" => 20, "item_name_0 - bundles" => 60, "item_name_1" => 20, "item_name_1 - bundles" => 60, "item_name_2" => 20, "item_name_2 - bundles" => 60})
         end
+      end
 
-        context 'when the items have request units' do
-          it 'return items with correct quantities calculated, grouped by packs' do
-            Flipper.enable(:enable_packs)
+      context 'when the items have request units' do
+        it 'return items with correct quantities calculated, grouped by packs' do
+          requests = [
+            create(:request, :with_item_requests, request_items: item_ids.map { |k| { "item_id" => k, "quantity" => 20, "request_unit" => "bundle"} }),
+            create(:request, :with_item_requests, request_items: item_ids.map { |k| { "item_id" => k, "quantity" => 10, "request_unit" => "bundle" } }),
+            create(:request, :with_item_requests, request_items: item_ids.map { |k| { "item_id" => k, "quantity" => 50, "request_unit" => "bundle" } })
+          ]
+          requests_with_units = Request.where(id: requests.map(&:id))
 
-            requests = [
-              create(:request, :with_item_requests, request_items: item_ids.map { |k| { "item_id" => k, "quantity" => 20, "request_unit" => "bundle"} }),
-              create(:request, :with_item_requests, request_items: item_ids.map { |k| { "item_id" => k, "quantity" => 10, "request_unit" => "bundle" } }),
-              create(:request, :with_item_requests, request_items: item_ids.map { |k| { "item_id" => k, "quantity" => 50, "request_unit" => "bundle" } })
-            ]
-            Request.where(id: requests.map(&:id))
+          result = RequestsTotalItemsService.new(requests: requests_with_units).calculate
 
-            result = RequestsTotalItemsService.new(requests: requests).calculate
-
-            expect(result).to eq({"item_name_0 - bundles" => 80, "item_name_1 - bundles" => 80, "item_name_2 - bundles" => 80})
-          end
+          expect(result).to eq({"item_name_0 - bundles" => 80, "item_name_1 - bundles" => 80, "item_name_2 - bundles" => 80})
         end
       end
 
@@ -86,37 +80,31 @@ RSpec.describe RequestsTotalItemsService, type: :service do
     end
 
     context 'when request item belongs to deleted item' do
-      context 'when enable_packs is enabled' do
-        context 'when the request unit is present' do
-          it 'returns item with correct quantity calculated' do
-            Flipper.enable(:enable_packs)
+      context 'when the request unit is present' do
+        it 'returns item with correct quantity calculated' do
+          item = create(:item, :with_unit, name: "Diaper", organization:, unit: "pack")
+          request = create(
+            :request,
+            :with_item_requests,
+            request_items: [{"item_id" => item.id, "quantity" => 10, "request_unit" => "pack"}]
+          )
+          item.destroy
 
-            item = create(:item, :with_unit, name: "Diaper", organization:, unit: "pack")
-            request = create(
-              :request,
-              :with_item_requests,
-              request_items: [{"item_id" => item.id, "quantity" => 10, "request_unit" => "pack"}]
-            )
-            item.destroy
-
-            expect(RequestsTotalItemsService.new(requests: [request]).calculate).to eq({"Diaper - packs" => 10})
-          end
+          expect(RequestsTotalItemsService.new(requests: [request]).calculate).to eq({"Diaper - packs" => 10})
         end
+      end
 
-        context 'when the request unit is not present' do
-          it 'returns item with correct quantity calculated, without the request unit' do
-            Flipper.enable(:enable_packs)
+      context 'when the request unit is not present' do
+        it 'returns item with correct quantity calculated, without the request unit' do
+          item = create(:item, :with_unit, name: "Diaper", organization:, unit: "pack")
+          request = create(
+            :request,
+            :with_item_requests,
+            request_items: [{"item_id" => item.id, "quantity" => 10}]
+          )
+          item.destroy
 
-            item = create(:item, :with_unit, name: "Diaper", organization:, unit: "pack")
-            request = create(
-              :request,
-              :with_item_requests,
-              request_items: [{"item_id" => item.id, "quantity" => 10}]
-            )
-            item.destroy
-
-            expect(RequestsTotalItemsService.new(requests: [request]).calculate).to eq({"Diaper" => 10})
-          end
+          expect(RequestsTotalItemsService.new(requests: [request]).calculate).to eq({"Diaper" => 10})
         end
       end
     end

--- a/spec/system/partners/requests_system_spec.rb
+++ b/spec/system/partners/requests_system_spec.rb
@@ -14,73 +14,55 @@ RSpec.describe "Partners profile served area behaviour", type: :system, js: true
       FactoryBot.create(:item_unit, name: "pack", item: item1)
     end
 
-    context "with packs off" do
-      before(:each) do
-        Flipper.disable(:enable_packs)
-      end
+    it "should require a unit selection" do
+      visit new_partners_request_path
+      expect(Request.count).to eq(0)
+      expect(page).not_to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
+      select "Item 1", from: "request_item_requests_attributes_0_item_id"
+      expect(page).to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
+      expect(page).to have_select("request_item_requests_attributes_0_request_unit",
+        selected: "Please select a unit",
+        options: ["Please select a unit", "units", "packs"])
+      fill_in "request_item_requests_attributes_0_quantity", with: 50
+      click_on "Submit Essentials Request"
 
-      it "should not show packs on selection" do
-        visit new_partners_request_path
-        select "Item 1", from: "request_item_requests_attributes_0_item_id"
-        expect(page).not_to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
-      end
+      expect(page).to have_text "Please ensure a single unit is selected for each item that supports it."
+      expect(Request.count).to eq(0)
     end
 
-    context "with packs on" do
-      before(:each) do
-        Flipper.enable(:enable_packs)
-      end
+    it "shows packs on selection" do
+      visit new_partners_request_path
+      expect(Request.count).to eq(0)
+      expect(page).not_to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
+      select "Item 1", from: "request_item_requests_attributes_0_item_id"
+      expect(page).to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
+      expect(page).to have_select("request_item_requests_attributes_0_request_unit",
+        selected: "Please select a unit",
+        options: ["Please select a unit", "units", "packs"])
+      select "packs", from: "request_item_requests_attributes_0_request_unit"
+      click_on "Add Another Item"
 
-      it "should require a unit selection" do
-        visit new_partners_request_path
-        expect(Request.count).to eq(0)
-        expect(page).not_to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
-        select "Item 1", from: "request_item_requests_attributes_0_item_id"
-        expect(page).to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
-        expect(page).to have_select("request_item_requests_attributes_0_request_unit",
-          selected: "Please select a unit",
-          options: ["Please select a unit", "units", "packs"])
-        fill_in "request_item_requests_attributes_0_quantity", with: 50
-        click_on "Submit Essentials Request"
+      # get selector to use in subsequent steps
+      new_item = find_all(:css, "select[data-item-units-target=itemSelect]")[1]
+      id = new_item[:id].match(/\d+/)[0]
 
-        expect(page).to have_text "Please ensure a single unit is selected for each item that supports it."
-        expect(Request.count).to eq(0)
-      end
+      expect(page).not_to have_selector("request_item_requests_attributes_#{id}_request_unit", visible: true)
+      select "Item 2", from: "request_item_requests_attributes_#{id}_item_id"
+      expect(page).not_to have_selector("request_item_requests_attributes_#{id}_request_unit", visible: true)
+      fill_in "request_item_requests_attributes_0_quantity", with: 50
+      fill_in "request_item_requests_attributes_#{id}_quantity", with: 20
+      click_on "Submit Essentials Request"
+      click_on "Yes, it's correct"
+      expect(page).to have_text "Request has been successfully created"
 
-      it "should show packs on selection" do
-        visit new_partners_request_path
-        expect(Request.count).to eq(0)
-        expect(page).not_to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
-        select "Item 1", from: "request_item_requests_attributes_0_item_id"
-        expect(page).to have_selector("#request_item_requests_attributes_0_request_unit", visible: true)
-        expect(page).to have_select("request_item_requests_attributes_0_request_unit",
-          selected: "Please select a unit",
-          options: ["Please select a unit", "units", "packs"])
-        select "packs", from: "request_item_requests_attributes_0_request_unit"
-        click_on "Add Another Item"
-
-        # get selector to use in subsequent steps
-        new_item = find_all(:css, "select[data-item-units-target=itemSelect]")[1]
-        id = new_item[:id].match(/\d+/)[0]
-
-        expect(page).not_to have_selector("request_item_requests_attributes_#{id}_request_unit", visible: true)
-        select "Item 2", from: "request_item_requests_attributes_#{id}_item_id"
-        expect(page).not_to have_selector("request_item_requests_attributes_#{id}_request_unit", visible: true)
-        fill_in "request_item_requests_attributes_0_quantity", with: 50
-        fill_in "request_item_requests_attributes_#{id}_quantity", with: 20
-        click_on "Submit Essentials Request"
-        click_on "Yes, it's correct"
-        expect(page).to have_text "Request has been successfully created"
-
-        expect(Request.count).to eq(1)
-        request = Request.last
-        expect(request.item_requests[0].quantity).to eq("50")
-        expect(request.item_requests[0].item_id).to eq(item1.id)
-        expect(request.item_requests[0].request_unit).to eq("pack")
-        expect(request.item_requests[1].quantity).to eq("20")
-        expect(request.item_requests[1].item_id).to eq(item2.id)
-        expect(request.item_requests[1].request_unit).to eq(nil)
-      end
+      expect(Request.count).to eq(1)
+      request = Request.last
+      expect(request.item_requests[0].quantity).to eq("50")
+      expect(request.item_requests[0].item_id).to eq(item1.id)
+      expect(request.item_requests[0].request_unit).to eq("pack")
+      expect(request.item_requests[1].quantity).to eq("20")
+      expect(request.item_requests[1].item_id).to eq(item2.id)
+      expect(request.item_requests[1].request_unit).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/human-essentials/issues/5251

### Description

"Enable packs" is now in service, and we no longer need it to be Flippered. This PR adjusts the code so that enable packs is no longer needed to be turned on, and defunct code is removed.

Follow up of https://github.com/rubyforgood/human-essentials/pull/5643

### Type of change

* Cleanup of fully enabled feature flag code, tests, and documentation.

### How Has This Been Tested?

https://github.com/rubyforgood/human-essentials/pull/5643 added more coverage for the missing paths for when the feature flag was enabled. Tests descriptions have been updated to expect for the flipper behaviour to be always on.
