### PR TITLE
Resolves #5668 Org level disable reminder emails

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -73,6 +73,7 @@ class Admin::OrganizationsController < AdminController
     params.require(:organization)
           .permit(:name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text, :account_request_id, :bank_is_set_up,
                   :reminder_schedule_definition, :deadline_day,
+                  :deadline_reminders_enabled, :distribution_reminders_enabled,
                   users_attributes: %i(name email organization_admin), account_request_attributes: %i(ndbn_member_id id))
   end
 

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -293,7 +293,7 @@ class DistributionsController < ApplicationController
   end
 
   def schedule_reminder_email(distribution)
-    return if distribution.past? || !distribution.partner.send_reminders
+    return if distribution.past? || !distribution.partner.send_reminders || !distribution.organization.distribution_reminders_enabled
 
     DistributionMailer.reminder_email(distribution.id).deliver_later(wait_until: distribution.issued_at - 1.day)
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -102,6 +102,7 @@ class OrganizationsController < ApplicationController
       :ytd_on_distribution_printout, :one_step_partner_invite,
       :hide_value_columns_on_receipt, :hide_package_column_on_receipt,
       :signature_for_distribution_pdf, :receive_email_on_requests,
+      :deadline_reminders_enabled, :distribution_reminders_enabled,
       :bank_is_set_up,
       :include_in_kind_values_in_exported_files,
       :include_packages_in_distribution_export,

--- a/app/javascript/controllers/reminder_toggle_controller.js
+++ b/app/javascript/controllers/reminder_toggle_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+/*
+ * ReminderToggleController shows/hides dependent reminder-schedule fields based
+ * on the selected value of a Yes/No radio-button group. Used on the organization
+ * settings form so the reminder schedule and reminder email text are only shown
+ * when "Send monthly deadline reminder emails?" is set to Yes.
+ */
+export default class extends Controller {
+  static targets = ["source", "dependentField"]
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    const selected = this.sourceTargets.find((input) => input.checked)
+    const show = selected?.value === "true"
+    this.dependentFieldTargets.forEach((field) => {
+      field.classList.toggle("d-none", !show)
+    })
+  }
+}

--- a/app/mailers/distribution_mailer.rb
+++ b/app/mailers/distribution_mailer.rb
@@ -45,6 +45,7 @@ class DistributionMailer < ApplicationMailer
     requester_email = distribution.request ? distribution.request.requester.email : @partner.email
 
     return if @distribution.past? || !@partner.send_reminders || @partner.deactivated?
+    return unless @distribution.organization.distribution_reminders_enabled
 
     mail(to: requester_email, cc: @partner.email, subject: "#{@partner.name} Distribution Reminder")
   end

--- a/app/mailers/reminder_deadline_mailer.rb
+++ b/app/mailers/reminder_deadline_mailer.rb
@@ -3,6 +3,11 @@ class ReminderDeadlineMailer < ApplicationMailer
   def notify_deadline(partner)
     @partner = partner
     @organization = partner.organization
