### PR TITLE
Relax CSRF origin check for tunnels/Codespaces via TUNNEL env var

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,9 +31,12 @@
     }
   },
 
-  // DOCKER env variable passed to Cuprite to enable --no-sandbox so Chrome can run in Docker
+  // DOCKER env variable passed to Cuprite to enable --no-sandbox so Chrome can run in Docker.
+  // TUNNEL relaxes the CSRF origin check in development (see config/environments/development.rb)
+  // so the app works behind the Codespaces port-forwarding proxy.
   "remoteEnv": {
-    "DOCKER": "true"
+    "DOCKER": "true",
+    "TUNNEL": "true"
   },
 
   "postCreateCommand": "bash -i .devcontainer/post-create.sh"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,6 +20,18 @@ Rails.application.configure do
   config.hosts << "diaper.test"
   config.hosts << ".app.github.dev"
 
+  # Reaching the dev server through a proxy -- a TLS-terminating tunnel like localhost.run,
+  # GitHub Codespaces port forwarding, or a port forward that changes the port -- means Rails
+  # cannot always work out the scheme the browser actually used. It then computes a base_url
+  # that disagrees with the Origin header and CSRF rejects every form, which surfaces as
+  # "Your session expired".
+  #
+  # Relaxing the ORIGIN check (not the token) is the right lever: the token is the actual
+  # defence, and the origin comparison is the part the proxy breaks. Forcing assume_ssl was
+  # wrong -- it fixes an https tunnel and breaks a plain http forward, which is worse,
+  # because the forward is the common case.
+  config.action_controller.forgery_protection_origin_check = false if ENV["TUNNEL"].present?
+
   # Show full error reports.
   config.consider_all_requests_local = true
   config.action_mailer.default_url_options = { host: "localhost:3000" }


### PR DESCRIPTION
Ports the forgery_protection_origin_check relaxation from the design branch and sets TUNNEL in the devcontainer so Codespaces port forwarding works without CSRF 'session expired' errors.

