### PR TITLE
User guide: Request export columns and cancellation email recipients (#5681, #5606)

### DIFF
--- a/docs/user_guide/bank/essentials_requests.md
+++ b/docs/user_guide/bank/essentials_requests.md
@@ -123,7 +123,7 @@ You will be prompted to provide a reason for the cancellation.
 The Partner will receive an email notifying them of the cancellation.
 ![cancel Request email](images/essentials/requests/essentials_requests_cancel_email.png)
 
-NOTE: This email goes to the Partner, rather than to the User who sent the request.
+NOTE: This email goes to the Partner's main email address *and* to the Partner user who sent the Request (if they are different).  The Partner's main email is often a director or a general mailbox, so this makes sure the person who actually placed the Request hears about the cancellation too.
 
 ## Exporting Requests
 
@@ -132,7 +132,10 @@ To export the Requests from the Request list, click "Export Requests"
 This will create a .csv file with the following information for each filtered Request:
 
 - Date
-- Requestor (partner)
+- Requestor (the Partner's name)
+- Request Sender (the Partner's email address)
+- Comments
+- Type (Quantity, Child, or Individual)
 - Status
 - For each of the bank's items.
   - the quantity requested

--- a/docs/user_guide/bank/exports.md
+++ b/docs/user_guide/bank/exports.md
@@ -414,7 +414,10 @@ The default is all Requests in the last 60 days
 ### Contents of Requests export
 For each filtered Request,
 - Date,
-- Requestor (i.e. partner)
+- Requestor (i.e. the Partner's name),
+- Request Sender (the Partner's email address),
+- Comments (the comments the Partner entered on the Request),
+- Type (Quantity, Child, or Individual -- see [Requests](essentials_requests.md)),
 - Status, and
 - the quantity of each Item requested. There will be a column for each unit that you have enabled for each Item.
 

--- a/docs/user_guide/bank/request_mailer_preview.md
+++ b/docs/user_guide/bank/request_mailer_preview.md
@@ -1,6 +1,8 @@
 From: <no-reply@humanessentials.app>
 
-To: <director@communityoutreach.org>
+To: <director@communityoutreach.org>, <requester@communityoutreach.org>
+
+(This email goes to the Partner's main email address and to the Partner user who submitted the Request.)
  
 Subject: Your essentials request (#1042) has been canceled.
 


### PR DESCRIPTION
Documents #5681 (Added Columns to csv "Requestor Email" "Comments") and #5606 (Send request cancellation email to the request sender as well as the partner).

- Requests and Exports pages: the Request Sender, Comments and Type columns in the Requests export.
- Requests page and Request Mailer preview: cancellation emails now go to the Partner user who submitted the Request as well as the Partner's main address.

Text only, no screenshots.

Stacked on #5712 (merge that first, or this PR's diff will include it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMAt57FU2qBq45yR7YCsEZ