+
+    # Do not send even if the partner (or its group) has reminders on when the
+    # organization has turned monthly deadline reminders off.
+    return unless @organization.deadline_reminders_enabled
+
     @deadline = deadline_date(partner)
     reminder_email_text = @organization.reminder_email_text
     @reminder_email_text_interpolated = TextInterpolatorService.new(reminder_email_text.body.to_s, {

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -6,8 +6,10 @@
 #  bank_is_set_up                           :boolean          default(FALSE), not null
 #  city                                     :string
 #  deadline_day                             :integer
+#  deadline_reminders_enabled               :boolean          default(FALSE), not null
 #  default_storage_location                 :integer
 #  distribute_monthly                       :boolean          default(FALSE), not null
+#  distribution_reminders_enabled           :boolean          default(FALSE), not null
 #  email                                    :string
 #  enable_child_based_requests              :boolean          default(TRUE), not null
 #  enable_individual_requests               :boolean          default(TRUE), not null

--- a/app/services/partners/fetch_partners_to_remind_now_service.rb
+++ b/app/services/partners/fetch_partners_to_remind_now_service.rb
@@ -4,9 +4,10 @@ module Partners
       current_day = Time.current
       deactivated_status = ::Partner.statuses[:deactivated]
 
-      partners_with_group_reminders = ::Partner.left_joins(:partner_group)
+      partners_with_group_reminders = ::Partner.left_joins(:partner_group, :organization)
         .where.not(partner_groups: {reminder_schedule_definition: nil})
         .where.not(partner_groups: {deadline_day: nil})
+        .where(organizations: {deadline_reminders_enabled: true})
         .where.not(status: deactivated_status)
 
       # where partner groups have reminder schedule match
@@ -17,6 +18,7 @@ module Partners
       partners_with_only_organization_reminders = ::Partner.left_joins(:partner_group, :organization)
         .where(partner_groups: {reminder_schedule_definition: nil})
         .where(send_reminders: true)
+        .where(organizations: {deadline_reminders_enabled: true})
         .where.not(organizations: {deadline_day: nil})
         .where.not(organizations: {reminder_schedule_definition: nil})
         .where.not(status: deactivated_status)

--- a/app/views/admin/organizations/new.html.erb
+++ b/app/views/admin/organizations/new.html.erb
@@ -47,6 +47,8 @@
                 <%= f.input :city %>
                 <%= f.input :state, collection: us_states, class: "form-control", placeholder: "state" %>
                 <%= f.input :zipcode %>
+                <%= f.input :deadline_reminders_enabled, label: 'Send monthly deadline reminder emails to partners?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
+                <%= f.input :distribution_reminders_enabled, label: 'Send day-before distribution reminder emails to partners?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
                 <%= render 'shared/deadline_day_fields', parent_form: f, parent_object: @organization %>
                 <%= f.simple_fields_for :account_request do |account_request| %>
                   <%= account_request.input :ndbn_member, label: 'NDBN Membership', wrapper: :input_group do %>

--- a/app/views/distributions/_form.html.erb
+++ b/app/views/distributions/_form.html.erb
@@ -23,7 +23,11 @@
     <div class='w-72'>
       <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date and time", html5: true, :input_html => { :value => date_place_holder&.strftime("%Y-%m-%dT%0k:%M")} %>
     </div>
-    <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
+    <% if current_organization.distribution_reminders_enabled %>
+      <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send email reminder the day before?" %>
+    <% else %>
+      <%= render 'shared/reminders_disabled_notice', reminder_type: :distribution %>
+    <% end %>
     <%= f.input :agency_rep, label: "Agency representative" %>
 
     <div class='d-flex flex-row' data-controller="distribution-delivery">

--- a/app/views/organizations/_details.html.erb
+++ b/app/views/organizations/_details.html.erb
@@ -176,6 +176,18 @@
 
             <h4>Other emails</h4>
             <div>
+              <h6 class="font-weight-bold">Send monthly deadline reminder emails to partners?</h6>
+              <p>
+                <%= humanize_boolean(@organization.deadline_reminders_enabled) %>
+              </p>
+            </div>
+            <div>
+              <h6 class="font-weight-bold">Send day-before distribution reminder emails to partners?</h6>
+              <p>
+                <%= humanize_boolean(@organization.distribution_reminders_enabled) %>
+              </p>
+            </div>
+            <div>
               <h6 class="font-weight-bold">Reminder emails are sent</h6>
               <p>
                 <%= fa_icon "calendar" %>

--- a/app/views/organizations/_details.html.erb
+++ b/app/views/organizations/_details.html.erb
@@ -187,38 +187,40 @@
                 <%= humanize_boolean(@organization.distribution_reminders_enabled) %>
               </p>
             </div>
-            <div>
-              <h6 class="font-weight-bold">Reminder emails are sent</h6>
-              <p>
-                <%= fa_icon "calendar" %>
-                <%= @organization.reminder_schedule&.show_description.blank? ? 'Not defined' : @organization.reminder_schedule&.show_description %>
-                <% if @organization.reminder_schedule.valid? %>
-                  <small class="mb-3 d-block text-muted">
-                    <%= "Your next reminder date is #{@organization.reminder_schedule.next_occurrence&.strftime('%a %b %d %Y')}." %>
-                  </small>
-                <% end %>
-              </p>
-            </div>
-            <div>
-              <h6 class="font-weight-bold">Deadline day in reminder email</h6>
-              <p>
-                <%= fa_icon "calendar" %>
-                <%= @organization.deadline_day.blank? ? 'Not defined' : "The #{@organization.deadline_day.ordinalize} after the reminder." %>
-                <small class="mb-3 d-block text-muted">
-                  <% if @organization.deadline_day && @organization.reminder_schedule.valid? %>
-                    <%= "The deadline on your next reminder email will be #{DeadlineService.new(
-                      deadline_day: @organization.deadline_day,
-                      today: @organization.reminder_schedule.next_occurrence).next_deadline&.strftime('%a %b %d %Y')}." %>
+            <% if @organization.deadline_reminders_enabled %>
+              <div>
+                <h6 class="font-weight-bold">Reminder emails are sent</h6>
+                <p>
+                  <%= fa_icon "calendar" %>
+                  <%= @organization.reminder_schedule&.show_description.blank? ? 'Not defined' : @organization.reminder_schedule&.show_description %>
+                  <% if @organization.reminder_schedule.valid? %>
+                    <small class="mb-3 d-block text-muted">
+                      <%= "Your next reminder date is #{@organization.reminder_schedule.next_occurrence&.strftime('%a %b %d %Y')}." %>
+                    </small>
                   <% end %>
-                </small>
-              </p>
-            </div>
-            <div>
-              <h6 class="font-weight-bold">Additional text for reminder email</h6>
-              <div class="border rounded p-2 mb-3">
-                <%= @organization.reminder_email_text.presence || 'Not defined' %>
+                </p>
               </div>
-            </div>
+              <div>
+                <h6 class="font-weight-bold">Deadline day in reminder email</h6>
+                <p>
+                  <%= fa_icon "calendar" %>
+                  <%= @organization.deadline_day.blank? ? 'Not defined' : "The #{@organization.deadline_day.ordinalize} after the reminder." %>
+                  <small class="mb-3 d-block text-muted">
+                    <% if @organization.deadline_day && @organization.reminder_schedule.valid? %>
+                      <%= "The deadline on your next reminder email will be #{DeadlineService.new(
+                        deadline_day: @organization.deadline_day,
+                        today: @organization.reminder_schedule.next_occurrence).next_deadline&.strftime('%a %b %d %Y')}." %>
+                    <% end %>
+                  </small>
+                </p>
+              </div>
+              <div>
+                <h6 class="font-weight-bold">Additional text for reminder email</h6>
+                <div class="border rounded p-2 mb-3">
+                  <%= @organization.reminder_email_text.presence || 'Not defined' %>
+                </div>
+              </div>
+            <% end %>
             <div>
               <h6 class="font-weight-bold">Distribution email content</h6>
               <div class="border rounded p-2 mb-3">

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -151,13 +151,17 @@
                 <hr>
 
                 <h4>Other emails</h4>
