### PR TITLE
Fix lockout from stale session[:current_role] when a different user signs in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
     @role = if !current_user
       nil
     else
-      Role.find_by(id: session[:current_role]) || UsersRole.current_role_for(current_user)
+      current_user.roles.find_by(id: session[:current_role]) || UsersRole.current_role_for(current_user)
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -17,6 +17,8 @@ class Users::SessionsController < Devise::SessionsController
   # POST /resource/sign_in
   def create
     super
+    # discard a role left over from a previously signed-in user
+    session.delete(:current_role) unless current_user.roles.exists?(id: session[:current_role])
     session[:current_role] ||= UsersRole.current_role_for(current_user)&.id
     UsersRole.set_last_role_for(current_user, @role)
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -71,6 +71,25 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe "current_role" do
+    let(:user) { create(:user, organization: organization) }
+    let(:other_user) { create(:user, organization: create(:organization)) }
+
+    before(:each) do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    it "uses the session role when it belongs to the current user" do
+      session[:current_role] = user.roles.first.id.to_s
+      expect(controller.current_role).to eq(user.roles.first)
+    end
+
+    it "ignores a session role that belongs to another user" do
+      session[:current_role] = other_user.roles.first.id.to_s
+      expect(controller.current_role).to eq(user.roles.first)
+    end
+  end
+
   describe "dashboard_path_from_current_role" do
     before(:each) do
       allow(controller).to receive(:current_user).and_return(user)

--- a/spec/requests/sessions_requests_spec.rb
+++ b/spec/requests/sessions_requests_spec.rb
@@ -93,6 +93,22 @@ RSpec.describe "Sessions", type: :request, order: :defined do
       end
     end
 
+    context "when a different user signs in on the same browser session" do
+      let(:first_org) { create(:organization) }
+      let(:second_org) { create(:organization) }
+      let(:first_user) { create(:user, organization: first_org) }
+      let(:second_user) { create(:user, organization: second_org) }
+
+      it "does not retain the previous user's role" do
+        post user_session_path, params: {user: {email: first_user.email, password: "password!"}}
+        post user_session_path, params: {user: {email: second_user.email, password: "password!"}}
+
+        get dashboard_path
+        expect(response).to be_successful
+        expect(session[:current_role]).to eq(second_user.roles.first.id)
+      end
+    end
+
     context "without a previously used role" do
       before do
         partner_user.add_role(Role::ORG_ADMIN, organization)


### PR DESCRIPTION
### Description

Signing in as one user and then signing in as a different user in the same browser (without signing out first) locks the second user out of the app entirely with an infinite redirect loop. The only escape is clearing cookies.

**Cause:** `Users::SessionsController#create` runs `sign_out_if_signed_in`, which is a *scoped* `sign_out` — it clears the Warden user but keeps the rest of the session, so `session[:current_role]` from the previous user survives into the new login. `session[:current_role] ||= ...` then sees a present value and leaves it alone.

`ApplicationController#current_role` did a global `Role.find_by(id: session[:current_role])`, so it happily returned a role the newly signed-in user does not hold. `current_organization` derived from that foreign role, `authorize_user` failed for every page — including the dashboard it redirects to — and the browser looped until `ERR_TOO_MANY_REDIRECTS`.

This was hit organically by two of us while doing local QA on another branch.

**Fix, in two parts:**
- `current_role` scopes the session-role lookup to `current_user.roles`, so a role the user doesn't hold is ignored and it falls back to `UsersRole.current_role_for`. This alone stops the lockout.
- `SessionsController#create` deletes a leftover `session[:current_role]` that doesn't belong to the newly signed-in user, so the session doesn't keep carrying another user's role around.

### Type of change

Bug fix.

### How Has This Been Tested?

Two new specs, both confirmed failing before the fix and passing after:
- `spec/requests/sessions_requests_spec.rb` — signing in as a second user in the same session reaches a successful dashboard and stores that user's own role.
- `spec/controllers/application_controller_spec.rb` — `current_role` uses a session role the user holds, and ignores one belonging to another user.

Also verified manually in a browser against local seed data: sign in as `org_admin1@example.com`, then sign in as `org_admin2@example.com` without signing out. On `main` the second login dead-ends in a redirect loop; with this change it lands on the SF Diaper Bank dashboard, and `/dashboard` continues to load correctly.

Full `spec/requests/sessions_requests_spec.rb`, `spec/controllers/application_controller_spec.rb`, `spec/requests/users_requests_spec.rb` and `spec/requests/dashboard_requests_spec.rb` pass (the existing session-role-preference cases around last-used and revoked roles still hold). Rubocop clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoUPX63nd1LSkKDPEiQ7jt