### PR TITLE
Resolves #5688 Camera now opens on barcode_items/new

### DIFF
--- a/app/views/barcode_items/_form.html.erb
+++ b/app/views/barcode_items/_form.html.erb
@@ -15,8 +15,8 @@
               <% end %>
               <%= f.association :barcodeable, collection: @items, label: "Item", wrapper: :input_group %>
               <%= f.input :value, label: "Barcode", wrapper: :input_group do %>
-                <span class="input-group-text"><i class="fa fa-barcode"></i></span>
                 <%= f.input_field :value, class: "form-control" %>
+                <button type=button id="barcode-scanner-btn" class="input-group-text barcode-scanner fa fa-barcode" style="font-weight: 900;"></button>
               <% end %>
             </div>
             <!-- /.card-body -->


### PR DESCRIPTION
Simple addition of the css id expected. Also changed the span to a button for a11y

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
- I acknowledge that I will *not* force push my branch once reviews have started.

-->

Resolves #5688  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change
Bug fix

### How Has This Been Tested?

Manually tested with the barcode from a package of dried mangos! Which, side note, are delicious. Also did a regression test of the barcode scan that already worked fine (audits/new) just in case. 

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