-                <%= f.input :deadline_reminders_enabled, label: 'Send monthly deadline reminder emails to partners?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
-                <%= f.input :distribution_reminders_enabled, label: 'Send day-before distribution reminder emails to partners?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
-                <%= render 'shared/deadline_day_fields', parent_form: f, parent_object: current_organization %>
-                <% default_reminder_email_text_hint = "You can use the variable <code>%{partner_name}</code> to include the partner's name in the message." %>
-                <%= f.input :reminder_email_text, label: "Additional text for reminder email", hint: default_reminder_email_text_hint.html_safe do %>
-                  <%= f.rich_text_area :reminder_email_text, placeholder: 'Enter reminder email content...' %>
-                <% end %>
+                <div data-controller="reminder-toggle">
+                  <%= f.input :deadline_reminders_enabled, label: 'Send monthly deadline reminder emails to partners?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first, input_html: { data: { 'reminder-toggle-target': 'source', action: 'change->reminder-toggle#toggle' } } %>
+                  <%= f.input :distribution_reminders_enabled, label: 'Send day-before distribution reminder emails to partners?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
+                  <div data-reminder-toggle-target="dependentField">
+                    <%= render 'shared/deadline_day_fields', parent_form: f, parent_object: current_organization %>
+                    <% default_reminder_email_text_hint = "You can use the variable <code>%{partner_name}</code> to include the partner's name in the message." %>
+                    <%= f.input :reminder_email_text, label: "Additional text for reminder email", hint: default_reminder_email_text_hint.html_safe do %>
+                      <%= f.rich_text_area :reminder_email_text, placeholder: 'Enter reminder email content...' %>
+                    <% end %>
+                  </div>
+                </div>
                 <% default_email_text_hint = "You can use the variables <code>%{partner_name}</code>, <code>%{delivery_method}</code>, <code>%{distribution_date}</code>, and <code>%{comment}</code> to include the partner's name, delivery method, distribution date, and comments sent in the request." %>
                 <%= f.input :default_email_text, label: "Distribution email content", hint: default_email_text_hint.html_safe do %>
                   <%= f.rich_text_area :default_email_text, placeholder: 'Enter distribution email content...' %>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -151,6 +151,8 @@
                 <hr>
 
                 <h4>Other emails</h4>
+                <%= f.input :deadline_reminders_enabled, label: 'Send monthly deadline reminder emails to partners?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
+                <%= f.input :distribution_reminders_enabled, label: 'Send day-before distribution reminder emails to partners?', as: :radio_buttons, collection: [[true, 'Yes'], [false, 'No']], label_method: :second, value_method: :first %>
                 <%= render 'shared/deadline_day_fields', parent_form: f, parent_object: current_organization %>
                 <% default_reminder_email_text_hint = "You can use the variable <code>%{partner_name}</code> to include the partner's name in the message." %>
                 <%= f.input :reminder_email_text, label: "Additional text for reminder email", hint: default_reminder_email_text_hint.html_safe do %>

--- a/app/views/partner_groups/_form.html.erb
+++ b/app/views/partner_groups/_form.html.erb
@@ -20,18 +20,24 @@
                 <%= f.association :item_categories, collection: @item_categories, as: :check_boxes, label: '' %>
               </div>
 
-              <div class='mt-3' data-controller='checkbox-with-nested-element'>
+              <div class='mt-3'>
                 <h2 class='text-bold text-lg'>Do you want to send deadline reminders to them every month?</h2>
-                <%= f.input :send_reminders, as: :boolean, label: "Yes", input_html: { data: { action: 'click->checkbox-with-nested-element#toggleNestedElementVisibility', 'checkbox-with-nested-element-target': 'checkbox' } } %>
+                <% if current_organization.deadline_reminders_enabled %>
+                  <div data-controller='checkbox-with-nested-element'>
+                    <%= f.input :send_reminders, as: :boolean, label: "Yes", input_html: { data: { action: 'click->checkbox-with-nested-element#toggleNestedElementVisibility', 'checkbox-with-nested-element-target': 'checkbox' } } %>
 
-                <div class='pl-5 d-none' data-checkbox-with-nested-element-target='nestedElement'>
-                  <div class="callout callout-info">
-                    <h5>That's great!</h5>
-                    <p>You must fill out the details below to send reminders.</p>
+                    <div class='pl-5 d-none' data-checkbox-with-nested-element-target='nestedElement'>
+                      <div class="callout callout-info">
+                        <h5>That's great!</h5>
+                        <p>You must fill out the details below to send reminders.</p>
+                      </div>
+
+                      <%= render 'shared/deadline_day_fields', parent_form: f, parent_object: @partner_group %>
+                    </div>
                   </div>
-
-                  <%= render 'shared/deadline_day_fields', parent_form: f, parent_object: @partner_group %>
-                </div>
+                <% else %>
+                  <%= render 'shared/reminders_disabled_notice', reminder_type: :deadline %>
+                <% end %>
               </div>
             </div>
 

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -41,6 +41,9 @@
                    <h5 class='text-uppercase font-weight-bold'>Reminder</h5>
                    <p>Please note that reminders will be sent out according to the settings of their partner group OR organization. This won't work unless you've set up at least one.</p>
                  </div>
+                 <% unless current_organization.deadline_reminders_enabled || current_organization.distribution_reminders_enabled %>
+                   <%= render 'shared/reminders_disabled_notice', reminder_type: :all %>
+                 <% end %>
               </div>
 
               <%= f.input :quota, label: "Quota", wrapper: :input_group do %>

--- a/app/views/shared/_reminders_disabled_notice.html.erb
+++ b/app/views/shared/_reminders_disabled_notice.html.erb
@@ -1,0 +1,27 @@
+<%#
+  Shown in place of reminder-configuration fields when the organization has
+  turned the relevant reminder emails off on its settings page.
+
+  Locals:
+    reminder_type - :deadline, :distribution, or :all
+%>
+<div class="callout callout-info">
+  <h5 class="font-weight-bold">
+    <% case reminder_type %>
+    <% when :distribution %>
+      Day-before distribution reminder emails are turned off
+    <% when :all %>
+      Reminder emails are turned off for your organization
+    <% else %>
+      Monthly deadline reminder emails are turned off
+    <% end %>
+  </h5>
+  <p class="mb-0">
+    Your organization has turned this off, so these emails will not be sent.
+    <% if can_administrate? %>
+      <%= link_to "Change this in your organization settings", edit_organization_path %>.
+    <% else %>
+      Contact your organization administrator to change this.
+    <% end %>
+  </p>
+</div>

--- a/db/migrate/20260829112930_add_reminder_toggles_to_organizations.rb
+++ b/db/migrate/20260829112930_add_reminder_toggles_to_organizations.rb
@@ -3,18 +3,9 @@ class AddReminderTogglesToOrganizations < ActiveRecord::Migration[8.1]
     add_column :organizations, :deadline_reminders_enabled, :boolean, null: false, default: false
     add_column :organizations, :distribution_reminders_enabled, :boolean, null: false, default: false
 
-    # Preserve current behavior for organizations that already have any reminder
-    # configuration. New organizations opt in explicitly via their settings.
-    configured_ids = Set.new
-    configured_ids.merge Organization.where.not(reminder_schedule_definition: nil).ids
-    configured_ids.merge Organization.where.not(deadline_day: nil).ids
-    configured_ids.merge Organization.where.not(reminder_day: nil).ids
-    configured_ids.merge Organization.joins(:partners).where(partners: {send_reminders: true}).distinct.ids
-    configured_ids.merge Organization.joins(:partner_groups).where(partner_groups: {send_reminders: true}).distinct.ids
-    configured_ids.merge Organization.joins(:distributions).where(distributions: {reminder_email_enabled: true}).distinct.ids
-
-    Organization.where(id: configured_ids.to_a)
-      .update_all(deadline_reminders_enabled: true, distribution_reminders_enabled: true)
+    # Set the existing orgs value to true.
+    # This preserves current behavior since emails only get sent if the org already has reminder settings.
+    Organization.update_all(deadline_reminders_enabled: true, distribution_reminders_enabled: true)
   end
 
   def down

--- a/db/migrate/20260829112930_add_reminder_toggles_to_organizations.rb
+++ b/db/migrate/20260829112930_add_reminder_toggles_to_organizations.rb
@@ -1,0 +1,24 @@
+class AddReminderTogglesToOrganizations < ActiveRecord::Migration[8.1]
+  def up
+    add_column :organizations, :deadline_reminders_enabled, :boolean, null: false, default: false
+    add_column :organizations, :distribution_reminders_enabled, :boolean, null: false, default: false
+
+    # Preserve current behavior for organizations that already have any reminder
+    # configuration. New organizations opt in explicitly via their settings.
+    configured_ids = Set.new
+    configured_ids.merge Organization.where.not(reminder_schedule_definition: nil).ids
+    configured_ids.merge Organization.where.not(deadline_day: nil).ids
+    configured_ids.merge Organization.where.not(reminder_day: nil).ids
+    configured_ids.merge Organization.joins(:partners).where(partners: {send_reminders: true}).distinct.ids
+    configured_ids.merge Organization.joins(:partner_groups).where(partner_groups: {send_reminders: true}).distinct.ids
+    configured_ids.merge Organization.joins(:distributions).where(distributions: {reminder_email_enabled: true}).distinct.ids
+
+    Organization.where(id: configured_ids.to_a)
+      .update_all(deadline_reminders_enabled: true, distribution_reminders_enabled: true)
+  end
+
+  def down
+    remove_column :organizations, :distribution_reminders_enabled
+    remove_column :organizations, :deadline_reminders_enabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_29_112930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -469,8 +469,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_130000) do
     t.string "city"
     t.datetime "created_at", precision: nil, null: false
     t.integer "deadline_day"
+    t.boolean "deadline_reminders_enabled", default: false, null: false
     t.integer "default_storage_location"
     t.boolean "distribute_monthly", default: false, null: false
+    t.boolean "distribution_reminders_enabled", default: false, null: false
     t.string "email"
     t.boolean "enable_child_based_requests", default: true, null: false
     t.boolean "enable_individual_requests", default: true, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_28_150820) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_29_112930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -240,6 +240,7 @@ RSpec.describe DistributionsController, type: :controller do
         context "when partner has enabled send_reminders" do
           before(:each) do
             partner.send_reminders = true
+            organization.update!(distribution_reminders_enabled: true)
           end
           it "should schedule the reminder email" do
             subject
@@ -259,6 +260,18 @@ RSpec.describe DistributionsController, type: :controller do
           it "should not schedule an email reminder for a partner that disabled reminders" do
             subject
             expect(enqueued_jobs.size).to eq(0)
+          end
+        end
+
+        context "when the partner has send_reminders enabled but the organization has disabled distribution reminders" do
+          before do
+            partner.update!(send_reminders: true)
+            organization.update!(distribution_reminders_enabled: false)
+          end
+
+          it "should not schedule an email reminder" do
+            subject
+            expect(enqueued_jobs.map { |job| job["arguments"][1] }).not_to include("reminder_email")
           end
         end
       end
@@ -416,6 +429,7 @@ RSpec.describe DistributionsController, type: :controller do
         context "when partner has enabled send_reminders" do
           before(:each) do
             partner.send_reminders = true
+            organization.update!(distribution_reminders_enabled: true)
           end
           it "should schedule the reminder email" do
             subject

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -6,8 +6,10 @@
 #  bank_is_set_up                           :boolean          default(FALSE), not null
 #  city                                     :string
 #  deadline_day                             :integer
+#  deadline_reminders_enabled               :boolean          default(FALSE), not null
 #  default_storage_location                 :integer
 #  distribute_monthly                       :boolean          default(FALSE), not null
+#  distribution_reminders_enabled           :boolean          default(FALSE), not null
 #  email                                    :string
 #  enable_child_based_requests              :boolean          default(TRUE), not null
 #  enable_individual_requests               :boolean          default(TRUE), not null

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -143,6 +143,9 @@ RSpec.describe DistributionMailer, type: :mailer do
   describe "#reminder_email" do
     let(:mail) { DistributionMailer.reminder_email(distribution.id) }
 
+    # New organizations have reminders disabled by default; opt in for these specs.
+    before { organization.update!(distribution_reminders_enabled: true) }
+
     context 'HTML format' do
       it "renders the body with organization's email text" do
         html = html_body(mail)
@@ -178,6 +181,18 @@ RSpec.describe DistributionMailer, type: :mailer do
         distribution = create(:distribution, organization: user.organization, comment: "Distribution comment", partner: partner, delivery_method: :delivery)
         mail = DistributionMailer.reminder_email(distribution.id)
         expect(mail.body.encoded).to match("delivery")
+      end
+    end
+
+    context "when the organization has disabled distribution reminders" do
+      before do
+        partner.update!(send_reminders: true)
+        organization.update!(distribution_reminders_enabled: false)
+      end
+
+      it "does not send the reminder even though the partner has send_reminders enabled" do
+        expect(mail.body).to be_blank
+        expect(mail.to).to be_nil
       end
     end
   end

--- a/spec/mailers/reminder_deadline_mailer_spec.rb
+++ b/spec/mailers/reminder_deadline_mailer_spec.rb
@@ -6,10 +6,22 @@ RSpec.describe ReminderDeadlineMailer, type: :job do
     let(:partner) { create(:partner, organization: organization) }
     before(:each) do
       organization.reminder_email_text = "Custom reminder message"
-      organization.update!(deadline_day: 1)
+      organization.update!(deadline_day: 1, deadline_reminders_enabled: true)
     end
 
     subject { described_class.notify_deadline(partner) }
+
+    context 'when the organization has disabled monthly deadline reminders' do
+      before do
+        partner.update!(send_reminders: true)
+        organization.update!(deadline_reminders_enabled: false)
+      end
+
+      it 'does not send even though the partner has reminders enabled' do
+        expect(subject.body).to be_blank
+        expect(subject.to).to be_nil
+      end
+    end
 
     it 'renders the subject' do
       expect(subject.subject).to eq("#{organization.name} Deadline Reminder")

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -6,8 +6,10 @@
 #  bank_is_set_up                           :boolean          default(FALSE), not null
 #  city                                     :string
 #  deadline_day                             :integer
+#  deadline_reminders_enabled               :boolean          default(FALSE), not null
 #  default_storage_location                 :integer
 #  distribute_monthly                       :boolean          default(FALSE), not null
+#  distribution_reminders_enabled           :boolean          default(FALSE), not null
 #  email                                    :string
 #  enable_child_based_requests              :boolean          default(TRUE), not null
 #  enable_individual_requests               :boolean          default(TRUE), not null
@@ -97,6 +99,20 @@ RSpec.describe Organization, type: :model do
       organization.update(deadline_day: 10)
       organization.reminder_schedule.assign_attributes(day_of_month: 10)
       expect(organization).to be_valid
+    end
+  end
+
+  describe "reminder toggles" do
+    it "defaults deadline_reminders_enabled to false for a new organization" do
+      expect(Organization.new.deadline_reminders_enabled).to be false
+      expect(build(:organization).deadline_reminders_enabled).to be false
+      expect(create(:organization).reload.deadline_reminders_enabled).to be false
+    end
+
+    it "defaults distribution_reminders_enabled to false for a new organization" do
+      expect(Organization.new.distribution_reminders_enabled).to be false
+      expect(build(:organization).distribution_reminders_enabled).to be false
+      expect(create(:organization).reload.distribution_reminders_enabled).to be false
     end
   end
 

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "Organizations", type: :request do
             every_nth_month: 1,
             day_of_month: 20
           }).to_ical
-          organization.update(reminder_schedule_definition: valid_reminder_schedule)
+          organization.update(reminder_schedule_definition: valid_reminder_schedule, deadline_reminders_enabled: true)
         end
 
         it "reports the next date a reminder email will be sent" do
@@ -177,6 +177,19 @@ RSpec.describe "Organizations", type: :request do
           get organization_path
           expect(response.body).to include "Your next reminder date is Tue Oct 20 2020."
           expect(response.body).to include "The deadline on your next reminder email will be Sun Oct 25 2020."
+        end
+
+        context "but monthly deadline reminders are disabled" do
+          before do
+            organization.update!(deadline_day: 25, deadline_reminders_enabled: false)
+            get organization_path
+          end
+
+          it "hides the reminder schedule details" do
+            expect(response.body).not_to include "Reminder emails are sent"
+            expect(response.body).not_to include "Deadline day in reminder email"
+            expect(response.body).not_to include "Additional text for reminder email"
+          end
         end
       end
 

--- a/spec/requests/organization_requests_spec.rb
+++ b/spec/requests/organization_requests_spec.rb
@@ -348,6 +348,19 @@ RSpec.describe "Organizations", type: :request do
         end
       end
 
+      context "toggles the reminder email settings" do
+        let(:update_param) do
+          { organization: { deadline_reminders_enabled: true, distribution_reminders_enabled: false } }
+        end
+
+        it "persists both flags" do
+          subject
+          organization.reload
+          expect(organization.deadline_reminders_enabled).to be true
+          expect(organization.distribution_reminders_enabled).to be false
+        end
+      end
+
       context "updates repackage essentials setting" do
         let(:update_param) { { organization: { repackage_essentials: true } } }
         it "works" do

--- a/spec/services/partners/fetch_partners_to_remind_now_service_spec.rb
+++ b/spec/services/partners/fetch_partners_to_remind_now_service_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Partners::FetchPartnersToRemindNowService do
 
     context "when there is a partner" do
       let!(:partner) { create(:partner) }
+      # New organizations have reminders disabled by default; these specs exercise
+      # the scheduling logic, so opt the partner's organization in.
+      before { partner.organization.update(deadline_reminders_enabled: true) }
       context "that has an organization with a global reminder & deadline" do
         context "that is for today" do
           before do
@@ -54,6 +57,17 @@ RSpec.describe Partners::FetchPartnersToRemindNowService do
             end
 
             it "should NOT include that partner" do
+              expect(subject).not_to include(partner)
+            end
+          end
+
+          context "but the organization has disabled deadline reminders" do
+            before do
+              partner.update!(send_reminders: true)
+              partner.organization.update(deadline_reminders_enabled: false)
+            end
+
+            it "should NOT include that partner even though the partner has send_reminders enabled" do
               expect(subject).not_to include(partner)
             end
           end
@@ -152,6 +166,16 @@ RSpec.describe Partners::FetchPartnersToRemindNowService do
 
               it "should include that partner" do
                 expect(subject).to include(partner)
+              end
+            end
+
+            context "but the organization has disabled deadline reminders" do
+              before do
+                partner.organization.update(deadline_reminders_enabled: false)
+              end
+
+              it "should NOT include that partner" do
+                expect(subject).not_to include(partner)
               end
             end
           end

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -138,6 +138,26 @@ RSpec.describe "Admin Organization Management", type: :system, js: true, seed_it
       expect(page).to have_content("invited")
     end
 
+    it "can create an organization with reminders left disabled" do
+      visit new_admin_organization_path
+      admin_user_params = attributes_for(:organization_admin)
+      within "form#new_organization" do
+        fill_in "organization_name", with: "No Reminders Org"
+        fill_in "organization_email", with: "no-reminders@example.com"
+        fill_in "organization_user_name", with: admin_user_params[:name]
+        fill_in "organization_user_email", with: admin_user_params[:email]
+
+        choose('organization[deadline_reminders_enabled]', option: false)
+        choose('organization[distribution_reminders_enabled]', option: false)
+        click_on "Save"
+      end
+
+      expect(page).to have_content("All Human Essentials Organizations")
+      org = Organization.find_by(name: "No Reminders Org")
+      expect(org.deadline_reminders_enabled).to be false
+      expect(org.distribution_reminders_enabled).to be false
+    end
+
     it "can view organization details", :aggregate_failures do
       visit admin_organizations_path
 
@@ -160,6 +180,7 @@ RSpec.describe "Admin Organization Management", type: :system, js: true, seed_it
         visit new_admin_organization_path
         within "form#new_organization" do
           fill_in "organization_name", with: "aaa" # So the new org will be on the first page
+          choose('organization[deadline_reminders_enabled]', option: true)
         end
       end
 

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -320,6 +320,27 @@ RSpec.feature "Distributions", type: :system do
       visit new_distribution_path
       expect(page).to have_no_content "Inactive R Us"
     end
+
+    context "when the organization has disabled day-before distribution reminders" do
+      before { organization.update!(distribution_reminders_enabled: false) }
+
+      it "replaces the reminder checkbox with a notice, linking an admin to settings" do
+        sign_in(organization_admin)
+        visit new_distribution_path
+
+        expect(page).not_to have_field("Send email reminder the day before?")
+        expect(page).to have_content("Day-before distribution reminder emails are turned off")
+        expect(page).to have_link("Change this in your organization settings", href: edit_organization_path)
+      end
+
+      it "tells a non-admin user to contact their administrator" do
+        visit new_distribution_path
+
+        expect(page).not_to have_field("Send email reminder the day before?")
+        expect(page).to have_content("Contact your organization administrator")
+        expect(page).not_to have_link("Change this in your organization settings")
+      end
+    end
   end
 
   it "errors if user does not fill storage_location" do

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -365,6 +365,7 @@ RSpec.feature "Distributions", type: :system do
     end
 
     it "sends an email if reminders are enabled" do
+      user.organization.update!(distribution_reminders_enabled: true)
       job = double('fake_job')
       allow(DistributionMailer).to receive(:reminder_email).and_return(job)
       allow(job).to receive(:deliver_later)

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -71,37 +71,48 @@ RSpec.describe "Organization management", type: :system, js: true do
         expect(page.find(".alert")).to have_content "Updated your organization!"
       end
 
-      it_behaves_like "deadline and reminder form", "organization", "Save", :post_form_submit
+      # Monthly deadline reminders are off by default; opt in before exercising
+      # the reminder schedule. A page refresh resets the radio, so re-select Yes.
+      def choose_deadline_reminders_yes
+        choose('organization[deadline_reminders_enabled]', option: true)
+      end
 
-      it "the deadline day form's reminder and deadline dates are consistent with the dates calculated by the FetchPartnersToRemindNowService and DeadlineService" do
-        travel_to Time.zone.local(2025, 9, 30)
-        refresh
-        choose "Day of Month"
-        fill_in "organization_reminder_schedule_service_day_of_month", with: safe_add_days(Time.zone.now, 1).day
-        fill_in "Deadline day in reminder email", with: safe_add_days(Time.zone.now, 2).day
+      context "with monthly deadline reminders enabled" do
+        before { choose_deadline_reminders_yes }
 
-        reminder_text = find('small[data-deadline-day-target="reminderText"]').text
-        reminder_text.slice!("Your next reminder date is ")
-        reminder_text.slice!(".")
-        shown_recurrence_date = Time.zone.strptime(reminder_text, "%a %b %d %Y")
+        it_behaves_like "deadline and reminder form", "organization", "Save", :post_form_submit, :choose_deadline_reminders_yes
 
-        deadline_text = find('small[data-deadline-day-target="deadlineText"]').text
-        deadline_text.slice!("The deadline on your next reminder email will be ")
-        deadline_text.slice!(".")
-        shown_deadline_date = Time.zone.strptime(deadline_text, "%a %b %d %Y")
+        it "the deadline day form's reminder and deadline dates are consistent with the dates calculated by the FetchPartnersToRemindNowService and DeadlineService" do
+          travel_to Time.zone.local(2025, 9, 30)
+          refresh
+          choose_deadline_reminders_yes
+          choose "Day of Month"
+          fill_in "organization_reminder_schedule_service_day_of_month", with: safe_add_days(Time.zone.now, 1).day
+          fill_in "Deadline day in reminder email", with: safe_add_days(Time.zone.now, 2).day
 
-        click_on "Save"
-        organization.reload
+          reminder_text = find('small[data-deadline-day-target="reminderText"]').text
+          reminder_text.slice!("Your next reminder date is ")
+          reminder_text.slice!(".")
+          shown_recurrence_date = Time.zone.strptime(reminder_text, "%a %b %d %Y")
 
-        expect(Partners::FetchPartnersToRemindNowService.new.fetch).to_not include(partner)
+          deadline_text = find('small[data-deadline-day-target="deadlineText"]').text
+          deadline_text.slice!("The deadline on your next reminder email will be ")
+          deadline_text.slice!(".")
+          shown_deadline_date = Time.zone.strptime(deadline_text, "%a %b %d %Y")
 
-        travel_to shown_recurrence_date
+          click_on "Save"
+          organization.reload
 
-        expect(Partners::FetchPartnersToRemindNowService.new.fetch).to include(partner)
-        expect(DeadlineService.new(deadline_day: DeadlineService.get_deadline_for_partner(partner)).next_deadline.in_time_zone(Time.zone)).to be_within(1.second).of shown_deadline_date
+          expect(Partners::FetchPartnersToRemindNowService.new.fetch).to_not include(partner)
 
-        expect(page).to have_content("Your next reminder date is #{reminder_text}.")
-        expect(page).to have_content("The deadline on your next reminder email will be #{deadline_text}.")
+          travel_to shown_recurrence_date
+
+          expect(Partners::FetchPartnersToRemindNowService.new.fetch).to include(partner)
+          expect(DeadlineService.new(deadline_day: DeadlineService.get_deadline_for_partner(partner)).next_deadline.in_time_zone(Time.zone)).to be_within(1.second).of shown_deadline_date
+
+          expect(page).to have_content("Your next reminder date is #{reminder_text}.")
+          expect(page).to have_content("The deadline on your next reminder email will be #{deadline_text}.")
+        end
       end
 
       it 'can select if the org repackages essentials' do

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -125,6 +125,16 @@ RSpec.describe "Organization management", type: :system, js: true do
         expect(page).to have_content("No")
       end
 
+      it 'can toggle the monthly deadline and day-before distribution reminder emails' do
+        choose('organization[deadline_reminders_enabled]', option: true)
+        choose('organization[distribution_reminders_enabled]', option: true)
+
+        click_on "Save"
+        expect(page).to have_content("Updated your organization!")
+        expect(organization.reload.deadline_reminders_enabled).to be true
+        expect(organization.distribution_reminders_enabled).to be true
+      end
+
       it 'can set a default storage location on the organization' do
         select(storage_location.name, from: 'Default Storage Location')
 

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -71,10 +71,24 @@ RSpec.describe "Organization management", type: :system, js: true do
         expect(page.find(".alert")).to have_content "Updated your organization!"
       end
 
-      # Monthly deadline reminders are off by default; opt in before exercising
-      # the reminder schedule. A page refresh resets the radio, so re-select Yes.
+      # The reminder-schedule fields only render when monthly deadline reminders
+      # are enabled, and the page re-hides them after a refresh, so re-select Yes.
       def choose_deadline_reminders_yes
         choose('organization[deadline_reminders_enabled]', option: true)
+      end
+
+      it "shows the reminder schedule fields only when monthly deadline reminders are enabled" do
+        expect(page).to have_content("Send monthly deadline reminder emails to partners?")
+        expect(page).not_to have_field("Deadline day in reminder email", visible: :visible)
+        expect(page).not_to have_content("Additional text for reminder email")
+
+        choose_deadline_reminders_yes
+        expect(page).to have_field("Deadline day in reminder email", visible: :visible)
+        expect(page).to have_content("Additional text for reminder email")
+
+        choose('organization[deadline_reminders_enabled]', option: false)
+        expect(page).not_to have_field("Deadline day in reminder email", visible: :visible)
+        expect(page).not_to have_content("Additional text for reminder email")
       end
 
       context "with monthly deadline reminders enabled" do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -701,6 +701,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 
       describe 'creating a new partner group' do
         it 'should allow creating a new partner group with item categories' do
+          organization.update!(deadline_reminders_enabled: true)
           travel_to Time.zone.local(2020, 10, 10)
           visit partners_path
 
@@ -724,6 +725,28 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           assert page.has_content? item_category_2.name
           expect(page).to have_content("Your next reminder date is Sun Nov 01 2020.")
           expect(page).to have_content("The deadline on your next reminder email will be Wed Nov 25 2020.")
+        end
+      end
+
+      describe 'when the organization has disabled monthly deadline reminders' do
+        before { organization.update!(deadline_reminders_enabled: false) }
+
+        it 'replaces the reminder schedule fields with a notice linking an admin to settings' do
+          sign_in(organization_admin)
+          visit new_partner_group_path
+
+          expect(page).to have_content('Do you want to send deadline reminders to them every month?')
+          expect(page).not_to have_field('partner_group_reminder_schedule_service_day_of_month')
+          expect(page).to have_content('Monthly deadline reminder emails are turned off')
+          expect(page).to have_link('Change this in your organization settings', href: edit_organization_path)
+        end
+
+        it 'tells a non-admin user to contact their administrator' do
+          visit new_partner_group_path
+
+          expect(page).to have_content('Monthly deadline reminder emails are turned off')
+          expect(page).to have_content('Contact your organization administrator')
+          expect(page).not_to have_link('Change this in your organization settings')
         end
       end
 
@@ -762,6 +785,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           end
 
           before do
+            organization.update!(deadline_reminders_enabled: true)
             partner.update!(partner_group: existing_partner_group)
             visit partners_path
 
@@ -776,7 +800,6 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           it_behaves_like "deadline and reminder form", "partner_group", "Update Partner Group", nil, :post_refresh
 
           it "the deadline day form's reminder and deadline dates are consistent with the dates calculated by the FetchPartnersToRemindNowService and DeadlineService" do
-            partner.organization.update!(deadline_reminders_enabled: true)
             travel_to Time.zone.local(2025, 9, 30)
             refresh
             post_refresh

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -776,6 +776,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           it_behaves_like "deadline and reminder form", "partner_group", "Update Partner Group", nil, :post_refresh
 
           it "the deadline day form's reminder and deadline dates are consistent with the dates calculated by the FetchPartnersToRemindNowService and DeadlineService" do
+            partner.organization.update!(deadline_reminders_enabled: true)
             travel_to Time.zone.local(2025, 9, 30)
             refresh
             post_refresh


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->
Resolves #5668 

### Description
This adds new columns to the data model to track reminder enablement on the org level, adds the option to the admin user views, and enforces that choice in the mailers. Specs have been added for all of the above

### Type of change

Feature!
### How Has This Been Tested?

Specs plus manual tests for each user type. 


